### PR TITLE
Facebook Ads OAuth Testing Fixes (Dec 2)

### DIFF
--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -759,13 +759,15 @@ class DltPipelineRunner:
                     # Convert single string to list (e.g., sheet name -> [sheet_name])
                     source_kwargs[param_name] = [value]
 
-        # Note: OAuth credentials are stored directly in secrets.toml at
-        # sources.{source_type}.credentials.* during the auth flow.
-        # No injection needed - dlt finds them automatically.
+        # Inject OAuth credentials from secrets.toml as explicit kwargs
+        # This ensures credentials are passed even if dlt's config resolution misses them
+        source_kwargs = self._inject_oauth_credentials(source_type.value, source_kwargs)
 
-        # Change to project root so dlt can find .dlt/ directory
-        # dlt automatically loads .dlt/secrets.toml and .dlt/config.toml from cwd
-        # IMPORTANT: Must happen BEFORE loading source (dlt.secrets.value resolution)
+        # Set DLT_PROJECT_DIR so dlt finds .dlt/ regardless of when import happened
+        # This is dlt's official mechanism for specifying project location
+        os.environ["DLT_PROJECT_DIR"] = str(self.project_root)
+
+        # Change to project root as additional fallback
         original_cwd = os.getcwd()
         os.chdir(self.project_root)
 
@@ -938,6 +940,57 @@ class DltPipelineRunner:
             resolved_config["end_date"] = end_date
 
         return resolved_config
