### PR TITLE
STD-001/002/003: Code standards, CLAUDE.md template, file header standard

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,428 @@
+# Dango Code Standards
+
+> **Tool Configuration:** All tool-enforced rules (line length, lint rules, mypy strictness) are defined in `pyproject.toml`. This document covers patterns and conventions that tools cannot enforce. Do not duplicate tool configuration here — reference `pyproject.toml` as the source of truth.
+
+> **Incremental Adoption:** These standards apply to **new files** and **files being actively modified**. Existing files are not bulk-updated. See [Section 1](#1-incremental-adoption-policy) for details.
+
+## Table of Contents
+
+1. [Incremental Adoption Policy](#1-incremental-adoption-policy)
+2. [File Organization](#2-file-organization)
+3. [Naming Conventions](#3-naming-conventions)
+4. [Import Ordering](#4-import-ordering)
+5. [Error Handling Patterns](#5-error-handling-patterns)
+6. [Logging Patterns](#6-logging-patterns)
+7. [Testing Patterns](#7-testing-patterns)
+8. [Documentation Requirements](#8-documentation-requirements)
+9. [Type Hints Policy](#9-type-hints-policy)
+10. [File Header Standard](#10-file-header-standard)
+
+---
+
+## 1. Incremental Adoption Policy
+
+Standards apply incrementally — not retroactively to the entire codebase.
+
+**Rules:**
+- **New files** must follow all standards from creation.
+- **Modified files** — apply standards to the code you touch, not the entire file. If you add a function, that function follows standards. You don't need to rewrite neighboring functions.
+- **Existing files** are exempt until actively modified. TASK-084 creates an exemption registry tracking known violations.
+- **Bulk reformatting PRs** are not allowed. Standards adoption happens organically through normal development.
+
+**Example:** If you fix a bug in `dango/cli/main.py` (a ~4600-line file that predates these standards), apply standards only to the lines you change. You do not need to restructure the entire file — that happens in TASK-005.
+
+---
+
+## 2. File Organization
+
+### Module structure
+
+Each module (directory with `__init__.py`) should follow this layout:
+
+```
+module/
+├── __init__.py         # Public exports + __all__
+├── models.py           # Data classes, Pydantic models, enums
+├── exceptions.py       # Module-specific exception classes
+└── {responsibility}.py # One file per distinct responsibility
+```
+
+**Good example — `dango/config/`** (5 files, each <200 lines, clear responsibilities):
+```
+config/
+├── __init__.py      # Re-exports all public symbols
+├── models.py        # DangoConfig, ProjectContext, SourcesConfig, enums
+├── loader.py        # ConfigLoader class, load/save YAML
+├── exceptions.py    # ConfigError hierarchy (4 classes)
+└── credentials.py   # Credential encryption/decryption
+```
+
+**Counter-example — `dango/cli/main.py`** (~4600 lines, many responsibilities in one file). This is refactored by TASK-005.
+
+### File size
+
+- **Soft limit:** 500 lines per file.
+- **When to split:** A file exceeds 500 lines, or contains 3+ unrelated responsibilities.
+- **How to split:** Extract related functions/classes into a new file within the same module. Update `__init__.py` exports.
+
+### `__init__.py` pattern
+
+Every module's `__init__.py` should have: a module docstring, imports of all public symbols, and an explicit `__all__` list.
+
+From `dango/config/__init__.py`:
+
+```python
+"""
+Dango Configuration Module
+
+Handles loading, validating, and managing Dango configuration files.
+"""
+
+from .models import (
+    DangoConfig,
+    ProjectContext,
+    SourcesConfig,
+    DataSource,
+    SourceType,
+    DeduplicationStrategy,
+)
+from .loader import ConfigLoader, get_config
+from .exceptions import (
+    ConfigError,
+    ConfigNotFoundError,
+    ConfigValidationError,
+    ProjectNotFoundError,
+)
+
+__all__ = [
+    # Models
+    "DangoConfig",
+    "ProjectContext",
+    "SourcesConfig",
+    "DataSource",
+    "SourceType",
+    "DeduplicationStrategy",
+    # Loader
+    "ConfigLoader",
+    "get_config",
+    # Exceptions
+    "ConfigError",
+    "ConfigNotFoundError",
+    "ConfigValidationError",
+    "ProjectNotFoundError",
+]
+```
+
+---
+
+## 3. Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Files | `snake_case.py` | `config/loader.py`, `utils/database.py` |
+| Classes | `PascalCase` | `ConfigLoader`, `DangoConfig`, `OAuthManager` |
+| Functions/methods | `snake_case` | `find_project_root`, `load_yaml`, `ensure_dbt_schemas` |
+| Constants | `UPPER_SNAKE_CASE` | `DANGO_DIR`, `PROJECT_FILE`, `SOURCES_FILE` |
+| Private members | `_prefix` | `_get_encryption_key`, `_deep_merge`, `_clean_pasted_input` |
+| Enums | `PascalCase` class, `UPPER_SNAKE_CASE` members | `DeduplicationStrategy.LATEST_ONLY` |
+
+**Examples from codebase:**
+
+```python
+# Constants (dango/config/loader.py)
+class ConfigLoader:
+    DANGO_DIR = ".dango"
+    PROJECT_FILE = "project.yml"
+    SOURCES_FILE = "sources.yml"
+
+# Enum (dango/config/models.py)
+class DeduplicationStrategy(str, Enum):
+    """Data deduplication strategies"""
+    NONE = "none"
+    LATEST_ONLY = "latest_only"
+    APPEND_ONLY = "append_only"
+    SCD_TYPE2 = "scd_type2"
+```
+
+---
+
+## 4. Import Ordering
+
+Import order is enforced by ruff's `"I"` (isort) rule — see `pyproject.toml` `[tool.ruff.lint]`.
+
+**Order:** stdlib → third-party → dango
+
+```python
+# stdlib
+import os
+from pathlib import Path
+from typing import Optional
+
+# third-party
+import yaml
+from pydantic import ValidationError
+
+# dango
+from dango.config.models import DangoConfig
+from .exceptions import ConfigError, ConfigNotFoundError
+```
+
+**Rules:**
+- Relative imports are OK within the same module: `from .models import DangoConfig`
+- Absolute imports for cross-module: `from dango.config import ConfigLoader`
+- One import block per category, separated by blank lines
+- ruff auto-fixes ordering on save — no manual effort needed
+
+---
+
+## 5. Error Handling Patterns
+
+### Current pattern (use until TASK-008)
+
+The `dango/config/exceptions.py` hierarchy is the model for new code:
+
+```python
+# dango/config/exceptions.py — current pattern
+class ConfigError(Exception):
+    """Base exception for configuration errors"""
+    pass
+
+class ConfigNotFoundError(ConfigError):
+    """Configuration file not found"""
+    pass
+
+class ConfigValidationError(ConfigError):
+    """Configuration validation failed"""
+    pass
+
+class ProjectNotFoundError(ConfigError):
+    """Not in a Dango project directory"""
+    pass
+```
+
+**Rules for new code (before TASK-008):**
+- Create a base exception per module (e.g., `IngestionError`, `OAuthError`)
+- Subclass for specific error cases
+- Never bare `except:` — always catch specific exceptions
+- Always include context in error messages (what failed, what was expected)
+- Catch-and-wrap external library exceptions at module boundaries
+
+**Example — catch with context** (from `dango/config/loader.py`):
+
+```python
+try:
+    with open(file_path, 'r') as f:
+        data = yaml.safe_load(f)
+        return data or {}
+except yaml.YAMLError as e:
+    raise ConfigError(f"Invalid YAML in {file_path}:\n{e}")
+```
+
+### Target pattern (TASK-008)
+
+> **⚠️ TARGET PATTERN** — Not yet implemented. Do not use this pattern until TASK-008 lands.
+
+```python
+class DangoError(Exception):
+    """Base for all dango errors."""
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: str,
+        context: dict | None = None,
+        user_message: str | None = None,
+    ):
+        self.error_code = error_code
+        self.context = context or {}
+        self.user_message = user_message or message
+        super().__init__(message)
+
+# Module exceptions inherit from DangoError
+class ConfigError(DangoError):
+    """Configuration-related errors."""
+    pass
+```
+
+---
+
+## 6. Logging Patterns
+
+### Current pattern (use until TASK-007)
+
+The codebase currently uses Rich `Console` for all output — there is no structured logging yet.
+
+**Rules for new code (before TASK-007):**
+- Continue using `from rich.console import Console` for user-facing output
+- Add `# TODO(TASK-007): structured logging` where structured logging would be appropriate
+- Do not introduce `logging` or `structlog` yet — TASK-007 sets up the infrastructure
+
+### Target pattern (TASK-007)
+
+> **⚠️ TARGET PATTERN** — Not yet implemented. Do not use this pattern until TASK-007 lands.
+
+```python
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Structured logging (JSON to file)
+logger.info("sync_completed", source="google_sheets", rows=1523, duration_s=4.2)
+logger.error("sync_failed", source="stripe", error=str(e), retry_in=60)
+
+# Rich console stays for user-facing output
+from rich.console import Console
+console = Console()
+console.print("[green]Sync complete![/green]")
+```
+
+**Log levels:**
+- `DEBUG` — internal state, useful for troubleshooting
+- `INFO` — normal operations (sync started, sync completed)
+- `WARNING` — recoverable issues (retry, fallback used)
+- `ERROR` — failures requiring attention
+
+---
+
+## 7. Testing Patterns
+
+> Testing infrastructure is set up by TASK-001 (directory structure) and TASK-002 (mock factories). This section defines the conventions those tasks implement.
+
+**Framework:** pytest
+
+**Directory structure:**
+
+```
+tests/
+├── conftest.py              # Shared fixtures
+├── unit/
+│   ├── conftest.py          # Unit test fixtures
+│   ├── test_config_loader.py
+│   └── test_config_models.py
+└── integration/
+    ├── conftest.py          # Integration test fixtures
+    └── test_config_loading.py
+```
+
+**Naming:**
+- Test files: `test_{module}.py` (e.g., `test_config_loader.py`)
+- Test functions: `test_{behavior}` (e.g., `test_load_yaml_raises_on_missing_file`)
+- Fixtures: descriptive names in `conftest.py` (e.g., `tmp_project_dir`, `sample_config`)
+
+**Fixture pattern:**
+
+```python
+# tests/conftest.py
+@pytest.fixture
+def tmp_project_dir(tmp_path: Path) -> Path:
+    """Create a temporary dango project directory."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    # ... set up project.yml, sources.yml
+    return tmp_path
+```
+
+**Rules:**
+- Unit tests have no I/O, no network, no database — use mocks and fixtures
+- Integration tests may use temp directories and real DuckDB files
+- Each test function tests one behavior — name describes the scenario
+- Use `pytest.raises` for expected exceptions, not try/except in tests
+- Factory pattern for test data (TASK-002 creates `tests/factories/`)
+
+---
+
+## 8. Documentation Requirements
+
+### Docstrings
+
+All public functions and classes require Google-style docstrings with `Args`, `Returns`, and `Raises` sections as applicable.
+
+**Function docstring** (from `dango/config/loader.py`):
+
+```python
+def load_yaml(self, file_path: Path) -> dict:
+    """
+    Load YAML file with error handling.
+
+    Args:
+        file_path: Path to YAML file
+
+    Returns:
+        Parsed YAML as dict
+
+    Raises:
+        ConfigNotFoundError: If file doesn't exist
+        ConfigError: If YAML is invalid
+    """
+```
+
+**Short docstring** — acceptable for simple methods:
+
+```python
+def is_dango_project(self) -> bool:
+    """Check if current directory is a Dango project"""
+```
+
+**Class docstring:**
+
+```python
+class ConfigLoader:
+    """Loads and validates Dango configuration"""
+```
+
+### Module `__init__.py`
+
+Every `__init__.py` must have:
+1. A module docstring (what the module does)
+2. An explicit `__all__` list
+
+See the [__init__.py pattern](#initpy-pattern) in Section 2.
+
+### Comments
+
+- Explain **why**, not **what** — the code shows what, comments explain intent
+- TODOs reference a task: `# TODO(TASK-007): add structured logging here`
+- Remove commented-out code — use git history instead
+
+---
+
+## 9. Type Hints Policy
+
+Type hints are enforced by mypy with `disallow_untyped_defs = true` — see `pyproject.toml` `[tool.mypy]`.
+
+**Rules:**
+- All function parameters and return types must be annotated
+- Use modern syntax (Python 3.10+): `str | None` not `Optional[str]`, `list[str]` not `List[str]`
+- Pydantic models get typed fields with `Field()` descriptions for important fields
+
+**Examples from codebase:**
+
+```python
+# Function signatures (dango/config/loader.py)
+def find_project_root(self, start_path: Optional[Path] = None) -> Optional[Path]:
+    ...
+
+def validate_config(self) -> tuple[bool, list[str]]:
+    ...
+
+# Pydantic fields with descriptions (dango/config/models.py)
+class ProjectContext(BaseModel):
+    """Project-level context and metadata"""
+    name: str
+    organization: Optional[str] = Field(
+        None,
+        description="Organization name (used in Metabase, Web UI, etc.)"
+    )
+    purpose: str = Field(description="Why this project exists, what it's used for")
+    stakeholders: list[Stakeholder] = Field(default_factory=list)
+```
+
+> **Note:** Some existing code uses `Optional[str]` (pre-3.10 style). New code should use `str | None`. Existing files are updated incrementally per [Section 1](#1-incremental-adoption-policy).
+
+---
+
+## 10. File Header Standard
+
+*Added by STD-003. See [Section 10](#10-file-header-standard) for the file header format, examples, and validation.*
+
+<!-- STD-003 adds the full content of this section -->

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -29,7 +29,7 @@ Standards apply incrementally — not retroactively to the entire codebase.
 - **Existing files** are exempt until actively modified. TASK-084 creates an exemption registry tracking known violations.
 - **Bulk reformatting PRs** are not allowed. Standards adoption happens organically through normal development.
 
-**Example:** If you fix a bug in `dango/cli/main.py` (a ~4600-line file that predates these standards), apply standards only to the lines you change. You do not need to restructure the entire file — that happens in TASK-005.
+**Example:** If you fix a bug in `dango/cli/main.py` (a ~3900-line file that predates these standards), apply standards only to the lines you change. You do not need to restructure the entire file — that happens in TASK-005.
 
 ---
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -47,7 +47,7 @@ module/
 └── {responsibility}.py # One file per distinct responsibility
 ```
 
-**Good example — `dango/config/`** (5 files, each <200 lines, clear responsibilities):
+**Good example — `dango/config/`** (5 files, each focused on one responsibility):
 ```
 config/
 ├── __init__.py      # Re-exports all public symbols
@@ -57,7 +57,7 @@ config/
 └── credentials.py   # Credential encryption/decryption
 ```
 
-**Counter-example — `dango/cli/main.py`** (~4600 lines, many responsibilities in one file). This is refactored by TASK-005.
+**Counter-example — `dango/cli/main.py`** (~3900 lines, many responsibilities in one file). This is refactored by TASK-005.
 
 ### File size
 
@@ -376,7 +376,7 @@ Every `__init__.py` must have:
 1. A module docstring (what the module does)
 2. An explicit `__all__` list
 
-See the [__init__.py pattern](#initpy-pattern) in Section 2.
+See the [`__init__.py` pattern](#__init__py-pattern) in Section 2.
 
 ### Comments
 
@@ -446,7 +446,7 @@ Entry points:
 
 ### Incremental adoption
 
-Currently 0 of ~151 Python files have headers. Headers are added when files are created or actively modified — not in a bulk update pass. The `scripts/validate_headers.py --all` audit mode tracks progress.
+Currently 0 of ~101 non-`__init__.py` Python files have headers (the validator skips `__init__.py` files). Headers are added when files are created or actively modified — not in a bulk update pass. The `scripts/validate_headers.py --all` audit mode tracks progress.
 
 ### Examples
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -423,6 +423,92 @@ class ProjectContext(BaseModel):
 
 ## 10. File Header Standard
 
-*Added by STD-003. See [Section 10](#10-file-header-standard) for the file header format, examples, and validation.*
+Every Python file should begin with a docstring header that identifies the file and its purpose. This helps LLMs and developers navigate the codebase quickly.
 
-<!-- STD-003 adds the full content of this section -->
+### Required format
+
+```python
+"""
+dango/{module}/{filename}.py
+
+{One-line purpose.}
+
+Related files:
+- {related_file} - {why}
+
+Entry points:
+- {function_or_class} - {description}
+"""
+```
+
+**Required elements:** file path line, purpose line.
+**Recommended elements:** related files, entry points (include when the file has non-obvious relationships or multiple public symbols).
+
+### Incremental adoption
+
+Currently 0 of ~151 Python files have headers. Headers are added when files are created or actively modified — not in a bulk update pass. The `scripts/validate_headers.py --all` audit mode tracks progress.
+
+### Examples
+
+**1. Module file** — `dango/config/loader.py`:
+
+```python
+"""
+dango/config/loader.py
+
+Loads and validates YAML configuration files for dango projects.
+
+Related files:
+- dango/config/models.py - Pydantic models this loader populates
+- dango/config/exceptions.py - Errors raised during loading
+
+Entry points:
+- ConfigLoader - Main class for loading/saving config
+- get_config() - Helper to load config in one call
+"""
+```
+
+**2. Helpers file** — `dango/utils/database.py`:
+
+```python
+"""
+dango/utils/database.py
+
+DuckDB schema management utilities.
+
+Related files:
+- dango/transformation/ - dbt uses schemas created here
+
+Entry points:
+- ensure_dbt_schemas() - Creates raw/staging/intermediate/marts schemas
+"""
+```
+
+**3. Test file** — `tests/unit/test_config_loader.py`:
+
+```python
+"""
+tests/unit/test_config_loader.py
+
+Unit tests for ConfigLoader YAML loading, saving, and project discovery.
+
+Related files:
+- dango/config/loader.py - Module under test
+- tests/conftest.py - Shared fixtures (tmp_project_dir)
+"""
+```
+
+### Validation
+
+Run the header validation script:
+
+```bash
+# Check specific files
+python scripts/validate_headers.py dango/config/loader.py
+
+# Check only files changed in current branch
+python scripts/validate_headers.py --changed
+
+# Audit all files (reports compliance, does not fail CI)
+python scripts/validate_headers.py --all
+```

--- a/docs/templates/CLAUDE_TEMPLATE.md
+++ b/docs/templates/CLAUDE_TEMPLATE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md Template for Dango Modules
+
+Use this template when creating a `CLAUDE.md` file for a dango module directory. All 6 sections are required. Copy the blank template below and fill it in for your module.
+
+---
+
+## Blank Template
+
+```markdown
+# {module_name}/
+
+## Purpose
+
+{One sentence describing what this module does and why it exists.}
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | {purpose} | {exports} |
+| `{file}.py` | {purpose} | {key symbols} |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| {task description} | `{file}` | `pytest tests/unit/{test_file}` |
+
+## Dependencies
+
+**Imports from:**
+- `{module}` — {what is imported and why}
+
+**Used by:**
+- `{module}` — {how this module is consumed}
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_{module}.py`
+- **Integration:** `pytest tests/integration/test_{module}.py`
+- **Manual:** {describe manual verification steps if any}
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `{file}` | {why it should not be modified} |
+```
+
+---
+
+## Filled Example: `config/`
+
+Below is a filled-in example using the `dango/config/` module to demonstrate each section.
+
+```markdown
+# config/
+
+## Purpose
+
+Loads, validates, and manages dango project configuration files (project.yml, sources.yml).
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | Public exports, `__all__` | Re-exports all public symbols |
+| `loader.py` | Load/save YAML config files | `ConfigLoader`, `get_config`, `load_config` |
+| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource` |
+| `exceptions.py` | Config-specific exception hierarchy | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError` |
+| `credentials.py` | Credential loading for dlt sources | `CredentialManager` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new config field | `models.py` | `pytest tests/unit/test_config_models.py` |
+| Change config loading logic | `loader.py` | `pytest tests/unit/test_config_loader.py` |
+| Add a new config error type | `exceptions.py` | `pytest tests/unit/test_config_loader.py` |
+| Add a new credential provider | `credentials.py` | `pytest tests/unit/test_credentials.py` |
+
+## Dependencies
+
+**Imports from:**
+- `pydantic` — model validation (`BaseModel`, `Field`, `validator`)
+- `yaml` — YAML parsing in `loader.py`
+- `toml` — TOML parsing in `credentials.py`
+
+**Used by:**
+- `dango/cli/` — loads config to drive CLI commands
+- `dango/ingestion/` — reads source definitions for sync jobs
+- `dango/web/` — serves config through API endpoints
+- `dango/oauth/` — reads OAuth credential config
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_config_loader.py tests/unit/test_config_models.py`
+- **Integration:** `pytest tests/integration/test_config_loading.py`
+- **Manual:** `dango config show` in a dango project directory
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `models.py` field names | Changing field names breaks existing project.yml/sources.yml files |
+```

--- a/scripts/validate_claude_md.py
+++ b/scripts/validate_claude_md.py
@@ -29,9 +29,14 @@ REQUIRED_SECTIONS = [
 SKIP_PATHS = {"CLAUDE.md"}
 
 
+def strip_code_fences(content: str) -> str:
+    """Remove fenced code blocks so we don't match headings inside them."""
+    return re.sub(r"^```.*?^```", "", content, flags=re.MULTILINE | re.DOTALL)
+
+
 def find_h2_sections(content: str) -> list[str]:
-    """Extract all H2 section titles from markdown content."""
-    return re.findall(r"^## (.+)$", content, re.MULTILINE)
+    """Extract all H2 section titles from markdown content (outside code fences)."""
+    return re.findall(r"^## (.+)$", strip_code_fences(content), re.MULTILINE)
 
 
 def get_section_content(content: str, section_name: str) -> str:
@@ -65,8 +70,9 @@ def validate_file(file_path: Path) -> list[str]:
     if not file_path.exists():
         return [f"File not found: {file_path}"]
 
-    content = file_path.read_text(encoding="utf-8")
-    sections = find_h2_sections(content)
+    raw_content = file_path.read_text(encoding="utf-8")
+    content = strip_code_fences(raw_content)
+    sections = find_h2_sections(raw_content)
 
     # Check all required sections exist
     for required in REQUIRED_SECTIONS:

--- a/scripts/validate_claude_md.py
+++ b/scripts/validate_claude_md.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Validate CLAUDE.md files against the required template structure.
+
+Checks that module-level CLAUDE.md files contain all 6 required sections:
+Purpose, Files, Common Tasks, Dependencies, Testing, Don't Modify.
+
+Usage:
+    python scripts/validate_claude_md.py dango/config/CLAUDE.md
+    python scripts/validate_claude_md.py dango/config/CLAUDE.md dango/oauth/CLAUDE.md
+    python scripts/validate_claude_md.py --recursive
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_SECTIONS = [
+    "Purpose",
+    "Files",
+    "Common Tasks",
+    "Dependencies",
+    "Testing",
+    "Don't Modify",
+]
+
+# Repo-root CLAUDE.md has a different structure (managed by DOC-000)
+SKIP_PATHS = {"CLAUDE.md"}
+
+
+def find_h2_sections(content: str) -> list[str]:
+    """Extract all H2 section titles from markdown content."""
+    return re.findall(r"^## (.+)$", content, re.MULTILINE)
+
+
+def get_section_content(content: str, section_name: str) -> str:
+    """Extract content under a specific H2 section."""
+    pattern = rf"^## {re.escape(section_name)}\s*\n(.*?)(?=^## |\Z)"
+    match = re.search(pattern, content, re.MULTILINE | re.DOTALL)
+    return match.group(1).strip() if match else ""
+
+
+def has_markdown_table(text: str) -> bool:
+    """Check if text contains a markdown table (line with | separators)."""
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("|") and stripped.endswith("|") and stripped.count("|") >= 3:
+            return True
+    return False
+
+
+def validate_file(file_path: Path) -> list[str]:
+    """
+    Validate a single CLAUDE.md file.
+
+    Args:
+        file_path: Path to the CLAUDE.md file
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors: list[str] = []
+
+    if not file_path.exists():
+        return [f"File not found: {file_path}"]
+
+    content = file_path.read_text(encoding="utf-8")
+    sections = find_h2_sections(content)
+
+    # Check all required sections exist
+    for required in REQUIRED_SECTIONS:
+        if required not in sections:
+            errors.append(f"Missing required section: ## {required}")
+
+    # Check Purpose is non-empty
+    purpose_content = get_section_content(content, "Purpose")
+    if "Purpose" in sections and not purpose_content:
+        errors.append("## Purpose section is empty")
+
+    # Check Files has a table
+    files_content = get_section_content(content, "Files")
+    if "Files" in sections and not has_markdown_table(files_content):
+        errors.append("## Files section must contain a markdown table")
+
+    return errors
+
+
+def find_claude_md_files(root: Path) -> list[Path]:
+    """Find all CLAUDE.md files under root, excluding repo-root."""
+    results = []
+    for path in sorted(root.rglob("CLAUDE.md")):
+        # Skip repo-root CLAUDE.md and anything in hidden dirs or __pycache__
+        rel = path.relative_to(root)
+        parts = rel.parts
+        if str(rel) in SKIP_PATHS:
+            continue
+        if any(p.startswith(".") or p == "__pycache__" for p in parts):
+            continue
+        results.append(path)
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate CLAUDE.md files against the required template structure."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="CLAUDE.md file(s) to validate",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recursively find and validate all CLAUDE.md files under current directory",
+    )
+    args = parser.parse_args()
+
+    if not args.files and not args.recursive:
+        parser.error("Provide file paths or use --recursive")
+
+    # Collect files
+    files: list[Path] = []
+    if args.recursive:
+        root = Path.cwd()
+        files = find_claude_md_files(root)
+        if not files:
+            print("No CLAUDE.md files found (excluding repo root).")
+            return 0
+    else:
+        files = args.files
+
+    # Validate
+    total_errors = 0
+    for file_path in files:
+        errors = validate_file(file_path)
+        if errors:
+            total_errors += len(errors)
+            print(f"\n{file_path}:")
+            for error in errors:
+                print(f"  - {error}")
+        else:
+            print(f"{file_path}: OK")
+
+    if total_errors > 0:
+        print(f"\n{total_errors} error(s) in {len(files)} file(s).")
+        return 1
+
+    print(f"\nAll {len(files)} file(s) valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_headers.py
+++ b/scripts/validate_headers.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Validate Python file header docstrings.
+
+Checks that Python files begin with a docstring containing:
+1. A file path line (e.g., "dango/config/loader.py")
+2. A purpose line (non-empty text after the path)
+
+Usage:
+    python scripts/validate_headers.py dango/config/loader.py
+    python scripts/validate_headers.py dango/config/loader.py dango/utils/database.py
+    python scripts/validate_headers.py --changed   # git diff against base branch
+    python scripts/validate_headers.py --all        # audit all .py files
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Directories to skip in --all mode
+SKIP_DIRS = {"__pycache__", ".git", "venv", ".venv", "node_modules", ".tox", ".eggs"}
+
+# Files to skip (auto-generated or trivially empty)
+SKIP_FILES = {"__init__.py"}
+
+
+def get_repo_root() -> Path:
+    """Find the git repository root."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def get_changed_python_files() -> list[Path]:
+    """Get Python files changed relative to the base branch (v1 or main)."""
+    repo_root = get_repo_root()
+
+    # Try v1 first (our integration branch), fall back to main
+    for base in ("v1", "origin/v1", "main", "origin/main"):
+        try:
+            result = subprocess.run(
+                ["git", "diff", "--name-only", "--diff-filter=ACM", base, "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=repo_root,
+            )
+            files = [
+                repo_root / f.strip()
+                for f in result.stdout.strip().split("\n")
+                if f.strip().endswith(".py")
+            ]
+            return [f for f in files if f.exists()]
+        except subprocess.CalledProcessError:
+            continue
+
+    # If no base branch found, check staged + unstaged changes
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACM", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=repo_root,
+        )
+        files = [
+            repo_root / f.strip()
+            for f in result.stdout.strip().split("\n")
+            if f.strip().endswith(".py")
+        ]
+        return [f for f in files if f.exists()]
+    except subprocess.CalledProcessError:
+        return []
+
+
+def find_all_python_files(root: Path) -> list[Path]:
+    """Find all Python files under root, excluding skipped dirs and files."""
+    results = []
+    for path in sorted(root.rglob("*.py")):
+        parts = path.relative_to(root).parts
+        if any(p in SKIP_DIRS for p in parts):
+            continue
+        if path.name in SKIP_FILES:
+            continue
+        results.append(path)
+    return results
+
+
+def validate_header(file_path: Path) -> list[str]:
+    """
+    Validate a Python file's header docstring.
+
+    Args:
+        file_path: Path to the Python file
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors: list[str] = []
+
+    if not file_path.exists():
+        return [f"File not found: {file_path}"]
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return [f"Cannot read file (encoding error): {file_path}"]
+
+    # Strip leading whitespace/blank lines
+    stripped = content.lstrip()
+
+    if not stripped:
+        return ["File is empty"]
+
+    # Must start with a docstring
+    if not stripped.startswith('"""'):
+        errors.append("File does not start with a docstring (expected triple-quoted \"\"\")")
+        return errors
+
+    # Extract the docstring content
+    # Find the closing """
+    docstring_start = stripped.index('"""') + 3
+    closing_idx = stripped.find('"""', docstring_start)
+    if closing_idx == -1:
+        errors.append("Docstring is not closed (missing closing \"\"\")")
+        return errors
+
+    docstring_body = stripped[docstring_start:closing_idx].strip()
+    lines = [line.strip() for line in docstring_body.split("\n")]
+
+    # Remove empty lines at start
+    while lines and not lines[0]:
+        lines.pop(0)
+
+    if not lines:
+        errors.append("Docstring is empty")
+        return errors
+
+    # First non-empty line should be a file path (contains / and ends with .py)
+    first_line = lines[0]
+    if not re.match(r"^[\w./-]+\.py$", first_line):
+        errors.append(
+            f"First line of docstring should be a file path (got: '{first_line}')"
+        )
+
+    # Must have a purpose line (non-empty line after the path, not a section header)
+    remaining = [l for l in lines[1:] if l]
+    purpose_found = False
+    for line in remaining:
+        # Skip section headers like "Related files:" or "Entry points:"
+        if line.endswith(":") or line.startswith("- "):
+            continue
+        # This is a purpose line
+        purpose_found = True
+        break
+
+    if not purpose_found:
+        errors.append("Docstring missing a purpose line after the file path")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Python file header docstrings."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Python file(s) to validate",
+    )
+    parser.add_argument(
+        "--changed",
+        action="store_true",
+        help="Validate only files changed relative to base branch",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Audit all Python files (report compliance stats)",
+    )
+    args = parser.parse_args()
+
+    if not args.files and not args.changed and not args.all:
+        parser.error("Provide file paths, --changed, or --all")
+
+    # Collect files
+    files: list[Path] = []
+    audit_mode = False
+
+    if args.all:
+        audit_mode = True
+        # Look for dango/ package and tests/ directory
+        root = Path.cwd()
+        files = find_all_python_files(root / "dango")
+        test_dir = root / "tests"
+        if test_dir.exists():
+            files.extend(find_all_python_files(test_dir))
+        if not files:
+            print("No Python files found.")
+            return 0
+    elif args.changed:
+        files = get_changed_python_files()
+        if not files:
+            print("No changed Python files found.")
+            return 0
+    else:
+        files = args.files
+
+    # Validate
+    valid_count = 0
+    invalid_count = 0
+    file_errors: list[tuple[Path, list[str]]] = []
+
+    for file_path in files:
+        errors = validate_header(file_path)
+        if errors:
+            invalid_count += 1
+            file_errors.append((file_path, errors))
+        else:
+            valid_count += 1
+
+    # Report
+    total = valid_count + invalid_count
+
+    if audit_mode:
+        print(f"Header compliance: {valid_count}/{total} files ({valid_count * 100 // total}%)")
+        if file_errors:
+            print(f"\nFiles missing headers ({invalid_count}):")
+            for file_path, errors in file_errors:
+                print(f"  {file_path}")
+        return 0  # Audit mode always exits 0
+
+    # Normal mode — show errors and fail if any
+    for file_path, errors in file_errors:
+        print(f"\n{file_path}:")
+        for error in errors:
+            print(f"  - {error}")
+
+    if valid_count > 0 and not file_errors:
+        print(f"\nAll {total} file(s) have valid headers.")
+
+    if file_errors:
+        print(f"\n{invalid_count} of {total} file(s) failed validation.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **STD-001:** `STANDARDS.md` with sections 1-9 (incremental adoption, file organization, naming, imports, error handling, logging, testing, docs, type hints). All examples reference actual dango files. Tool config defers to `pyproject.toml`.
- **STD-002:** `docs/templates/CLAUDE_TEMPLATE.md` (blank template + filled `config/` example) and `scripts/validate_claude_md.py` (stdlib-only, code-fence-aware).
- **STD-003:** Section 10 added to `STANDARDS.md` (file header standard with 3 examples) and `scripts/validate_headers.py` (stdlib-only, supports `--changed` and `--all` modes).

## Test plan

- [x] `python3 scripts/validate_claude_md.py docs/templates/CLAUDE_TEMPLATE.md` — correctly fails (template, not a real CLAUDE.md)
- [x] `python3 scripts/validate_claude_md.py --recursive` — 0 files found (expected, none created yet)
- [x] `python3 scripts/validate_headers.py --all` — 0/101 compliance (expected, no headers yet)
- [x] `python3 scripts/validate_headers.py dango/config/loader.py` — correctly fails (no header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)