### PR TITLE
Add structured logging infrastructure (TASK-007)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
               │                                                            │
               │   config/     utils/      security/    templates/          │
               │                                                            │
-              │   exceptions.py* (Phase 2)    logging.py* (Phase 2)       │
+              │   exceptions.py* (Phase 2)    logging.py                  │
               └───────────────────────────────────────────────────────────┘
                                         │
               ┌─────────────────────────┴──────────────────────────────────┐
@@ -67,12 +67,12 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 | Level | Role | Modules |
 |-------|------|---------|
-| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `templates/`, `exceptions.py`\*, `logging.py`\* |
+| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `templates/`, `logging.py`, `exceptions.py`\* |
 | 1 (core) | Imports Level 0 only | `oauth/`, `ingestion/`, `transformation/`, `auth/`\* |
 | 2 (platform) | Imports Level 0-1 | `platform/`, `web/`, `visualization/` |
 | 3 (ui) | Imports any level | `cli/` |
 
-\* = planned, not yet implemented
+\* = planned, not yet implemented (`exceptions.py`)
 
 **Three rules govern imports:**
 
@@ -268,11 +268,11 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 ### Planned Modules
 
+#### `logging.py`
+Structured logging configuration (structlog + stdlib integration). Provides `configure_logging()`, `get_logger()`, and correlation ID support via contextvars. See module docstring for full API.
+
 #### `exceptions.py` (Phase 2)
 Centralized exception hierarchy for consistent error handling across modules.
-
-#### `logging.py` (Phase 2)
-Structured logging configuration with per-module loggers.
 
 #### `auth/` (Phase 2)
 User authentication and authorization — session management, roles, permissions.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,6 +150,15 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 **Imports from:** None (Level 0).
 
+---
+
+#### `logging.py`
+**Responsibility:** Structured logging infrastructure (structlog wrapping stdlib). JSON to rotating log file, human-readable to stderr. Correlation ID support via contextvars.
+
+**Public API:** `configure_logging()`, `get_logger()`, `bind_contextvars`, `clear_contextvars`, `unbind_contextvars`
+
+**Imports from:** None (Level 0). Uses structlog + stdlib only.
+
 ### Level 1 — Core
 
 #### `ingestion/`
@@ -267,9 +276,6 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 **Imports from:** `config/` (Level 0), `utils/` (Level 0), `ingestion/` (Level 1), `transformation/` (Level 1), `visualization/` (Level 2). Also imports `cli/utils` (Level 3) — see Known Violations.
 
 ### Planned Modules
-
-#### `logging.py`
-Structured logging configuration (structlog + stdlib integration). Provides `configure_logging()`, `get_logger()`, and correlation ID support via contextvars. See module docstring for full API.
 
 #### `exceptions.py` (Phase 2)
 Centralized exception hierarchy for consistent error handling across modules.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | dbt / transformations | `dango/transformation/` | [`dango/transformation/CLAUDE.md`](dango/transformation/CLAUDE.md) |
 | Token encryption / keychain | `dango/security/` | [`dango/security/CLAUDE.md`](dango/security/CLAUDE.md) |
 | Shared utilities | `dango/utils/` | [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md) |
+| Logging / diagnostics | `dango/logging.py` | Module docstring |
 | Docker / file watcher | `dango/platform/` | `dango/platform/CLAUDE.md` (Phase 3) |
 | Jinja2 templates / Dockerfiles | `dango/templates/` | [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md) |
 | Auth / users / sessions | `dango/auth/` | Not yet created (Phase 2) |
