### PR TITLE
DOC-001 + DOC-018: Add CLAUDE.md for dango/ and cli/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (945 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (955 lines)
 │   │   ├── project.py          # init/rename/info
 │   │   ├── source.py           # source group (add/list/remove) + sync (521 lines)
 │   │   ├── transform.py        # run/docs/generate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 
 | Task Type | Go To | Read First |
 |-----------|-------|------------|
-| CLI commands | `dango/cli/` | `dango/cli/CLAUDE.md` (Phase 1) |
+| CLI commands | `dango/cli/` | [`dango/cli/CLAUDE.md`](dango/cli/CLAUDE.md) |
 | Data ingestion / sync | `dango/ingestion/` | [`dango/ingestion/CLAUDE.md`](dango/ingestion/CLAUDE.md) |
 | OAuth / token flows | `dango/oauth/` | [`dango/oauth/CLAUDE.md`](dango/oauth/CLAUDE.md) |
 | Web UI / API endpoints | `dango/web/` | [`dango/web/CLAUDE.md`](dango/web/CLAUDE.md) |
@@ -215,6 +215,8 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 Module CLAUDE.md files provide per-module navigation, public API, and patterns.
 
 **Existing:**
+- [`dango/CLAUDE.md`](dango/CLAUDE.md) (package root)
+- [`dango/cli/CLAUDE.md`](dango/cli/CLAUDE.md)
 - [`dango/config/CLAUDE.md`](dango/config/CLAUDE.md)
 - [`dango/ingestion/CLAUDE.md`](dango/ingestion/CLAUDE.md)
 - [`dango/oauth/CLAUDE.md`](dango/oauth/CLAUDE.md)
@@ -223,11 +225,6 @@ Module CLAUDE.md files provide per-module navigation, public API, and patterns.
 - [`dango/security/CLAUDE.md`](dango/security/CLAUDE.md)
 - [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md)
 - [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md)
-
-**Planned Phase 1:**
-- `dango/cli/CLAUDE.md` (after TASK-005)
-
-**Created:**
 - [`dango/web/CLAUDE.md`](dango/web/CLAUDE.md)
 
 **Planned later phases:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,11 +194,11 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 1696 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 1440 | — (metadata-only) |
-| `cli/source_wizard.py` | 1225 | — |
+| `cli/source_wizard.py` | 1324 | — |
 | `visualization/metabase.py` | 1207 | — |
 | `visualization/dashboard_manager.py` | 1102 | — |
-| `cli/init.py` | 945 | — |
-| `cli/commands/platform.py` | 945 | — (extracted from main.py by TASK-005) |
+| `cli/init.py` | 965 | — |
+| `cli/commands/platform.py` | 955 | — (extracted from main.py by TASK-005) |
 | `oauth/providers.py` | 761 | — |
 | `ingestion/csv_loader.py` | 761 | — |
 | `cli/commands/auth.py` | 707 | — (extracted from main.py by TASK-005) |
@@ -206,7 +206,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `transformation/generator.py` | 560 | — |
 | `platform/watcher.py` | 531 | — |
 | `cli/commands/source.py` | 521 | — (extracted from main.py by TASK-005) |
-| `cli/model_wizard.py` | 517 | — |
+| `cli/model_wizard.py` | 507 | — |
 | `web/helpers.py` | 798 | — (extracted from app.py by TASK-085) |
 | `web/routes/upload.py` | 664 | — (extracted from app.py by TASK-085) |
 

--- a/dango/CLAUDE.md
+++ b/dango/CLAUDE.md
@@ -1,0 +1,45 @@
+# dango/
+
+## Purpose
+
+Root Python package for Dango — contains all module subpackages (cli, config, ingestion, etc.) and shared top-level infrastructure (logging, package metadata).
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | Package metadata: version, author, license | `__version__`, `__author__`, `__license__` |
+| `logging.py` | Structured logging (structlog + stdlib integration) | `configure_logging()`, `get_logger()`, `bind_contextvars`, `clear_contextvars`, `unbind_contextvars` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Change package version | `__init__.py` (also update `pyproject.toml`) | `python -c "import dango; print(dango.__version__)"` |
+| Configure logging | `logging.py` | `pytest tests/unit/test_logging.py` |
+| Add a new module | Create `{module}/` dir with `__init__.py` and `CLAUDE.md` | `python scripts/validate_claude_md.py dango/{module}/CLAUDE.md` |
+| Find which module handles a task | Read root `CLAUDE.md` routing table | — |
+
+## Dependencies
+
+**Imports from:**
+- `structlog` — structured logging in `logging.py`
+
+**Used by:**
+- All submodules import from dango subpackages (config, utils, etc.)
+- `pyproject.toml` defines `getdango` as the installable package
+- Entry point: `dango.cli.main:cli` (configured in `pyproject.toml`)
+
+## Testing
+
+- **All tests:** `pytest`
+- **Unit only:** `pytest -m unit`
+- **Integration only:** `pytest -m integration`
+- **Logging tests:** `pytest tests/unit/test_logging.py`
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `__init__.py` `__version__` | Version is also in `pyproject.toml` — update both together |
+| Module `__init__.py` exports | Other modules depend on re-exported symbols |

--- a/dango/CLAUDE.md
+++ b/dango/CLAUDE.md
@@ -23,10 +23,11 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 ## Dependencies
 
 **Imports from:**
-- `structlog` — structured logging in `logging.py`
+- `structlog` — structured logging in `logging.py` (also uses stdlib `logging`, `pathlib`)
 
 **Used by:**
-- All submodules import from dango subpackages (config, utils, etc.)
+- `dango/cli/main.py`, `dango/cli/init.py`, `dango/cli/wizard.py` — import `__version__`
+- `dango.logging` — not yet imported by any module (available for future use)
 - `pyproject.toml` defines `getdango` as the installable package
 - Entry point: `dango.cli.main:cli` (configured in `pyproject.toml`)
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -82,7 +82,7 @@ dango (top-level group)
 | Add subcommand to existing group | Add to relevant `commands/*.py` | `dango <group> --help` |
 | Add a new command group | Create in `commands/`, register in `main.py` | `dango <group> --help` |
 | Modify source wizard | `source_wizard.py` | `dango source add` |
-| Add new project init step | `init.py` (`DangoProjectInitializer`) | `dango init` in temp dir |
+| Add new project init step | `init.py` (`ProjectInitializer`) | `dango init` in temp dir |
 | Modify validation logic | `validate.py` | `dango validate` |
 
 ## Dependencies

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -25,15 +25,15 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
 | `init.py` (965 lines) | Project initialization wizard | `DangoProjectInitializer` |
-| `wizard.py` (296 lines) | Interactive setup wizards | — |
+| `wizard.py` (296 lines) | Interactive setup wizards | `SetupWizard` |
 | `source_wizard.py` (1324 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |
 | `utils.py` (129 lines) | Display helpers + project context | `require_project_context()` |
 | `validate.py` (651 lines) | Project validation logic | `validate_project()` |
 | `db_helpers.py` (129 lines) | Schema/table matching for db commands | `build_schema_table_mapping()`, `is_table_configured()` |
-| `env_helpers.py` (319 lines) | `.env` file management | — |
-| `oauth.py` (428 lines) | OAuth CLI flows | — |
+| `env_helpers.py` (319 lines) | `.env` file management | `create_env_template()`, `validate_env_file()`, `guide_env_setup()` |
+| `oauth.py` (428 lines) | OAuth CLI flows | `authenticate_facebook()`, `authenticate_google()`, `check_token_expiry()` |
 | `schema_manager.py` (335 lines) | dbt `schema.yml` auto-generation | `update_model_schemas()` |
 | `helpers/__init__.py` (6 lines) | Package marker | — |
 | `helpers/port_manager.py` (48 lines) | Port checking | `check_port_in_use()` |
@@ -94,7 +94,7 @@ dango (top-level group)
 - `dango.config/` — `ConfigLoader`, models, helpers (most commands)
 - `dango.ingestion/` — `run_sync`, source registry (source commands)
 - `dango.oauth/` — `OAuthManager`, providers, storage (auth commands)
-- `dango.transformation/` — `DbtModelGenerator`, `run_dbt_models` (transform commands)
+- `dango.transformation/` — `DbtModelGenerator` (transform commands)
 - `dango.visualization/` — `DashboardManager`, metabase functions (dashboard/metabase commands)
 - `dango.platform/` — `DockerManager`, `NetworkConfig`, watcher lifecycle (platform commands)
 - `dango.utils/` — `DbtLock`, process utilities, `dbt_status` (various commands)

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -24,8 +24,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (965 lines) | Project initialization wizard | `DangoProjectInitializer` |
-| `wizard.py` (296 lines) | Interactive setup wizards | `SetupWizard` |
+| `init.py` (965 lines) | Project initialization wizard | `ProjectInitializer` |
+| `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (1324 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -1,0 +1,118 @@
+# cli/
+
+## Purpose
+
+Click-based command-line interface for all Dango operations — project init, source management, sync, platform lifecycle, dbt transforms, Metabase management, and OAuth authentication.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `main.py` (86 lines) | CLI entry point, registers all commands | `cli` (Click group), `main()` |
+| `__init__.py` (12 lines) | Shared `console` (Rich Console) instance | `console` |
+| **commands/** | | |
+| `commands/__init__.py` (4 lines) | Package marker | — |
+| `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
+| `commands/source.py` (521 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/platform.py` (955 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/auth.py` (707 lines) | `auth` group (10 subcommands) | `auth`, `auth_setup()`, `auth_status()`, `auth_check()`, etc. |
+| `commands/transform.py` (326 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
+| `commands/data.py` (360 lines) | `db` group (`status`, `clean`) + `validate` | `db`, `validate()` |
+| `commands/config_cmd.py` (179 lines) | `config` group (`validate`, `show`) | `config` |
+| `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
+| `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
+| `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
+| `commands/web.py` (66 lines) | `web` dev server command | `web()` |
+| **Wizards** | | |
+| `init.py` (965 lines) | Project initialization wizard | `DangoProjectInitializer` |
+| `wizard.py` (296 lines) | Interactive setup wizards | — |
+| `source_wizard.py` (1324 lines) | Source configuration wizard | `add_source()` |
+| `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
+| **Helpers** | | |
+| `utils.py` (129 lines) | Display helpers + project context | `require_project_context()` |
+| `validate.py` (651 lines) | Project validation logic | `validate_project()` |
+| `db_helpers.py` (129 lines) | Schema/table matching for db commands | `build_schema_table_mapping()`, `is_table_configured()` |
+| `env_helpers.py` (319 lines) | `.env` file management | — |
+| `oauth.py` (428 lines) | OAuth CLI flows | — |
+| `schema_manager.py` (335 lines) | dbt `schema.yml` auto-generation | `update_model_schemas()` |
+| `helpers/__init__.py` (6 lines) | Package marker | — |
+| `helpers/port_manager.py` (48 lines) | Port checking | `check_port_in_use()` |
+| `helpers/process_manager.py` (336 lines) | FastAPI server process management | `start_fastapi_server()` |
+
+## Architecture
+
+### Command Hierarchy
+
+```
+dango (top-level group)
+├── init, rename, info          ← commands/project.py
+├── start, stop, status         ← commands/platform.py
+├── sync                        ← commands/source.py
+├── run, docs, generate         ← commands/transform.py
+├── validate                    ← commands/data.py
+├── web                         ← commands/web.py
+├── source (group)              ← commands/source.py
+│   ├── add, list, remove
+├── config (group)              ← commands/config_cmd.py
+│   ├── validate, show
+├── db (group)                  ← commands/data.py
+│   ├── status, clean
+├── auth (group)                ← commands/auth.py
+│   ├── status, setup, check, list, remove, refresh,
+│   │   facebook_ads, google_sheets, google_analytics, google_ads
+├── model (group)               ← commands/model.py
+│   ├── add, remove
+├── dashboard (group)           ← commands/dashboard.py
+│   ├── provision
+└── metabase (group)            ← commands/metabase_cmd.py
+    ├── save, load, refresh
+```
+
+### Patterns
+
+- **Lazy imports:** All command functions use `from dango.xxx import ...` inside the function body, not at module level. This prevents circular imports and speeds up CLI startup.
+- **Shared console:** All command modules import `console` from `dango.cli` for Rich terminal output.
+- **Project root via context:** `ctx.obj["project_root"]` is set by the top-level `cli` group in `main.py` (via `dango.config.helpers.find_project_root`).
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new top-level command | Create in `commands/`, register in `main.py` via `cli.add_command()` | `pytest tests/unit/test_cli_commands.py` |
+| Add subcommand to existing group | Add to relevant `commands/*.py` | `dango <group> --help` |
+| Add a new command group | Create in `commands/`, register in `main.py` | `dango <group> --help` |
+| Modify source wizard | `source_wizard.py` | `dango source add` |
+| Add new project init step | `init.py` (`DangoProjectInitializer`) | `dango init` in temp dir |
+| Modify validation logic | `validate.py` | `dango validate` |
+
+## Dependencies
+
+**Imports from:**
+- `click` — command framework
+- `rich` — terminal output (`Console`, `Panel`, `Table`)
+- `inquirer` — interactive prompts (wizards)
+- `dango.config/` — `ConfigLoader`, models, helpers (most commands)
+- `dango.ingestion/` — `run_sync`, source registry (source commands)
+- `dango.oauth/` — `OAuthManager`, providers, storage (auth commands)
+- `dango.transformation/` — `DbtModelGenerator`, `run_dbt_models` (transform commands)
+- `dango.visualization/` — `DashboardManager`, metabase functions (dashboard/metabase commands)
+- `dango.platform/` — `DockerManager`, `NetworkConfig`, watcher lifecycle (platform commands)
+- `dango.utils/` — `DbtLock`, process utilities, `dbt_status` (various commands)
+- `dango.web/` — app instance (web dev command)
+
+**Used by:**
+- `pyproject.toml` entry point: `dango = "dango.cli.main:cli"`
+- No other dango modules import from `cli/` (Level 3 = top of hierarchy)
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_cli_commands.py`
+- **Manual:** `dango --help`, `dango <command> --help`, run commands in a test project
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `main.py` command registration order | Groups and commands are registered in logical order for `--help` output |
+| Click context pattern (`ctx.obj`) | All commands depend on `project_root` from context |
+| Lazy import pattern in commands | Prevents circular imports and speeds up CLI startup |


### PR DESCRIPTION
## Summary
- **DOC-001:** Create `dango/CLAUDE.md` — package root documentation (metadata, logging, module routing)
- **DOC-018:** Create `dango/cli/CLAUDE.md` — CLI module documentation (27 files, command hierarchy, patterns)
- Update root `CLAUDE.md` routing table and module documentation index

## Details
Both files follow the STD-002 6-section template and pass `scripts/validate_claude_md.py` validation.

All content verified against actual codebase — line counts, function names, import chains, and Click command registrations checked via grep/read (not from memory).

## Test plan
- [x] `python scripts/validate_claude_md.py dango/CLAUDE.md dango/cli/CLAUDE.md` passes
- [x] Pre-commit hooks pass (trailing whitespace, end-of-file, CLAUDE.md staleness)
- [x] Navigation: root CLAUDE.md routing table → cli/CLAUDE.md → any command file in 2 lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)