### PR TITLE
Fix: Make venv activation instructions unmissable

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -275,17 +275,37 @@ function Initialize-Project {
 
 # Function to print activation instructions
 function Write-ActivationInstructions {
-    param([string]$VenvPath, [string]$ProjectDir)
+    param(
+        [string]$VenvPath,
+        [string]$ProjectDir,
+        [bool]$CreatedSubdir
+    )
 
     Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
     Write-Host "Installation complete!" -ForegroundColor Green
     Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "To activate your environment:"
-    Write-Host "  cd $ProjectDir" -ForegroundColor Yellow
-    Write-Host "  .\$VenvPath\Scripts\Activate.ps1" -ForegroundColor Yellow
+    Write-Host "⚠️  IMPORTANT: Activate your environment first!" -ForegroundColor Yellow
     Write-Host ""
-    Write-Host "Quick start commands:"
+
+    if ($CreatedSubdir) {
+        Write-Host "Run these commands to get started:"
+        Write-Host ""
+        Write-Host "  cd $ProjectDir" -ForegroundColor Yellow
+        Write-Host "  .\$VenvPath\Scripts\Activate.ps1" -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "Run this command to activate:"
+        Write-Host ""
+        Write-Host "  .\$VenvPath\Scripts\Activate.ps1" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "You need to activate the environment EVERY TIME you work on this project." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "Once activated, try these commands:"
     Write-Host "  dango source add" -ForegroundColor Yellow -NoNewline
     Write-Host "    # Add a data source (CSV or Stripe)"
     Write-Host "  dango sync" -ForegroundColor Yellow -NoNewline
@@ -293,21 +313,33 @@ function Write-ActivationInstructions {
     Write-Host "  dango start" -ForegroundColor Yellow -NoNewline
     Write-Host "         # Start platform (opens http://localhost:8800)"
     Write-Host ""
-    Write-Host "Documentation:"
-    Write-Host "  https://github.com/getdango/dango"
-    Write-Host ""
-    Write-Host "Get help:"
-    Write-Host "  https://github.com/getdango/dango/issues"
+    Write-Host "Documentation: https://github.com/getdango/dango"
+    Write-Host "Get help: https://github.com/getdango/dango/issues"
     Write-Host ""
 }
 
 # Function to print success message
 function Write-SuccessMessage {
+    param(
+        [string]$VenvPath,
+        [bool]$IsActivated
+    )
+
     Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
     Write-Host "Installation complete!" -ForegroundColor Green
     Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "Your environment is ready!"
+
+    if ($IsActivated) {
+        Write-Host "✓ Your environment is already activated!" -ForegroundColor Green
+    }
+    else {
+        Write-Host "⚠️  Don't forget to activate your environment:" -ForegroundColor Yellow
+        Write-Host "  .\$VenvPath\Scripts\Activate.ps1" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
     Write-Host ""
     Write-Host "Quick start commands:"
     Write-Host "  dango source add" -ForegroundColor Yellow -NoNewline
@@ -317,11 +349,8 @@ function Write-SuccessMessage {
     Write-Host "  dango start" -ForegroundColor Yellow -NoNewline
     Write-Host "         # Start platform (opens http://localhost:8800)"
     Write-Host ""
-    Write-Host "Documentation:"
-    Write-Host "  https://github.com/getdango/dango"
-    Write-Host ""
-    Write-Host "Get help:"
-    Write-Host "  https://github.com/getdango/dango/issues"
+    Write-Host "Documentation: https://github.com/getdango/dango"
+    Write-Host "Get help: https://github.com/getdango/dango/issues"
     Write-Host ""
 }
 
@@ -374,7 +403,7 @@ function Main {
             Initialize-Project -VenvPath "venv"
 
             # Show activation instructions
-            Write-ActivationInstructions -VenvPath "venv" -ProjectDir $projectDir
+            Write-ActivationInstructions -VenvPath "venv" -ProjectDir $projectDir -CreatedSubdir $true
         }
 
         "existing_with_venv" {
@@ -394,11 +423,11 @@ function Main {
             switch ($action.ToLower()) {
                 "i" {
                     Install-Dango -VenvPath "venv"
-                    Write-SuccessMessage
+                    Write-SuccessMessage -VenvPath "venv" -IsActivated $true
                 }
                 "u" {
                     Update-Dango -VenvPath "venv"
-                    Write-SuccessMessage
+                    Write-SuccessMessage -VenvPath "venv" -IsActivated $true
                 }
                 default {
                     Write-Info "Cancelled"
@@ -437,7 +466,7 @@ function Main {
 
             # Show activation instructions
             $currentDir = Split-Path -Leaf (Get-Location)
-            Write-ActivationInstructions -VenvPath "venv" -ProjectDir $currentDir
+            Write-ActivationInstructions -VenvPath "venv" -ProjectDir $currentDir -CreatedSubdir $false
         }
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -227,46 +227,77 @@ setup_direnv() {
 print_activation_instructions() {
     local venv_path=$1
     local project_dir=$2
+    local created_subdir=$3
 
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${GREEN}Installation complete!${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo
-    echo "To activate your environment:"
-    echo -e "  ${YELLOW}cd $project_dir${NC}"
-    echo -e "  ${YELLOW}source $venv_path/bin/activate${NC}"
+    echo -e "${YELLOW}⚠️  IMPORTANT: Activate your environment first!${NC}"
     echo
-    echo "Quick start commands:"
+
+    if [ "$created_subdir" = "true" ]; then
+        echo "Run these commands to get started:"
+        echo
+        echo -e "  ${YELLOW}cd $project_dir${NC}"
+        echo -e "  ${YELLOW}source $venv_path/bin/activate${NC}"
+    else
+        echo "Run this command to activate:"
+        echo
+        echo -e "  ${YELLOW}source $venv_path/bin/activate${NC}"
+    fi
+
+    echo
+    echo -e "${YELLOW}You need to activate the environment EVERY TIME you work on this project.${NC}"
+    echo
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo
+    echo "Once activated, try these commands:"
     echo -e "  ${YELLOW}dango source add${NC}    # Add a data source (CSV or Stripe)"
     echo -e "  ${YELLOW}dango sync${NC}          # Sync data"
     echo -e "  ${YELLOW}dango start${NC}         # Start platform (opens http://localhost:8800)"
     echo
-    echo "Documentation:"
-    echo "  https://github.com/getdango/dango"
+    echo "Optional: Auto-activate with direnv (advanced users)"
+    echo "  Install direnv: https://direnv.net/"
+    echo "  It will auto-activate the venv when you cd into this directory"
     echo
-    echo "Get help:"
-    echo "  https://github.com/getdango/dango/issues"
+    echo "Documentation: https://github.com/getdango/dango"
+    echo "Get help: https://github.com/getdango/dango/issues"
     echo
 }
 
 # Function to print success message (when direnv is active)
 print_success_message() {
+    local created_subdir=$1
+    local project_dir=$2
+
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${GREEN}Installation complete!${NC}"
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo
-    echo "Your environment is ready!"
+    echo -e "${GREEN}✓${NC} Your environment is ready with direnv auto-activation!"
+    echo
+
+    if [ "$created_subdir" = "true" ]; then
+        echo "Next step:"
+        echo -e "  ${YELLOW}cd $project_dir${NC}"
+        echo
+        echo "The virtual environment will activate automatically."
+        echo
+    else
+        echo "Your virtual environment is already activated."
+        echo
+    fi
+
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo
     echo "Quick start commands:"
     echo -e "  ${YELLOW}dango source add${NC}    # Add a data source (CSV or Stripe)"
     echo -e "  ${YELLOW}dango sync${NC}          # Sync data"
     echo -e "  ${YELLOW}dango start${NC}         # Start platform (opens http://localhost:8800)"
     echo
-    echo "Documentation:"
-    echo "  https://github.com/getdango/dango"
-    echo
-    echo "Get help:"
-    echo "  https://github.com/getdango/dango/issues"
+    echo "Documentation: https://github.com/getdango/dango"
+    echo "Get help: https://github.com/getdango/dango/issues"
     echo
 }
 
@@ -321,9 +352,9 @@ main() {
 
             # Setup direnv or show activation instructions
             if ! setup_direnv "venv"; then
-                print_activation_instructions "venv" "$PROJECT_DIR"
+                print_activation_instructions "venv" "$PROJECT_DIR" "true"
             else
-                print_success_message
+                print_success_message "true" "$PROJECT_DIR"
             fi
             ;;
 
@@ -344,11 +375,11 @@ main() {
             case $action in
                 i|I)
                     install_dango "venv"
-                    print_success_message
+                    print_success_message "false" ""
                     ;;
                 u|U)
                     upgrade_dango "venv"
-                    print_success_message
+                    print_success_message "false" ""
                     ;;
                 *)
                     print_info "Cancelled"
@@ -388,9 +419,9 @@ main() {
             # Setup direnv or show activation instructions
             PROJECT_DIR=$(basename "$PWD")
             if ! setup_direnv "venv"; then
-                print_activation_instructions "venv" "$PROJECT_DIR"
+                print_activation_instructions "venv" "$PROJECT_DIR" "false"
             else
-                print_success_message
+                print_success_message "false" ""
             fi
             ;;
     esac


### PR DESCRIPTION
## Summary

This PR makes virtual environment activation instructions impossible to miss when the installer completes. Addresses the issue where users tried to run `dango` commands without activating the venv first.

## Changes

**Improved messaging with:**
- ⚠️ Prominent warning symbols and visual separators
- Scenario-aware instructions (subdirectory created vs current directory)
- Clear separation of required activation steps vs optional quick start commands
- Explicit reminder that venv needs activation EVERY TIME
- Optional direnv tip for advanced users

**Updated files:**
- `install.sh` - macOS/Linux installer
- `install.ps1` - Windows PowerShell installer

**Example output (new project):**
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Installation complete!
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

⚠️  IMPORTANT: Activate your environment first!

Run these commands to get started:

  cd my-analytics
  source venv/bin/activate

You need to activate the environment EVERY TIME you work on this project.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Once activated, try these commands:
  dango source add    # Add a data source (CSV or Stripe)
  dango sync          # Sync data
  dango start         # Start platform (opens http://localhost:8800)

Optional: Auto-activate with direnv (advanced users)
  Install direnv: https://direnv.net/
  It will auto-activate the venv when you cd into this directory
```

## Test plan

- [x] Updated bash installer activation instructions
- [x] Updated PowerShell installer activation instructions  
- [x] Handled subdirectory creation scenario
- [x] Handled existing directory scenario
- [ ] Test on macOS with curl installer
- [ ] Test on Windows with PowerShell installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)