### PR TITLE
docs: add module-level CLAUDE.md for 5 modules

### DIFF
--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -9,7 +9,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports, `__all__` | Re-exports all public symbols |
-| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings` |
+| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `ShopifySourceConfig` |
 | `loader.py` | Load/save YAML config files | `ConfigLoader`, `get_config`, `load_config`, `save_config` |
 | `credentials.py` | Credential loading for dlt sources | `CredentialManager`, `init_dlt_directory` |
 | `exceptions.py` | Config-specific exception hierarchy | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError`, `ProjectNotFoundError` |

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -1,0 +1,54 @@
+# config/
+
+## Purpose
+
+Loads, validates, and manages dango project configuration files (project.yml, sources.yml) and dlt credentials.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | Public exports, `__all__` | Re-exports all public symbols |
+| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings` |
+| `loader.py` | Load/save YAML config files | `ConfigLoader`, `get_config`, `load_config`, `save_config` |
+| `credentials.py` | Credential loading for dlt sources | `CredentialManager`, `init_dlt_directory` |
+| `exceptions.py` | Config-specific exception hierarchy | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError`, `ProjectNotFoundError` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new config field | `models.py` | `pytest tests/unit/test_config_models.py` |
+| Add a new source type | `models.py` (`SourceType` enum) | `pytest tests/unit/test_config_models.py` |
+| Change config loading logic | `loader.py` | `pytest tests/unit/test_config_loader.py` |
+| Add a new config error type | `exceptions.py` | `pytest tests/unit/test_config_loader.py` |
+| Add a new credential provider | `credentials.py` | Manual: create test project with `.dlt/secrets.toml` |
+
+## Dependencies
+
+**Imports from:**
+- `pydantic` — model validation (`BaseModel`, `Field`, `validator`)
+- `yaml` — YAML parsing in `loader.py`
+- `toml` — TOML parsing in `credentials.py`
+
+**Used by:**
+- `dango/cli/` — loads config to drive CLI commands
+- `dango/ingestion/` — reads `DataSource`, `SourceType`, `DeduplicationStrategy`, `CSVSourceConfig`
+- `dango/transformation/` — reads `DataSource`, `SourceType`, `DeduplicationStrategy`
+- `dango/oauth/` — uses `CredentialManager` for token storage
+- `dango/web/` — serves config through API endpoints
+- `dango/platform/` — reads config for Docker and watcher setup
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_config_loader.py tests/unit/test_config_models.py`
+- **Integration:** `pytest tests/integration/test_config_loading.py`
+- **Manual:** `dango config show` in a dango project directory
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `models.py` field names | Changing field names breaks existing project.yml/sources.yml files |
+| `models.py` `SourceType` enum values | Enum values are stored in user config files and referenced across modules |
+| `exceptions.py` class hierarchy | Exception classes are caught by name in cli/, web/, and ingestion/ |

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -11,7 +11,7 @@ Loads data into DuckDB from external sources via dlt pipelines and CSV files, wi
 | `__init__.py` | Public exports | `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
 | `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync`, `SyncTimeoutError` |
 | `csv_loader.py` | Incremental CSV loading with metadata tracking and 4 dedup strategies | `CSVLoader`, `CSVSchemaMismatchError` |
-| `sources/__init__.py` | Sources subpackage exports | Re-exports from `registry` |
+| `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
 | `sources/registry.py` | Central registry of 33 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
 | `dlt_sources/` | Third-party dlt verified source implementations (27 directories, 105+ files) | DO NOT MODIFY — see "Don't Modify" section |
 

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -1,0 +1,54 @@
+# ingestion/
+
+## Purpose
+
+Loads data into DuckDB from external sources via dlt pipelines and CSV files, with a central registry of 33 supported data sources.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | Public exports | `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
+| `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync`, `SyncTimeoutError` |
+| `csv_loader.py` | Incremental CSV loading with metadata tracking and 4 dedup strategies | `CSVLoader`, `CSVSchemaMismatchError` |
+| `sources/__init__.py` | Sources subpackage exports | Re-exports from `registry` |
+| `sources/registry.py` | Central registry of 33 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
+| `dlt_sources/` | Third-party dlt verified source implementations (27 directories, 105+ files) | DO NOT MODIFY — see "Don't Modify" section |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new source to the registry | `sources/registry.py` (`SOURCE_REGISTRY` dict) | Manual: `dango add` and check new source appears |
+| Change CSV loading behavior | `csv_loader.py` | `pytest tests/unit/test_csv_loader.py` (when created) |
+| Change sync execution logic | `dlt_runner.py` | Manual: `dango sync <source_name>` |
+| Add a new dedup strategy | `csv_loader.py` + `config/models.py` (`DeduplicationStrategy`) | Manual: sync CSV source with new strategy |
+
+## Dependencies
+
+**Imports from:**
+- `dango/config/models.py` — `DataSource`, `SourceType`, `DeduplicationStrategy`, `CSVSourceConfig`, `RESTAPISourceConfig`, `DltNativeConfig`
+- `dango/oauth/storage.py` — `OAuthStorage` for token expiry checks (lazy import in `dlt_runner.py`)
+- `dango/utils/` — `activity_log`, `sync_history`, `db_health` (lazy imports in `dlt_runner.py`)
+- `dango/transformation/` — `DbtModelGenerator`, `run_dbt_models`, `generate_dbt_docs` (lazy imports for post-sync auto-transform)
+- `dango/visualization/metabase.py` — `refresh_metabase_connection`, `sync_metabase_schema` (lazy imports for post-sync Metabase refresh)
+
+**Used by:**
+- `dango/cli/main.py` — `run_sync` for `dango sync` command
+- `dango/cli/source_wizard.py` — registry queries during `dango add`
+- `dango/cli/validate.py` — `get_source_metadata`, `AuthType` for source validation
+- `dango/web/app.py` — `run_sync` for API-triggered syncs
+- `dango/transformation/generator.py` — `get_source_metadata` for dbt model generation
+
+## Testing
+
+- **Unit:** None yet (will be `tests/unit/test_ingestion.py`)
+- **Integration:** None yet (will be `tests/integration/test_ingestion.py`)
+- **Manual:** `dango sync <source_name>` in a dango project directory
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `dlt_sources/` (entire directory) | Third-party dlt verified source implementations; updates come from upstream dlt, local changes would be lost |
+| `sources/registry.py` source metadata structure | Registry keys (`dlt_source_name`, `dlt_function`, `auth_type`, etc.) are referenced by `dlt_runner.py` and `cli/source_wizard.py` |

