### PR TITLE
feat: codebase audit & exemption registry (TASK-084)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - run: pip install pyyaml
 
       - name: File sizes
         run: python scripts/check_file_sizes.py --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,24 +80,24 @@ jobs:
       - run: pip install pyyaml
 
       - name: File sizes
-        run: python scripts/check_file_sizes.py --all
+        run: python3 scripts/check_file_sizes.py --all
 
       - name: CLAUDE.md structure
         continue-on-error: true
-        run: python scripts/validate_claude_md.py --recursive
+        run: python3 scripts/validate_claude_md.py --recursive
 
       - name: File headers
         continue-on-error: true
-        run: python scripts/validate_headers.py --all
+        run: python3 scripts/validate_headers.py --all
 
       - name: Docstring coverage
         continue-on-error: true
-        run: python scripts/check_docstrings.py --all
+        run: python3 scripts/check_docstrings.py --all
 
       - name: Orphan files
         continue-on-error: true
-        run: python scripts/check_orphan_files.py
+        run: python3 scripts/check_orphan_files.py
 
       - name: Pinned deps
         continue-on-error: true
-        run: python scripts/check_pinned_deps.py
+        run: python3 scripts/check_pinned_deps.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy type checking
-        entry: mypy --ignore-missing-imports
+        entry: python3 -m mypy --ignore-missing-imports
         language: system
         types: [python]
         pass_filenames: true
@@ -33,14 +33,14 @@ repos:
 
       - id: file-size-check
         name: Check file sizes
-        entry: python scripts/check_file_sizes.py
+        entry: python3 scripts/check_file_sizes.py
         language: system
         types: [python]
         pass_filenames: true
 
       - id: file-header-check
         name: Check file headers
-        entry: python scripts/validate_headers.py
+        entry: python3 scripts/validate_headers.py
         language: system
         types: [python]
         pass_filenames: true
@@ -48,7 +48,7 @@ repos:
 
       - id: docstring-check
         name: Check public function docstrings
-        entry: python scripts/check_docstrings.py
+        entry: python3 scripts/check_docstrings.py
         language: system
         types: [python]
         pass_filenames: true
@@ -56,7 +56,7 @@ repos:
 
       - id: claude-md-staleness
         name: CLAUDE.md staleness warning
-        entry: python scripts/check_claude_md_staleness.py
+        entry: python3 scripts/check_claude_md_staleness.py
         language: system
         types_or: [python, markdown]
         pass_filenames: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | Token encryption / keychain | `dango/security/` | [`dango/security/CLAUDE.md`](dango/security/CLAUDE.md) |
 | Shared utilities | `dango/utils/` | [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md) |
 | Docker / file watcher | `dango/platform/` | `dango/platform/CLAUDE.md` (Phase 3) |
-| Jinja2 templates / Dockerfiles | `dango/templates/` | See `ARCHITECTURE.md` §4 |
+| Jinja2 templates / Dockerfiles | `dango/templates/` | [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md) |
 | Auth / users / sessions | `dango/auth/` | Not yet created (Phase 2) |
 | Notebooks | `dango/notebooks/` | Not yet created (Phase 6) |
 | Data governance | `dango/governance/` | Not yet created (Phase 7) |
@@ -150,19 +150,27 @@ DuckDB allows only one writer process at a time. All write operations are serial
 
 ### Monolithic Files
 
-These files exceed 500 lines. The largest three have planned refactoring:
+These files exceed 500 lines. Two have planned refactoring; the rest are exempt (stable MVP code).
+Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
 | `cli/main.py` | 3927 | TASK-005 (split into `cli/commands/`) |
 | `web/app.py` | 2900 | TASK-085 (split into `web/routes/`) |
-| `ingestion/dlt_runner.py` | 1696 | Phase 3 (extract orchestration) |
-| `ingestion/sources/registry.py` | 1440 | Metadata-only, no refactor planned |
+| `ingestion/dlt_runner.py` | 1696 | — (exempt, too risky) |
+| `ingestion/sources/registry.py` | 1440 | — (metadata-only) |
+| `cli/source_wizard.py` | 1225 | — |
 | `visualization/metabase.py` | 1207 | — |
 | `visualization/dashboard_manager.py` | 1102 | — |
