### PR TITLE
docs: remove stale dependency from transformation/CLAUDE.md

### DIFF
--- a/dango/transformation/CLAUDE.md
+++ b/dango/transformation/CLAUDE.md
@@ -24,7 +24,6 @@ Integrates with dbt for data transformation, including auto-generation of stagin
 
 **Imports from:**
 - `dango/config/models.py` — `DataSource`, `SourceType`, `DeduplicationStrategy`
-- `dango/ingestion/sources/registry.py` — `get_source_metadata` (source metadata for model generation)
 - `dango/utils/dbt_status.py` — `update_model_status` (lazy import in `run_dbt_models`)
 
 **Used by:**


### PR DESCRIPTION
## Summary

- Remove `dango/ingestion/sources/registry.py` from transformation/CLAUDE.md Dependencies section — the `get_source_metadata` import was removed in #31 but the CLAUDE.md wasn't updated to match

## Test plan

- [x] Verified `get_source_metadata` is no longer imported in `transformation/generator.py`
- [x] Remaining dependency claims (`config/models.py`, `utils/dbt_status.py`) are still accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)