--- a/dango/oauth/CLAUDE.md
+++ b/dango/oauth/CLAUDE.md
@@ -1,0 +1,48 @@
+# oauth/
+
+## Purpose
+
+Manages browser-based OAuth authentication flows, provider-specific token exchange, and credential persistence for dlt data sources.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | OAuth flow orchestration and local callback server | `OAuthManager`, `OAuthCallbackHandler`, `create_oauth_manager` |
+| `providers.py` | Provider-specific OAuth implementations | `BaseOAuthProvider`, `GoogleOAuthProvider`, `FacebookOAuthProvider`, `ShopifyOAuthProvider` |
+| `router.py` | Routes OAuth requests to correct provider | `run_oauth_for_source`, `check_oauth_credentials_exist`, `OAUTH_PROVIDER_MAP` |
+| `storage.py` | Token persistence to `.dlt/secrets.toml` with metadata | `OAuthStorage`, `OAuthCredential` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new OAuth provider | `providers.py` (new class), `router.py` (`OAUTH_PROVIDER_MAP`) | Manual: `dango add` and select new source type |
+| Change token storage format | `storage.py` | Manual: verify `.dlt/secrets.toml` after auth |
+| Change callback server behavior | `__init__.py` (`OAuthCallbackHandler`) | Manual: run OAuth flow and check callback |
+| Check credential existence logic | `router.py` (`check_oauth_credentials_exist`) | Manual: `dango validate` after auth |
+
+## Dependencies
+
+**Imports from:**
+- `dango/config/credentials.py` — `CredentialManager` for reading/writing `.dlt/secrets.toml`
+
+**Used by:**
+- `dango/cli/main.py` — OAuth management commands (`dango auth`)
+- `dango/cli/source_wizard.py` — inline OAuth during `dango add`
+- `dango/cli/validate.py` — credential validation
+- `dango/ingestion/dlt_runner.py` — `OAuthStorage` for token expiry checks before sync
+
+## Testing
+
+- **Unit:** None yet (will be `tests/unit/test_oauth.py`)
+- **Integration:** None yet (will be `tests/integration/test_oauth.py`)
+- **Manual:** `dango add` → select Google/Facebook/Shopify source → complete OAuth flow
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `providers.py` OAuth endpoints and scopes | Set by third-party APIs (Google, Facebook, Shopify); changes break authentication |
+| `storage.py` credential key structure | Must match dlt's expected secrets.toml format (e.g., `sources.{type}.credentials` for Google, flat keys for others) |
+| `router.py` `OAUTH_PROVIDER_MAP` keys | Source type keys must match `SourceType` enum values in `config/models.py` |