-| `ingestion/csv_loader.py` | 761 | — |
+| `cli/init.py` | 945 | — |
+| `cli/utils.py` | 780 | — |
 | `oauth/providers.py` | 761 | — |
+| `ingestion/csv_loader.py` | 761 | — |
+| `cli/validate.py` | 677 | — |
 | `transformation/generator.py` | 560 | — |
+| `platform/watcher.py` | 531 | — |
+| `cli/model_wizard.py` | 517 | — |
+| `platform/network.py` | 509 | — |
 
 ## Module Documentation Index
 
@@ -176,6 +184,7 @@ Module CLAUDE.md files provide per-module navigation, public API, and patterns.
 - [`dango/visualization/CLAUDE.md`](dango/visualization/CLAUDE.md)
 - [`dango/security/CLAUDE.md`](dango/security/CLAUDE.md)
 - [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md)
+- [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md)
 
 **Planned Phase 1:**
 - `dango/cli/CLAUDE.md` (after TASK-005)

--- a/dango/templates/CLAUDE.md
+++ b/dango/templates/CLAUDE.md
@@ -1,0 +1,48 @@
+# templates/
+
+## Purpose
+
+Jinja2 templates and Dockerfiles used by CLI project scaffolding and dbt model generation.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | Package marker | — |
+| `docker-compose.yml.j2` | Jinja2 template for Docker Compose config | Rendered by `cli/init.py` |
+| `Dockerfile.metabase` | Metabase container image | Copied by `cli/init.py` |
+| `nginx.conf.j2` | Jinja2 template for nginx reverse proxy config | Not yet consumed (placeholder) |
+| `dbt/sources.yml.j2` | dbt source definition template | Rendered by `transformation/generator.py` |
+| `dbt/staging_model.sql.j2` | dbt staging model SQL template | Rendered by `transformation/generator.py` |
+| `dbt/staging_schema.yml.j2` | dbt staging schema YAML template | Rendered by `transformation/generator.py` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Change Docker Compose structure | `docker-compose.yml.j2` | `dango init` in a test project |
+| Change Metabase container setup | `Dockerfile.metabase` | `docker build -f Dockerfile.metabase .` |
+| Change generated dbt model SQL | `dbt/staging_model.sql.j2` | `pytest tests/unit/test_transformation.py` |
+| Change generated dbt schema | `dbt/staging_schema.yml.j2` | `pytest tests/unit/test_transformation.py` |
+| Add a new dbt template | `dbt/` + `transformation/generator.py` | `pytest tests/unit/test_transformation.py` |
+
+## Dependencies
+
+**Imports from:**
+- None (templates are static files, no Python imports)
+
+**Used by:**
+- `cli/init.py` — renders `docker-compose.yml.j2` and copies `Dockerfile.metabase` during project scaffolding (via `jinja2.PackageLoader('dango', 'templates')`)
+- `transformation/generator.py` — renders `dbt/*.j2` templates for dbt model generation (via `jinja2.FileSystemLoader`)
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_transformation.py` (covers dbt template rendering)
+- **Integration:** `dango init` in a temp directory, verify generated files
+- **Manual:** Inspect generated `docker-compose.yml` and dbt models after `dango init` + `dango sync`
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| Template variable names (e.g. `{{ project_name }}`) | Changing variables breaks `cli/init.py` and `transformation/generator.py` rendering |

--- a/dango/templates/CLAUDE.md
+++ b/dango/templates/CLAUDE.md
@@ -22,9 +22,9 @@ Jinja2 templates and Dockerfiles used by CLI project scaffolding and dbt model g
 |-------|-----------|--------------|
 | Change Docker Compose structure | `docker-compose.yml.j2` | `dango init` in a test project |
 | Change Metabase container setup | `Dockerfile.metabase` | `docker build -f Dockerfile.metabase .` |
-| Change generated dbt model SQL | `dbt/staging_model.sql.j2` | `pytest tests/unit/test_transformation.py` |
-| Change generated dbt schema | `dbt/staging_schema.yml.j2` | `pytest tests/unit/test_transformation.py` |
-| Add a new dbt template | `dbt/` + `transformation/generator.py` | `pytest tests/unit/test_transformation.py` |
+| Change generated dbt model SQL | `dbt/staging_model.sql.j2` | Manual: run `dango sync` and inspect output |
+| Change generated dbt schema | `dbt/staging_schema.yml.j2` | Manual: run `dango sync` and inspect output |
+| Add a new dbt template | `dbt/` + `transformation/generator.py` | Manual: run `dango sync` and inspect output |
 
 ## Dependencies
 
@@ -37,7 +37,7 @@ Jinja2 templates and Dockerfiles used by CLI project scaffolding and dbt model g
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_transformation.py` (covers dbt template rendering)
+- **Unit:** No dedicated test file yet (templates are static files; dbt rendering tested via `transformation/` tests when available)
 - **Integration:** `dango init` in a temp directory, verify generated files
 - **Manual:** Inspect generated `docker-compose.yml` and dbt models after `dango init` + `dango sync`
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -1,0 +1,121 @@
+# Exemption registry for files exceeding the 500-line soft limit (STANDARDS.md §2).
+# Consumed by scripts/check_file_sizes.py for CI and pre-commit checks.
+# Line counts captured at time of audit (2026-02-10) — informational, not enforced by script.
+#
+# Categories:
+#   refactor — planned for refactoring in v1 (linked to a task)
+#   exempt   — stable MVP code, not modified in v1
+
+schema_version: 1
+limit: 500
+
+exemptions:
+  # --- Refactoring planned in v1 ---
+  - file: dango/cli/main.py
+    lines: 3927
+    category: refactor
+    task: TASK-005
+    reason: "Monolithic CLI entry point; will be split into cli/commands/ submodules"
+    review_by: "v1.0"
+
+  - file: dango/web/app.py
+    lines: 2900
+    category: refactor
+    task: TASK-085
+    reason: "Monolithic web server; will be split into web/routes/ submodules"
+    review_by: "v1.0"
+
+  # --- Exempt (stable, not modified in v1) ---
+  - file: dango/ingestion/dlt_runner.py
+    lines: 1696
+    category: exempt
+    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage."
+    review_by: "v1.1"
+
+  - file: dango/ingestion/sources/registry.py
+    lines: 1440
+    category: exempt
+    reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type."
+    review_by: "v1.1"
+
+  - file: dango/cli/source_wizard.py
+    lines: 1225
+    category: exempt
+    reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting."
+    review_by: "v1.1"
+
+  - file: dango/visualization/metabase.py
+    lines: 1207
+    category: exempt
+    reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations."
+    review_by: "v1.1"
+
+  - file: dango/visualization/dashboard_manager.py
+    lines: 1102
+    category: exempt
+    reason: "Dashboard export/import operations. Tightly coupled to metabase.py API surface."
+    review_by: "v1.1"
+
+  - file: dango/cli/init.py
+    lines: 945
+    category: exempt
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit."
+    review_by: "v1.1"
+
+  - file: dango/cli/utils.py
+    lines: 780
+    category: exempt
+    reason: "CLI utility functions shared across commands. Stable, rarely modified."
+    review_by: "v1.1"
+
+  - file: dango/oauth/providers.py
+    lines: 761
+    category: exempt
+    reason: "OAuth provider definitions (Google, Facebook, Shopify). Each provider is self-contained — file grows linearly with providers."
+    review_by: "v1.1"
+
+  - file: dango/ingestion/csv_loader.py
+    lines: 761
+    category: exempt
+    reason: "CSV loading with deduplication. Single-purpose module, stable."
+    review_by: "v1.1"
+
+  - file: dango/cli/validate.py
+    lines: 677
+    category: exempt
+    reason: "Validation commands (config, sources, connections). Each validator is independent."
+    review_by: "v1.1"
+
+  - file: dango/transformation/generator.py
+    lines: 560
+    category: exempt
+    reason: "DbtModelGenerator — generates dbt models from source configs. Stable, rarely modified."
+    review_by: "v1.1"
+
+  - file: dango/platform/watcher.py
+    lines: 531
+    category: exempt
+    reason: "File change detection for auto-sync. Event-driven logic, stable."
+    review_by: "v1.1"
+
+  - file: dango/cli/model_wizard.py
+    lines: 517
+    category: exempt
+    reason: "Interactive dbt model creation wizard. Sequential prompting, stable."
+    review_by: "v1.1"
+
+  - file: dango/platform/network.py
+    lines: 509
+    category: exempt
+    reason: "Network utilities (port allocation, nginx config generation). Stable."
+    review_by: "v1.1"
+
+# Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
+vendored:
+  - file: dango/ingestion/dlt_sources/mongodb/helpers.py
+    lines: 665
+    reason: "Vendored dlt MongoDB connector"
+
+  - file: dango/ingestion/dlt_sources/hubspot/__init__.py
+    lines: 537
+    reason: "Vendored dlt HubSpot connector"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -7,7 +7,7 @@
 #   exempt   — stable MVP code, not modified in v1
 
 schema_version: 1
