### PR TITLE
Fix documentation positioning and accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # 🍡 Dango
 
-**Production-ready analytics platform in minutes, not weeks**
+**Professional analytics stack built with production-grade tools**
 
-Dango deploys a complete data stack (DuckDB + dbt + Metabase) to your laptop with one command.
+Works on your laptop today. Designed to scale to production tomorrow.
+
+Dango deploys a complete data stack (dlt + dbt + DuckDB + Metabase) to your laptop with one command.
 
 ## Installation
 
@@ -140,9 +142,10 @@ Start-Process http://localhost:8800
 
 **What you get:**
 - **Web UI** at `http://localhost:8800` - Monitor your data pipeline
-- **Metabase** for dashboards and SQL queries
-- **dbt Docs** for data catalog
+- **dlt** for data ingestion (29+ verified sources)
+- **dbt** for SQL transformations and modeling
 - **DuckDB** as your analytics database
+- **Metabase** for dashboards and SQL queries
 
 ## Features (v0.0.1)
 
@@ -167,6 +170,12 @@ Start-Process http://localhost:8800
 - REST API framework for custom sources
 - Demo project with sample data
 - Full documentation website
+
+**🔮 Beyond v0.1.0:**
+- Cloud deployment guides and infrastructure templates
+- Advanced scheduling and orchestration
+- Team collaboration features
+- Enhanced monitoring and alerting
 
 ## Architecture
 
@@ -195,12 +204,12 @@ Start-Process http://localhost:8800
 ## Why Dango?
 
 **Most tools force you to choose:**
-- ❌ Local-first (limited features) OR Cloud (expensive, complex)
+- ❌ Simple setup (limited features) OR Enterprise platforms (expensive, complex)
 - ❌ No-code (inflexible) OR Full-code (steep learning curve)
 - ❌ Fast setup (toy project) OR Production-grade (weeks of work)
 
 **Dango gives you both:**
-- ✅ Local-first AND production-ready
+- ✅ Starts on your laptop, designed to scale to your infrastructure
 - ✅ Wizard-driven AND fully customizable
 - ✅ Fast setup AND best practices built-in
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "getdango"
 version = "0.0.1"
-description = "Local-first data platform - Laptop to cloud data stack in one weekend"
+description = "Professional analytics stack built with production-grade tools - Open source data platform with dlt, dbt, DuckDB, and Metabase"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "Dango Team", email = "hello@getdango.dev"}
 ]
-keywords = ["data", "analytics", "dbt", "duckdb", "metabase", "etl", "local-first"]
+keywords = ["data", "analytics", "dbt", "duckdb", "metabase", "dlt", "etl", "data-platform", "open-source"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary
- Removed misleading "local-first" positioning (it was chronological development order, not a product philosophy)
- Balanced current state (works on laptop today) with future vision (designed to scale to production)
- Added dlt to all stack descriptions (was missing from hero section and "What you get")
- Added "Beyond v0.1.0" section to clarify cloud deployment is post-v0.1.0
- Updated pyproject.toml description and keywords to match new messaging
- Replaced "production-ready" claim with honest "production-grade tools" language

## Changes
### README.md
- **Hero section**: Changed from "Production-ready platform in minutes" to "Professional analytics stack built with production-grade tools. Works on your laptop today. Designed to scale to production tomorrow."
- **Stack description**: Added dlt (was "DuckDB + dbt + Metabase", now "dlt + dbt + DuckDB + Metabase")
- **What you get**: Added dlt explicitly with "(29+ verified sources)"
- **Why Dango**: Removed "Local-first AND production-ready", replaced with "Starts on your laptop, designed to scale to your infrastructure"
- **New section**: Added "Beyond v0.1.0" with cloud deployment, scheduling, team features, monitoring

### pyproject.toml
- **Description**: Updated to match README messaging
- **Keywords**: Removed "local-first", added "dlt", "data-platform", "open-source"

## Rationale
The previous "local-first" and "production-ready" messaging created confusion:
1. "Local-first" suggested a product philosophy, but it's actually just the chronological development order
2. "Production-ready" contradicted the FAQ which says "Not recommended for production use yet"

The new messaging is transparent about current capabilities (laptop deployment) while showing the design direction (production scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)