### PR TITLE
Fix dango init to read from terminal when installer is piped

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -199,7 +199,7 @@ init_project() {
     echo
 
     source "$venv_path/bin/activate"
-    dango init
+    dango init < /dev/tty
 
     print_success "Project initialized"
     echo


### PR DESCRIPTION
## Summary
Fix `dango init` command in installer to read from terminal, preventing "Inappropriate ioctl for device" error.

## Problem
After previous fix (#7) for shell prompts, the installer would fail when running `dango init`:

```
▶ Initializing Dango project...

🍡 Initializing Dango project...
[?] Project name: My Analytics
Error: (25, 'Inappropriate ioctl for device')
Aborted!
```

**Root cause:** The `dango init` command uses interactive Python libraries (inquirer/click) that need access to a terminal. When stdin isn't connected to a tty, they fail with ioctl errors.

## Solution
Redirect stdin from `/dev/tty` for the `dango init` command:

**Before:**
```bash
dango init
```

**After:**
```bash
dango init < /dev/tty
```

## Testing
**Before fix:**
```bash
$ curl -sSL ... | bash
▶ Initializing Dango project...
Error: (25, 'Inappropriate ioctl for device')  # ❌ Failed
```

**After fix:**
```bash
$ curl -sSL ... | bash
▶ Initializing Dango project...
[?] Project name: My Analytics  # ✅ Works!
```

## Related
- PR #7: Fixed shell `read` commands to use `/dev/tty`
- This PR: Fixes Python CLI commands to use `/dev/tty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)