### PR TITLE
Add CODEOWNERS file (TASK-083)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Default owner for all files
+* @aaronteoh
+
+# Package modules
+/dango/cli/              @aaronteoh
+/dango/config/           @aaronteoh
+/dango/ingestion/        @aaronteoh
+/dango/oauth/            @aaronteoh
+/dango/platform/         @aaronteoh
+/dango/security/         @aaronteoh
+/dango/templates/        @aaronteoh
+/dango/transformation/   @aaronteoh
+/dango/utils/            @aaronteoh
+/dango/visualization/    @aaronteoh
+/dango/web/              @aaronteoh
+
+# Tests and documentation
+/tests/                  @aaronteoh
+/docs/                   @aaronteoh
+*.md                     @aaronteoh


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` defining `@aaronteoh` as owner for all files
- Explicit entries for all 11 package modules, plus tests/, docs/, and *.md

## Test plan
- [x] File exists at `.github/CODEOWNERS`
- [x] All 11 modules listed with correct owner
- [x] Pre-commit hooks pass
- [ ] GitHub validates CODEOWNERS syntax (check for warnings in PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)