@@ -56,6 +57,7 @@ When unsure which module to look at:
 ```
 dango/                          # Python package source
 ├── __init__.py
+├── logging.py                  # Level 0 — Structured logging (structlog + stdlib)
 ├── cli/                        # Level 3 — Click CLI (primary user interface)
 │   ├── __init__.py             # Shared Console instance
 │   ├── main.py                 # Slim entry point (~86 lines) — registers commands
@@ -165,7 +167,7 @@ tests/
 
 | Level | Role | Modules |
 |-------|------|---------|
-| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `templates/` |
+| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `templates/`, `logging.py` |
 | 1 (core) | Imports Level 0 only | `oauth/`, `ingestion/`, `transformation/` |
 | 2 (platform) | Imports Level 0–1 | `platform/`, `web/`, `visualization/` |
 | 3 (ui) | Imports any level | `cli/` |

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -248,35 +248,41 @@ class ConfigError(DangoError):
 
 ## 6. Logging Patterns
 
-### Current pattern (use until TASK-007)
+Structured logging is provided by `dango/logging.py` (structlog wrapping stdlib). Rich Console stays for user-facing CLI/web output.
 
-The codebase currently uses Rich `Console` for all output — there is no structured logging yet.
-
-**Rules for new code (before TASK-007):**
-- Continue using `from rich.console import Console` for user-facing output
-- Add `# TODO(TASK-007): structured logging` where structured logging would be appropriate
-- Do not introduce `logging` or `structlog` yet — TASK-007 sets up the infrastructure
-
-### Target pattern (TASK-007)
-
-> **⚠️ TARGET PATTERN** — Not yet implemented. Do not use this pattern until TASK-007 lands.
+### Structured logging
 
 ```python
-import structlog
+from dango.logging import get_logger
 
-logger = structlog.get_logger(__name__)
+logger = get_logger(__name__)
 
-# Structured logging (JSON to file)
+# Structured logging (JSON to file, human-readable to stderr)
 logger.info("sync_completed", source="google_sheets", rows=1523, duration_s=4.2)
 logger.error("sync_failed", source="stripe", error=str(e), retry_in=60)
+```
 
-# Rich console stays for user-facing output
+### Rich Console (user-facing output)
+
+```python
 from rich.console import Console
 console = Console()
 console.print("[green]Sync complete![/green]")
 ```
 
-**Log levels:**
+Use Rich Console for interactive CLI output (progress bars, tables, styled text). Use structured logging for operational events that should be recorded to log files.
+
+### Entry point setup
+
+Call `configure_logging()` once at each entry point (CLI, web server) before any logging occurs:
+
+```python
+from dango.logging import configure_logging
+configure_logging()  # uses DANGO_LOG_LEVEL env var or defaults to INFO
+```
+
+### Log levels
+
 - `DEBUG` — internal state, useful for troubleshooting
 - `INFO` — normal operations (sync started, sync completed)
 - `WARNING` — recoverable issues (retry, fallback used)

--- a/dango/logging.py
+++ b/dango/logging.py
@@ -40,9 +40,6 @@ __all__ = [
     "unbind_contextvars",
 ]
 
-# Sentinel to allow idempotent reconfiguration
-_configured: bool = False
-
 # Defaults
 _DEFAULT_LOG_LEVEL = "INFO"
 _DEFAULT_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
