### PR TITLE
Fix installer to read user input from terminal when piped

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ check_docker() {
         echo "  Linux:   https://docs.docker.com/engine/install/"
         echo
         echo -n "Continue without Docker? (y/N): "
-        read -r response
+        read -r response < /dev/tty
         if [[ ! "$response" =~ ^[Yy]$ ]]; then
             print_info "Installation cancelled"
             echo
@@ -119,7 +119,7 @@ check_docker() {
         echo
         echo "Or continue without Docker (Metabase won't work):"
         echo -n "Continue? (y/N): "
-        read -r response
+        read -r response < /dev/tty
         if [[ ! "$response" =~ ^[Yy]$ ]]; then
             print_info "Installation cancelled"
             echo
@@ -288,7 +288,7 @@ main() {
 
             # Get project directory name
             echo -n "Enter project directory name (e.g., my-analytics): "
-            read -r PROJECT_DIR
+            read -r PROJECT_DIR < /dev/tty
 
             if [ -z "$PROJECT_DIR" ]; then
                 print_error "Project name cannot be empty"
@@ -339,7 +339,7 @@ main() {
             echo "  [c] Cancel"
             echo
             echo -n "Choice: "
-            read -r action
+            read -r action < /dev/tty
 
             case $action in
                 i|I)
@@ -364,7 +364,7 @@ main() {
             echo "This project needs a virtual environment for Dango."
             echo
             echo -n "Create virtual environment now? [Y/n]: "
-            read -r response
+            read -r response < /dev/tty
 
             if [[ "$response" =~ ^[Nn]$ ]]; then
                 print_info "Cancelled"


### PR DESCRIPTION
## Summary
Fix interactive prompts in install.sh to work correctly when the installer is piped through bash (`curl ... | bash`).

## Problem
When running:
```bash
curl -sSL https://raw.githubusercontent.com/getdango/dango/main/install.sh | bash
```

All user input prompts immediately exited without waiting for input:
```
Enter project directory name (e.g., my-analytics): %
# Script exits immediately
```

**Root cause:** When piping through bash, stdin comes from the curl output stream, not the terminal. The `read` command gets EOF from the exhausted pipe and exits.

## Solution
Change all `read` commands to explicitly read from `/dev/tty` (the controlling terminal):

**Before:**
```bash
read -r PROJECT_DIR
```

**After:**
```bash
read -r PROJECT_DIR < /dev/tty
```

## Changes Made
Updated 5 `read` commands in install.sh:
1. Line 101: Docker not found prompt
2. Line 122: Docker not running prompt  
3. Line 291: Project directory name prompt
4. Line 342: Existing project action choice
5. Line 367: Create venv confirmation

## Testing
**Before fix:**
```bash
$ curl -sSL https://raw.../install.sh | bash
Enter project directory name (e.g., my-analytics): %  # Exits immediately
```

**After fix:**
```bash
$ curl -sSL https://raw.../install.sh | bash
Enter project directory name (e.g., my-analytics): my-test  # Waits for input ✅
```

## Note
PowerShell's `Read-Host` doesn't have this issue because it always reads from the console, not stdin. No changes needed for install.ps1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)