### PR TITLE
Remove 'local-first' positioning from install scripts and CLI

### DIFF
--- a/dango/__init__.py
+++ b/dango/__init__.py
@@ -1,7 +1,7 @@
 """
-Dango - Local-first data platform
+Dango - Open source data platform
 
-Laptop to cloud data stack in one weekend.
+Professional analytics stack built with production-grade tools.
 """
 
 __version__ = "0.0.1"

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -18,9 +18,9 @@ console = Console(force_terminal=True, legacy_windows=False)
 @click.pass_context
 def cli(ctx):
     """
-    🍡 Dango - Local-first data platform
+    🍡 Dango - Open source data platform
 
-    Laptop to cloud data stack in one weekend.
+    Professional analytics stack built with production-grade tools.
 
     Common commands:
       dango init       Create a new data project

--- a/install.ps1
+++ b/install.ps1
@@ -10,7 +10,7 @@
 function Write-Header {
     Write-Host ""
     Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
-    Write-Host "  Dango Installer - Local-First Data Platform" -ForegroundColor Cyan
+    Write-Host "  Dango Installer - Open Source Data Platform" -ForegroundColor Cyan
     Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
     Write-Host ""
 }

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ NC='\033[0m' # No Color
 # Print functions
 print_header() {
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "${CYAN}  Dango Installer - Local-First Data Platform${NC}"
+    echo -e "${CYAN}  Dango Installer - Open Source Data Platform${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo
 }


### PR DESCRIPTION
## Summary
Complete the removal of "local-first" positioning by updating the remaining references in install scripts and CLI help text.

## Changes Made

### Install Scripts
- **install.sh**: Updated header from "Local-First Data Platform" to "Open Source Data Platform"
- **install.ps1**: Updated header from "Local-First Data Platform" to "Open Source Data Platform"

### CLI & Package
- **dango/__init__.py**: Updated package docstring
  - "Local-first data platform" → "Open source data platform"
  - "Laptop to cloud data stack in one weekend" → "Professional analytics stack built with production-grade tools"
- **dango/cli/main.py**: Updated CLI help text
  - "Local-first data platform" → "Open source data platform"
  - "Laptop to cloud data stack in one weekend" → "Professional analytics stack built with production-grade tools"

## Rationale
These were the last remaining references to "local-first" positioning after:
- PR #3: Fixed README and pyproject.toml
- Website PR #5: Fixed website components

"Local-first" suggested a product philosophy when it was actually just chronological development order (laptop deployment first, cloud later). The new messaging accurately positions Dango as an open source data platform.

## Related PRs
- dango#3: Fix documentation positioning and accuracy  
- website#5: Align website messaging with dango repo positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)