### PR TITLE
TASK-008: Unified error handling, input validation, and CLI bug fixes

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -177,71 +177,72 @@ from .exceptions import ConfigError, ConfigNotFoundError
 
 ## 5. Error Handling Patterns
 
-### Current pattern (use until TASK-008)
+All Dango exceptions live in `dango/exceptions.py` and inherit from `DangoError`.
+Module files (e.g., `config/exceptions.py`) re-export for backward compatibility.
 
-The `dango/config/exceptions.py` hierarchy is the model for new code:
+### DangoError base class
 
 ```python
-# dango/config/exceptions.py — current pattern
-class ConfigError(Exception):
-    """Base exception for configuration errors"""
-    pass
+from dango.exceptions import DangoError, ConfigError, ConfigNotFoundError
 
-class ConfigNotFoundError(ConfigError):
-    """Configuration file not found"""
-    pass
+# Every exception carries:
+#   error_code  — stable identifier (e.g. "DANGO-C002")
+#   context     — dict for structured logging / API responses
+#   user_message — human-readable (defaults to message)
 
-class ConfigValidationError(ConfigError):
-    """Configuration validation failed"""
-    pass
+# Existing raise sites work unchanged — _default_error_code is a class attribute:
+raise ConfigError("Missing sources.yml")
+# ↑ error_code = "DANGO-C001" (the class default)
 
-class ProjectNotFoundError(ConfigError):
-    """Not in a Dango project directory"""
-    pass
+# Pass explicit error_code / context when useful:
+raise ConfigNotFoundError(
+    "sources.yml not found",
+    context={"path": str(sources_file)},
+)
 ```
 
-**Rules for new code (before TASK-008):**
-- Create a base exception per module (e.g., `IngestionError`, `OAuthError`)
-- Subclass for specific error cases
+### Import convention
+
+Prefer importing from `dango.exceptions` directly:
+
+```python
+from dango.exceptions import ConfigError, ConfigNotFoundError
+```
+
+Old-style imports still work via re-export shims:
+
+```python
+from dango.config.exceptions import ConfigError  # same class object
+```
+
+### Rules
+
 - Never bare `except:` — always catch specific exceptions
 - Always include context in error messages (what failed, what was expected)
 - Catch-and-wrap external library exceptions at module boundaries
+- Use `from e` (not `from None`) unless suppressing the chain is intentional (see §B904 in CLAUDE.md)
 
-**Example — catch with context** (from `dango/config/loader.py`):
+### Debug mode (`DANGO_DEBUG`)
+
+Set `DANGO_DEBUG=1` to surface full stack traces in CLI error handlers.
 
 ```python
-try:
-    with open(file_path, 'r') as f:
-        data = yaml.safe_load(f)
-        return data or {}
-except yaml.YAMLError as e:
-    raise ConfigError(f"Invalid YAML in {file_path}:\n{e}")
+from dango.exceptions import is_debug_mode
+
+except Exception as e:
+    console.print(f"[red]Error:[/red] {e}")
+    if is_debug_mode():
+        import traceback
+        traceback.print_exc()
 ```
 
-### Target pattern (TASK-008)
-
-> **⚠️ TARGET PATTERN** — Not yet implemented. Do not use this pattern until TASK-008 lands.
+### Input validation (dango/validation.py)
 
 ```python
-class DangoError(Exception):
-    """Base for all dango errors."""
-    def __init__(
-        self,
-        message: str,
-        *,
-        error_code: str,
-        context: dict | None = None,
-        user_message: str | None = None,
-    ):
-        self.error_code = error_code
-        self.context = context or {}
-        self.user_message = user_message or message
-        super().__init__(message)
+from dango.validation import validate_source_name, validate_date_string
 
-# Module exceptions inherit from DangoError
-class ConfigError(DangoError):
-    """Configuration-related errors."""
-    pass
+validate_source_name(name)       # raises InvalidSourceNameError
+validate_date_string("2024-01-15")  # raises InvalidDateFormatError
 ```
 
 ---

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -220,20 +220,22 @@ from dango.config.exceptions import ConfigError  # same class object
 - Never bare `except:` — always catch specific exceptions
 - Always include context in error messages (what failed, what was expected)
 - Catch-and-wrap external library exceptions at module boundaries
-- Use `from e` (not `from None`) unless suppressing the chain is intentional (see §B904 in CLAUDE.md)
+- Use `from e` (not `from None`) unless suppressing the chain is intentional (KeyboardInterrupt handlers, security boundaries, user-facing error translations)
 
 ### Debug mode (`DANGO_DEBUG`)
 
 Set `DANGO_DEBUG=1` to surface full stack traces in CLI error handlers.
 
 ```python
-from dango.exceptions import is_debug_mode
-
 except Exception as e:
     console.print(f"[red]Error:[/red] {e}")
+    from dango.exceptions import is_debug_mode  # lazy import inside handler
+
     if is_debug_mode():
         import traceback
+
         console.print(traceback.format_exc())
+    raise click.Abort() from e
 ```
 
 ### Input validation (dango/validation.py)

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -233,7 +233,7 @@ except Exception as e:
     console.print(f"[red]Error:[/red] {e}")
     if is_debug_mode():
         import traceback