--- a/dango/transformation/CLAUDE.md
+++ b/dango/transformation/CLAUDE.md
@@ -1,0 +1,47 @@
+# transformation/
+
+## Purpose
+
+Integrates with dbt for data transformation, including auto-generation of staging models from ingested data sources with deduplication strategy mapping.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | dbt CLI execution functions | `run_dbt_models`, `generate_dbt_docs`, `_get_dbt_executable` |
+| `generator.py` | Auto-generates dbt staging models from data sources | `DbtModelGenerator`, `generate_staging_models` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Change dbt run behavior | `__init__.py` (`run_dbt_models`) | Manual: `dango transform` |
+| Add a new dedup strategy mapping | `generator.py` (`CSV_TO_DBT_STRATEGY_MAP`) | Manual: `dango generate-models` with source using new strategy |
+| Change generated model SQL | `generator.py` + `dango/templates/dbt/staging_model.sql.j2` | Manual: `dango generate-models` and inspect output |
+| Change sources.yml generation | `generator.py` (`generate_sources_yml`) | Manual: `dango generate-models` and inspect `dbt/models/staging/` |
+
+## Dependencies
+
+**Imports from:**
+- `dango/config/models.py` — `DataSource`, `SourceType`, `DeduplicationStrategy`
+- `dango/ingestion/sources/registry.py` — `get_source_metadata` (source metadata for model generation)
+- `dango/utils/dbt_status.py` — `update_model_status` (lazy import in `run_dbt_models`)
+
+**Used by:**
+- `dango/cli/main.py` — `DbtModelGenerator` for `dango generate-models` command
+- `dango/ingestion/dlt_runner.py` — `DbtModelGenerator`, `run_dbt_models`, `generate_dbt_docs` for post-sync auto-transform
+- `dango/web/app.py` — `run_dbt_models` via API endpoint
+- `dango/platform/watcher_runner.py` — `generate_dbt_docs` for watch-triggered doc generation
+
+## Testing
+
+- **Unit:** None yet (will be `tests/unit/test_transformation.py`)
+- **Integration:** None yet (will be `tests/integration/test_transformation.py`)
+- **Manual:** `dango generate-models` then `dango transform` in a dango project directory
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `generator.py` dedup strategy mappings (`CSV_TO_DBT_STRATEGY_MAP`, `DBT_TEMPLATE_STRATEGIES`) | Maps config dedup strategies to dbt SQL patterns; changes must be coordinated with `config/models.py` `DeduplicationStrategy` enum |
+| Jinja2 templates in `dango/templates/dbt/` | Templates define generated model SQL syntax; changes cascade to all auto-generated models |

--- a/dango/visualization/CLAUDE.md
+++ b/dango/visualization/CLAUDE.md
@@ -1,0 +1,46 @@
+# visualization/
+
+## Purpose
+
+Integrates with Metabase for dashboard provisioning, auto-setup, schema synchronization, and git-based dashboard export/import.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | Public exports | `provision_dashboard`, `create_pipeline_health_dashboard` |
+| `metabase.py` | Metabase auto-setup, DuckDB connection, schema sync | `MetabaseProvisioner`, `setup_metabase`, `sync_metabase_schema`, `refresh_metabase_connection` |
+| `dashboard_manager.py` | YAML-based dashboard/question export and import with rollback | `DashboardManager`, `import_dashboards` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Change Metabase auto-setup behavior | `metabase.py` (`setup_metabase`) | Manual: `dango start` on fresh project |
+| Add a new pipeline health query | `metabase.py` (`DASHBOARD_QUERIES` dict) | Manual: `dango metabase provision` |
+| Change dashboard export format | `dashboard_manager.py` (`card_to_yaml`, `dashboard_to_yaml`) | Manual: `dango metabase export` |
+| Change schema visibility rules | `metabase.py` (`sync_metabase_schema`) | Manual: `dango metabase sync` |
+
+## Dependencies
+
+**Imports from:**
+- No dango module imports (isolated module). Uses `requests` to call Metabase API, reads credentials from `.dango/metabase.yml` at runtime.
+
+**Used by:**
+- `dango/cli/main.py` — Metabase CLI commands (`dango metabase setup/sync/export/import/provision/refresh`)
+- `dango/ingestion/dlt_runner.py` — `sync_metabase_schema`, `refresh_metabase_connection` after data syncs
+- `dango/web/app.py` — `sync_metabase_schema`, `refresh_metabase_connection` via API endpoints
+
+## Testing
+
+- **Unit:** None yet (will be `tests/unit/test_visualization.py`)
+- **Integration:** None yet (will be `tests/integration/test_visualization.py`)
+- **Manual:** `dango start` then `dango metabase export` / `dango metabase import`
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `metabase.py` Metabase API response handling | Tied to Metabase REST API format; changes must match Metabase version expectations |
+| `metabase.py` `DASHBOARD_QUERIES` SQL | Pre-defined queries reference internal dango table schemas (`_dango_*`, `_dlt_*`); changes must match warehouse schema |
+| `dashboard_manager.py` YAML serialization format | Exported YAML files may be committed to user git repos; format changes break existing exports |


### PR DESCRIPTION
## Summary

- Create CLAUDE.md files for `config/`, `oauth/`, `ingestion/`, `visualization/`, and `transformation/` modules following the STD-002 template
- Covers DOC-002, DOC-003, DOC-019, DOC-020, DOC-021 (Phase 1 Batch 7)
- All 5 files pass `scripts/validate_claude_md.py` validation (6 required sections, non-empty Purpose, Files table)

Each file documents: purpose, files with key classes/functions, common tasks, dependency graph (imports from / used by), testing, and what not to modify — all verified against actual code via grep/read.

## Test plan

- [x] `python3 scripts/validate_claude_md.py` passes for all 5 files
- [x] Every file/class/function reference verified against actual codebase
- [x] Dependency claims (imports from / used by) verified via grep
- [x] "Don't Modify" warnings are accurate and justified

🤖 Generated with [Claude Code](https://claude.com/claude-code)