### PR TITLE
TASK-001: Set up pytest infrastructure with fixtures and demo tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ dev = [
     "black>=24.0.0",
     "ruff>=0.6.0",
     "mypy>=1.11.0",
+    "pre-commit>=3.6.0",
+    "pip-audit>=2.7.0",
 ]
 
 # Note: dlt distributes sources via `dlt init <source>`, not pip extras.
@@ -137,3 +139,12 @@ python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+markers = [
+    "unit: Unit tests (no I/O, no network, no database)",
+    "integration: Integration tests (may use temp dirs, real files, DuckDB)",
+]
+addopts = "--strict-markers"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+"""Root test fixtures for the Dango test suite."""
+
+import pytest
+import yaml
+
+from dango.config.models import (
+    CSVSourceConfig,
+    DangoConfig,
+    DataSource,
+    ProjectContext,
+    SourcesConfig,
+    SourceType,
+)
+
+
+@pytest.fixture
+def sample_project_context():
+    """A minimal valid ProjectContext instance (no I/O)."""
+    return ProjectContext(
+        name="Test Analytics",
+        created_by="test@example.com",
+        purpose="Unit testing the Dango config system",
+    )
+
+
+@pytest.fixture
+def sample_sources_config():
+    """A SourcesConfig with one CSV source (no I/O)."""
+    return SourcesConfig(
+        sources=[
+            DataSource(
+                name="test_csv",
+                type=SourceType.CSV,
+                csv=CSVSourceConfig(directory="/tmp/test_data"),
+            )
+        ]
+    )
+
+
+@pytest.fixture
+def sample_config(sample_project_context, sample_sources_config):
+    """A complete DangoConfig combining project context and sources (no I/O)."""
+    return DangoConfig(
+        project=sample_project_context,
+        sources=sample_sources_config,
+    )
+
+
+@pytest.fixture
+def tmp_project_dir(tmp_path):
+    """Create a temporary Dango project directory with valid config files.
+
+    Returns the project root path containing .dango/project.yml and .dango/sources.yml.
+    """
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+
+    project_data = {
+        "project": {
+            "name": "Test Project",
+            "created_by": "test@example.com",
+            "purpose": "Integration testing",
+        }
+    }
+    with open(dango_dir / "project.yml", "w") as f:
+        yaml.safe_dump(project_data, f, default_flow_style=False)
+
+    sources_data = {
+        "version": "1.0",
+        "sources": [
+            {
+                "name": "test_csv",
+                "type": "csv",
+                "csv": {
+                    "directory": str(tmp_path / "data"),
+                },
+            }
+        ],
+    }
+    with open(dango_dir / "sources.yml", "w") as f:
+        yaml.safe_dump(sources_data, f, default_flow_style=False)
+
+    return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def sample_sources_config():
             DataSource(
                 name="test_csv",
                 type=SourceType.CSV,
-                csv=CSVSourceConfig(directory="/tmp/test_data"),
+                csv=CSVSourceConfig(directory="data/test_csv"),
             )
         ]
     )