-        traceback.print_exc()
+        console.print(traceback.format_exc())
 ```
 
 ### Input validation (dango/validation.py)

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -83,6 +83,12 @@ def auth_list(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -142,6 +148,12 @@ def auth_status(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -193,6 +205,12 @@ def auth_remove(ctx: click.Context, source_type: str) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -264,6 +282,12 @@ def auth_refresh(ctx: click.Context, oauth_name: str) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -301,6 +325,12 @@ def auth_facebook_ads(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -333,6 +363,12 @@ def auth_google_sheets(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -365,6 +401,12 @@ def auth_google_analytics(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -397,6 +439,12 @@ def auth_google_ads(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -527,6 +575,12 @@ def auth_check(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -704,4 +758,10 @@ def auth_setup(ctx: click.Context, provider: str) -> None:
         raise click.Abort() from None
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/config_cmd.py
+++ b/dango/cli/commands/config_cmd.py
@@ -110,6 +110,12 @@ def config_validate(ctx: click.Context) -> None:
                     except Exception as e:
                         all_valid = False
                         dbt_errors.append(f"{sources_file.relative_to(project_root)}: {str(e)}")
+                        from dango.exceptions import is_debug_mode
+
+                        if is_debug_mode():
+                            import traceback
+
+                            console.print(traceback.format_exc())
 
                 if dbt_errors:
                     all_valid = False
@@ -131,6 +137,12 @@ def config_validate(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -176,4 +188,10 @@ def config_show(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/dashboard.py
+++ b/dango/cli/commands/dashboard.py
@@ -119,7 +119,10 @@ def dashboard_provision(ctx: click.Context, url: str, username: str, password: s
         raise click.Abort() from None
     except Exception as e:
         console.print(f"\n[red]Error:[/red] {e}")
-        import traceback
+        from dango.exceptions import is_debug_mode
 
-        console.print(traceback.format_exc())
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/data.py
+++ b/dango/cli/commands/data.py
@@ -354,7 +354,10 @@ def validate(ctx: click.Context) -> None:
         raise  # Re-raise SystemExit
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
-        import traceback
+        from dango.exceptions import is_debug_mode
 
-        console.print(traceback.format_exc())
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/data.py
+++ b/dango/cli/commands/data.py
@@ -133,6 +133,12 @@ def db_status(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -256,6 +262,12 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
 
             except Exception as e:
                 console.print(f"[red]✗[/red] Failed to drop {schema}.{table}: {e}")
+                from dango.exceptions import is_debug_mode
+
+                if is_debug_mode():
+                    import traceback
+
+                    console.print(traceback.format_exc())
 
         # Clean up metadata for orphaned sources (only if metadata table exists)
         if orphaned_sources:
@@ -302,6 +314,12 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
                         console.print(
                             f"[yellow]⚠[/yellow] Could not clean metadata for '{source_name}': {e}"
                         )
+                        from dango.exceptions import is_debug_mode
+
+                        if is_debug_mode():
+                            import traceback
+
+                            console.print(traceback.format_exc())
 
         conn.close()
 
@@ -312,6 +330,12 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 

--- a/dango/cli/commands/metabase_cmd.py
+++ b/dango/cli/commands/metabase_cmd.py
@@ -138,6 +138,12 @@ def metabase_save(ctx: click.Context, include_personal: bool, collections: str |
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -289,6 +295,12 @@ def metabase_load(ctx: click.Context, overwrite: bool, dry_run: bool) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -428,4 +440,10 @@ def metabase_refresh(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -55,9 +55,12 @@ def model_add(ctx: click.Context) -> None:
         raise click.Abort() from None
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
-        import traceback
+        from dango.exceptions import is_debug_mode
 
-        console.print(traceback.format_exc())
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 

--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -199,6 +199,12 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
                     console.print(f"[green]✓[/green] Dropped table: {layer}.{model_name}")
                 except Exception as e:
                     console.print(f"[red]✗[/red] Failed to drop table: {e}")
+                    from dango.exceptions import is_debug_mode
+
+                    if is_debug_mode():
+                        import traceback
+
+                        console.print(traceback.format_exc())
             else:
                 console.print(
                     f"[yellow]⚠[/yellow]  Table {layer}.{model_name} still exists in DuckDB"
@@ -212,4 +218,10 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -692,7 +692,7 @@ def start(ctx: click.Context) -> None:
             import traceback
 
             console.print("[dim]Stack trace:[/dim]")
-            traceback.print_exc()
+            console.print(traceback.format_exc())
             console.print()
         raise click.Abort() from None
 

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -458,92 +458,89 @@ def start(ctx: click.Context) -> None:
             raise click.Abort()
 
         # Docker services started successfully
-        if True:  # TODO: dead code — remove this always-true conditional
-            # Metabase auto-setup (first-time only)
-            console.print()
-            console.print("[cyan]Checking Metabase setup...[/cyan]")
-            from dango.visualization.metabase import setup_metabase
+        # Metabase auto-setup (first-time only)
+        console.print()
+        console.print("[cyan]Checking Metabase setup...[/cyan]")
+        from dango.visualization.metabase import setup_metabase
 
-            metabase_configured = False
-            credentials_file = project_root / ".dango" / "metabase.yml"
-            if not credentials_file.exists():
-                # First time - run auto-setup
-                console.print("[dim]First time setup detected...[/dim]")
-                organization = getattr(config.project, "organization", None)
-                setup_result = setup_metabase(project_root, project_name, organization)
+        metabase_configured = False
+        credentials_file = project_root / ".dango" / "metabase.yml"
+        if not credentials_file.exists():
+            # First time - run auto-setup
+            console.print("[dim]First time setup detected...[/dim]")
+            organization = getattr(config.project, "organization", None)
+            setup_result = setup_metabase(project_root, project_name, organization)
 
-                if setup_result.get("success"):
-                    console.print("[green]✓[/green] Metabase configured automatically")
-                    if setup_result.get("collections_created"):
-                        console.print(
-                            f"[dim]  Collections: {', '.join(setup_result['collections_created'])}[/dim]"
-                        )
-                    metabase_configured = True
-                else:
-                    # Metabase setup failed
-                    console.print("[red]✗[/red] Metabase setup failed")
-                    if setup_result.get("errors"):
-                        for error in setup_result["errors"]:
-                            console.print(f"[red]  • {error}[/red]")
-
-                    # Check if DuckDB connection failed (critical)
-                    if not setup_result.get("duckdb_connected"):
-                        # DuckDB connection is critical - abort and rollback
-                        console.print()
-                        console.print(
-                            "[red]❌ Critical error: Cannot connect Metabase to DuckDB[/red]"
-                        )
-                        console.print()
-                        console.print("[yellow]Rolling back: Stopping Docker services...[/yellow]")
-                        manager.stop_services()
-                        console.print()
-                        console.print("[bold]All services have been stopped.[/bold]")
-                        console.print()
-                        console.print("[bold]Troubleshooting:[/bold]")
-                        console.print("  1. Check if DuckDB file exists: data/warehouse.duckdb")
-                        console.print(
-                            "  2. Verify DuckDB driver: metabase-plugins/duckdb.metabase-driver.jar"
-                        )
-                        console.print(
-                            "  3. Check Metabase logs: '[cyan]docker logs $(docker ps -q -f name=metabase)[/cyan]'"
-                        )
-                        console.print("  4. Try again: '[cyan]dango start[/cyan]'")
-                        console.print()
-                        raise click.Abort()
-                    else:
-                        # DuckDB connected but other setup failed (collections, etc.)
-                        # This is non-critical - can continue
-                        console.print()
-                        console.print(
-                            "[yellow]⚠ Metabase partially configured (DuckDB connected, but setup incomplete)[/yellow]"
-                        )
-                        console.print(
-                            "[dim]  You can manually complete setup at http://localhost:3000[/dim]"
-                        )
-                        metabase_configured = True  # Allow platform to start
-            else:
-                console.print("[green]✓[/green] Metabase already configured")
+            if setup_result.get("success"):
+                console.print("[green]✓[/green] Metabase configured automatically")
+                if setup_result.get("collections_created"):
+                    console.print(
+                        f"[dim]  Collections: {', '.join(setup_result['collections_created'])}[/dim]"
+                    )
                 metabase_configured = True
+            else:
+                # Metabase setup failed
+                console.print("[red]✗[/red] Metabase setup failed")
+                if setup_result.get("errors"):
+                    for error in setup_result["errors"]:
+                        console.print(f"[red]  • {error}[/red]")
 
-            # Import dashboards (if any exist)
-            dashboards_dir = project_root / "dashboards"
-            if dashboards_dir.exists() and list(dashboards_dir.glob("*.yml")):
-                console.print()
-                console.print("[cyan]Importing dashboards...[/cyan]")
-                from dango.visualization.dashboard_manager import import_dashboards
+                # Check if DuckDB connection failed (critical)
+                if not setup_result.get("duckdb_connected"):
+                    # DuckDB connection is critical - abort and rollback
+                    console.print()
+                    console.print("[red]❌ Critical error: Cannot connect Metabase to DuckDB[/red]")
+                    console.print()
+                    console.print("[yellow]Rolling back: Stopping Docker services...[/yellow]")
+                    manager.stop_services()
+                    console.print()
+                    console.print("[bold]All services have been stopped.[/bold]")
+                    console.print()
+                    console.print("[bold]Troubleshooting:[/bold]")
+                    console.print("  1. Check if DuckDB file exists: data/warehouse.duckdb")
+                    console.print(
+                        "  2. Verify DuckDB driver: metabase-plugins/duckdb.metabase-driver.jar"
+                    )
+                    console.print(
+                        "  3. Check Metabase logs: '[cyan]docker logs $(docker ps -q -f name=metabase)[/cyan]'"
+                    )
+                    console.print("  4. Try again: '[cyan]dango start[/cyan]'")
+                    console.print()
+                    raise click.Abort()
+                else:
+                    # DuckDB connected but other setup failed (collections, etc.)
+                    # This is non-critical - can continue
+                    console.print()
+                    console.print(
+                        "[yellow]⚠ Metabase partially configured (DuckDB connected, but setup incomplete)[/yellow]"
+                    )
+                    console.print(
+                        "[dim]  You can manually complete setup at http://localhost:3000[/dim]"
+                    )
+                    metabase_configured = True  # Allow platform to start
+        else:
+            console.print("[green]✓[/green] Metabase already configured")
+            metabase_configured = True
 
-                try:
-                    import_result = import_dashboards(project_root)
-                    if import_result.get("imported"):
-                        console.print(
-                            f"[green]✓[/green] Imported {len(import_result['imported'])} dashboard(s)"
-                        )
-                    elif import_result.get("skipped"):
-                        console.print("[dim]✓ All dashboards already imported[/dim]")
-                except Exception as e:
-                    console.print(f"[yellow]⚠[/yellow]  Dashboard import failed: {e}")
-
+        # Import dashboards (if any exist)
+        dashboards_dir = project_root / "dashboards"
+        if dashboards_dir.exists() and list(dashboards_dir.glob("*.yml")):
             console.print()
+            console.print("[cyan]Importing dashboards...[/cyan]")
+            from dango.visualization.dashboard_manager import import_dashboards
+
+            try:
+                import_result = import_dashboards(project_root)
+                if import_result.get("imported"):
+                    console.print(
+                        f"[green]✓[/green] Imported {len(import_result['imported'])} dashboard(s)"
+                    )
+                elif import_result.get("skipped"):
+                    console.print("[dim]✓ All dashboards already imported[/dim]")
+            except Exception as e:
+                console.print(f"[yellow]⚠[/yellow]  Dashboard import failed: {e}")
+
+        console.print()
 
         # Start FastAPI backend (critical - must succeed)
         console.print("[cyan]Starting Web UI backend...[/cyan]")
@@ -689,11 +686,14 @@ def start(ctx: click.Context) -> None:
         console.print()
         console.print("[bold]All services have been stopped.[/bold]")
         console.print()
-        import traceback
+        from dango.exceptions import is_debug_mode
 
-        console.print("[dim]Stack trace:[/dim]")
-        traceback.print_exc()
-        console.print()
+        if is_debug_mode():
+            import traceback
+
+            console.print("[dim]Stack trace:[/dim]")
+            traceback.print_exc()
+            console.print()
         raise click.Abort() from None
 
 
@@ -715,7 +715,7 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
     from pathlib import Path
 
     from dango.config import ConfigLoader
-    from dango.platform import DockerManager  # TODO: duplicate import — also imported at line 725
+    from dango.platform import DockerManager
     from dango.platform.network import NetworkConfig
 
     from ..helpers.process_manager import stop_fastapi_server
@@ -726,8 +726,6 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
 
     # Handle --all flag (doesn't require project context)
     if stop_all:
-        from dango.platform import DockerManager
-
         # Create a dummy manager just to call the global cleanup method
         manager = DockerManager(Path.cwd())
         manager.stop_all_dango_containers()

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -582,6 +582,12 @@ def start(ctx: click.Context) -> None:
             except RuntimeError as e:
                 # File watcher is non-critical - platform still works without it
                 console.print(f"[yellow]⚠[/yellow]  File watcher failed to start: {e}")
+                from dango.exceptions import is_debug_mode
+
+                if is_debug_mode():
+                    import traceback
+
+                    console.print(traceback.format_exc())
                 console.print("[dim]Platform will work, but auto-sync is disabled.[/dim]")
                 console.print("[dim]You can manually run 'dango sync' when files change.[/dim]")
                 console.print()
@@ -791,6 +797,12 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -950,4 +962,10 @@ def status(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/project.py
+++ b/dango/cli/commands/project.py
@@ -206,9 +206,12 @@ def rename(ctx: click.Context, new_name: str) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
-        import traceback
+        from dango.exceptions import is_debug_mode
 
-        traceback.print_exc()
+        if is_debug_mode():
+            import traceback
+
+            traceback.print_exc()
         raise click.Abort() from e
 
 

--- a/dango/cli/commands/project.py
+++ b/dango/cli/commands/project.py
@@ -211,7 +211,7 @@ def rename(ctx: click.Context, new_name: str) -> None:
         if is_debug_mode():
             import traceback
 
-            traceback.print_exc()
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 

--- a/dango/cli/commands/project.py
+++ b/dango/cli/commands/project.py
@@ -298,4 +298,10 @@ def info(ctx: click.Context) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/project.py
+++ b/dango/cli/commands/project.py
@@ -37,6 +37,12 @@ def init(ctx: click.Context, project_name: str, skip_wizard: bool, force: bool) 
         init_project(project_dir, skip_wizard=skip_wizard, force=force)
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -511,6 +511,12 @@ def sync(
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
     finally:
         if lock is not None:

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -365,6 +365,7 @@ def sync(
     console.print("🍡 [bold]Syncing data...[/bold]")
     console.print()
 
+    lock = None
     try:
         # Get project context
         project_root = require_project_context(ctx)
@@ -506,16 +507,14 @@ def sync(
 
         # Exit with error code if any sources failed
         if summary["failed_count"] > 0:
-            lock.release()
             raise click.Abort()
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
-        lock.release()  # TODO: lock may be undefined if error occurs before acquisition
         raise click.Abort() from e
     finally:
-        # Always release the lock (if it was acquired)
-        try:
-            lock.release()
-        except Exception:
-            pass
+        if lock is not None:
+            try:
+                lock.release()
+            except Exception:
+                pass

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -218,6 +218,12 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 
@@ -321,6 +327,12 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -37,6 +37,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
 
     from ..utils import require_project_context
 
+    lock = None
     try:
         project_root = require_project_context(ctx)
         dbt_dir = project_root / "dbt"
@@ -105,18 +106,16 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Cancelled[/yellow]")
-        lock.release()  # TODO: lock may be undefined if error occurs before acquisition
         raise click.Abort() from None
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
-        lock.release()  # TODO: lock may be undefined if error occurs before acquisition
         raise click.Abort() from e
     finally:
-        # Always release the lock (if it was acquired)
-        try:
-            lock.release()
-        except Exception:
-            pass
+        if lock is not None:
+            try:
+                lock.release()
+            except Exception:
+                pass
 
 
 @click.command("docs")
@@ -320,7 +319,10 @@ def generate(ctx: click.Context, models: bool, generate_all: bool) -> None:
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
-        import traceback
+        from dango.exceptions import is_debug_mode
 
-        console.print(traceback.format_exc())
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -109,6 +109,12 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
         raise click.Abort() from None
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
     finally:
         if lock is not None:
@@ -199,6 +205,12 @@ def docs(ctx: click.Context) -> None:
         raise click.Abort() from None
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e
 
 

--- a/dango/cli/commands/web.py
+++ b/dango/cli/commands/web.py
@@ -60,7 +60,10 @@ def web(ctx: click.Context, host: str, port: int, reload: bool) -> None:
         console.print("\n[yellow]Server stopped[/yellow]")
     except Exception as e:
         console.print(f"\n[red]Error starting server:[/red] {e}")
-        import traceback
+        from dango.exceptions import is_debug_mode
 
-        console.print(traceback.format_exc())
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
         raise click.Abort() from e

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -13,7 +13,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
 | `credentials.py` | Credential loading for dlt sources | `CredentialManager`, `init_dlt_directory` |
-| `exceptions.py` | Config-specific exception hierarchy | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError`, `ProjectNotFoundError` |
+| `exceptions.py` | Re-export shim — classes live in `dango/exceptions.py` | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError`, `ProjectNotFoundError` |
 
 ## Common Tasks
 
@@ -52,4 +52,4 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 |------|--------|
 | `models.py` field names | Changing field names breaks existing project.yml/sources.yml files |
 | `models.py` `SourceType` enum values | Enum values are stored in user config files and referenced across modules |
-| `exceptions.py` class hierarchy | Exception classes are caught by name in cli/, web/, and ingestion/ |
+| `exceptions.py` re-export shim | Exception classes are caught by name in cli/, web/, and ingestion/. Adding/removing classes here must mirror `dango/exceptions.py`. |

--- a/dango/config/exceptions.py
+++ b/dango/config/exceptions.py
@@ -1,28 +1,21 @@
 """dango/config/exceptions.py
 
-Custom exceptions for configuration handling.
+Re-export shim — all exception classes now live in ``dango.exceptions``.
+
+Existing imports like ``from dango.config.exceptions import ConfigError``
+continue to work unchanged.
 """
 
+from dango.exceptions import (  # noqa: F401
+    ConfigError,
+    ConfigNotFoundError,
+    ConfigValidationError,
+    ProjectNotFoundError,
+)
 
-class ConfigError(Exception):
-    """Base exception for configuration errors"""
-
-    pass
-
-
-class ConfigNotFoundError(ConfigError):
-    """Configuration file not found"""
-
-    pass
-
-
-class ConfigValidationError(ConfigError):
-    """Configuration validation failed"""
-
-    pass
-
-
-class ProjectNotFoundError(ConfigError):
-    """Not in a Dango project directory"""
-
-    pass
+__all__ = [
+    "ConfigError",
+    "ConfigNotFoundError",
+    "ConfigValidationError",
+    "ProjectNotFoundError",
+]

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -22,6 +22,27 @@ from __future__ import annotations
 import os
 from typing import Any
 
+__all__ = [
+    "DangoError",
+    "ConfigError",
+    "ConfigNotFoundError",
+    "ConfigValidationError",
+    "ProjectNotFoundError",
+    "IngestionError",
+    "SyncTimeoutError",
+    "CSVSchemaMismatchError",
+    "InfrastructureError",
+    "DiskSpaceError",
+    "DuckDBHealthError",
+    "DbtLockError",
+    "ValidationError",
+    "InvalidSourceNameError",
+    "InvalidDateFormatError",
+    "InvalidPortError",
+    "WebAPIError",
+    "is_debug_mode",
+]
+
 # ---------------------------------------------------------------------------
 # Debug mode helper
 # ---------------------------------------------------------------------------
@@ -59,10 +80,14 @@ class DangoError(Exception):
         context: dict[str, Any] | None = None,
         user_message: str | None = None,
     ) -> None:
-        self.error_code: str = error_code or self._default_error_code
-        self.context: dict[str, Any] = context or {}
-        self.user_message: str = user_message or message
+        self.error_code: str = error_code if error_code is not None else self._default_error_code
+        self.context: dict[str, Any] = context if context is not None else {}
+        self.user_message: str = user_message if user_message is not None else message
         super().__init__(message)
+
+    def __repr__(self) -> str:
+        cls = type(self).__name__
+        return f"{cls}({str(self)!r}, error_code={self.error_code!r})"
 
 
 # ---------------------------------------------------------------------------

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -1,0 +1,207 @@
+"""dango/exceptions.py
+
+Unified exception hierarchy for all Dango modules.
+
+Every Dango exception inherits from ``DangoError`` and carries:
+
+- ``error_code``  — stable identifier (e.g. ``DANGO-C002``) for docs / logs
+- ``context``     — structured key/value dict for programmatic inspection
+- ``user_message``— human-readable message (defaults to the raw message)
+
+Subclasses define ``_default_error_code`` so that existing ``raise ConfigError("msg")``
+call sites work without passing ``error_code=`` explicitly.
+
+Debug mode
+----------
+Set ``DANGO_DEBUG=1`` (or ``true`` / ``yes``) to surface full stack traces in
+CLI error handlers. Checked via :func:`is_debug_mode`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Debug mode helper
+# ---------------------------------------------------------------------------
+
+
+def is_debug_mode() -> bool:
+    """Return True when ``DANGO_DEBUG`` is enabled (``1``, ``true``, or ``yes``)."""
+    return os.environ.get("DANGO_DEBUG", "").lower() in ("1", "true", "yes")
+
+
+# ---------------------------------------------------------------------------
+# Base exception
+# ---------------------------------------------------------------------------
+
+
+class DangoError(Exception):
+    """Root of the Dango exception hierarchy.
+
+    Args:
+        message: Human-readable error description.
+        error_code: Stable error identifier (e.g. ``DANGO-C002``).
+            Falls back to the class-level ``_default_error_code``.
+        context: Arbitrary key/value pairs for structured logging / API responses.
+        user_message: Simplified message safe to display to end-users.
+            Defaults to *message*.
+    """
+
+    _default_error_code: str = "DANGO-G000"
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        error_code: str | None = None,
+        context: dict[str, Any] | None = None,
+        user_message: str | None = None,
+    ) -> None:
+        self.error_code: str = error_code or self._default_error_code
+        self.context: dict[str, Any] = context or {}
+        self.user_message: str = user_message or message
+        super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Config exceptions  (DANGO-C***)
+# ---------------------------------------------------------------------------
+
+
+class ConfigError(DangoError):
+    """Base exception for configuration errors."""
+
+    _default_error_code = "DANGO-C001"
+
+
+class ConfigNotFoundError(ConfigError):
+    """Configuration file not found."""
+
+    _default_error_code = "DANGO-C002"
+
+
+class ConfigValidationError(ConfigError):
+    """Configuration validation failed."""
+
+    _default_error_code = "DANGO-C003"
+
+
+class ProjectNotFoundError(ConfigError):
+    """Not in a Dango project directory."""
+
+    _default_error_code = "DANGO-C004"
+
+
+# ---------------------------------------------------------------------------
+# Ingestion exceptions  (DANGO-I***)
+# ---------------------------------------------------------------------------
+
+
+class IngestionError(DangoError):
+    """Base exception for data ingestion errors."""
+
+    _default_error_code = "DANGO-I001"
+
+
+class SyncTimeoutError(IngestionError):
+    """Raised when a sync operation exceeds its timeout."""
+
+    _default_error_code = "DANGO-I002"
+
+
+class CSVSchemaMismatchError(IngestionError):
+    """Raised when a CSV file schema doesn't match the existing table schema."""
+
+    _default_error_code = "DANGO-I003"
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure / Utils exceptions  (DANGO-U***)
+# ---------------------------------------------------------------------------
+
+
+class InfrastructureError(DangoError):
+    """Base exception for infrastructure errors."""
+
+    _default_error_code = "DANGO-U001"
+
+
+class DiskSpaceError(InfrastructureError):
+    """Raised when disk space is insufficient."""
+
+    _default_error_code = "DANGO-U002"
+
+
+class DuckDBHealthError(InfrastructureError):
+    """Raised when a DuckDB health check fails."""
+
+    _default_error_code = "DANGO-U003"
+
+
+class DbtLockError(InfrastructureError):
+    """Raised when unable to acquire the dbt lock.
+
+    Preserves the ``lock_info`` keyword for backward compatibility with
+    existing callers in ``utils/dbt_lock.py``.
+    """
+
+    _default_error_code = "DANGO-U004"
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        lock_info: dict[str, Any] | None = None,
+        error_code: str | None = None,
+        context: dict[str, Any] | None = None,
+        user_message: str | None = None,
+    ) -> None:
+        self.lock_info = lock_info
+        super().__init__(
+            message,
+            error_code=error_code,
+            context=context,
+            user_message=user_message,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Validation exceptions  (DANGO-V***)
+# ---------------------------------------------------------------------------
+
+
+class ValidationError(DangoError):
+    """Base exception for input validation errors."""
+
+    _default_error_code = "DANGO-V001"
+
+
+class InvalidSourceNameError(ValidationError):
+    """Raised when a source name contains invalid characters."""
+
+    _default_error_code = "DANGO-V002"
+
+
+class InvalidDateFormatError(ValidationError):
+    """Raised when a date string does not match the expected format."""
+
+    _default_error_code = "DANGO-V003"
+
+
+class InvalidPortError(ValidationError):
+    """Raised when a port number is outside the valid range (1-65535)."""
+
+    _default_error_code = "DANGO-V004"
+
+
+# ---------------------------------------------------------------------------
+# Web exceptions  (DANGO-W***)
+# ---------------------------------------------------------------------------
+
+
+class WebAPIError(DangoError):
+    """Base exception for web API errors."""
+
+    _default_error_code = "DANGO-W001"

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -184,6 +184,12 @@ class DbtLockError(InfrastructureError):
         user_message: str | None = None,
     ) -> None:
         self.lock_info = lock_info
+        # Merge lock_info into context so it appears in API debug responses
+        if lock_info:
+            merged = dict(lock_info)
+            if context:
+                merged.update(context)
+            context = merged
         super().__init__(
             message,
             error_code=error_code,

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -9,8 +9,8 @@ Loads data into DuckDB from external sources via dlt pipelines and CSV files, wi
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports | `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
-| `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync`, `SyncTimeoutError` |
-| `csv_loader.py` | Incremental CSV loading with metadata tracking and 4 dedup strategies | `CSVLoader`, `CSVSchemaMismatchError` |
+| `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync` (imports `SyncTimeoutError` from `dango.exceptions`) |
+| `csv_loader.py` | Incremental CSV loading with metadata tracking and 4 dedup strategies | `CSVLoader` (imports `CSVSchemaMismatchError` from `dango.exceptions`) |
 | `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
 | `sources/registry.py` | Central registry of 33 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
 | `dlt_sources/` | Third-party dlt verified source implementations (27 directories, 105+ files) | DO NOT MODIFY — see "Don't Modify" section |

--- a/dango/ingestion/csv_loader.py
+++ b/dango/ingestion/csv_loader.py
@@ -13,14 +13,9 @@ import duckdb
 from rich.console import Console
 
 from dango.config.models import CSVSourceConfig
+from dango.exceptions import CSVSchemaMismatchError
 
 console = Console()
-
-
-class CSVSchemaMismatchError(Exception):
-    """Raised when CSV file schema doesn't match existing table schema"""
-
-    pass
 
 
 class CSVLoader:

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -166,8 +166,9 @@ class DltPipelineRunner:
         Returns:
             Dictionary with load statistics and status
         """
+        from dango.exceptions import DiskSpaceError
         from dango.utils.activity_log import log_activity
-        from dango.utils.db_health import DiskSpaceError, check_disk_space, check_duckdb_health
+        from dango.utils.db_health import check_disk_space, check_duckdb_health
         from dango.utils.sync_history import save_sync_history_entry
 
         source_name = source_config.name

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -21,16 +21,11 @@ from dango.config.models import (
     DataSource,
     SourceType,
 )
+from dango.exceptions import SyncTimeoutError
 from dango.ingestion.csv_loader import CSVLoader
 from dango.ingestion.sources.registry import get_source_metadata
 
 console = Console()
-
-
-class SyncTimeoutError(Exception):
-    """Raised when sync exceeds timeout"""
-
-    pass
 
 
 class DltPipelineRunner:

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -13,8 +13,8 @@ Shared utilities for process management, activity logging, sync history tracking
 | `activity_log.py` | JSONL activity logging to `.dango/logs/activity.jsonl` | `log_activity()`, `get_activity_log_file()` |
 | `sync_history.py` | Per-source sync history (JSON, last 100 entries) | `save_sync_history_entry()`, `load_sync_history()`, `get_sync_history_file()` |
 | `database.py` | DuckDB schema initialization (raw, staging, intermediate, marts) | `ensure_dbt_schemas()` |
-| `db_health.py` | Disk space checks and DuckDB health monitoring | `check_disk_space()`, `check_duckdb_health()`, `get_disk_usage_summary()`, `print_health_summary()`, `DiskSpaceError`, `DuckDBHealthError` |
-| `dbt_lock.py` | Cross-process file lock for dbt operations (fcntl/msvcrt) | `DbtLock`, `DbtLockError`, `dbt_lock()` context manager |
+| `db_health.py` | Disk space checks and DuckDB health monitoring | `check_disk_space()`, `check_duckdb_health()`, `get_disk_usage_summary()`, `print_health_summary()` (imports `DiskSpaceError`, `DuckDBHealthError` from `dango.exceptions`) |
+| `dbt_lock.py` | Cross-process file lock for dbt operations (fcntl/msvcrt) | `DbtLock`, `dbt_lock()` context manager (imports `DbtLockError` from `dango.exceptions`) |
 | `dbt_status.py` | Persistent dbt model status from run_results.json | `update_model_status()`, `get_model_statuses()` |
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -10,19 +10,9 @@ from typing import Any
 import duckdb
 from rich.console import Console
 
+from dango.exceptions import DiskSpaceError, DuckDBHealthError
+
 console = Console()
-
-
-class DiskSpaceError(Exception):
-    """Raised when disk space is insufficient"""
-
-    pass
-
-
-class DuckDBHealthError(Exception):
-    """Raised when DuckDB health check fails"""
-
-    pass
 
 
 def check_disk_space(project_root: Path, min_free_gb: int = 5) -> bool:

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -13,19 +13,13 @@ from typing import Any
 
 import psutil
 
+from dango.exceptions import DbtLockError
+
 # Platform-specific file locking
 if sys.platform == "win32":
     import msvcrt
 else:
     import fcntl
-
-
-class DbtLockError(Exception):
-    """Raised when unable to acquire dbt lock."""
-
-    def __init__(self, message: str, lock_info: dict[str, Any] | None = None):
-        super().__init__(message)
-        self.lock_info = lock_info
 
 
 class DbtLock:

--- a/dango/validation.py
+++ b/dango/validation.py
@@ -1,0 +1,143 @@
+"""dango/validation.py
+
+Input validation and sanitization utilities for Dango.
+
+All validators raise a specific ``ValidationError`` subclass from
+``dango.exceptions`` on failure, keeping validation logic separate from
+business logic.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from dango.exceptions import (
+    InvalidDateFormatError,
+    InvalidPortError,
+    InvalidSourceNameError,
+)
+
+# Matches the pattern in config/models.py DataSource.validate_name_format:
+# letters, numbers, underscores only.
+_SOURCE_NAME_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+_SOURCE_NAME_MAX_LEN = 128
+
+
+def validate_source_name(name: str) -> str:
+    """Validate a source name.
+
+    Must be 1-128 characters, containing only letters, digits, and underscores
+    (matching ``DataSource.validate_name_format`` in ``config/models.py``).
+
+    Args:
+        name: Source name to validate.
+
+    Returns:
+        The validated name (unchanged).
+
+    Raises:
+        InvalidSourceNameError: If the name is empty, too long, or contains
+            invalid characters.
+    """
+    if not name:
+        raise InvalidSourceNameError(
+            "Source name must not be empty.",
+            context={"name": name},
+        )
+    if len(name) > _SOURCE_NAME_MAX_LEN:
+        raise InvalidSourceNameError(
+            f"Source name must be at most {_SOURCE_NAME_MAX_LEN} characters (got {len(name)}).",
+            context={"name": name, "length": len(name)},
+        )
+    if not _SOURCE_NAME_RE.match(name):
+        raise InvalidSourceNameError(
+            f"Source name '{name}' is invalid. Use only letters, numbers, and underscores.",
+            context={"name": name},
+        )
+    return name
+
+
+def validate_date_string(value: str, fmt: str = "%Y-%m-%d") -> datetime:
+    """Parse and validate a date string.
+
+    Args:
+        value: Date string to validate (e.g. ``"2024-01-15"``).
+        fmt: Expected ``strftime`` format (default ``%Y-%m-%d``).
+
+    Returns:
+        Parsed ``datetime`` object.
+
+    Raises:
+        InvalidDateFormatError: If the string does not match *fmt*.
+    """
+    try:
+        return datetime.strptime(value, fmt)
+    except ValueError as exc:
+        raise InvalidDateFormatError(
+            f"Invalid date '{value}' — expected format '{fmt}'.",
+            context={"value": value, "format": fmt},
+        ) from exc
+
+
+def validate_port_range(port: int) -> int:
+    """Validate that *port* is in the range 1-65535.
+
+    Args:
+        port: Port number to validate.
+
+    Returns:
+        The validated port number.
+
+    Raises:
+        InvalidPortError: If the port is out of range.
+    """
+    if not isinstance(port, int) or isinstance(port, bool):
+        raise InvalidPortError(
+            f"Port must be an integer, got {type(port).__name__}.",
+            context={"port": port},
+        )
+    if port < 1 or port > 65535:
+        raise InvalidPortError(
+            f"Port {port} is out of range (must be 1-65535).",
+            context={"port": port},
+        )
+    return port
+
+
+def validate_limit(limit: int, max_val: int = 10000) -> int:
+    """Clamp *limit* to the range ``[1, max_val]``.
+
+    This is a graceful-degradation validator — it never raises, just clamps.
+
+    Args:
+        limit: Requested limit value.
+        max_val: Upper bound (default 10 000).
+
+    Returns:
+        Clamped limit value.
+    """
+    if not isinstance(limit, int) or isinstance(limit, bool):
+        return 1
+    return max(1, min(limit, max_val))
+
+
+def sanitize_path_component(name: str) -> str:
+    """Strip dangerous characters from a path component.
+
+    Removes ``/``, ``\\``, ``..``, and null bytes to prevent path-traversal
+    attacks when constructing file paths from user input.
+
+    Args:
+        name: Raw path component.
+
+    Returns:
+        Sanitized string safe for use as a single path component.
+    """
+    # Remove null bytes
+    name = name.replace("\x00", "")
+    # Remove path separators
+    name = name.replace("/", "").replace("\\", "")
+    # Remove parent-directory traversal
+    name = name.replace("..", "")
+    return name

--- a/dango/validation.py
+++ b/dango/validation.py
@@ -59,12 +59,12 @@ def validate_source_name(name: str) -> str:
     if len(name) > _SOURCE_NAME_MAX_LEN:
         raise InvalidSourceNameError(
             f"Source name must be at most {_SOURCE_NAME_MAX_LEN} characters (got {len(name)}).",
-            context={"name": name, "length": len(name)},
+            context={"name": name[:256], "length": len(name)},
         )
     if not _SOURCE_NAME_RE.match(name):
         raise InvalidSourceNameError(
-            f"Source name '{name}' is invalid. Use only letters, numbers, and underscores.",
-            context={"name": name},
+            f"Source name {name!r} is invalid. Use only letters, numbers, and underscores.",
+            context={"name": name[:256]},
         )
     return name.lower()
 
@@ -124,11 +124,12 @@ def validate_port_range(port: int) -> int:
 def validate_limit(limit: int, max_val: int = 10000) -> int:
     """Clamp *limit* to the range ``[1, max_val]``.
 
-    This is a graceful-degradation validator — it never raises, just clamps.
+    This is a graceful-degradation validator — it clamps rather than raising.
+    Non-integer *limit* values are silently treated as ``1``.
 
     Args:
         limit: Requested limit value.
-        max_val: Upper bound (default 10 000).
+        max_val: Upper bound (default 10 000).  Must be a positive ``int``.
 
     Returns:
         Clamped limit value.
@@ -141,9 +142,9 @@ def validate_limit(limit: int, max_val: int = 10000) -> int:
 def sanitize_path_component(name: str) -> str:
     """Sanitize a user-supplied filename for safe use as a single path component.
 
-    Uses a two-step approach: first strips the raw name down to its basename
-    (removing any directory components), then removes null bytes. The result
-    is guaranteed to be a flat filename with no directory traversal.
+    Strips null bytes and control characters, extracts the basename (removing
+    any directory components), and strips leading/trailing whitespace.  The
+    result is guaranteed to be a flat filename with no directory traversal.
 
     Args:
         name: Raw filename (e.g. from an HTTP upload).
@@ -154,14 +155,16 @@ def sanitize_path_component(name: str) -> str:
     """
     from pathlib import PurePosixPath
 
-    # Remove null bytes first
-    name = name.replace("\x00", "")
+    # Remove null bytes and control characters (U+0000–U+001F, U+007F)
+    name = "".join(ch for ch in name if ch == "\t" or (ch >= " " and ch != "\x7f"))
     # Extract just the filename (strips all directory components on both
     # POSIX and Windows-style paths)
     name = PurePosixPath(name).name
     # Also strip Windows backslash paths that PurePosixPath doesn't handle
     if "\\" in name:
         name = name.rsplit("\\", 1)[-1]
+    # Strip leading/trailing whitespace
+    name = name.strip()
     # Reject special directory names and empty results
     if not name or name in (".", ".."):
         return "unnamed"

--- a/dango/validation.py
+++ b/dango/validation.py
@@ -18,6 +18,15 @@ from dango.exceptions import (
     InvalidSourceNameError,
 )
 
+__all__ = [
+    "validate_source_name",
+    "validate_identifier",
+    "validate_date_string",
+    "validate_port_range",
+    "validate_limit",
+    "sanitize_path_component",
+]
+
 # Stricter than config/models.py's isalnum() check: ASCII-only letters,
 # digits, and underscores.  The model validator also lowercases; we do the
 # same here so validated names always match what the config stores.
@@ -153,7 +162,7 @@ def sanitize_path_component(name: str) -> str:
     # Also strip Windows backslash paths that PurePosixPath doesn't handle
     if "\\" in name:
         name = name.rsplit("\\", 1)[-1]
-    # Remove parent-directory traversal fragments
-    name = name.replace("..", "")
-    # Reject empty results
-    return name if name else "unnamed"
+    # Reject special directory names and empty results
+    if not name or name in (".", ".."):
+        return "unnamed"
+    return name

--- a/dango/validation.py
+++ b/dango/validation.py
@@ -18,23 +18,25 @@ from dango.exceptions import (
     InvalidSourceNameError,
 )
 
-# Matches the pattern in config/models.py DataSource.validate_name_format:
-# letters, numbers, underscores only.
+# Stricter than config/models.py's isalnum() check: ASCII-only letters,
+# digits, and underscores.  The model validator also lowercases; we do the
+# same here so validated names always match what the config stores.
 _SOURCE_NAME_RE = re.compile(r"^[a-zA-Z0-9_]+$")
 _SOURCE_NAME_MAX_LEN = 128
 
 
 def validate_source_name(name: str) -> str:
-    """Validate a source name.
+    """Validate and normalize a source / identifier name.
 
-    Must be 1-128 characters, containing only letters, digits, and underscores
-    (matching ``DataSource.validate_name_format`` in ``config/models.py``).
+    Must be 1-128 ASCII characters (letters, digits, underscores).
+    Returns the **lowercased** name to match the normalization performed by
+    ``DataSource.validate_name_format`` in ``config/models.py``.
 
     Args:
         name: Source name to validate.
 
     Returns:
-        The validated name (unchanged).
+        The validated, lowercased name.
 
     Raises:
         InvalidSourceNameError: If the name is empty, too long, or contains
@@ -55,7 +57,12 @@ def validate_source_name(name: str) -> str:
             f"Source name '{name}' is invalid. Use only letters, numbers, and underscores.",
             context={"name": name},
         )
-    return name
+    return name.lower()
+
+
+# Alias for use with dbt model names and other identifiers that follow the
+# same [a-zA-Z0-9_] pattern.
+validate_identifier = validate_source_name
 
 
 def validate_date_string(value: str, fmt: str = "%Y-%m-%d") -> datetime:
@@ -123,21 +130,30 @@ def validate_limit(limit: int, max_val: int = 10000) -> int:
 
 
 def sanitize_path_component(name: str) -> str:
-    """Strip dangerous characters from a path component.
+    """Sanitize a user-supplied filename for safe use as a single path component.
 
-    Removes ``/``, ``\\``, ``..``, and null bytes to prevent path-traversal
-    attacks when constructing file paths from user input.
+    Uses a two-step approach: first strips the raw name down to its basename
+    (removing any directory components), then removes null bytes. The result
+    is guaranteed to be a flat filename with no directory traversal.
 
     Args:
-        name: Raw path component.
+        name: Raw filename (e.g. from an HTTP upload).
 
     Returns:
-        Sanitized string safe for use as a single path component.
+        Sanitized filename.  Returns ``"unnamed"`` if the result would be
+        empty after sanitization.
     """
-    # Remove null bytes
+    from pathlib import PurePosixPath
+
+    # Remove null bytes first
     name = name.replace("\x00", "")
-    # Remove path separators
-    name = name.replace("/", "").replace("\\", "")
-    # Remove parent-directory traversal
+    # Extract just the filename (strips all directory components on both
+    # POSIX and Windows-style paths)
+    name = PurePosixPath(name).name
+    # Also strip Windows backslash paths that PurePosixPath doesn't handle
+    if "\\" in name:
+        name = name.rsplit("\\", 1)[-1]
+    # Remove parent-directory traversal fragments
     name = name.replace("..", "")
-    return name
+    # Reject empty results
+    return name if name else "unnamed"

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -8,7 +8,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `app.py` | Entry point: `create_app()`, middleware, router registration, lifecycle events | `create_app()`, `app` (global FastAPI instance) |
+| `app.py` | Entry point: `create_app()`, middleware, router registration, lifecycle events, global exception handlers (`DangoError` → structured JSON, generic `Exception` → 500) | `create_app()`, `app` (global FastAPI instance), `dango_error_handler()`, `unhandled_error_handler()` |
 | `models.py` | Pydantic request/response DTOs | `TableInfo`, `SourceStatus`, `ServiceHealth`, `SyncRequest`, `SyncResponse`, `LogEntry`, `WatcherStatus` |
 | `helpers.py` | Shared helpers: DuckDB queries, config loading, service health, logging | `get_project_root()`, `load_sources_config()`, `get_duckdb_path()`, `get_dbt_models()`, `mask_sensitive_config()`, `get_source_freshness()`, `append_log_entry()`, `load_all_logs()`, `check_service_status_async()`, `get_platform_health_data()`, `get_source_status_data()` |
 | `__init__.py` | Public exports | `app` module |

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -26,6 +26,7 @@ from dango.exceptions import (
     DbtLockError,
     DiskSpaceError,
     DuckDBHealthError,
+    InfrastructureError,
     IngestionError,
     ProjectNotFoundError,
     SyncTimeoutError,
@@ -100,10 +101,13 @@ _STATUS_MAP: dict[type[DangoError], int] = {
     DiskSpaceError: 503,
     DuckDBHealthError: 503,
     DbtLockError: 409,
+    InfrastructureError: 500,
     # Validation errors
     ValidationError: 400,
     # Web errors
     WebAPIError: 500,
+    # Explicit fallback (makes default status code visible in code)
+    DangoError: 500,
 }
 
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -8,18 +8,29 @@ exception handlers.
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.exception_handlers import http_exception_handler
+from fastapi.exception_handlers import (
+    http_exception_handler,
+    request_validation_exception_handler,
+)
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from dango.exceptions import (
+    ConfigError,
     ConfigNotFoundError,
     ConfigValidationError,
+    CSVSchemaMismatchError,
     DangoError,
     DbtLockError,
+    DiskSpaceError,
+    DuckDBHealthError,
+    IngestionError,
     ProjectNotFoundError,
+    SyncTimeoutError,
     ValidationError,
+    WebAPIError,
     is_debug_mode,
 )
 from dango.logging import get_logger
@@ -76,11 +87,23 @@ if static_dir.exists():
 
 # Map exception types to HTTP status codes
 _STATUS_MAP: dict[type[DangoError], int] = {
+    # Config errors
     ConfigNotFoundError: 404,
     ProjectNotFoundError: 404,
     ConfigValidationError: 422,
+    ConfigError: 500,
+    # Ingestion errors
+    CSVSchemaMismatchError: 422,
+    SyncTimeoutError: 504,
+    IngestionError: 500,
+    # Infrastructure errors
+    DiskSpaceError: 503,
+    DuckDBHealthError: 503,
     DbtLockError: 409,
+    # Validation errors
     ValidationError: 400,
+    # Web errors
+    WebAPIError: 500,
 }
 
 
@@ -105,11 +128,14 @@ async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse
 
 
 @app.exception_handler(Exception)
-async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
+async def unhandled_error_handler(request: Request, exc: Exception) -> Response:
     """Catch-all for unexpected exceptions (return generic 500)."""
     # Delegate HTTPExceptions to FastAPI's built-in handler
     if isinstance(exc, HTTPException):
         return await http_exception_handler(request, exc)
+    # Delegate Pydantic request validation errors to FastAPI's built-in handler
+    if isinstance(exc, RequestValidationError):
+        return await request_validation_exception_handler(request, exc)
 
     logger.error("unhandled_exception", path=request.url.path, error=str(exc), exc_info=True)
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -8,6 +8,7 @@ exception handlers.
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.exception_handlers import http_exception_handler
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -106,11 +107,11 @@ async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse
 @app.exception_handler(Exception)
 async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
     """Catch-all for unexpected exceptions (return generic 500)."""
-    # Let FastAPI handle its own HTTPExceptions (404s, 422 validation, etc.)
+    # Delegate HTTPExceptions to FastAPI's built-in handler
     if isinstance(exc, HTTPException):
-        raise exc
+        return await http_exception_handler(request, exc)
 
-    logger.error("unhandled_exception", path=request.url.path, error=str(exc), exc_info=exc)
+    logger.error("unhandled_exception", path=request.url.path, error=str(exc), exc_info=True)
 
     body: dict = {
         "error_code": "DANGO-G001",

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -1,21 +1,30 @@
 """dango/web/app.py
 
 FastAPI application entry point. Creates the app, registers middleware,
-mounts static files, and includes all route modules.
+mounts static files, includes all route modules, and installs global
+exception handlers.
 """
 
-import logging
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from dango.exceptions import (
+    ConfigNotFoundError,
+    ConfigValidationError,
+    DangoError,
+    DbtLockError,
+    ProjectNotFoundError,
+    ValidationError,
+    is_debug_mode,
+)
+from dango.logging import get_logger
 from dango.web.helpers import get_project_root
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def create_app(project_root: Path | None = None) -> FastAPI:
@@ -59,6 +68,60 @@ static_dir = Path(__file__).parent / "static"
 if static_dir.exists():
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
+
+# ---------------------------------------------------------------------------
+# Global exception handlers
+# ---------------------------------------------------------------------------
+
+# Map exception types to HTTP status codes
+_STATUS_MAP: dict[type[DangoError], int] = {
+    ConfigNotFoundError: 404,
+    ProjectNotFoundError: 404,
+    ConfigValidationError: 422,
+    DbtLockError: 409,
+    ValidationError: 400,
+}
+
+
+@app.exception_handler(DangoError)
+async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse:
+    """Return structured JSON for all DangoError subclasses."""
+    # Walk the MRO to find the most specific status code
+    status_code = 500
+    for cls in type(exc).__mro__:
+        if cls in _STATUS_MAP:
+            status_code = _STATUS_MAP[cls]
+            break
+
+    body: dict = {
+        "error_code": exc.error_code,
+        "message": exc.user_message,
+    }
+    if is_debug_mode() and exc.context:
+        body["detail"] = exc.context
+
+    return JSONResponse(status_code=status_code, content=body)
+
+
+@app.exception_handler(Exception)
+async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Catch-all for unexpected exceptions (return generic 500)."""
+    # Let FastAPI handle its own HTTPExceptions (404s, 422 validation, etc.)
+    if isinstance(exc, HTTPException):
+        raise exc
+
+    logger.error("unhandled_exception", path=request.url.path, error=str(exc), exc_info=exc)
+
+    body: dict = {
+        "error_code": "DANGO-G001",
+        "message": "An internal error occurred.",
+    }
+    if is_debug_mode():
+        body["detail"] = str(exc)
+
+    return JSONResponse(status_code=500, content=body)
+
+
 # ---------------------------------------------------------------------------
 # Register routers — Dango API routes first, then proxy routes (catch-all last)
 # ---------------------------------------------------------------------------
@@ -92,14 +155,13 @@ app.include_router(metabase_proxy_router)
 @app.on_event("startup")
 async def startup_event():
     """Run on application startup."""
-    logger.info("Dango Web API starting up...")
-    logger.info(f"Project root: {get_project_root()}")
+    logger.info("api_starting", project_root=str(get_project_root()))
 
 
 @app.on_event("shutdown")
 async def shutdown_event():
     """Run on application shutdown."""
-    logger.info("Dango Web API shutting down...")
+    logger.info("api_shutting_down")
 
 
 if __name__ == "__main__":

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -14,7 +14,7 @@ import httpx
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import Response
 
-from dango.validation import validate_source_name
+from dango.validation import validate_identifier
 from dango.web.helpers import get_dbt_manifest, get_dbt_models, get_project_root
 from dango.web.routes.websocket import ws_manager
 
@@ -49,7 +49,7 @@ async def run_dbt_model(model_name: str, background_tasks: BackgroundTasks, casc
     Returns:
         Success message
     """
-    validate_source_name(model_name)
+    validate_identifier(model_name)
     # Check if model exists (use manifest only, avoid DuckDB query which can block)
     manifest = get_dbt_manifest()
     if manifest:

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -14,6 +14,7 @@ import httpx
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from fastapi.responses import Response
 
+from dango.validation import validate_source_name
 from dango.web.helpers import get_dbt_manifest, get_dbt_models, get_project_root
 from dango.web.routes.websocket import ws_manager
 
@@ -48,6 +49,7 @@ async def run_dbt_model(model_name: str, background_tasks: BackgroundTasks, casc
     Returns:
         Success message
     """
+    validate_source_name(model_name)
     # Check if model exists (use manifest only, avoid DuckDB query which can block)
     manifest = get_dbt_manifest()
     if manifest:

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -35,7 +35,7 @@ async def list_dbt_models():
         return {"models": models}
     except Exception as e:
         logger.error(f"Error fetching dbt models: {e}")
-        raise HTTPException(status_code=500, detail=f"Error fetching dbt models: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Error fetching dbt models") from e
 
 
 @router.post("/api/dbt/models/{model_name}/run")
@@ -95,6 +95,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool):
     dbt_dir = project_root / "dbt"
 
     # Try to acquire lock before running dbt
+    lock = None
     try:
         lock = DbtLock(
             project_root=project_root,
@@ -228,8 +229,11 @@ async def run_dbt_model_task(model_name: str, cascade: bool):
             }
         )
     finally:
-        # Always release the lock
-        lock.release()
+        if lock is not None:
+            try:
+                lock.release()
+            except Exception:
+                pass
 
 
 # ==============================================================================
@@ -263,7 +267,7 @@ async def dbt_docs_assets(request: Request):
             )
     except Exception as e:
         logger.error(f"dbt docs asset proxy error: {e}")
-        return Response(content=f"Asset not found: {str(e)}", status_code=404)
+        return Response(content="Asset not found", status_code=404)
 
 
 @router.api_route("/dbt-docs/{path:path}", methods=["GET"])
@@ -312,4 +316,4 @@ async def dbt_docs_proxy(request: Request, path: str = ""):
 
     except Exception as e:
         logger.error(f"dbt docs proxy error: {e}")
-        return Response(content=f"Proxy error: {str(e)}", status_code=502)
+        return Response(content="Proxy error", status_code=502)

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -49,7 +49,7 @@ async def run_dbt_model(model_name: str, background_tasks: BackgroundTasks, casc
     Returns:
         Success message
     """
-    validate_identifier(model_name)
+    model_name = validate_identifier(model_name)
     # Check if model exists (use manifest only, avoid DuckDB query which can block)
     manifest = get_dbt_manifest()
     if manifest:

--- a/dango/web/routes/logs.py
+++ b/dango/web/routes/logs.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException
 
+from dango.validation import validate_limit, validate_source_name
 from dango.web.helpers import get_project_root, load_all_logs
 from dango.web.models import LogEntry
 
@@ -27,6 +28,8 @@ async def get_source_logs(source_name: str, limit: int = 100):
     Returns:
         List of log entries
     """
+    validate_source_name(source_name)
+    limit = validate_limit(limit)
     log_file = get_project_root() / "logs" / f"{source_name}_sync.log"
 
     if not log_file.exists():
@@ -68,6 +71,7 @@ async def get_all_logs(limit: int = 1000):
     Returns:
         List of all log entries
     """
+    limit = validate_limit(limit)
     try:
         logs = load_all_logs(limit=limit)
         return logs

--- a/dango/web/routes/logs.py
+++ b/dango/web/routes/logs.py
@@ -28,7 +28,7 @@ async def get_source_logs(source_name: str, limit: int = 100):
     Returns:
         List of log entries
     """
-    validate_source_name(source_name)
+    source_name = validate_source_name(source_name)
     limit = validate_limit(limit)
     log_file = get_project_root() / "logs" / f"{source_name}_sync.log"
 

--- a/dango/web/routes/logs.py
+++ b/dango/web/routes/logs.py
@@ -58,7 +58,7 @@ async def get_source_logs(source_name: str, limit: int = 100):
 
     except Exception as e:
         logger.error(f"Error reading logs for {source_name}: {e}")
-        raise HTTPException(status_code=500, detail=f"Error reading logs: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Error reading logs") from e
 
 
 @router.get("/api/logs")
@@ -77,4 +77,4 @@ async def get_all_logs(limit: int = 1000):
         return logs
     except Exception as e:
         logger.error(f"Error fetching logs: {e}")
-        raise HTTPException(status_code=500, detail=f"Error fetching logs: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Error fetching logs") from e

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -55,7 +55,7 @@ async def get_source_details(source_name: str):
     Returns:
         Source configuration (masked) and sync history
     """
-    validate_source_name(source_name)
+    source_name = validate_source_name(source_name)
     sources_config = load_sources_config()
 
     # Find the source

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -8,6 +8,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
+from dango.validation import validate_source_name
 from dango.web.helpers import (
     get_source_freshness,
     get_source_row_count,
@@ -54,6 +55,7 @@ async def get_source_details(source_name: str):
     Returns:
         Source configuration (masked) and sync history
     """
+    validate_source_name(source_name)
     sources_config = load_sources_config()
 
     # Find the source

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -56,7 +56,7 @@ async def get_source_details(source_name: str):
         Source configuration (masked) and sync history
     """
     source_name = validate_source_name(source_name)
-    sources_config = load_sources_config()
+    sources_config = await asyncio.to_thread(load_sources_config)
 
     # Find the source
     source_config = None

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 
+from dango.validation import validate_date_string, validate_source_name
 from dango.web.helpers import (
     append_log_entry,
     get_project_root,
@@ -37,6 +38,12 @@ async def trigger_sync(
     Returns:
         Sync response with status
     """
+    validate_source_name(source_name)
+    if sync_request.start_date:
+        validate_date_string(sync_request.start_date)
+    if sync_request.end_date:
+        validate_date_string(sync_request.end_date)
+
     # Verify source exists
     sources_config = load_sources_config()
     source_exists = any(s.get("name") == source_name for s in sources_config)

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -151,13 +151,11 @@ async def run_sync_task(
 
         # Use the same run_sync function as CLI for consistent behavior
         # This ensures: data load -> dbt run -> docs generation -> Metabase sync
-        from datetime import datetime as dt
-
         from dango.ingestion import run_sync
 
-        # Parse dates if provided
-        start_date_obj = dt.strptime(start_date, "%Y-%m-%d") if start_date else None
-        end_date_obj = dt.strptime(end_date, "%Y-%m-%d") if end_date else None
+        # Parse dates if provided (validate_date_string raises InvalidDateFormatError)
+        start_date_obj = validate_date_string(start_date) if start_date else None
+        end_date_obj = validate_date_string(end_date) if end_date else None
 
         # Log before running sync
         append_log_entry(

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -38,7 +38,7 @@ async def trigger_sync(
     Returns:
         Sync response with status
     """
-    validate_source_name(source_name)
+    source_name = validate_source_name(source_name)
     if sync_request.start_date:
         validate_date_string(sync_request.start_date)
     if sync_request.end_date:

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -90,6 +90,7 @@ async def run_sync_task(
     project_root = get_project_root()
 
     # Try to acquire lock before running sync (which includes dbt)
+    lock = None
     try:
         lock = DbtLock(
             project_root=project_root,
@@ -340,5 +341,8 @@ async def run_sync_task(
             }
         )
     finally:
-        # Always release the lock
-        lock.release()
+        if lock is not None:
+            try:
+                lock.release()
+            except Exception:
+                pass

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -15,7 +15,7 @@ import duckdb
 import yaml
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, UploadFile
 
-from dango.validation import validate_source_name
+from dango.validation import sanitize_path_component, validate_source_name
 from dango.web.helpers import (
     append_log_entry,
     get_duckdb_path,
@@ -99,12 +99,18 @@ async def upload_csv_to_source(
         # Create data directory if it doesn't exist
         data_dir.mkdir(parents=True, exist_ok=True)
 
+        # Sanitize the uploaded filename to prevent directory traversal
+        safe_filename = sanitize_path_component(file.filename or "unnamed")
+
         # Check if file already exists
-        file_path = data_dir / file.filename
+        file_path = data_dir / safe_filename
+        # Defense-in-depth: ensure resolved path stays within data_dir
+        if not file_path.resolve().is_relative_to(data_dir.resolve()):
+            raise HTTPException(status_code=400, detail="Invalid filename.")
         if file_path.exists():
             raise HTTPException(
                 status_code=409,
-                detail=f"File '{file.filename}' already exists. Delete the existing file first or rename your file.",
+                detail=f"File '{safe_filename}' already exists. Delete the existing file first or rename your file.",
             )
         async with aiofiles.open(file_path, "wb") as buffer:
             content = await file.read()
@@ -117,7 +123,7 @@ async def upload_csv_to_source(
             {
                 "event": "csv_uploaded",
                 "source": source_name,
-                "message": f"CSV file {file.filename} uploaded to {source_name}",
+                "message": f"CSV file {safe_filename} uploaded to {source_name}",
                 "timestamp": datetime.now().isoformat(),
             }
         )

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -15,6 +15,7 @@ import duckdb
 import yaml
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, UploadFile
 
+from dango.validation import validate_source_name
 from dango.web.helpers import (
     append_log_entry,
     get_duckdb_path,
@@ -51,6 +52,7 @@ async def upload_csv_to_source(
     Returns:
         Success message and file info
     """
+    validate_source_name(source_name)
     try:
         import aiofiles
 
@@ -154,6 +156,7 @@ async def get_csv_files(source_name: str):
     Returns:
         List of files with their status (on_disk, loaded, both)
     """
+    validate_source_name(source_name)
     try:
         project_root = get_project_root()
 
@@ -318,6 +321,7 @@ async def delete_csv_file(
     Returns:
         Success message with deletion details
     """
+    validate_source_name(source_name)
     logger.info(
         f"DELETE ENDPOINT CALLED - VERSION 2025-11-04-v2 - source: {source_name}, file: {file_path}"
     )

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -137,11 +137,10 @@ async def upload_csv_to_source(
 
         return {
             "success": True,
-            "message": f"CSV uploaded successfully: {file.filename}"
+            "message": f"CSV uploaded successfully: {safe_filename}"
             + (" - Sync started." if trigger_sync else ""),
             "source_name": source_name,
-            "file_path": str(file_path),
-            "file_name": file.filename,
+            "file_name": safe_filename,
             "auto_sync": trigger_sync,
         }
 
@@ -149,7 +148,7 @@ async def upload_csv_to_source(
         raise
     except Exception as e:
         logger.error(f"Error uploading CSV: {e}")
-        raise HTTPException(status_code=500, detail=f"Upload failed: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Upload failed") from e
 
 
 @router.get("/api/sources/{source_name}/csv-files")
@@ -306,7 +305,7 @@ async def get_csv_files(source_name: str):
         raise
     except Exception as e:
         logger.error(f"Error getting CSV files: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get CSV files: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to get CSV files") from e
 
 
 @router.delete("/api/sources/{source_name}/csv-files")
@@ -401,7 +400,7 @@ async def delete_csv_file(
             logger.info(f"Tables in database: {all_tables}")
 
             # Delete rows for this file from raw table (if table exists)
-            target_table = f"raw.{source_name}"
+            target_table = f'"raw"."{source_name}"'
             logger.info(f"Deleting from {target_table} WHERE _dango_filename = '{filename}'")
 
             # Check if table exists first
@@ -507,7 +506,7 @@ async def delete_csv_file(
     except Exception as e:
         logger.error(f"UNEXPECTED ERROR deleting CSV file: {type(e).__name__}: {str(e)}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        raise HTTPException(status_code=500, detail=f"Failed to delete file: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to delete file") from e
 
 
 async def run_dbt_after_delete(source_name: str):
@@ -523,6 +522,7 @@ async def run_dbt_after_delete(source_name: str):
     project_root = get_project_root()
 
     # Try to acquire lock before running dbt
+    lock = None
     try:
         lock = DbtLock(
             project_root=project_root,
@@ -673,5 +673,8 @@ async def run_dbt_after_delete(source_name: str):
         }
         save_sync_history_entry(source_name, history_entry)
     finally:
-        # Always release the lock
-        lock.release()
+        if lock is not None:
+            try:
+                lock.release()
+            except Exception:
+                pass

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -52,7 +52,7 @@ async def upload_csv_to_source(
     Returns:
         Success message and file info
     """
-    validate_source_name(source_name)
+    source_name = validate_source_name(source_name)
     try:
         import aiofiles
 
@@ -162,7 +162,7 @@ async def get_csv_files(source_name: str):
     Returns:
         List of files with their status (on_disk, loaded, both)
     """
-    validate_source_name(source_name)
+    source_name = validate_source_name(source_name)
     try:
         project_root = get_project_root()
 
@@ -327,7 +327,7 @@ async def delete_csv_file(
     Returns:
         Success message with deletion details
     """
-    validate_source_name(source_name)
+    source_name = validate_source_name(source_name)
     logger.info(
         f"DELETE ENDPOINT CALLED - VERSION 2025-11-04-v2 - source: {source_name}, file: {file_path}"
     )

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -84,7 +84,7 @@ async def upload_csv_to_source(
             )
 
         # Validate file type
-        if not file.filename.endswith(".csv"):
+        if not file.filename or not file.filename.endswith(".csv"):
             raise HTTPException(status_code=400, detail="Only CSV files are supported")
 
         # Get directory from source config
@@ -406,10 +406,13 @@ async def delete_csv_file(
 
             # Check if table exists first
             table_exists = (
-                conn.execute(f"""
-                SELECT COUNT(*) FROM information_schema.tables
-                WHERE table_schema = 'raw' AND table_name = '{source_name}'
-            """).fetchone()[0]
+                conn.execute(
+                    """
+                    SELECT COUNT(*) FROM information_schema.tables
+                    WHERE table_schema = 'raw' AND table_name = ?
+                    """,
+                    [source_name],
+                ).fetchone()[0]
                 > 0
             )
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -177,7 +177,20 @@ class TestDbtLockErrorCompat:
     def test_lock_info_with_context(self):
         exc = DbtLockError("locked", lock_info={"pid": 1}, context={"op": "sync"})
         assert exc.lock_info == {"pid": 1}
-        assert exc.context == {"op": "sync"}
+        # lock_info is merged into context; explicit context keys take precedence
+        assert exc.context == {"pid": 1, "op": "sync"}
+
+    def test_lock_info_merged_into_context(self):
+        info = {"pid": 123, "source": "cli", "operation": "sync"}
+        exc = DbtLockError("locked", lock_info=info)
+        # lock_info keys appear in context for API debug responses
+        assert exc.context["pid"] == 123
+        assert exc.context["source"] == "cli"
+
+    def test_lock_info_none_context_empty(self):
+        exc = DbtLockError("locked")
+        assert exc.lock_info is None
+        assert exc.context == {}
 
 
 @pytest.mark.unit

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -61,6 +61,19 @@ class TestDangoErrorBase:
         assert str(exc) == ""
         assert exc.user_message == ""
 
+    def test_catchable_as_exception(self):
+        exc = DangoError("test")
+        assert isinstance(exc, Exception)
+
+    def test_repr(self):
+        exc = DangoError("oops", error_code="DANGO-X001")
+        assert repr(exc) == "DangoError('oops', error_code='DANGO-X001')"
+
+    def test_explicit_empty_user_message(self):
+        exc = DangoError("internal", user_message="")
+        assert exc.user_message == ""
+        assert str(exc) == "internal"
+
 
 @pytest.mark.unit
 class TestExceptionHierarchy:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,230 @@
+"""tests/unit/test_exceptions.py
+
+Tests for the unified exception hierarchy in dango/exceptions.py.
+"""
+
+import pytest
+
+from dango.exceptions import (
+    ConfigError,
+    ConfigNotFoundError,
+    ConfigValidationError,
+    CSVSchemaMismatchError,
+    DangoError,
+    DbtLockError,
+    DiskSpaceError,
+    DuckDBHealthError,
+    InfrastructureError,
+    IngestionError,
+    InvalidDateFormatError,
+    InvalidPortError,
+    InvalidSourceNameError,
+    ProjectNotFoundError,
+    SyncTimeoutError,
+    ValidationError,
+    WebAPIError,
+    is_debug_mode,
+)
+
+
+@pytest.mark.unit
+class TestDangoErrorBase:
+    """Tests for DangoError base class."""
+
+    def test_basic_construction(self):
+        exc = DangoError("something broke")
+        assert str(exc) == "something broke"
+        assert exc.error_code == "DANGO-G000"
+        assert exc.context == {}
+        assert exc.user_message == "something broke"
+
+    def test_explicit_error_code(self):
+        exc = DangoError("oops", error_code="DANGO-X999")
+        assert exc.error_code == "DANGO-X999"
+
+    def test_context_dict(self):
+        ctx = {"path": "/tmp/test", "size": 42}
+        exc = DangoError("fail", context=ctx)
+        assert exc.context == ctx
+
+    def test_user_message_override(self):
+        exc = DangoError("internal detail", user_message="Something went wrong.")
+        assert exc.user_message == "Something went wrong."
+        assert str(exc) == "internal detail"
+
+    def test_user_message_defaults_to_message(self):
+        exc = DangoError("the message")
+        assert exc.user_message == "the message"
+
+    def test_empty_message(self):
+        exc = DangoError()
+        assert str(exc) == ""
+        assert exc.user_message == ""
+
+
+@pytest.mark.unit
+class TestExceptionHierarchy:
+    """Tests for inheritance relationships."""
+
+    @pytest.mark.parametrize(
+        "exc_class",
+        [
+            ConfigError,
+            ConfigNotFoundError,
+            ConfigValidationError,
+            ProjectNotFoundError,
+            IngestionError,
+            SyncTimeoutError,
+            CSVSchemaMismatchError,
+            InfrastructureError,
+            DiskSpaceError,
+            DuckDBHealthError,
+            DbtLockError,
+            ValidationError,
+            InvalidSourceNameError,
+            InvalidDateFormatError,
+            InvalidPortError,
+            WebAPIError,
+        ],
+    )
+    def test_all_inherit_from_dango_error(self, exc_class):
+        assert issubclass(exc_class, DangoError)
+        exc = exc_class("test")
+        assert isinstance(exc, DangoError)
+
+    def test_config_hierarchy(self):
+        assert issubclass(ConfigNotFoundError, ConfigError)
+        assert issubclass(ConfigValidationError, ConfigError)
+        assert issubclass(ProjectNotFoundError, ConfigError)
+
+    def test_ingestion_hierarchy(self):
+        assert issubclass(SyncTimeoutError, IngestionError)
+        assert issubclass(CSVSchemaMismatchError, IngestionError)
+
+    def test_infrastructure_hierarchy(self):
+        assert issubclass(DiskSpaceError, InfrastructureError)
+        assert issubclass(DuckDBHealthError, InfrastructureError)
+        assert issubclass(DbtLockError, InfrastructureError)
+
+    def test_validation_hierarchy(self):
+        assert issubclass(InvalidSourceNameError, ValidationError)
+        assert issubclass(InvalidDateFormatError, ValidationError)
+        assert issubclass(InvalidPortError, ValidationError)
+
+
+@pytest.mark.unit
+class TestDefaultErrorCodes:
+    """Tests for _default_error_code class attributes."""
+
+    @pytest.mark.parametrize(
+        ("exc_class", "expected_code"),
+        [
+            (DangoError, "DANGO-G000"),
+            (ConfigError, "DANGO-C001"),
+            (ConfigNotFoundError, "DANGO-C002"),
+            (ConfigValidationError, "DANGO-C003"),
+            (ProjectNotFoundError, "DANGO-C004"),
+            (IngestionError, "DANGO-I001"),
+            (SyncTimeoutError, "DANGO-I002"),
+            (CSVSchemaMismatchError, "DANGO-I003"),
+            (InfrastructureError, "DANGO-U001"),
+            (DiskSpaceError, "DANGO-U002"),
+            (DuckDBHealthError, "DANGO-U003"),
+            (DbtLockError, "DANGO-U004"),
+            (ValidationError, "DANGO-V001"),
+            (InvalidSourceNameError, "DANGO-V002"),
+            (InvalidDateFormatError, "DANGO-V003"),
+            (InvalidPortError, "DANGO-V004"),
+            (WebAPIError, "DANGO-W001"),
+        ],
+    )
+    def test_default_error_code(self, exc_class, expected_code):
+        exc = exc_class("test")
+        assert exc.error_code == expected_code
+
+    def test_explicit_code_overrides_default(self):
+        exc = ConfigError("test", error_code="DANGO-C999")
+        assert exc.error_code == "DANGO-C999"
+
+
+@pytest.mark.unit
+class TestDbtLockErrorCompat:
+    """Tests for DbtLockError backward compatibility."""
+
+    def test_lock_info_param(self):
+        info = {"pid": 123, "source": "cli"}
+        exc = DbtLockError("locked", lock_info=info)
+        assert exc.lock_info == info
+        assert exc.error_code == "DANGO-U004"
+
+    def test_lock_info_defaults_to_none(self):
+        exc = DbtLockError("locked")
+        assert exc.lock_info is None
+
+    def test_lock_info_with_context(self):
+        exc = DbtLockError("locked", lock_info={"pid": 1}, context={"op": "sync"})
+        assert exc.lock_info == {"pid": 1}
+        assert exc.context == {"op": "sync"}
+
+
+@pytest.mark.unit
+class TestIsDebugMode:
+    """Tests for is_debug_mode() function."""
+
+    def test_not_set(self, monkeypatch):
+        monkeypatch.delenv("DANGO_DEBUG", raising=False)
+        assert is_debug_mode() is False
+
+    def test_set_to_1(self, monkeypatch):
+        monkeypatch.setenv("DANGO_DEBUG", "1")
+        assert is_debug_mode() is True
+
+    def test_set_to_true(self, monkeypatch):
+        monkeypatch.setenv("DANGO_DEBUG", "true")
+        assert is_debug_mode() is True
+
+    def test_set_to_yes(self, monkeypatch):
+        monkeypatch.setenv("DANGO_DEBUG", "yes")
+        assert is_debug_mode() is True
+
+    def test_set_to_TRUE_uppercase(self, monkeypatch):
+        monkeypatch.setenv("DANGO_DEBUG", "TRUE")
+        assert is_debug_mode() is True
+
+    def test_set_to_0(self, monkeypatch):
+        monkeypatch.setenv("DANGO_DEBUG", "0")
+        assert is_debug_mode() is False
+
+    def test_set_to_empty(self, monkeypatch):
+        monkeypatch.setenv("DANGO_DEBUG", "")
+        assert is_debug_mode() is False
+
+    def test_set_to_random_string(self, monkeypatch):
+        monkeypatch.setenv("DANGO_DEBUG", "maybe")
+        assert is_debug_mode() is False
+
+
+@pytest.mark.unit
+class TestBackwardCompatImports:
+    """Tests that re-export shims return the same class objects."""
+
+    def test_config_exceptions_reexport(self):
+        from dango.config.exceptions import ConfigError as CE1
+        from dango.config.exceptions import ConfigNotFoundError as CNFE1
+        from dango.config.exceptions import ConfigValidationError as CVE1
+        from dango.config.exceptions import ProjectNotFoundError as PNFE1
+
+        assert CE1 is ConfigError
+        assert CNFE1 is ConfigNotFoundError
+        assert CVE1 is ConfigValidationError
+        assert PNFE1 is ProjectNotFoundError
+
+    def test_utils_dbt_lock_reexport(self):
+        from dango.utils.dbt_lock import DbtLockError as DLE1
+
+        assert DLE1 is DbtLockError
+
+    def test_utils_init_reexport(self):
+        from dango.utils import DbtLockError as DLE2
+
+        assert DLE2 is DbtLockError

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,0 +1,194 @@
+"""tests/unit/test_validation.py
+
+Tests for input validation utilities in dango/validation.py.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from dango.exceptions import (
+    InvalidDateFormatError,
+    InvalidPortError,
+    InvalidSourceNameError,
+)
+from dango.validation import (
+    sanitize_path_component,
+    validate_date_string,
+    validate_limit,
+    validate_port_range,
+    validate_source_name,
+)
+
+
+@pytest.mark.unit
+class TestValidateSourceName:
+    """Tests for validate_source_name()."""
+
+    def test_valid_lowercase(self):
+        assert validate_source_name("my_source") == "my_source"
+
+    def test_valid_uppercase(self):
+        assert validate_source_name("MySource") == "MySource"
+
+    def test_valid_with_numbers(self):
+        assert validate_source_name("source_123") == "source_123"
+
+    def test_valid_single_char(self):
+        assert validate_source_name("s") == "s"
+
+    def test_valid_underscores(self):
+        assert validate_source_name("my__source") == "my__source"
+
+    def test_empty_string(self):
+        with pytest.raises(InvalidSourceNameError, match="must not be empty"):
+            validate_source_name("")
+
+    def test_hyphens_rejected(self):
+        with pytest.raises(InvalidSourceNameError, match="invalid"):
+            validate_source_name("my-source")
+
+    def test_spaces_rejected(self):
+        with pytest.raises(InvalidSourceNameError, match="invalid"):
+            validate_source_name("my source")
+
+    def test_dots_rejected(self):
+        with pytest.raises(InvalidSourceNameError, match="invalid"):
+            validate_source_name("my.source")
+
+    def test_path_traversal_rejected(self):
+        with pytest.raises(InvalidSourceNameError, match="invalid"):
+            validate_source_name("../etc/passwd")
+
+    def test_slash_rejected(self):
+        with pytest.raises(InvalidSourceNameError, match="invalid"):
+            validate_source_name("source/name")
+
+    def test_too_long(self):
+        name = "a" * 129
+        with pytest.raises(InvalidSourceNameError, match="at most 128"):
+            validate_source_name(name)
+
+    def test_max_length_ok(self):
+        name = "a" * 128
+        assert validate_source_name(name) == name
+
+
+@pytest.mark.unit
+class TestValidateDateString:
+    """Tests for validate_date_string()."""
+
+    def test_valid_date(self):
+        result = validate_date_string("2024-01-15")
+        assert isinstance(result, datetime)
+        assert result.year == 2024
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_invalid_format(self):
+        with pytest.raises(InvalidDateFormatError, match="Invalid date"):
+            validate_date_string("15/01/2024")
+
+    def test_invalid_date(self):
+        with pytest.raises(InvalidDateFormatError, match="Invalid date"):
+            validate_date_string("2024-13-45")
+
+    def test_empty_string(self):
+        with pytest.raises(InvalidDateFormatError, match="Invalid date"):
+            validate_date_string("")
+
+    def test_custom_format(self):
+        result = validate_date_string("15/01/2024", fmt="%d/%m/%Y")
+        assert result.day == 15
+        assert result.month == 1
+
+    def test_preserves_original_chain(self):
+        with pytest.raises(InvalidDateFormatError) as exc_info:
+            validate_date_string("not-a-date")
+        assert exc_info.value.__cause__ is not None  # chained from ValueError
+
+
+@pytest.mark.unit
+class TestValidatePortRange:
+    """Tests for validate_port_range()."""
+
+    def test_valid_port(self):
+        assert validate_port_range(8080) == 8080
+
+    def test_min_port(self):
+        assert validate_port_range(1) == 1
+
+    def test_max_port(self):
+        assert validate_port_range(65535) == 65535
+
+    def test_zero_rejected(self):
+        with pytest.raises(InvalidPortError, match="out of range"):
+            validate_port_range(0)
+
+    def test_negative_rejected(self):
+        with pytest.raises(InvalidPortError, match="out of range"):
+            validate_port_range(-1)
+
+    def test_too_high(self):
+        with pytest.raises(InvalidPortError, match="out of range"):
+            validate_port_range(65536)
+
+    def test_non_int_rejected(self):
+        with pytest.raises(InvalidPortError, match="integer"):
+            validate_port_range("8080")  # type: ignore[arg-type]
+
+    def test_bool_rejected(self):
+        with pytest.raises(InvalidPortError, match="integer"):
+            validate_port_range(True)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestValidateLimit:
+    """Tests for validate_limit()."""
+
+    def test_normal_value(self):
+        assert validate_limit(100) == 100
+
+    def test_clamp_to_max(self):
+        assert validate_limit(20000) == 10000
+
+    def test_clamp_to_min(self):
+        assert validate_limit(0) == 1
+
+    def test_negative(self):
+        assert validate_limit(-5) == 1
+
+    def test_custom_max(self):
+        assert validate_limit(500, max_val=200) == 200
+
+    def test_non_int_returns_1(self):
+        assert validate_limit("100") == 1  # type: ignore[arg-type]
+
+    def test_bool_returns_1(self):
+        assert validate_limit(True) == 1  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestSanitizePathComponent:
+    """Tests for sanitize_path_component()."""
+
+    def test_clean_name(self):
+        assert sanitize_path_component("my_source") == "my_source"
+
+    def test_removes_slashes(self):
+        assert sanitize_path_component("foo/bar") == "foobar"
+
+    def test_removes_backslashes(self):
+        assert sanitize_path_component("foo\\bar") == "foobar"
+
+    def test_removes_dot_dot(self):
+        assert sanitize_path_component("../etc") == "etc"
+
+    def test_removes_null_bytes(self):
+        assert sanitize_path_component("foo\x00bar") == "foobar"
+
+    def test_multiple_traversals(self):
+        assert sanitize_path_component("../../etc/passwd") == "etcpasswd"
+
+    def test_empty_string(self):
+        assert sanitize_path_component("") == ""

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -15,6 +15,7 @@ from dango.exceptions import (
 from dango.validation import (
     sanitize_path_component,
     validate_date_string,
+    validate_identifier,
     validate_limit,
     validate_port_range,
     validate_source_name,
@@ -28,8 +29,8 @@ class TestValidateSourceName:
     def test_valid_lowercase(self):
         assert validate_source_name("my_source") == "my_source"
 
-    def test_valid_uppercase(self):
-        assert validate_source_name("MySource") == "MySource"
+    def test_valid_uppercase_normalized(self):
+        assert validate_source_name("MySource") == "mysource"
 
     def test_valid_with_numbers(self):
         assert validate_source_name("source_123") == "source_123"
@@ -39,6 +40,12 @@ class TestValidateSourceName:
 
     def test_valid_underscores(self):
         assert validate_source_name("my__source") == "my__source"
+
+    def test_numeric_only(self):
+        assert validate_source_name("123") == "123"
+
+    def test_underscore_only(self):
+        assert validate_source_name("_") == "_"
 
     def test_empty_string(self):
         with pytest.raises(InvalidSourceNameError, match="must not be empty"):
@@ -73,6 +80,9 @@ class TestValidateSourceName:
         name = "a" * 128
         assert validate_source_name(name) == name
 
+    def test_validate_identifier_is_alias(self):
+        assert validate_identifier is validate_source_name
+
 
 @pytest.mark.unit
 class TestValidateDateString:
@@ -105,7 +115,7 @@ class TestValidateDateString:
     def test_preserves_original_chain(self):
         with pytest.raises(InvalidDateFormatError) as exc_info:
             validate_date_string("not-a-date")
-        assert exc_info.value.__cause__ is not None  # chained from ValueError
+        assert isinstance(exc_info.value.__cause__, ValueError)
 
 
 @pytest.mark.unit
@@ -173,22 +183,35 @@ class TestSanitizePathComponent:
     """Tests for sanitize_path_component()."""
 
     def test_clean_name(self):
-        assert sanitize_path_component("my_source") == "my_source"
+        assert sanitize_path_component("my_source.csv") == "my_source.csv"
 
-    def test_removes_slashes(self):
-        assert sanitize_path_component("foo/bar") == "foobar"
+    def test_strips_directory_slash(self):
+        assert sanitize_path_component("foo/bar.csv") == "bar.csv"
 
-    def test_removes_backslashes(self):
-        assert sanitize_path_component("foo\\bar") == "foobar"
+    def test_strips_directory_backslash(self):
+        assert sanitize_path_component("foo\\bar.csv") == "bar.csv"
 
-    def test_removes_dot_dot(self):
-        assert sanitize_path_component("../etc") == "etc"
+    def test_strips_dot_dot_traversal(self):
+        assert sanitize_path_component("../etc/passwd") == "passwd"
 
     def test_removes_null_bytes(self):
-        assert sanitize_path_component("foo\x00bar") == "foobar"
+        assert sanitize_path_component("foo\x00bar.csv") == "foobar.csv"
 
-    def test_multiple_traversals(self):
-        assert sanitize_path_component("../../etc/passwd") == "etcpasswd"
+    def test_deep_traversal(self):
+        assert sanitize_path_component("../../etc/passwd") == "passwd"
 
-    def test_empty_string(self):
-        assert sanitize_path_component("") == ""
+    def test_empty_string_returns_unnamed(self):
+        assert sanitize_path_component("") == "unnamed"
+
+    def test_dot_dot_only_returns_unnamed(self):
+        # PurePosixPath("..").name = "..", then ".." → "" after replace
+        assert sanitize_path_component("..") == "unnamed"
+
+    def test_windows_path(self):
+        assert sanitize_path_component("C:\\Users\\data\\file.csv") == "file.csv"
+
+    def test_mixed_separators(self):
+        assert sanitize_path_component("foo/bar\\baz.csv") == "baz.csv"
+
+    def test_null_byte_in_path(self):
+        assert sanitize_path_component("foo\x00/bar.csv") == "bar.csv"

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -204,8 +204,18 @@ class TestSanitizePathComponent:
         assert sanitize_path_component("") == "unnamed"
 
     def test_dot_dot_only_returns_unnamed(self):
-        # PurePosixPath("..").name = "..", then ".." → "" after replace
         assert sanitize_path_component("..") == "unnamed"
+
+    def test_single_dot_returns_unnamed(self):
+        assert sanitize_path_component(".") == "unnamed"
+
+    def test_triple_dot_preserved(self):
+        # "..." is a valid filename (not a directory reference)
+        assert sanitize_path_component("...") == "..."
+
+    def test_legitimate_double_dot_in_filename(self):
+        # "file..v2.csv" should be preserved (not mangled)
+        assert sanitize_path_component("file..v2.csv") == "file..v2.csv"
 
     def test_windows_path(self):
         assert sanitize_path_component("C:\\Users\\data\\file.csv") == "file.csv"

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -55,6 +55,13 @@ class TestValidateSourceName:
         with pytest.raises(InvalidSourceNameError, match="invalid"):
             validate_source_name("my-source")
 
+    def test_error_message_uses_repr(self):
+        """Error message should use repr() to prevent Rich markup injection."""
+        with pytest.raises(InvalidSourceNameError) as exc_info:
+            validate_source_name("[red]alert[/red]")
+        # repr wraps in quotes, so the message should contain the repr form
+        assert "'" in str(exc_info.value) or '"' in str(exc_info.value)
+
     def test_spaces_rejected(self):
         with pytest.raises(InvalidSourceNameError, match="invalid"):
             validate_source_name("my source")
@@ -225,3 +232,23 @@ class TestSanitizePathComponent:
 
     def test_null_byte_in_path(self):
         assert sanitize_path_component("foo\x00/bar.csv") == "bar.csv"
+
+    def test_whitespace_only_returns_unnamed(self):
+        assert sanitize_path_component("   ") == "unnamed"
+
+    def test_newline_in_filename(self):
+        # Control chars are stripped; result is clean filename
+        assert sanitize_path_component("file\nname.csv") == "filename.csv"
+
+    def test_tab_preserved(self):
+        # Tab is allowed (only control char kept)
+        assert sanitize_path_component("file\tname.csv") == "file\tname.csv"
+
+    def test_leading_trailing_whitespace_stripped(self):
+        assert sanitize_path_component("  data.csv  ") == "data.csv"
+
+    def test_slash_only_returns_unnamed(self):
+        assert sanitize_path_component("/") == "unnamed"
+
+    def test_backslash_only_returns_unnamed(self):
+        assert sanitize_path_component("\\") == "unnamed"


### PR DESCRIPTION
## Summary

- **Unified exception hierarchy** in `dango/exceptions.py` — all 17 exception classes inherit from `DangoError` with `error_code`, `context`, `user_message` attributes. Module files become re-export shims for backward compatibility.
- **Input validation layer** in `dango/validation.py` — `validate_source_name`, `validate_date_string`, `validate_port_range`, `validate_limit`, `sanitize_path_component`.
- **4 pre-existing CLI bugs fixed** — lock-undefined in `source.py`/`transform.py`, dead code `if True:` and duplicate import in `platform.py`.
- **Debug-gated stack traces** — all 7 CLI files now gate `traceback.print_exc()` behind `DANGO_DEBUG` env var.
- **Global FastAPI exception handlers** — `DangoError` → structured JSON (with error_code), unhandled `Exception` → generic 500. Replaced `logging.basicConfig` with structlog.
- **Web route validation** — 5 route files now validate source names, dates, and limits at entry points.
- **Documentation** — Updated STANDARDS.md Section 5 and 4 module CLAUDE.md files.

## Test plan

- [x] 99 new tests in `test_exceptions.py` (58) and `test_validation.py` (41)
- [x] Full test suite: 300 tests pass, zero regressions
- [x] Ruff lint + format: all clean
- [x] All pre-commit hooks pass
- [x] Backward-compatible imports verified (`from dango.config.exceptions import ConfigError` returns same class as `from dango.exceptions import ConfigError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)