@@ -91,8 +88,6 @@ def configure_logging(
         json_console: If True, console output uses JSON. Otherwise uses
             structlog's ``ConsoleRenderer`` (human-readable, colored when TTY).
     """
-    global _configured  # noqa: PLW0603
-
     level = _resolve_log_level(log_level)
 
     # Resolve log directory
@@ -101,6 +96,7 @@ def configure_logging(
 
     # --- Build handlers ---
     handlers: dict[str, dict] = {}
+    shared_processors = _build_shared_processors()
 
     # File handler — JSON output
     file_handler_ok = _setup_file_handler(handlers, log_dir, level)
@@ -131,7 +127,7 @@ def configure_logging(
                         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                         structlog.processors.JSONRenderer(),
                     ],
-                    "foreign_pre_chain": _build_shared_processors(),
+                    "foreign_pre_chain": shared_processors,
                 },
                 "console": {
                     "()": structlog.stdlib.ProcessorFormatter,
@@ -139,7 +135,7 @@ def configure_logging(
                         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                         structlog.dev.ConsoleRenderer(),
                     ],
-                    "foreign_pre_chain": _build_shared_processors(),
+                    "foreign_pre_chain": shared_processors,
                 },
             },
             "handlers": handlers,
@@ -153,15 +149,13 @@ def configure_logging(
     # --- structlog configuration ---
     structlog.configure(
         processors=[
-            *_build_shared_processors(),
+            *shared_processors,
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=False,
     )
-
-    _configured = True
 
     if not file_handler_ok:
         logger = get_logger("dango.logging")

--- a/dango/logging.py
+++ b/dango/logging.py
@@ -1,0 +1,219 @@
+"""dango/logging.py
+
+Structured logging infrastructure for Dango (structlog + stdlib integration).
+
+Provides JSON-formatted file logging and human-readable console logging.
+Wraps stdlib logging so existing ``logging.getLogger(__name__)`` calls in
+web/app.py and metabase.py automatically produce structured output once
+``configure_logging()`` has been called.
+
+Public API:
+    configure_logging   — one-time setup (call from entry points)
+    get_logger          — convenience wrapper for structlog.get_logger
+    bind_contextvars    — add correlation IDs / request context
+    clear_contextvars   — clear all bound context
+    unbind_contextvars  — remove specific context keys
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.config
+import logging.handlers
+import os
+import warnings
+from pathlib import Path
+
+import structlog
+from structlog.contextvars import (
+    bind_contextvars,
+    clear_contextvars,
+    merge_contextvars,
+    unbind_contextvars,
+)
+
+__all__ = [
+    "configure_logging",
+    "get_logger",
+    "bind_contextvars",
+    "clear_contextvars",
+    "unbind_contextvars",
+]
+
+# Sentinel to allow idempotent reconfiguration
+_configured: bool = False
+
+# Defaults
+_DEFAULT_LOG_LEVEL = "INFO"
+_DEFAULT_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+_DEFAULT_BACKUP_COUNT = 5
+
+
+def _resolve_log_level(log_level: str | None) -> str:
+    """Resolve log level: explicit arg > DANGO_LOG_LEVEL env var > INFO default."""
+    level = log_level or os.environ.get("DANGO_LOG_LEVEL") or _DEFAULT_LOG_LEVEL
+    level = level.upper()
+    if level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        msg = f"Invalid log level: {level!r}. Must be one of DEBUG, INFO, WARNING, ERROR, CRITICAL."
+        raise ValueError(msg)
+    return level
+
+
+def _build_shared_processors() -> list[structlog.types.Processor]:
+    """Build the structlog processor chain shared by all handlers."""
+    return [
+        merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+    ]
+
+
+def configure_logging(
+    *,
+    log_level: str | None = None,
+    log_dir: Path | None = None,
+    json_console: bool = False,
+) -> None:
+    """Configure structured logging for Dango.
+
+    Safe to call multiple times — reconfigures with new settings.
+
+    Args:
+        log_level: Logging level. Falls back to ``DANGO_LOG_LEVEL`` env var,
+            then ``"INFO"``.
+        log_dir: Directory for ``dango.log``. Defaults to
+            ``.dango/logs`` relative to cwd. If the directory is not writable,
+            falls back to console-only logging with a warning.
+        json_console: If True, console output uses JSON. Otherwise uses
+            structlog's ``ConsoleRenderer`` (human-readable, colored when TTY).
+    """
+    global _configured  # noqa: PLW0603
+
+    level = _resolve_log_level(log_level)
+
+    # Resolve log directory
+    if log_dir is None:
+        log_dir = Path.cwd() / ".dango" / "logs"
+
+    # --- Build handlers ---
+    handlers: dict[str, dict] = {}
+
+    # File handler — JSON output
+    file_handler_ok = _setup_file_handler(handlers, log_dir, level)
+
+    # Console handler — human-readable or JSON
+    if json_console:
+        console_formatter = "json"
+    else:
+        console_formatter = "console"
+
+    handlers["console"] = {
+        "class": "logging.StreamHandler",
+        "formatter": console_formatter,
+        "stream": "ext://sys.stderr",
+        "level": level,
+    }
+
+    # --- stdlib logging config ---
+    handler_names = list(handlers.keys())
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": [
+                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                        structlog.processors.JSONRenderer(),
+                    ],
+                    "foreign_pre_chain": _build_shared_processors(),
+                },
+                "console": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": [
+                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                        structlog.dev.ConsoleRenderer(),
+                    ],
+                    "foreign_pre_chain": _build_shared_processors(),
+                },
+            },
+            "handlers": handlers,
+            "root": {
+                "handlers": handler_names,
+                "level": level,
+            },
+        }
+    )
+
+    # --- structlog configuration ---
+    structlog.configure(
+        processors=[
+            *_build_shared_processors(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=False,
+    )
+
+    _configured = True
+
+    if not file_handler_ok:
+        logger = get_logger("dango.logging")
+        logger.warning(
+            "file_logging_unavailable",
+            log_dir=str(log_dir),
+            reason="directory not writable",
+        )
+
+
+def _setup_file_handler(
+    handlers: dict[str, dict],
+    log_dir: Path,
+    level: str,
+) -> bool:
+    """Try to create the file handler. Returns True on success."""
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / "dango.log"
+        # Verify we can write
+        log_file.touch(exist_ok=True)
+    except OSError:
+        warnings.warn(
+            f"Cannot write to log directory {log_dir}. Falling back to console-only logging.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+        return False
+
+    handlers["file"] = {
+        "class": "logging.handlers.RotatingFileHandler",
+        "formatter": "json",
+        "filename": str(log_file),
+        "maxBytes": _DEFAULT_MAX_BYTES,
+        "backupCount": _DEFAULT_BACKUP_COUNT,
+        "level": level,
+        "encoding": "utf-8",
+    }
+    return True
+
+
+def get_logger(name: str) -> structlog.stdlib.BoundLogger:
+    """Get a structured logger.
+
+    Convenience wrapper around ``structlog.get_logger()``. The returned logger
+    supports all standard log methods (debug, info, warning, error, critical)
+    plus structlog's key-value binding.
+
+    Args:
+        name: Logger name — typically ``__name__`` for the calling module.
+
+    Returns:
+        A structlog ``BoundLogger`` instance.
+    """
+    return structlog.get_logger(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "websockets>=12.0",
     "aiofiles>=23.2.0",
     "psutil>=5.9.0",
+    "structlog>=24.1.0",
 
     # Security and encryption
     "keyring>=24.0.0",    # Secure credential storage in OS keychain

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,308 @@
+"""tests/unit/test_logging.py
+
+Tests for dango.logging — structured logging configuration and public API.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.handlers
+from pathlib import Path
+
+import pytest
+import structlog
+
+from dango.logging import (
+    bind_contextvars,
+    clear_contextvars,
+    configure_logging,
+    get_logger,
+    unbind_contextvars,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging():
+    """Reset logging state between tests to ensure isolation."""
+    import dango.logging as dl
+
+    yield
+
+    # Reset the configured flag
+    dl._configured = False
+
+    # Clear contextvars
+    clear_contextvars()
+
+    # Remove all handlers from root logger
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        handler.close()
+        root.removeHandler(handler)
+
+    # Reset structlog to defaults
+    structlog.reset_defaults()
+
+
+@pytest.mark.unit
+class TestConfigureLogging:
+    def test_creates_log_directory(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        assert log_dir.exists()
+
+    def test_creates_log_file(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        assert (log_dir / "dango.log").exists()
+
+    def test_creates_file_handler(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        root = logging.getLogger()
+        handler_types = [type(h).__name__ for h in root.handlers]
+        assert "RotatingFileHandler" in handler_types
+
+    def test_creates_console_handler(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        root = logging.getLogger()
+        handler_types = [type(h).__name__ for h in root.handlers]
+        assert "StreamHandler" in handler_types
+
+    def test_writes_json_to_file(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        logger = get_logger("test")
+        logger.info("test_event", key="value")
+
+        log_file = log_dir / "dango.log"
+        content = log_file.read_text().strip()
+        assert content  # not empty
+        record = json.loads(content)
+        assert record["event"] == "test_event"
+        assert record["key"] == "value"
+
+    def test_idempotent_reconfiguration(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="DEBUG")
+
+        import dango.logging as dl
+
+        assert dl._configured is True
+
+        # Should still be functional after reconfiguration
+        logger = get_logger("test")
+        logger.info("after_reconfig")
+
+        log_file = log_dir / "dango.log"
+        lines = [line for line in log_file.read_text().strip().split("\n") if line]
+        # There should be at least one entry from after_reconfig
+        events = [json.loads(line)["event"] for line in lines]
+        assert "after_reconfig" in events
+
+    def test_invalid_level_raises_value_error(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid log level"):
+            configure_logging(log_dir=tmp_path / "logs", log_level="INVALID")
+
+    def test_fallback_on_unwritable_directory(self, tmp_path: Path) -> None:
+        # Use a path that cannot be created (file instead of dir)
+        blocker = tmp_path / "blocker"
+        blocker.write_text("I am a file")
+        bad_log_dir = blocker / "logs"  # Can't mkdir inside a file
+
+        # Should not raise — falls back to console-only
+        with pytest.warns(RuntimeWarning, match="Cannot write to log directory"):
+            configure_logging(log_dir=bad_log_dir, json_console=True)
+
+        # File handler should NOT be present
+        root = logging.getLogger()
+        handler_types = [type(h).__name__ for h in root.handlers]
+        assert "RotatingFileHandler" not in handler_types
+        assert "StreamHandler" in handler_types
+
+
+@pytest.mark.unit
+class TestGetLogger:
+    def test_returns_logger_with_standard_methods(self, tmp_path: Path) -> None:
+        configure_logging(log_dir=tmp_path / "logs", json_console=True)
+        logger = get_logger("test.module")
+        assert callable(logger.debug)
+        assert callable(logger.info)
+        assert callable(logger.warning)
+        assert callable(logger.error)
+        assert callable(logger.critical)
+
+    def test_preserves_logger_name_in_output(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        logger = get_logger("my.custom.name")
+        logger.info("name_test")
+
+        log_file = log_dir / "dango.log"
+        record = json.loads(log_file.read_text().strip())
+        assert record["logger"] == "my.custom.name"
+
+
+@pytest.mark.unit
+class TestLogLevelConfiguration:
+    def test_default_level_is_info(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        root = logging.getLogger()
+        assert root.level == logging.INFO
+
+    def test_explicit_override(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True, log_level="DEBUG")
+        root = logging.getLogger()
+        assert root.level == logging.DEBUG
+
+    def test_env_var_override(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DANGO_LOG_LEVEL", "WARNING")
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        root = logging.getLogger()
+        assert root.level == logging.WARNING
+
+    def test_explicit_beats_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DANGO_LOG_LEVEL", "WARNING")
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True, log_level="ERROR")
+        root = logging.getLogger()
+        assert root.level == logging.ERROR
+
+    def test_case_insensitive(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True, log_level="debug")
+        root = logging.getLogger()
+        assert root.level == logging.DEBUG
+
+
+@pytest.mark.unit
+class TestJSONOutput:
+    def test_required_fields_present(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        logger = get_logger("fields.test")
+        logger.info("check_fields")
+
+        record = json.loads((log_dir / "dango.log").read_text().strip())
+        assert "timestamp" in record
+        assert "level" in record
+        assert "logger" in record
+        assert "event" in record
+
+    def test_correct_level_values(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True, log_level="DEBUG")
+        logger = get_logger("levels.test")
+
+        logger.debug("d")
+        logger.info("i")
+        logger.warning("w")
+        logger.error("e")
+
+        lines = (log_dir / "dango.log").read_text().strip().split("\n")
+        records = [json.loads(line) for line in lines]
+        levels = [r["level"] for r in records]
+        assert "debug" in levels
+        assert "info" in levels
+        assert "warning" in levels
+        assert "error" in levels
+
+    def test_structlog_kv_pairs_in_json(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        logger = get_logger("kv.test")
+        logger.info("sync_done", source="stripe", rows=42)
+
+        record = json.loads((log_dir / "dango.log").read_text().strip())
+        assert record["source"] == "stripe"
+        assert record["rows"] == 42
+
+
+@pytest.mark.unit
+class TestFileRotation:
+    def test_max_bytes_configured(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        root = logging.getLogger()
+        rotating_handlers = [
+            h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+        ]
+        assert len(rotating_handlers) == 1
+        assert rotating_handlers[0].maxBytes == 10 * 1024 * 1024
+
+    def test_backup_count_configured(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        root = logging.getLogger()
+        rotating_handlers = [
+            h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+        ]
+        assert len(rotating_handlers) == 1
+        assert rotating_handlers[0].backupCount == 5
+
+
+@pytest.mark.unit
+class TestCorrelationIds:
+    def test_bind_adds_fields_to_output(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        bind_contextvars(request_id="req-123", user_id="usr-456")
+        logger = get_logger("ctx.test")
+        logger.info("with_context")
+
+        record = json.loads((log_dir / "dango.log").read_text().strip())
+        assert record["request_id"] == "req-123"
+        assert record["user_id"] == "usr-456"
+
+    def test_clear_removes_all_context(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        bind_contextvars(request_id="req-123")
+        clear_contextvars()
+        logger = get_logger("ctx.test")
+        logger.info("after_clear")
+
+        record = json.loads((log_dir / "dango.log").read_text().strip())
+        assert "request_id" not in record
+
+    def test_unbind_removes_specific_keys(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        bind_contextvars(request_id="req-123", user_id="usr-456")
+        unbind_contextvars("request_id")
+        logger = get_logger("ctx.test")
+        logger.info("partial_unbind")
+
+        record = json.loads((log_dir / "dango.log").read_text().strip())
+        assert "request_id" not in record
+        assert record["user_id"] == "usr-456"
+
+
+@pytest.mark.unit
+class TestStdlibIntegration:
+    def test_stdlib_logger_produces_structured_json(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        stdlib_logger = logging.getLogger("stdlib.test")
+        stdlib_logger.info("stdlib_event")
+
+        record = json.loads((log_dir / "dango.log").read_text().strip())
+        assert record["event"] == "stdlib_event"
+        assert "timestamp" in record
+        assert "level" in record
+
+    def test_stdlib_logger_includes_bound_correlation_ids(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+        bind_contextvars(trace_id="trace-abc")
+        stdlib_logger = logging.getLogger("stdlib.corr")
+        stdlib_logger.info("stdlib_with_ctx")
+
+        record = json.loads((log_dir / "dango.log").read_text().strip())
+        assert record["trace_id"] == "trace-abc"

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -25,12 +25,7 @@ from dango.logging import (
 @pytest.fixture(autouse=True)
 def _reset_logging():
     """Reset logging state between tests to ensure isolation."""
-    import dango.logging as dl
-
     yield
-
-    # Reset the configured flag
-    dl._configured = False
 
     # Clear contextvars
     clear_contextvars()
@@ -89,17 +84,12 @@ class TestConfigureLogging:
         configure_logging(log_dir=log_dir, json_console=True)
         configure_logging(log_dir=log_dir, json_console=True, log_level="DEBUG")
 
-        import dango.logging as dl
-
-        assert dl._configured is True
-
         # Should still be functional after reconfiguration
         logger = get_logger("test")
         logger.info("after_reconfig")
 
         log_file = log_dir / "dango.log"
         lines = [line for line in log_file.read_text().strip().split("\n") if line]
-        # There should be at least one entry from after_reconfig
         events = [json.loads(line)["event"] for line in lines]
         assert "after_reconfig" in events
 


### PR DESCRIPTION
## Summary

- Create `dango/logging.py` — Level 0 module providing structured logging via structlog wrapping stdlib
- Public API: `configure_logging()`, `get_logger()`, `bind_contextvars`, `clear_contextvars`, `unbind_contextvars`
- JSON output to rotating log file (10MB, 5 backups), human-readable to stderr
- Existing `logging.getLogger()` calls in web/app.py and metabase.py auto-format via stdlib integration
- Add `structlog>=24.1.0` dependency to pyproject.toml
- Update ARCHITECTURE.md, STANDARDS.md, CLAUDE.md to reflect logging.py as implemented

## Test plan

- [x] 25 unit tests across 7 test classes (configure, get_logger, log levels, JSON output, file rotation, correlation IDs, stdlib integration)
- [x] Full test suite passes (201 tests, 0 failures)
- [x] ruff lint + format clean
- [x] All pre-commit hooks pass (headers, docstrings, file sizes, CLAUDE.md staleness)
- [x] stdlib `logging` not shadowed (verified via `import logging; print(logging.__file__)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)