--- a/tests/fixtures/invalid_project.yml
+++ b/tests/fixtures/invalid_project.yml
@@ -1,0 +1,3 @@
+project:
+  name: [this is not valid
+  created_by: missing closing bracket

--- a/tests/fixtures/valid_project.yml
+++ b/tests/fixtures/valid_project.yml
@@ -1,0 +1,4 @@
+project:
+  name: My Analytics
+  created_by: user@example.com
+  purpose: Track business metrics and KPIs

--- a/tests/fixtures/valid_sources.yml
+++ b/tests/fixtures/valid_sources.yml
@@ -1,0 +1,7 @@
+version: "1.0"
+sources:
+  - name: sales_data
+    type: csv
+    csv:
+      directory: ./data/sales
+      file_pattern: "*.csv"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,22 @@
+"""Integration test fixtures."""
+
+import pytest
+import duckdb
+
+
+@pytest.fixture
+def test_duckdb(tmp_path):
+    """Create a temporary DuckDB database with standard Dango schemas.
+
+    Returns the path to the database file.
+    """
+    db_path = tmp_path / "test_warehouse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute("CREATE SCHEMA IF NOT EXISTS raw")
+        conn.execute("CREATE SCHEMA IF NOT EXISTS staging")
+        conn.execute("CREATE SCHEMA IF NOT EXISTS intermediate")
+        conn.execute("CREATE SCHEMA IF NOT EXISTS marts")
+    finally:
+        conn.close()
+    return db_path

--- a/tests/integration/test_config_loading.py
+++ b/tests/integration/test_config_loading.py
@@ -6,8 +6,8 @@ from dango.config.loader import ConfigLoader
 from dango.config.models import DangoConfig
 
 
+@pytest.mark.integration
 class TestConfigLoading:
-    @pytest.mark.integration
     def test_load_config_from_valid_project(self, tmp_project_dir):
         """Loading config from a valid project directory produces a DangoConfig."""
         loader = ConfigLoader(project_root=tmp_project_dir)

--- a/tests/integration/test_config_loading.py
+++ b/tests/integration/test_config_loading.py
@@ -1,0 +1,20 @@
+"""Integration tests for full config loading from disk."""
+
+import pytest
+
+from dango.config.loader import ConfigLoader
+from dango.config.models import DangoConfig
+
+
+class TestConfigLoading:
+    @pytest.mark.integration
+    def test_load_config_from_valid_project(self, tmp_project_dir):
+        """Loading config from a valid project directory produces a DangoConfig."""
+        loader = ConfigLoader(project_root=tmp_project_dir)
+        config = loader.load_config()
+
+        assert isinstance(config, DangoConfig)
+        assert config.project.name == "Test Project"
+        assert config.project.created_by == "test@example.com"
+        assert len(config.sources.sources) == 1
+        assert config.sources.sources[0].name == "test_csv"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,4 @@
+"""Unit test fixtures.
+
+Shared fixtures from tests/conftest.py are available automatically.
+"""

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -6,6 +6,7 @@ from dango.config.exceptions import ConfigNotFoundError
 from dango.config.loader import ConfigLoader
 
 
+@pytest.mark.unit
 class TestConfigLoaderPaths:
     def test_config_loader_sets_paths_from_project_root(self, tmp_path):
         """ConfigLoader derives .dango dir and config file paths from project_root."""
@@ -16,6 +17,7 @@ class TestConfigLoaderPaths:
         assert loader.sources_file == tmp_path / ".dango" / "sources.yml"
 
 
+@pytest.mark.unit
 class TestLoadYaml:
     def test_load_yaml_raises_on_missing_file(self, tmp_path):
         """load_yaml raises ConfigNotFoundError for a nonexistent file."""

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,0 +1,25 @@
+"""Tests for dango.config.loader — ConfigLoader path setup and YAML loading."""
+
+import pytest
+
+from dango.config.exceptions import ConfigNotFoundError
+from dango.config.loader import ConfigLoader
+
+
+class TestConfigLoaderPaths:
+    def test_config_loader_sets_paths_from_project_root(self, tmp_path):
+        """ConfigLoader derives .dango dir and config file paths from project_root."""
+        loader = ConfigLoader(project_root=tmp_path)
+        assert loader.project_root == tmp_path
+        assert loader.dango_dir == tmp_path / ".dango"
+        assert loader.project_file == tmp_path / ".dango" / "project.yml"
+        assert loader.sources_file == tmp_path / ".dango" / "sources.yml"
+
+
+class TestLoadYaml:
+    def test_load_yaml_raises_on_missing_file(self, tmp_path):
+        """load_yaml raises ConfigNotFoundError for a nonexistent file."""
+        loader = ConfigLoader(project_root=tmp_path)
+        missing = tmp_path / "nonexistent.yml"
+        with pytest.raises(ConfigNotFoundError):
+            loader.load_yaml(missing)

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from dango.config.models import DataSource, ProjectContext, SourceType
 
 
+@pytest.mark.unit
 class TestSourceType:
     def test_source_type_has_expected_members(self):
         """SourceType enum contains key source types used by Dango."""
@@ -14,6 +15,7 @@ class TestSourceType:
         assert expected.issubset(actual)
 
 
+@pytest.mark.unit
 class TestProjectContext:
     def test_project_context_creation(self, sample_project_context):
         """ProjectContext can be created with required fields and has correct values."""
@@ -24,6 +26,7 @@ class TestProjectContext:
         assert ctx.created is not None
 
 
+@pytest.mark.unit
 class TestDataSource:
     def test_data_source_rejects_hyphenated_names(self):
         """DataSource name validator rejects hyphens and raises ValueError."""

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -1,0 +1,31 @@
+"""Tests for dango.config.models — Pydantic models and enums."""
+
+import pytest
+from pydantic import ValidationError
+
+from dango.config.models import DataSource, ProjectContext, SourceType
+
+
+class TestSourceType:
+    def test_source_type_has_expected_members(self):
+        """SourceType enum contains key source types used by Dango."""
+        expected = {"csv", "google_sheets", "hubspot", "stripe", "shopify", "slack"}
+        actual = {member.value for member in SourceType}
+        assert expected.issubset(actual)
+
+
+class TestProjectContext:
+    def test_project_context_creation(self, sample_project_context):
+        """ProjectContext can be created with required fields and has correct values."""
+        ctx = sample_project_context
+        assert ctx.name == "Test Analytics"
+        assert ctx.created_by == "test@example.com"
+        assert ctx.purpose == "Unit testing the Dango config system"
+        assert ctx.created is not None
+
+
+class TestDataSource:
+    def test_data_source_rejects_hyphenated_names(self):
+        """DataSource name validator rejects hyphens and raises ValueError."""
+        with pytest.raises(ValidationError, match="invalid"):
+            DataSource(name="my-source", type=SourceType.CSV)


### PR DESCRIPTION
## Summary
- Add `[tool.pytest.ini_options]` to `pyproject.toml` with `testpaths`, `pythonpath`, strict markers (`unit`, `integration`)
- Add `pre-commit>=3.6.0` and `pip-audit>=2.7.0` to dev dependencies
- Create test directory structure (`tests/unit/`, `tests/integration/`, `tests/fixtures/`) with root and per-directory conftest files
- Write 6 initial tests (5 unit + 1 integration) covering config models, enums, loader paths, and full config loading from disk

## Test plan
- [x] `pip install -e ".[dev]"` installs successfully (Python 3.11)
- [x] `pytest` — 6/6 tests pass
- [x] `pytest --cov=dango` — coverage report generated
- [x] `pytest tests/unit/` — 5 unit tests pass
- [x] `pytest tests/integration/` — 1 integration test passes
- [x] `--strict-markers` rejects unregistered markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)