### PR TITLE
Standardize primary messaging to 'open source data platform'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🍡 Dango
 
-**Professional analytics stack built with production-grade tools**
+**Open source data platform built with production-grade tools**
 
 Works on your laptop today. Designed to scale to production tomorrow.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "getdango"
 version = "0.0.1"
-description = "Professional analytics stack built with production-grade tools - Open source data platform with dlt, dbt, DuckDB, and Metabase"
+description = "Open source data platform built with production-grade tools - dlt, dbt, DuckDB, and Metabase"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Standardize the primary tagline across all materials to "Open source data platform" for consistency and better positioning.

## Changes Made

### README.md (Line 3)
- **Before:** "**Professional analytics stack built with production-grade tools**"
- **After:** "**Open source data platform built with production-grade tools**"

### pyproject.toml (Line 8)
- **Before:** "Professional analytics stack built with production-grade tools - Open source data platform with dlt, dbt, DuckDB, and Metabase"
- **After:** "Open source data platform built with production-grade tools - dlt, dbt, DuckDB, and Metabase"

## Rationale

After updating install scripts and CLI (PR #4), we had an inconsistency:
- Install scripts, CLI, and `__init__.py` all use "Open source data platform" as primary
- README and pyproject.toml still led with "Professional analytics stack"

**Why "Open source" should be primary:**
1. It's the key differentiator vs. expensive enterprise platforms
2. Target audience (small teams, fractional consultants) actively seeks open source solutions
3. Emphasizes core value props: free, no vendor lock-in, full ownership
4. More distinctive in a crowded market

**Note:** "Professional" and "production-grade tools" remain as supporting descriptors throughout.

## Consistency Check
After this PR, all materials consistently lead with "Open source data platform":
- ✅ README hero
- ✅ pyproject.toml description (shown on PyPI)
- ✅ install.sh and install.ps1 headers
- ✅ CLI help text (`dango --help`)
- ✅ Package docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)