+
+    def _inject_oauth_credentials(self, source_type: str, source_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Inject OAuth credentials from secrets.toml into source kwargs.
+
+        This ensures credentials are explicitly passed to dlt sources even if
+        dlt's automatic config resolution fails (e.g., due to import timing).
+
+        Args:
+            source_type: dlt source type (e.g., "facebook_ads", "google_sheets")
+            source_kwargs: Existing source kwargs
+
+        Returns:
+            Updated source kwargs with injected credentials
+        """
+        import toml
+
+        secrets_file = self.project_root / ".dlt" / "secrets.toml"
+        if not secrets_file.exists():
+            return source_kwargs
+
+        try:
+            secrets = toml.load(secrets_file)
+            source_secrets = secrets.get("sources", {}).get(source_type, {})
+
+            if not source_secrets:
+                return source_kwargs
+
+            # Google sources use nested credentials object (GcpOAuthCredentials)
+            CREDENTIALS_OBJECT_SOURCES = {"google_ads", "google_analytics", "google_sheets"}
+
+            if source_type in CREDENTIALS_OBJECT_SOURCES:
+                # Google: inject 'credentials' dict if not already present
+                if "credentials" not in source_kwargs and "credentials" in source_secrets:
+                    source_kwargs["credentials"] = source_secrets["credentials"]
+                    console.print(f"  [dim]Injected OAuth credentials for {source_type}[/dim]")
+            else:
+                # Non-Google: inject flat parameters (access_token, api_key, etc.)
+                # Common OAuth credential keys to inject
+                CREDENTIAL_KEYS = {"access_token", "api_key", "api_secret", "refresh_token", "shop_url"}
+
+                for key in CREDENTIAL_KEYS:
+                    if key not in source_kwargs and key in source_secrets:
+                        source_kwargs[key] = source_secrets[key]
+                        console.print(f"  [dim]Injected {key} for {source_type}[/dim]")
+
+            return source_kwargs
+
+        except Exception as e:
+            console.print(f"  [dim]Warning: Could not inject credentials: {e}[/dim]")
+            return source_kwargs
 
     def _load_dlt_source(self, dlt_package: str, dlt_function: str, source_kwargs: Dict[str, Any]) -> Any:
         """

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -982,9 +982,12 @@ class DltPipelineRunner:
                 CREDENTIAL_KEYS = {"access_token", "api_key", "api_secret", "refresh_token", "shop_url"}
 
                 for key in CREDENTIAL_KEYS:
-                    if key not in source_kwargs and key in source_secrets:
-                        source_kwargs[key] = source_secrets[key]
-                        console.print(f"  [dim]Injected {key} for {source_type}[/dim]")
+                    # Inject if key is missing OR if key exists but value is None/empty
+                    if key in source_secrets:
+                        current_value = source_kwargs.get(key)
+                        if current_value is None or current_value == "":
+                            source_kwargs[key] = source_secrets[key]
+                            console.print(f"  [dim]Injected {key} for {source_type}[/dim]")
 
             return source_kwargs
 

--- a/dango/oauth/providers.py
+++ b/dango/oauth/providers.py
@@ -436,10 +436,6 @@ class FacebookOAuthProvider(BaseOAuthProvider):
 
             console.print(Panel("\n".join(instructions), title="Setup Instructions", border_style="cyan"))
 
-            if Confirm.ask("\n[cyan]Open Facebook Graph API Explorer?[/cyan]", default=True):
-                import webbrowser
-                webbrowser.open("https://developers.facebook.com/tools/explorer/")
-
             # Get short-lived token
             console.print("\n[bold]Step 1: Short-lived Access Token[/bold]")
             short_token = _clean_pasted_input(Prompt.ask("Paste short-lived access token"))

--- a/dango/oauth/providers.py
+++ b/dango/oauth/providers.py
@@ -448,9 +448,10 @@ class FacebookOAuthProvider(BaseOAuthProvider):
 
             # Get App credentials
             console.print("\n[bold]Step 2: App Credentials[/bold]")
-            console.print("[dim]Find at: https://developers.facebook.com/apps/[/dim]")
+            console.print("[dim]Find at: developers.facebook.com/apps → Your App → Settings → Basic[/dim]")
 
             app_id = _clean_pasted_input(Prompt.ask("Facebook App ID"))
+            console.print("[dim]Click 'Show' next to App Secret to reveal it[/dim]")
             app_secret = _clean_pasted_input(Prompt.ask("Facebook App Secret", password=True))
 
             if not app_id or not app_secret:
@@ -467,10 +468,10 @@ class FacebookOAuthProvider(BaseOAuthProvider):
 
             # Get Ad Account ID with confirmation
             console.print("\n[bold]Step 3: Ad Account ID[/bold]")
-            console.print("[dim]Find in Ads Manager URL: facebook.com/adsmanager/manage/accounts?act=ACCOUNT_ID[/dim]")
+            console.print("[dim]Go to adsmanager.facebook.com → Look at URL for act=XXXXX or click account dropdown[/dim]")
 
             while True:
-                account_id = _clean_pasted_input(Prompt.ask("Ad Account ID (e.g., act_123456789)"))
+                account_id = _clean_pasted_input(Prompt.ask("Ad Account ID (e.g., 123456789)"))
 
                 if not account_id:
                     console.print("[red]✗ Account ID is required[/red]")

--- a/dango/oauth/storage.py
+++ b/dango/oauth/storage.py
@@ -129,12 +129,21 @@ class OAuthStorage:
             if 'oauth' not in secrets['dango']:
                 secrets['dango']['oauth'] = {}
 
-            # Write credentials in dlt's expected format (provider-specific)
+            # Write credentials in dlt's expected format
+            #
+            # dlt sources have two credential patterns:
+            # 1. Google sources use GcpOAuthCredentials - expects nested 'credentials' object
+            # 2. All other sources use flat parameters (dlt.secrets.value for individual params)
+            #
+            # This generalized approach future-proofs all OAuth sources without per-source hardcoding.
             source_section = secrets['sources'][oauth_cred.source_type]
             creds = oauth_cred.credentials
 
-            # Google sources: credentials subsection + sibling fields for google_ads
-            if oauth_cred.source_type in ('google_ads', 'google_analytics', 'google_sheets'):
+            # Only Google sources use credentials object (GcpOAuthCredentials pattern)
+            CREDENTIALS_OBJECT_SOURCES = {'google_ads', 'google_analytics', 'google_sheets'}
+
+            if oauth_cred.source_type in CREDENTIALS_OBJECT_SOURCES:
+                # Google: nested credentials object (dlt GcpOAuthCredentials)
                 source_section['credentials'] = {
                     'client_id': creds.get('client_id'),
                     'client_secret': creds.get('client_secret'),
@@ -149,24 +158,12 @@ class OAuthStorage:
                         source_section['dev_token'] = creds['dev_token']
                     if creds.get('customer_id'):
                         source_section['customer_id'] = creds['customer_id']
-
-            # Facebook: flat structure with access_token
-            elif oauth_cred.source_type == 'facebook_ads':
-                source_section['credentials'] = {
-                    'access_token': creds.get('access_token'),
-                    'account_id': creds.get('account_id'),
-                }
-
-            # Shopify: flat structure with private_app_password
-            elif oauth_cred.source_type == 'shopify':
-                source_section['credentials'] = {
-                    'private_app_password': creds.get('private_app_password'),
-                    'shop_url': creds.get('shop_url'),
-                }
-
-            # Default: store all credentials as-is
             else:
-                source_section['credentials'] = creds
+                # All other sources: flat parameters (dlt.secrets.value pattern)
+                # This covers Facebook, Shopify, Slack, HubSpot, Notion, etc.
+                for key, value in creds.items():
+                    if value is not None:
+                        source_section[key] = value
 
             # Write metadata for tracking (not used by dlt)
             secrets['dango']['oauth'][oauth_cred.source_type] = {


### PR DESCRIPTION
## Summary

Fixes discovered during Facebook Ads OAuth + sync testing. All fixes are **generalized** to work with future OAuth sources (Shopify, HubSpot, etc.).

### Changes

**1. dlt Credential Resolution (`dlt_runner.py`)**
- Set `DLT_PROJECT_DIR` env var so dlt finds secrets.toml regardless of import timing
- Added `_inject_oauth_credentials()` to explicitly inject credentials into source kwargs

**2. OAuth Storage Format (`storage.py`)**
- Fixed `get()`, `list()`, `exists()`, `delete()` to handle both credential patterns:
  - Google sources: nested `credentials` object
  - All others: flat parameters (`access_token`, `api_key`, etc.)

**3. Metabase Setup Recovery (`metabase.py`)**
- If `/api/setup` fails with "user already exists", fall back to login with default credentials
- Prevents data loss when Metabase volume persists but credentials file is missing

**4. Facebook OAuth UX (`providers.py`, `source_wizard.py`)**
- Skip prompting for account_id if already collected via OAuth
- Improved helper text clarity

## Test Plan

- [x] Facebook Ads OAuth flow - token exchange works
- [x] Facebook Ads sync - 11 rows loaded successfully
- [x] dbt staging models generated (2 models)
- [x] dbt docs generated
- [x] Metabase shows data correctly

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `dango/ingestion/dlt_runner.py` | +68/-3 | DLT_PROJECT_DIR + credential injection |
| `dango/oauth/storage.py` | +111/-68 | Handle flat credentials |
| `dango/visualization/metabase.py` | +52/-6 | Graceful recovery on existing user |
| `dango/cli/source_wizard.py` | +43/-4 | Skip redundant prompts |
| `dango/oauth/providers.py` | +11/-2 | UX improvements |

🤖 Generated with [Claude Code](https://claude.com/claude-code)