### PR TITLE
feat: CI pipeline and pre-commit hooks (TASK-003, TASK-004)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: CI
+
+on:
+  push:
+    branches: [v1, main]
+  pull_request:
+    branches: [v1, main]
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    # TODO(TASK-088): Remove continue-on-error after bulk compliance
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install ruff
+      - name: ruff check
+        run: ruff check .
+      - name: ruff format check
+        run: ruff format --check .
+
+  type-check:
+    name: Type check (mypy)
+    runs-on: ubuntu-latest
+    # TODO(TASK-088): Remove continue-on-error after bulk compliance
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - name: mypy
+        run: mypy dango/ --ignore-missing-imports
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - name: pytest
+        run: pytest --tb=short -q
+
+  security:
+    name: Security (pip-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -e ".[dev]"
+      - name: pip-audit
+        run: pip-audit
+
+  llm-checks:
+    name: LLM checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: File sizes
+        run: python scripts/check_file_sizes.py --all
+
+      - name: CLAUDE.md structure
+        continue-on-error: true
+        run: python scripts/validate_claude_md.py --recursive
+
+      - name: File headers
+        continue-on-error: true
+        run: python scripts/validate_headers.py --all
+
+      - name: Docstring coverage
+        continue-on-error: true
+        run: python scripts/check_docstrings.py --all
+
+      - name: Orphan files
+        continue-on-error: true
+        run: python scripts/check_orphan_files.py
+
+      - name: Pinned deps
+        continue-on-error: true
+        run: python scripts/check_pinned_deps.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,64 @@
+repos:
+  # Standard file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: dango/ingestion/dlt_sources/
+      - id: end-of-file-fixer
+        exclude: dango/ingestion/dlt_sources/
+      - id: check-yaml
+        exclude: tests/fixtures/
+      - id: check-added-large-files
+
+  # Ruff linting + formatting (auto-fix)
+  # Reads exclude from pyproject.toml [tool.ruff] (dlt_sources/ excluded there)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # Local custom hooks
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy type checking
+        entry: mypy --ignore-missing-imports
+        language: system
+        types: [python]
+        pass_filenames: true
+        exclude: dango/ingestion/dlt_sources/
+
+      - id: file-size-check
+        name: Check file sizes
+        entry: python scripts/check_file_sizes.py
+        language: system
+        types: [python]
+        pass_filenames: true
+
+      - id: file-header-check
+        name: Check file headers
+        entry: python scripts/validate_headers.py
+        language: system
+        types: [python]
+        pass_filenames: true
+        exclude: (/__init__\.py$|dango/ingestion/dlt_sources/)
+
+      - id: docstring-check
+        name: Check public function docstrings
+        entry: python scripts/check_docstrings.py
+        language: system
+        types: [python]
+        pass_filenames: true
+        exclude: (/tests/|dango/ingestion/dlt_sources/)
+
+      - id: claude-md-staleness
+        name: CLAUDE.md staleness warning
+        entry: python scripts/check_claude_md_staleness.py
+        language: system
+        types_or: [python, markdown]
+        pass_filenames: true
+        verbose: true
+        exclude: dango/ingestion/dlt_sources/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ target-version = ["py310", "py311", "py312"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+exclude = ["dango/ingestion/dlt_sources/"]
 
 [tool.ruff.lint]
 select = [
@@ -139,6 +140,7 @@ python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+exclude = ["dango/ingestion/dlt_sources/"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/check_claude_md_staleness.py
+++ b/scripts/check_claude_md_staleness.py
@@ -1,0 +1,63 @@
+"""scripts/check_claude_md_staleness.py
+
+Warn when Python files are modified but the module's CLAUDE.md is not staged.
+Pre-commit only. Always exits 0 (warning only).
+"""
+
+import os
+import sys
+
+
+def _get_module_dir(path: str) -> str | None:
+    """Get the module directory for a Python file under dango/."""
+    parts = path.replace(os.sep, "/").split("/")
+    # We care about files under dango/<module>/
+    if len(parts) < 3 or parts[0] != "dango":
+        return None
+    # Module is the second component: dango/<module>/...
+    return f"{parts[0]}/{parts[1]}"
+
+
+def main() -> int:
+    files = sys.argv[1:]
+    if not files:
+        return 0
+
+    # Group .py files by module, track which CLAUDE.md files are staged
+    modules_touched: dict[str, list[str]] = {}
+    claude_mds_staged: set[str] = set()
+
+    for path in files:
+        normalized = path.replace(os.sep, "/")
+        if normalized.endswith("CLAUDE.md"):
+            # Track the directory of the staged CLAUDE.md
+            claude_mds_staged.add(os.path.dirname(normalized))
+            continue
+        if not normalized.endswith(".py"):
+            continue
+
+        module_dir = _get_module_dir(normalized)
+        if module_dir:
+            modules_touched.setdefault(module_dir, []).append(normalized)
+
+    # Check each touched module
+    warnings = []
+    for module_dir, py_files in modules_touched.items():
+        claude_md_path = os.path.join(module_dir, "CLAUDE.md")
+        # Only warn if CLAUDE.md exists but wasn't staged
+        if os.path.exists(claude_md_path) and module_dir not in claude_mds_staged:
+            warnings.append((module_dir, py_files))
+
+    if warnings:
+        for module_dir, py_files in sorted(warnings):
+            print(f"WARNING: Modified {module_dir}/ files but {module_dir}/CLAUDE.md not staged:")
+            for f in sorted(py_files):
+                print(f"  {f}")
+            print(f"  Consider updating {module_dir}/CLAUDE.md")
+        print()
+
+    return 0  # Always exit 0 (warning only)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_docstrings.py
+++ b/scripts/check_docstrings.py
@@ -1,0 +1,114 @@
+"""scripts/check_docstrings.py
+
+Check that public functions and classes have docstrings.
+Pre-commit mode: accepts file paths, exits 1 on violations.
+CI mode (--all): audit all files, exits 0 with report.
+"""
+
+import argparse
+import ast
+import os
+import sys
+
+SKIP_DIRS = {"venv", ".venv", "__pycache__", ".git", "dlt_sources", "node_modules"}
+
+
+def _should_skip(path: str) -> bool:
+    """Check if file should be skipped."""
+    parts = path.replace(os.sep, "/").split("/")
+    if any(part in SKIP_DIRS for part in parts):
+        return True
+    basename = os.path.basename(path)
+    if basename == "__init__.py":
+        return True
+    # Skip test files
+    if basename.startswith("test_") or basename.startswith("conftest"):
+        return True
+    if any(part == "tests" for part in parts):
+        return True
+    return False
+
+
+def _find_all_python_files() -> list[str]:
+    """Find all Python files under dango/ and scripts/."""
+    files = []
+    for search_dir in ["dango", "scripts"]:
+        if not os.path.isdir(search_dir):
+            continue
+        for root, dirs, filenames in os.walk(search_dir):
+            dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+            for fn in filenames:
+                if fn.endswith(".py"):
+                    files.append(os.path.join(root, fn))
+    return files
+
+
+def check_file(path: str) -> list[str]:
+    """Check a single file for missing docstrings. Returns list of violations."""
+    violations = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        tree = ast.parse(source, filename=path)
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        # Skip private/protected names
+        if node.name.startswith("_"):
+            continue
+        docstring = ast.get_docstring(node)
+        if docstring is None:
+            kind = "class" if isinstance(node, ast.ClassDef) else "function"
+            violations.append(f"  line {node.lineno}: {kind} '{node.name}' missing docstring")
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check public function/class docstrings")
+    parser.add_argument("files", nargs="*", help="Files to check (pre-commit mode)")
+    parser.add_argument("--all", action="store_true", help="Audit all Python files (CI mode)")
+    args = parser.parse_args()
+
+    if args.all:
+        files = _find_all_python_files()
+        audit_mode = True
+    elif args.files:
+        files = args.files
+        audit_mode = False
+    else:
+        parser.error("Provide file paths or use --all")
+        return 1
+
+    total_violations = 0
+    files_with_violations = 0
+
+    for path in files:
+        if _should_skip(path):
+            continue
+        if not os.path.isfile(path):
+            continue
+
+        violations = check_file(path)
+        if violations:
+            files_with_violations += 1
+            total_violations += len(violations)
+            print(f"{path}:")
+            for v in violations:
+                print(v)
+
+    if total_violations > 0:
+        print(f"\n{total_violations} missing docstring(s) in {files_with_violations} file(s).")
+        if audit_mode:
+            return 0  # Audit mode: report only
+        return 1
+    else:
+        print("All public functions/classes have docstrings.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_file_sizes.py
+++ b/scripts/check_file_sizes.py
@@ -1,0 +1,140 @@
+"""scripts/check_file_sizes.py
+
+Check Python file sizes against project limits.
+Pre-commit mode: warn >300 lines, fail >500 lines.
+CI mode (--all): fail >500 lines.
+"""
+
+import argparse
+import os
+import sys
+
+# TODO(TASK-084): Move exemptions to docs/file-exemptions.yml
+EXEMPT_FILES = {
+    # Cataloged in MEMORY.md (known technical debt)
+    "dango/ingestion/dlt_runner.py",
+    "dango/ingestion/sources/registry.py",
+    "dango/visualization/metabase.py",
+    "dango/visualization/dashboard_manager.py",
+    "dango/ingestion/csv_loader.py",
+    "dango/oauth/providers.py",
+    "dango/transformation/generator.py",
+    # Additional MVP files over 500 lines
+    "dango/cli/init.py",
+    "dango/cli/main.py",
+    "dango/cli/model_wizard.py",
+    "dango/cli/source_wizard.py",
+    "dango/cli/utils.py",
+    "dango/cli/validate.py",
+    "dango/platform/network.py",
+    "dango/platform/watcher.py",
+    "dango/web/app.py",
+}
+
+SKIP_DIRS = {"venv", ".venv", "__pycache__", ".git", "dlt_sources", "node_modules"}
+WARN_THRESHOLD = 300
+FAIL_THRESHOLD = 500
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize path to use forward slashes relative to repo root."""
+    abs_path = os.path.abspath(path)
+    # Try to find repo root by looking for pyproject.toml
+    candidate = os.path.dirname(abs_path)
+    while candidate != os.path.dirname(candidate):
+        if os.path.exists(os.path.join(candidate, "pyproject.toml")):
+            return os.path.relpath(abs_path, candidate).replace(os.sep, "/")
+        candidate = os.path.dirname(candidate)
+    return path.replace(os.sep, "/")
+
+
+def _should_skip(path: str) -> bool:
+    """Check if file should be skipped."""
+    parts = path.replace(os.sep, "/").split("/")
+    if any(part in SKIP_DIRS for part in parts):
+        return True
+    if os.path.basename(path) == "__init__.py":
+        return True
+    return False
+
+
+def _count_lines(path: str) -> int:
+    """Count lines in a file."""
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return sum(1 for line in f)
+
+
+def _find_all_python_files() -> list[str]:
+    """Find all Python files under dango/ and scripts/."""
+    files = []
+    for search_dir in ["dango", "scripts", "tests"]:
+        if not os.path.isdir(search_dir):
+            continue
+        for root, dirs, filenames in os.walk(search_dir):
+            dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+            for fn in filenames:
+                if fn.endswith(".py"):
+                    files.append(os.path.join(root, fn))
+    return files
+
+
+def check_files(files: list[str], audit_mode: bool = False) -> int:
+    """Check file sizes. Returns exit code."""
+    warnings = []
+    failures = []
+
+    for path in files:
+        if _should_skip(path):
+            continue
+        if not os.path.isfile(path):
+            continue
+
+        rel_path = _normalize_path(path)
+        if rel_path in EXEMPT_FILES:
+            continue
+
+        line_count = _count_lines(path)
+
+        if line_count > FAIL_THRESHOLD:
+            failures.append((rel_path, line_count))
+        elif line_count > WARN_THRESHOLD and not audit_mode:
+            warnings.append((rel_path, line_count))
+
+    if warnings:
+        print(f"WARNING: {len(warnings)} file(s) exceed {WARN_THRESHOLD} lines:")
+        for path, count in sorted(warnings):
+            print(f"  {path}: {count} lines")
+
+    if failures:
+        print(f"FAIL: {len(failures)} file(s) exceed {FAIL_THRESHOLD} lines:")
+        for path, count in sorted(failures):
+            print(f"  {path}: {count} lines")
+        return 1
+
+    if not warnings and not failures:
+        checked = [f for f in files if not _should_skip(f) and os.path.isfile(f)]
+        exempt_count = sum(1 for f in checked if _normalize_path(f) in EXEMPT_FILES)
+        total = len(checked) - exempt_count
+        print(f"All files within size limits ({total} checked, {exempt_count} exempt).")
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check Python file sizes")
+    parser.add_argument("files", nargs="*", help="Files to check (pre-commit mode)")
+    parser.add_argument("--all", action="store_true", help="Check all Python files (CI mode)")
+    args = parser.parse_args()
+
+    if args.all:
+        files = _find_all_python_files()
+        return check_files(files, audit_mode=True)
+    elif args.files:
+        return check_files(args.files, audit_mode=False)
+    else:
+        parser.error("Provide file paths or use --all")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_orphan_files.py
+++ b/scripts/check_orphan_files.py
@@ -1,0 +1,105 @@
+"""scripts/check_orphan_files.py
+
+Find Python files >100 lines under dango/ not mentioned in any CLAUDE.md.
+CI-only check. Always exits 0 (warning only).
+"""
+
+import os
+import re
+import sys
+
+SKIP_DIRS = {"venv", ".venv", "__pycache__", ".git", "dlt_sources", "node_modules"}
+MIN_LINES = 100
+
+
+def _count_lines(path: str) -> int:
+    """Count lines in a file."""
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return sum(1 for _ in f)
+
+
+def _find_python_files() -> list[tuple[str, int]]:
+    """Find Python files >MIN_LINES under dango/, returning (path, line_count)."""
+    results = []
+    for root, dirs, filenames in os.walk("dango"):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn == "__init__.py":
+                continue
+            if not fn.endswith(".py"):
+                continue
+            path = os.path.join(root, fn)
+            line_count = _count_lines(path)
+            if line_count > MIN_LINES:
+                results.append((path.replace(os.sep, "/"), line_count))
+    return results
+
+
+def _find_claude_md_files() -> list[str]:
+    """Find all CLAUDE.md files in the repo."""
+    results = []
+    for root, dirs, filenames in os.walk("."):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn == "CLAUDE.md":
+                results.append(os.path.join(root, fn))
+    return results
+
+
+def _extract_filenames_from_claude_md(path: str) -> set[str]:
+    """Extract .py filenames mentioned in a CLAUDE.md file."""
+    filenames = set()
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    # Single regex catches all .py references (table rows, backticks, bare)
+    for match in re.finditer(r"(\S+\.py)", content):
+        filenames.add(match.group(1).strip("`"))
+
+    return filenames
+
+
+def _is_mentioned(path: str, claude_md_path: str, mentioned: set[str]) -> bool:
+    """Check if a file is mentioned in the CLAUDE.md that owns its module."""
+    # Only count mentions from the CLAUDE.md in the same module directory
+    module_dir = os.path.dirname(path)
+    claude_dir = os.path.dirname(claude_md_path).replace(os.sep, "/").lstrip("./")
+    if not module_dir.startswith(claude_dir):
+        return False
+    basename = os.path.basename(path)
+    return basename in mentioned or path in mentioned
+
+
+def main() -> int:
+    py_files = _find_python_files()
+    if not py_files:
+        print("No Python files >100 lines found.")
+        return 0
+
+    # Collect mentions per CLAUDE.md file
+    claude_md_mentions: list[tuple[str, set[str]]] = []
+    for claude_md in _find_claude_md_files():
+        claude_md_mentions.append((claude_md, _extract_filenames_from_claude_md(claude_md)))
+
+    # Check which files are orphans
+    orphans = []
+    for path, line_count in py_files:
+        found = any(
+            _is_mentioned(path, claude_md, mentioned)
+            for claude_md, mentioned in claude_md_mentions
+        )
+        if not found:
+            orphans.append((path, line_count))
+
+    if orphans:
+        print(f"WARNING: {len(orphans)} Python file(s) >100 lines not in any CLAUDE.md:")
+        for path, line_count in sorted(orphans):
+            print(f"  {path} ({line_count} lines)")
+    else:
+        print(f"All {len(py_files)} Python files >100 lines are documented in CLAUDE.md files.")
+
+    return 0  # Always exit 0 (warning only)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_pinned_deps.py
+++ b/scripts/check_pinned_deps.py
@@ -1,0 +1,60 @@
+"""scripts/check_pinned_deps.py
+
+Check that all dependencies in pyproject.toml have version constraints.
+CI-only check. Always exits 0 (warning only).
+"""
+
+import re
+import sys
+
+PYPROJECT_PATH = "pyproject.toml"
+VERSION_PATTERN = re.compile(r"[><=~!]")
+
+
+def main() -> int:
+    try:
+        with open(PYPROJECT_PATH, encoding="utf-8") as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"ERROR: {PYPROJECT_PATH} not found.")
+        return 0
+
+    # Parse dependencies from [project.dependencies]
+    in_deps = False
+    unpinned = []
+
+    for line in content.splitlines():
+        stripped = line.strip()
+
+        if stripped == "dependencies = [":
+            in_deps = True
+            continue
+        if in_deps and stripped == "]":
+            break
+        if not in_deps:
+            continue
+
+        # Extract dependency string from quoted line
+        match = re.search(r'"([^"]+)"', stripped)
+        if not match:
+            continue
+
+        dep_str = match.group(1)
+        # Extract package name (before any version specifier or extras)
+        pkg_name = re.split(r"[><=~!\[;]", dep_str)[0].strip()
+
+        if not VERSION_PATTERN.search(dep_str):
+            unpinned.append(pkg_name)
+
+    if unpinned:
+        print(f"WARNING: {len(unpinned)} dependency(ies) without version constraints:")
+        for pkg in unpinned:
+            print(f"  {pkg}")
+    else:
+        print("All dependencies have version constraints.")
+
+    return 0  # Always exit 0 (warning only)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI with 5 jobs: lint, type-check, test (matrix 3.10/3.12), security (pip-audit), and LLM-specific checks (file sizes, CLAUDE.md structure, headers, docstrings, orphan files, pinned deps)
- Add pre-commit config with ruff (auto-fix), mypy, file size, header, docstring, and CLAUDE.md staleness checks
- Exclude vendored `dango/ingestion/dlt_sources/` from ruff and mypy via `pyproject.toml`
- Ruff/mypy/headers/docstrings are soft-fail (`continue-on-error: true`) until TASK-088 bulk compliance
- 5 new check scripts in `scripts/`: `check_file_sizes.py`, `check_docstrings.py`, `check_orphan_files.py`, `check_pinned_deps.py`, `check_claude_md_staleness.py`
- 16 files over 500-line limit exempted in `check_file_sizes.py` (tracked for TASK-084)

## Test plan
- [x] All 7 scripts run successfully (`check_file_sizes --all`, `check_docstrings --all`, `check_orphan_files`, `check_pinned_deps`, `validate_claude_md --recursive`, `validate_headers --all`, `check_claude_md_staleness` with sample args)
- [x] New scripts pass `ruff check` and `ruff format --check`
- [x] CI and pre-commit YAML validated as valid syntax
- [x] `pre-commit install` and `pre-commit run --all-files` runs (expected failures on legacy code, passes on new files)
- [x] `pytest --tb=short -q` passes (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)