-limit: 500
+limit: 500  # Informational — scripts/check_file_sizes.py owns the enforced threshold
 
 exemptions:
   # --- Refactoring planned in v1 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "black>=24.0.0",
     "ruff>=0.6.0",
     "mypy>=1.11.0",
+    "types-PyYAML>=6.0.0",
     "pre-commit>=3.6.0",
     "pip-audit>=2.7.0",
 ]

--- a/scripts/check_file_sizes.py
+++ b/scripts/check_file_sizes.py
@@ -37,7 +37,7 @@ def _load_exemptions(path: str) -> set[str]:
         return set()
     with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
-    if not data or not isinstance(data.get("exemptions"), list):
+    if not isinstance(data, dict) or not isinstance(data.get("exemptions"), list):
         print(f"WARNING: No exemptions found in {path}")
         return set()
     return {entry["file"] for entry in data["exemptions"] if "file" in entry}

--- a/scripts/check_file_sizes.py
+++ b/scripts/check_file_sizes.py
@@ -2,38 +2,45 @@
 
 Check Python file sizes against project limits.
 Pre-commit mode: warn >300 lines, fail >500 lines.
-CI mode (--all): fail >500 lines.
+CI mode (--all): fail >500 lines, detect stale exemptions.
+
+Exemptions loaded from docs/file-exemptions.yml (TASK-084).
 """
 
 import argparse
 import os
 import sys
 
-# TODO(TASK-084): Move exemptions to docs/file-exemptions.yml
-EXEMPT_FILES = {
-    # Cataloged in MEMORY.md (known technical debt)
-    "dango/ingestion/dlt_runner.py",
-    "dango/ingestion/sources/registry.py",
-    "dango/visualization/metabase.py",
-    "dango/visualization/dashboard_manager.py",
-    "dango/ingestion/csv_loader.py",
-    "dango/oauth/providers.py",
-    "dango/transformation/generator.py",
-    # Additional MVP files over 500 lines
-    "dango/cli/init.py",
-    "dango/cli/main.py",
-    "dango/cli/model_wizard.py",
-    "dango/cli/source_wizard.py",
-    "dango/cli/utils.py",
-    "dango/cli/validate.py",
-    "dango/platform/network.py",
-    "dango/platform/watcher.py",
-    "dango/web/app.py",
-}
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+EXEMPTIONS_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "docs",
+    "file-exemptions.yml",
+)
 
 SKIP_DIRS = {"venv", ".venv", "__pycache__", ".git", "dlt_sources", "node_modules"}
 WARN_THRESHOLD = 300
 FAIL_THRESHOLD = 500
+
+
+def _load_exemptions(path: str) -> set[str]:
+    """Load exempt file paths from YAML. Returns empty set on failure."""
+    if yaml is None:
+        print(f"WARNING: PyYAML not installed, cannot load exemptions from {path}")
+        return set()
+    if not os.path.isfile(path):
+        print(f"WARNING: Exemptions file not found: {path}")
+        return set()
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not data or not isinstance(data.get("exemptions"), list):
+        print(f"WARNING: No exemptions found in {path}")
+        return set()
+    return {entry["file"] for entry in data["exemptions"] if "file" in entry}
 
 
 def _normalize_path(path: str) -> str:
@@ -78,8 +85,30 @@ def _find_all_python_files() -> list[str]:
     return files
 
 
-def check_files(files: list[str], audit_mode: bool = False) -> int:
+def _check_stale_exemptions(exempt_files: set[str]) -> None:
+    """Print notices for exemptions that are stale (file missing or now <=limit)."""
+    stale = []
+    for file_path in sorted(exempt_files):
+        if not os.path.isfile(file_path):
+            stale.append((file_path, "file not found"))
+        else:
+            line_count = _count_lines(file_path)
+            if line_count <= FAIL_THRESHOLD:
+                stale.append((file_path, f"now {line_count} lines (within limit)"))
+    if stale:
+        print(f"\nNOTICE: {len(stale)} stale exemption(s):")
+        for path, reason in stale:
+            print(f"  {path}: {reason}")
+        print("  Consider removing from docs/file-exemptions.yml\n")
+
+
+def check_files(
+    files: list[str], audit_mode: bool = False, exempt_files: set[str] | None = None
+) -> int:
     """Check file sizes. Returns exit code."""
+    if exempt_files is None:
+        exempt_files = set()
+
     warnings = []
     failures = []
 
@@ -90,7 +119,7 @@ def check_files(files: list[str], audit_mode: bool = False) -> int:
             continue
 
         rel_path = _normalize_path(path)
-        if rel_path in EXEMPT_FILES:
+        if rel_path in exempt_files:
             continue
 
         line_count = _count_lines(path)
@@ -113,7 +142,7 @@ def check_files(files: list[str], audit_mode: bool = False) -> int:
 
     if not warnings and not failures:
         checked = [f for f in files if not _should_skip(f) and os.path.isfile(f)]
-        exempt_count = sum(1 for f in checked if _normalize_path(f) in EXEMPT_FILES)
+        exempt_count = sum(1 for f in checked if _normalize_path(f) in exempt_files)
         total = len(checked) - exempt_count
         print(f"All files within size limits ({total} checked, {exempt_count} exempt).")
 
@@ -121,16 +150,21 @@ def check_files(files: list[str], audit_mode: bool = False) -> int:
 
 
 def main() -> int:
+    """Entry point for file size checking (CLI and pre-commit)."""
     parser = argparse.ArgumentParser(description="Check Python file sizes")
     parser.add_argument("files", nargs="*", help="Files to check (pre-commit mode)")
     parser.add_argument("--all", action="store_true", help="Check all Python files (CI mode)")
     args = parser.parse_args()
 
+    exempt_files = _load_exemptions(EXEMPTIONS_PATH)
+
     if args.all:
         files = _find_all_python_files()
-        return check_files(files, audit_mode=True)
+        result = check_files(files, audit_mode=True, exempt_files=exempt_files)
+        _check_stale_exemptions(exempt_files)
+        return result
     elif args.files:
-        return check_files(args.files, audit_mode=False)
+        return check_files(args.files, audit_mode=False, exempt_files=exempt_files)
     else:
         parser.error("Provide file paths or use --all")
         return 1


### PR DESCRIPTION
## Summary

- Create `docs/file-exemptions.yml` — machine-readable exemption registry for all 16 non-vendored files >500 lines (2 refactor, 14 exempt) plus 2 vendored files
- Replace hardcoded `EXEMPT_FILES` in `scripts/check_file_sizes.py` with YAML-driven loader; adds stale exemption detection in `--all` mode
- Create `dango/templates/CLAUDE.md` — module documentation with grep-verified consumer imports
- Expand root `CLAUDE.md` monolithic files table from 9 → 16 rows, add templates/ to doc index and routing table
- Fix pre-commit hooks to use `python3` instead of bare `python`/`mypy` (project convention)
- Add `types-PyYAML` to dev dependencies for mypy

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('docs/file-exemptions.yml'))"` — YAML valid
- [x] `python scripts/check_file_sizes.py --all` — exit 0, 39 checked, 16 exempt
- [x] Temp 501-line file → script correctly reports FAIL
- [x] `python scripts/validate_claude_md.py dango/templates/CLAUDE.md` — OK
- [x] `ruff check scripts/check_file_sizes.py` — clean
- [x] `pytest --tb=short -q` — 150 passed
- [x] All 11 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)