### PR TITLE
TASK-092: mypy hardening & Pydantic V1→V2 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
   type-check:
     name: Type check (mypy)
     runs-on: ubuntu-latest
-    # TODO: Remove continue-on-error after mypy compliance pass
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -35,7 +33,7 @@ jobs:
           cache: pip
       - run: pip install -e ".[dev]"
       - name: mypy
-        run: mypy dango/ --ignore-missing-imports
+        run: mypy dango/
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,14 +25,11 @@ repos:
     hooks:
       - id: mypy
         name: mypy type checking
-        entry: python3 -m mypy --ignore-missing-imports
+        entry: python3 -m mypy
         language: system
         types: [python]
         pass_filenames: true
         exclude: dango/ingestion/dlt_sources/
-        # TODO: Remove stages: [manual] after mypy compliance pass
-        # Currently 57 pre-existing type errors; CI runs mypy as continue-on-error
-        stages: [manual]
 
       - id: file-size-check
         name: Check file sizes

--- a/dango/cli/commands/data.py
+++ b/dango/cli/commands/data.py
@@ -66,7 +66,8 @@ def db_status(ctx: click.Context) -> None:
         result = []
         for schema, table in tables:
             try:
-                count = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()[0]
+                row = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
+                count = row[0] if row else 0
                 result.append((schema, table, f"{count:,} rows"))
             except Exception:
                 result.append((schema, table, "Error"))
@@ -78,7 +79,7 @@ def db_status(ctx: click.Context) -> None:
 
         # Build actual raw tables mapping from database
         # This is used to validate that staging tables have corresponding raw tables
-        actual_raw_tables = {}
+        actual_raw_tables: dict[str, set[str]] = {}
         for schema, table, _size in result:
             if schema.startswith("raw_") and not table.startswith("_dlt_"):
                 if schema not in actual_raw_tables:
@@ -191,7 +192,8 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
         result = []
         for schema, table in tables:
             try:
-                count = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()[0]
+                row = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
+                count = row[0] if row else 0
                 result.append((schema, table, f"{count:,} rows"))
             except Exception:
                 result.append((schema, table, "Error"))
@@ -203,7 +205,7 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
 
         # Build actual raw tables mapping from database
         # This is used to validate that staging tables have corresponding raw tables
-        actual_raw_tables = {}
+        actual_raw_tables: dict[str, set[str]] = {}
         for schema, table, _size in result:
             if schema.startswith("raw_") and not table.startswith("_dlt_"):
                 if schema not in actual_raw_tables:
@@ -272,13 +274,11 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
         # Clean up metadata for orphaned sources (only if metadata table exists)
         if orphaned_sources:
             # Check if metadata table exists (only created for CSV sources)
-            metadata_table_exists = (
-                conn.execute("""
+            _row = conn.execute("""
                     SELECT COUNT(*) FROM information_schema.tables
                     WHERE table_name = '_dango_file_metadata'
-                """).fetchone()[0]
-                > 0
-            )
+                """).fetchone()
+            metadata_table_exists = (_row[0] if _row else 0) > 0
 
             if metadata_table_exists:
                 console.print()
@@ -288,13 +288,14 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
                 for source_name in orphaned_sources:
                     try:
                         # Count entries first
-                        count = conn.execute(
+                        _row = conn.execute(
                             """
                             SELECT COUNT(*) FROM _dango_file_metadata
                             WHERE source_name = ?
                         """,
                             [source_name],
-                        ).fetchone()[0]
+                        ).fetchone()
+                        count = _row[0] if _row else 0
 
                         if count > 0:
                             # Delete entries

--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -126,7 +126,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
                     SELECT COUNT(*) FROM information_schema.tables
                     WHERE table_schema = '{layer}' AND table_name = '{model_name}'
                 """).fetchone()
-                table_exists = result[0] > 0
+                table_exists = (result[0] > 0) if result else False
                 conn.close()
             except Exception:
                 pass

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -3,6 +3,8 @@
 dbt transformation commands (run, docs, generate).
 """
 
+from typing import Any
+
 import click
 
 from dango.cli import console
@@ -273,7 +275,8 @@ def generate(ctx: click.Context, models: bool, generate_all: bool) -> None:
         )
 
         # Display results
-        if summary["generated"]:
+        generated_items: list[dict[str, Any]] = summary.get("generated") or []
+        if generated_items:
             console.print("[green]✅ Generated Models:[/green]\n")
 
             table = Table(show_header=True, header_style="bold cyan")
@@ -282,12 +285,12 @@ def generate(ctx: click.Context, models: bool, generate_all: bool) -> None:
             table.add_column("Dedup Strategy", style="cyan")
             table.add_column("Files", style="dim")
 
-            for item in summary["generated"]:
+            for item in generated_items:
                 source_name = item["source"]
-                models = item.get("models", [])
+                item_models = item.get("models", [])
 
                 # For each model generated for this source
-                for model in models:
+                for model in item_models:
                     files = "model"
                     if item.get("schema"):
                         files += " + schema"

--- a/dango/cli/db_helpers.py
+++ b/dango/cli/db_helpers.py
@@ -25,8 +25,8 @@ def build_schema_table_mapping(config: DangoConfig) -> tuple[dict[str, set[str]]
           - schema_to_tables: Dict[schema_name, Set[table_names]]
           - source_to_schema: Dict[source_name, schema_name]
     """
-    schema_to_tables = {}  # schema → set of table names
-    source_to_schema = {}  # source_name → schema_name (for staging lookup)
+    schema_to_tables: dict[str, set[str]] = {}  # schema → set of table names
+    source_to_schema: dict[str, str] = {}  # source_name → schema_name (for staging lookup)
 
     for source in config.sources.sources:
         source_name = source.name.lower()
@@ -63,7 +63,7 @@ def is_table_configured(
     table: str,
     schema_to_tables: dict[str, set[str]],
     source_to_schema: dict[str, str],
-    actual_raw_tables: dict[str, set[str]] = None,
+    actual_raw_tables: dict[str, set[str]] | None = None,
 ) -> bool:
     """
     Check if a table is configured in sources.yml

--- a/dango/cli/env_helpers.py
+++ b/dango/cli/env_helpers.py
@@ -54,7 +54,7 @@ def create_env_template(
     # Build new vars section (only if not already present)
     new_content = []
     for var_config in env_vars:
-        var_name = var_config.get("name")
+        var_name = var_config.get("name", "")
 
         if var_name not in existing_vars:
             # Add section header with source information
@@ -171,7 +171,7 @@ def guide_env_setup(
     env_file: Path,
     required_vars: list[dict[str, str]],
     source_name: str,
-    setup_guide: list[str] = None,
+    setup_guide: list[str] | None = None,
 ) -> bool:
     """
     Guide user through .env setup with optional file opening and validation.
@@ -235,7 +235,7 @@ def guide_env_setup(
     input()
 
     # Validate
-    var_names = [v.get("name") for v in required_vars]
+    var_names = [v.get("name", "") for v in required_vars if v.get("name")]
     is_valid, missing = validate_env_file(env_file, var_names)
 
     return handle_validation_result(is_valid, missing, env_file, source_name)

--- a/dango/cli/helpers/port_manager.py
+++ b/dango/cli/helpers/port_manager.py
@@ -40,8 +40,9 @@ def get_process_using_port(port: int) -> int | None:
     """
     try:
         for conn in psutil.net_connections():
-            if conn.laddr.port == port and conn.status == "LISTEN":
-                return conn.pid
+            laddr = conn.laddr
+            if hasattr(laddr, "port") and laddr.port == port and conn.status == "LISTEN":  # type: ignore[union-attr]
+                return int(conn.pid) if conn.pid is not None else None
     except (psutil.AccessDenied, AttributeError):
         pass
 

--- a/dango/cli/helpers/process_manager.py
+++ b/dango/cli/helpers/process_manager.py
@@ -228,9 +228,9 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
             dango_pids = []
             other_pids = []
 
-            for proc_pid in pids:
+            for proc_pid_str in pids:
                 try:
-                    proc_pid = int(proc_pid.strip())
+                    proc_pid = int(proc_pid_str.strip())
 
                     # Get process command line
                     cmd_result = subprocess.run(
@@ -326,7 +326,7 @@ def get_fastapi_status(project_root: Path) -> dict:
     log_file = project_root / ".dango" / "web.log"
     port = 8080  # Default port
 
-    status = {"running": False, "pid": None, "port": port, "url": None, "log_file": log_file}
+    status: dict = {"running": False, "pid": None, "port": port, "url": None, "log_file": log_file}
 
     if pid and is_process_running(pid):
         status["running"] = True

--- a/dango/cli/oauth.py
+++ b/dango/cli/oauth.py
@@ -44,7 +44,7 @@ class OAuthHelper:
                 env_lines = f.readlines()
 
         # Remove existing key if present
-        new_lines = []
+        new_lines: list[str] = []
         skip_next = False
         for i, line in enumerate(env_lines):
             if skip_next:
@@ -216,7 +216,7 @@ class FacebookOAuthHelper(OAuthHelper):
 
             if long_token:
                 console.print("[green]✓[/green] Long-lived token obtained")
-                return long_token
+                return str(long_token)
             else:
                 console.print("[red]✗ No access_token in response[/red]")
                 return None
@@ -307,14 +307,14 @@ class GoogleOAuthHelper(OAuthHelper):
                 return False
 
             # Validate JSON file
-            creds_path = Path(creds_path).expanduser()
-            if not creds_path.exists():
-                console.print(f"[red]✗ File not found: {creds_path}[/red]")
+            creds_path_obj = Path(creds_path).expanduser()
+            if not creds_path_obj.exists():
+                console.print(f"[red]✗ File not found: {creds_path_obj}[/red]")
                 return False
 
             # Read and validate JSON
             try:
-                with open(creds_path) as f:
+                with open(creds_path_obj) as f:
                     creds_data = json.load(f)
 
                 # Check if it's service account or OAuth client

--- a/dango/cli/schema_manager.py
+++ b/dango/cli/schema_manager.py
@@ -152,7 +152,8 @@ class SchemaManager:
 
         try:
             with open(schema_path) as f:
-                return yaml.safe_load(f)
+                result = yaml.safe_load(f)
+                return result if isinstance(result, dict) else None
         except Exception:
             # Corrupted YAML - return None to regenerate
             return None
@@ -174,7 +175,7 @@ class SchemaManager:
         Returns:
             Tuple of (updated_schema, changes_dict)
         """
-        changes = {
+        changes: dict[str, Any] = {
             "is_new": False,
             "added_columns": [],
             "removed_columns": [],
@@ -206,11 +207,15 @@ class SchemaManager:
             if col_name in existing_descriptions:
                 # Preserve existing description
                 description = existing_descriptions[col_name]
-                changes["preserved_columns"] += 1
+                preserved_count = changes["preserved_columns"]
+                if isinstance(preserved_count, int):
+                    changes["preserved_columns"] = preserved_count + 1
             else:
                 # New column - add helpful placeholder
                 description = "TODO: Add description\n(Auto-generated - edit in dbt/models/[layer]/schema.yml)"
-                changes["added_columns"].append(col_name)
+                added_cols = changes["added_columns"]
+                if isinstance(added_cols, list):
+                    added_cols.append(col_name)
 
             new_columns.append({"name": col_name, "description": description})
 
@@ -218,7 +223,9 @@ class SchemaManager:
         actual_col_names = {col["name"] for col in actual_columns}
         for col_name, description in existing_descriptions.items():
             if col_name not in actual_col_names:
-                changes["removed_columns"].append({"name": col_name, "description": description})
+                removed_cols = changes["removed_columns"]
+                if isinstance(removed_cols, list):
+                    removed_cols.append({"name": col_name, "description": description})
 
         # Build model entry
         new_model = {

--- a/dango/cli/schema_manager.py
+++ b/dango/cli/schema_manager.py
@@ -175,10 +175,12 @@ class SchemaManager:
         Returns:
             Tuple of (updated_schema, changes_dict)
         """
+        added_columns: list[str] = []
+        removed_columns: list[dict[str, str]] = []
         changes: dict[str, Any] = {
             "is_new": False,
-            "added_columns": [],
-            "removed_columns": [],
+            "added_columns": added_columns,
+            "removed_columns": removed_columns,
             "preserved_columns": 0,
         }
 
@@ -207,15 +209,11 @@ class SchemaManager:
             if col_name in existing_descriptions:
                 # Preserve existing description
                 description = existing_descriptions[col_name]
-                preserved_count = changes["preserved_columns"]
-                if isinstance(preserved_count, int):
-                    changes["preserved_columns"] = preserved_count + 1
+                changes["preserved_columns"] += 1
             else:
                 # New column - add helpful placeholder
                 description = "TODO: Add description\n(Auto-generated - edit in dbt/models/[layer]/schema.yml)"
-                added_cols = changes["added_columns"]
-                if isinstance(added_cols, list):
-                    added_cols.append(col_name)
+                added_columns.append(col_name)
 
             new_columns.append({"name": col_name, "description": description})
 
@@ -223,9 +221,7 @@ class SchemaManager:
         actual_col_names = {col["name"] for col in actual_columns}
         for col_name, description in existing_descriptions.items():
             if col_name not in actual_col_names:
-                removed_cols = changes["removed_columns"]
-                if isinstance(removed_cols, list):
-                    removed_cols.append({"name": col_name, "description": description})
+                removed_columns.append({"name": col_name, "description": description})
 
         # Build model entry
         new_model = {

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -36,27 +36,27 @@ def require_project_context(ctx: click.Context) -> Path:
         raise click.Abort() from e
 
 
-def print_error(message: str):
+def print_error(message: str) -> None:
     """Print error message."""
     console.print(f"[red]Error:[/red] {message}")
 
 
-def print_success(message: str):
+def print_success(message: str) -> None:
     """Print success message."""
     console.print(f"[green]✓[/green] {message}")
 
 
-def print_info(message: str):
+def print_info(message: str) -> None:
     """Print info message."""
     console.print(f"[blue]ℹ[/blue] {message}")
 
 
-def print_warning(message: str):
+def print_warning(message: str) -> None:
     """Print warning message."""
     console.print(f"[yellow]⚠[/yellow] {message}")
 
 
-def print_panel(content: str, title: str, border_style: str = "blue"):
+def print_panel(content: str, title: str, border_style: str = "blue") -> None:
     """Print content in a panel."""
     console.print(Panel(content, title=title, border_style=border_style))
 

--- a/dango/cli/wizard.py
+++ b/dango/cli/wizard.py
@@ -64,6 +64,8 @@ class ProjectWizard:
             created=datetime.now(),
             created_by=created_by,
             purpose="Data analytics project",
+            sla=None,
+            limitations=None,
             getting_started=self._default_getting_started(),
         )
 
@@ -97,7 +99,7 @@ class ProjectWizard:
                 default_name = name  # Keep their input as new default
                 continue
 
-            return name
+            return str(name)
 
     def _ask_organization(self) -> str | None:
         """Ask for organization name (optional)"""
@@ -106,7 +108,7 @@ class ProjectWizard:
         answers = inquirer.prompt(questions)
         if answers is None:
             raise KeyboardInterrupt()
-        org = answers.get("organization", "").strip()
+        org = str(answers.get("organization", "")).strip()
         return org if org else None
 
     def _get_git_user(self) -> str | None:
@@ -139,7 +141,9 @@ class ProjectWizard:
             )
         ]
         answers = inquirer.prompt(questions)
-        return answers["created_by"]
+        if answers is None:
+            raise KeyboardInterrupt()
+        return str(answers["created_by"])
 
     def _ask_purpose(self) -> str:
         """Ask for project purpose"""
@@ -217,9 +221,11 @@ class ProjectWizard:
 
         questions = [inquirer.Text("sla", message="SLA", default="Daily by 9am")]
         answers = inquirer.prompt(questions)
-        return answers["sla"]
+        if answers is None:
+            raise KeyboardInterrupt()
+        return str(answers["sla"])
 
-    def _ask_limitations(self) -> str:
+    def _ask_limitations(self) -> str | None:
         """Ask for limitations"""
         console.print()
         console.print("[cyan]Known limitations or gotchas[/cyan]")
@@ -237,14 +243,16 @@ class ProjectWizard:
             )
         ]
         answers = inquirer.prompt(questions)
-        limitations = answers["limitations"].strip()
+        if answers is None:
+            raise KeyboardInterrupt()
+        limitations = str(answers["limitations"]).strip()
 
         # Remove the default comment if user didn't change it
         if limitations.startswith("# Known limitations"):
             lines = limitations.split("\n")
             limitations = "\n".join(lines[1:]).strip()
 
-        return limitations or None
+        return limitations if limitations else None
 
     def _default_getting_started(self) -> str:
         """Default getting started guide"""
@@ -255,8 +263,11 @@ class ProjectWizard:
             "4. Open dashboards: http://localhost:8800"
         )
 
-    def _print_summary(self):
+    def _print_summary(self) -> None:
         """Print configuration summary - only show fields with meaningful values"""
+        if self.config is None:
+            return
+
         console.print()
 
         # Build summary with only populated fields

--- a/dango/config/credentials.py
+++ b/dango/config/credentials.py
@@ -134,7 +134,7 @@ truncate_staging_dataset = true
 
         try:
             with open(self.secrets_file) as f:
-                secrets = toml.load(f)
+                secrets: dict[str, Any] = toml.load(f)
             return secrets
         except Exception as e:
             console.print(f"[yellow]Warning: Could not load .dlt/secrets.toml: {e}[/yellow]")
@@ -152,7 +152,7 @@ truncate_staging_dataset = true
 
         try:
             with open(self.config_file) as f:
-                config = toml.load(f)
+                config: dict[str, Any] = toml.load(f)
             return config
         except Exception as e:
             console.print(f"[yellow]Warning: Could not load .dlt/config.toml: {e}[/yellow]")
@@ -246,7 +246,8 @@ truncate_staging_dataset = true
         # Check .dlt/secrets.toml first
         secrets = self.load_secrets()
         if "sources" in secrets and source_name in secrets["sources"]:
-            return secrets["sources"][source_name]
+            result: dict[str, Any] = secrets["sources"][source_name]
+            return result
 
         # Fallback to .env file
         # This is for backward compatibility with existing .env-based setup

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -4,6 +4,7 @@ Handles loading and validation of YAML configuration files.
 """
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import ValidationError
@@ -83,7 +84,7 @@ class ConfigLoader:
         except Exception as e:
             raise ConfigError(f"Error reading {file_path}: {e}") from e
 
-    def save_yaml(self, data: dict, file_path: Path):
+    def save_yaml(self, data: dict[str, Any], file_path: Path) -> None:
         """
         Save dict as YAML file atomically.
 
@@ -181,7 +182,7 @@ class ConfigLoader:
 
         return DangoConfig(project=project, sources=sources, platform=platform)
 
-    def save_project_context(self, project: ProjectContext):
+    def save_project_context(self, project: ProjectContext) -> None:
         """Save project context to project.yml"""
         # Check if project.yml exists and has platform settings
         existing_platform = {}
@@ -195,12 +196,12 @@ class ConfigLoader:
         }
         self.save_yaml(data, self.project_file)
 
-    def save_sources_config(self, sources: SourcesConfig):
+    def save_sources_config(self, sources: SourcesConfig) -> None:
         """Save sources config to sources.yml"""
         data = sources.model_dump(mode="json", exclude_none=True)
         self.save_yaml(data, self.sources_file)
 
-    def save_config(self, config: DangoConfig):
+    def save_config(self, config: DangoConfig) -> None:
         """Save complete configuration"""
         # Save project context and platform settings together in project.yml
         data = {

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -8,7 +8,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class DeduplicationStrategy(str, Enum):
@@ -108,10 +108,8 @@ class ProjectContext(BaseModel):
 
     getting_started: str | None = Field(None, description="Quick start guide for new team members")
 
-    class Config:
-        """Pydantic model configuration."""
-
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "name": "Shopee Analytics",
                 "created_by": "Aaron Teoh <aaron@company.com>",
@@ -128,6 +126,7 @@ class ProjectContext(BaseModel):
                 "getting_started": "Run 'dango sync' to refresh data, then open http://dango.local",
             }
         }
+    )
 
 
 class CSVSourceConfig(BaseModel):
@@ -162,8 +161,9 @@ class GoogleSheetsSourceConfig(BaseModel):
     range_names: list[str]  # Sheet/tab names to load (each becomes a table)
     deduplication: DeduplicationStrategy = DeduplicationStrategy.LATEST_ONLY
 
-    @validator("range_names", pre=True)
-    def ensure_list(cls, v):
+    @field_validator("range_names", mode="before")
+    @classmethod
+    def ensure_list(cls, v: Any) -> Any:
         """Convert single string to list for backward compatibility"""
         if isinstance(v, str):
             return [v]
@@ -371,8 +371,9 @@ class DataSource(BaseModel):
     description: str | None = None
     tags: list[str] = Field(default_factory=list)
 
-    @validator("name")
-    def validate_name_format(cls, v):
+    @field_validator("name")
+    @classmethod
+    def validate_name_format(cls, v: str) -> str:
         """Ensure source name uses only letters, numbers, and underscores (no hyphens)."""
         if not v or not v.replace("_", "").isalnum():
             raise ValueError(

--- a/dango/logging.py
+++ b/dango/logging.py
@@ -210,4 +210,4 @@ def get_logger(name: str) -> structlog.stdlib.BoundLogger:
     Returns:
         A structlog ``BoundLogger`` instance.
     """
-    return structlog.get_logger(name)
+    return structlog.get_logger(name)  # type: ignore[no-any-return]

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -45,7 +45,7 @@ class OAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
     oauth_response = None
     oauth_error = None
 
-    def do_GET(self):
+    def do_GET(self) -> None:
         """Handle GET request from OAuth provider"""
         # Parse query parameters
         parsed = urlparse(self.path)
@@ -115,7 +115,7 @@ class OAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(b"Invalid OAuth callback")
 
-    def log_message(self, format, *args):
+    def log_message(self, format: str, *args: object) -> None:
         """Suppress server log messages"""
         pass
 

--- a/dango/oauth/router.py
+++ b/dango/oauth/router.py
@@ -50,11 +50,13 @@ def run_oauth_for_source(source_type: str, source_name: str, project_root: Path)
     # Route to correct provider
     try:
         if provider_name == "google":
+            if service is None:
+                console.print("[red]Missing service for Google OAuth provider[/red]")
+                return False
             google_provider = GoogleOAuthProvider(oauth_manager)
             # Pass source_name for instance-specific credentials
             return (
-                google_provider.authenticate(service=service or "", source_name=source_name)
-                is not None
+                google_provider.authenticate(service=service, source_name=source_name) is not None
             )
 
         elif provider_name == "facebook":

--- a/dango/oauth/router.py
+++ b/dango/oauth/router.py
@@ -50,19 +50,22 @@ def run_oauth_for_source(source_type: str, source_name: str, project_root: Path)
     # Route to correct provider
     try:
         if provider_name == "google":
-            provider = GoogleOAuthProvider(oauth_manager)
+            google_provider = GoogleOAuthProvider(oauth_manager)
             # Pass source_name for instance-specific credentials
-            return provider.authenticate(service=service, source_name=source_name)
+            return (
+                google_provider.authenticate(service=service or "", source_name=source_name)
+                is not None
+            )
 
         elif provider_name == "facebook":
-            provider = FacebookOAuthProvider(oauth_manager)
+            fb_provider = FacebookOAuthProvider(oauth_manager)
             # Pass source_name for instance-specific credentials
-            return provider.authenticate(source_name=source_name)
+            return fb_provider.authenticate(source_name=source_name) is not None
 
         elif provider_name == "shopify":
-            provider = ShopifyOAuthProvider(oauth_manager)
+            shopify_provider = ShopifyOAuthProvider(oauth_manager)
             # Pass source_name for instance-specific credentials
-            return provider.authenticate(source_name=source_name)
+            return shopify_provider.authenticate(source_name=source_name) is not None
 
         else:
             console.print(f"[red]❌ Unknown OAuth provider: {provider_name}[/red]")

--- a/dango/oauth/storage.py
+++ b/dango/oauth/storage.py
@@ -89,7 +89,8 @@ class OAuthStorage:
     def _load_secrets(self) -> dict[str, Any]:
         """Load secrets.toml"""
         if self.secrets_file.exists() and self.secrets_file.stat().st_size > 0:
-            return toml.load(self.secrets_file)
+            result: dict[str, Any] = toml.load(self.secrets_file)
+            return result
         return {}
 
     def _save_secrets(self, secrets: dict[str, Any]) -> None:

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -276,7 +276,7 @@ class DockerManager:
         except (subprocess.TimeoutExpired, Exception):
             return {}
 
-    def print_status(self):
+    def print_status(self) -> None:
         """Print service status table"""
         statuses = self.get_service_status()
 
@@ -318,7 +318,7 @@ class DockerManager:
 
         console.print(table)
 
-    def _print_service_urls(self):
+    def _print_service_urls(self) -> None:
         """Print service URLs (via FastAPI proxy)"""
         # Load config to get the configured port
         from dango.config.loader import ConfigLoader

--- a/dango/platform/network.py
+++ b/dango/platform/network.py
@@ -3,12 +3,15 @@
 Manages shared nginx instance for clean URLs across multiple Dango projects. Architecture: Shared nginx on port 80, routing by domain to different backend ports.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import socket
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 
 class NetworkConfig:
@@ -21,7 +24,7 @@ class NetworkConfig:
     - Track nginx state
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.dango_home = Path.home() / ".dango"
         self.routing_file = self.dango_home / "routing.json"
         self.shared_nginx_dir = self.dango_home / "shared-nginx"
@@ -34,15 +37,16 @@ class NetworkConfig:
         self.sites_dir.mkdir(exist_ok=True)
         self.logs_dir.mkdir(exist_ok=True)
 
-    def load_routing(self) -> dict:
+    def load_routing(self) -> dict[str, Any]:
         """Load routing.json or create default"""
         if not self.routing_file.exists():
             return {"version": "1.0", "port": 80, "projects": {}, "next_available_port": 8800}
 
         with open(self.routing_file) as f:
-            return json.load(f)
+            result: dict[str, Any] = json.load(f)
+            return result
 
-    def save_routing(self, routing: dict):
+    def save_routing(self, routing: dict[str, Any]) -> None:
         """Save routing.json"""
         with open(self.routing_file, "w") as f:
             json.dump(routing, f, indent=2)
@@ -65,7 +69,7 @@ class NetworkConfig:
         routing["next_available_port"] = port + 1
         self.save_routing(routing)
 
-        return port
+        return int(port)
 
     @staticmethod
     def is_port_free(port: int) -> bool:
@@ -79,7 +83,7 @@ class NetworkConfig:
 
     def register_project(
         self, project_name: str, project_path: Path, backend_port: int, domain: str | None = None
-    ) -> dict:
+    ) -> dict[str, Any]:
         """
         Register a project in routing.json
 
@@ -109,29 +113,31 @@ class NetworkConfig:
 
         return project_info
 
-    def unregister_project(self, project_name: str):
+    def unregister_project(self, project_name: str) -> None:
         """Remove project from routing.json"""
         routing = self.load_routing()
         if project_name in routing["projects"]:
             del routing["projects"][project_name]
             self.save_routing(routing)
 
-    def update_project_status(self, project_name: str, status: str):
+    def update_project_status(self, project_name: str, status: str) -> None:
         """Update project status (running/stopped)"""
         routing = self.load_routing()
         if project_name in routing["projects"]:
             routing["projects"][project_name]["status"] = status
             self.save_routing(routing)
 
-    def get_project_info(self, project_name: str) -> dict | None:
+    def get_project_info(self, project_name: str) -> dict[str, Any] | None:
         """Get project information"""
         routing = self.load_routing()
-        return routing["projects"].get(project_name)
+        result: dict[str, Any] | None = routing["projects"].get(project_name)
+        return result
 
-    def list_projects(self) -> dict[str, dict]:
+    def list_projects(self) -> dict[str, dict[str, Any]]:
         """List all registered projects"""
         routing = self.load_routing()
-        return routing["projects"]
+        result: dict[str, dict[str, Any]] = routing["projects"]
+        return result
 
 
 class NginxManager:
@@ -241,20 +247,20 @@ server {{
 """
         return conf.strip()
 
-    def write_base_config(self):
+    def write_base_config(self) -> None:
         """Write base nginx.conf"""
         config = self.generate_base_config()
         with open(self.nginx_conf, "w") as f:
             f.write(config)
 
-    def write_project_config(self, project_name: str, domain: str, backend_port: int):
+    def write_project_config(self, project_name: str, domain: str, backend_port: int) -> None:
         """Write project-specific nginx site config"""
         config = self.generate_project_config(project_name, domain, backend_port)
         site_conf = self.config.sites_dir / f"{project_name}.conf"
         with open(site_conf, "w") as f:
             f.write(config)
 
-    def remove_project_config(self, project_name: str):
+    def remove_project_config(self, project_name: str) -> None:
         """Remove project nginx site config"""
         site_conf = self.config.sites_dir / f"{project_name}.conf"
         if site_conf.exists():
@@ -367,7 +373,7 @@ class HostsManager:
         self.config = config
         self.backup_file = self.config.dango_home / "hosts-backup"
 
-    def backup_hosts(self):
+    def backup_hosts(self) -> None:
         """Backup /etc/hosts before first modification"""
         if not self.backup_file.exists():
             with open(self.HOSTS_FILE) as f:

--- a/dango/platform/watcher_lifecycle.py
+++ b/dango/platform/watcher_lifecycle.py
@@ -161,7 +161,11 @@ def get_watcher_status(project_root: Path) -> dict:
     pid_file = get_watcher_pid_file_path(project_root)
     log_file = project_root / ".dango" / "watcher.log"
 
-    status = {"running": False, "pid": None, "log_file": log_file}
+    status: dict[str, bool | int | Path | None] = {
+        "running": False,
+        "pid": None,
+        "log_file": log_file,
+    }
 
     if pid_file.exists():
         try:

--- a/dango/platform/watcher_runner.py
+++ b/dango/platform/watcher_runner.py
@@ -4,18 +4,21 @@
 Background process that monitors file changes and triggers sync/dbt operations. Started by `dango start` and stopped by `dango stop`.
 """
 
+from __future__ import annotations
+
 import signal
 import subprocess
 import sys
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 
-def setup_signal_handlers(watcher):
+def setup_signal_handlers(watcher: Any) -> None:
     """Set up graceful shutdown on SIGTERM/SIGINT"""
 
-    def signal_handler(signum, frame):
+    def signal_handler(signum: int, frame: Any) -> None:
         """Handle SIGTERM/SIGINT for graceful watcher shutdown."""
         print("[FileWatcher] Received shutdown signal, stopping...")
         watcher.stop()
@@ -25,7 +28,7 @@ def setup_signal_handlers(watcher):
     signal.signal(signal.SIGINT, signal_handler)
 
 
-def run_sync_command(project_root: Path):
+def run_sync_command(project_root: Path) -> bool:
     """Execute dango sync command"""
     print(f"[FileWatcher] Triggering sync at {datetime.now().isoformat()}")
 
@@ -55,7 +58,7 @@ def run_sync_command(project_root: Path):
         return False
 
 
-def run_dbt_command(project_root: Path, changed_files: list = None):
+def run_dbt_command(project_root: Path, changed_files: list[Any] | None = None) -> bool:
     """
     Execute dbt run command with optional selective run based on changed files
 
@@ -141,7 +144,7 @@ def run_dbt_command(project_root: Path, changed_files: list = None):
         lock.release()
 
 
-def run_validate_command(project_root: Path):
+def run_validate_command(project_root: Path) -> bool:
     """Execute dango validate command"""
     print(f"[FileWatcher] Triggering validation at {datetime.now().isoformat()}")
 
@@ -171,7 +174,7 @@ def run_validate_command(project_root: Path):
         return False
 
 
-def main():
+def main() -> None:
     """Main entry point for watcher runner"""
 
     # Get project root from command line argument
@@ -216,7 +219,7 @@ def main():
     # Target 1: CSV files → sync (auto-generates staging + dbt)
     if platform.auto_sync:
 
-        def csv_callback(event_data: dict):
+        def csv_callback(event_data: dict) -> None:
             """CSV file changes → trigger sync"""
             files = event_data["files"]
             print(f"[FileWatcher] CSV changes detected, triggering sync for {len(files)} files")
@@ -239,7 +242,7 @@ def main():
     # Target 2: dbt models (SQL files) → dbt run
     if platform.auto_dbt:
 
-        def dbt_callback(event_data: dict):
+        def dbt_callback(event_data: dict) -> None:
             """dbt model changes → trigger selective dbt run"""
             files = event_data["files"]
             print(
@@ -263,7 +266,7 @@ def main():
             print(f"[FileWatcher] dbt models directory not found: {dbt_models_dir}")
 
     # Target 3: sources.yml → validation + docs regeneration
-    def sources_callback(event_data: dict):
+    def sources_callback(event_data: dict) -> None:
         """sources.yml changes → trigger validation + regenerate docs"""
         print("[FileWatcher] sources.yml changed, triggering validation")
         run_validate_command(project_root)
@@ -292,7 +295,7 @@ def main():
         print(f"[FileWatcher] Watching sources.yml in: {dango_dir}")
 
     # Set up signal handlers
-    def signal_handler(signum, frame):
+    def signal_handler(signum: int, frame: Any) -> None:
         """Handle SIGTERM/SIGINT for graceful multi-watcher shutdown."""
         print("[FileWatcher] Received shutdown signal, stopping...")
         multi_watcher.stop()

--- a/dango/security/token_storage.py
+++ b/dango/security/token_storage.py
@@ -115,7 +115,7 @@ class SecureTokenStorage:
 
             # Decrypt and deserialize
             decrypted = f.decrypt(encrypted_data.encode("utf-8"))
-            token_data = json.loads(decrypted.decode("utf-8"))
+            token_data: dict[str, Any] = json.loads(decrypted.decode("utf-8"))
 
             return token_data
 

--- a/dango/utils/activity_log.py
+++ b/dango/utils/activity_log.py
@@ -20,7 +20,7 @@ def get_activity_log_file(project_root: Path) -> Path:
 
 def log_activity(
     project_root: Path, level: LogLevel, source: str, message: str, timestamp: str | None = None
-):
+) -> None:
     """
     Write an activity log entry
 

--- a/dango/utils/data_validation.py
+++ b/dango/utils/data_validation.py
@@ -34,20 +34,37 @@ def validate_cursor_field(
             "issues": list
         }
     """
-    result = {"valid": False, "exists": False, "data_type": None, "sample_values": [], "issues": []}
+    result: dict[str, Any] = {
+        "valid": False,
+        "exists": False,
+        "data_type": None,
+        "sample_values": [],
+        "issues": [],
+    }
 
     try:
         conn = duckdb.connect(str(duckdb_path), read_only=True)
 
         # Check if table exists
-        table_exists = conn.execute(f"""
+        table_exists_row = conn.execute(f"""
             SELECT COUNT(*)
             FROM information_schema.tables
             WHERE table_schema='{schema}' AND table_name='{source_name}'
-        """).fetchone()[0]
+        """).fetchone()
+
+        if table_exists_row is None:
+            issues_list = result["issues"]
+            assert isinstance(issues_list, list)
+            issues_list.append(f"Failed to check if table {schema}.{source_name} exists")
+            conn.close()
+            return result
+
+        table_exists = table_exists_row[0]
 
         if not table_exists:
-            result["issues"].append(f"Table {schema}.{source_name} does not exist")
+            issues_list = result["issues"]
+            assert isinstance(issues_list, list)
+            issues_list.append(f"Table {schema}.{source_name} does not exist")
             conn.close()
             return result
 
@@ -61,7 +78,9 @@ def validate_cursor_field(
         """).fetchone()
 
         if not column_info:
-            result["issues"].append(f"Cursor field '{cursor_field}' not found in table")
+            issues_list = result["issues"]
+            assert isinstance(issues_list, list)
+            issues_list.append(f"Cursor field '{cursor_field}' not found in table")
             result["exists"] = False
             conn.close()
             return result
@@ -82,31 +101,48 @@ def validate_cursor_field(
 
         # Validate data type is appropriate for cursor
         valid_types = ["TIMESTAMP", "DATE", "INTEGER", "BIGINT", "VARCHAR"]
-        if not any(vtype in result["data_type"].upper() for vtype in valid_types):
-            result["issues"].append(
-                f"Cursor field has unexpected type '{result['data_type']}'. "
+        data_type = result["data_type"]
+        if isinstance(data_type, str) and not any(
+            vtype in data_type.upper() for vtype in valid_types
+        ):
+            issues_list = result["issues"]
+            assert isinstance(issues_list, list)
+            issues_list.append(
+                f"Cursor field has unexpected type '{data_type}'. "
                 f"Expected: {', '.join(valid_types)}"
             )
 
         # Check if cursor field has NULL values
-        null_count = conn.execute(f"""
+        null_count_row = conn.execute(f"""
             SELECT COUNT(*)
             FROM "{schema}"."{source_name}"
             WHERE "{cursor_field}" IS NULL
-        """).fetchone()[0]
+        """).fetchone()
 
-        if null_count > 0:
-            result["issues"].append(f"{null_count} NULL values found in cursor field")
+        if null_count_row is None:
+            issues_list = result["issues"]
+            assert isinstance(issues_list, list)
+            issues_list.append("Failed to check for NULL values in cursor field")
+        else:
+            null_count = null_count_row[0]
+            if null_count > 0:
+                issues_list = result["issues"]
+                assert isinstance(issues_list, list)
+                issues_list.append(f"{null_count} NULL values found in cursor field")
 
         conn.close()
 
         # Overall validation
-        result["valid"] = result["exists"] and len(result["issues"]) == 0
+        issues_list = result["issues"]
+        assert isinstance(issues_list, list)
+        result["valid"] = result["exists"] and len(issues_list) == 0
 
         return result
 
     except Exception as e:
-        result["issues"].append(f"Validation error: {e}")
+        issues_list = result["issues"]
+        assert isinstance(issues_list, list)
+        issues_list.append(f"Validation error: {e}")
         return result
 
 
@@ -159,14 +195,16 @@ def detect_schema_changes(
 
         # Compare with expected schema if provided
         if expected_schema:
-            current_set = set(result["current_columns"])
+            current_columns = result["current_columns"]
+            assert isinstance(current_columns, list)
+            current_set = set(current_columns)
             expected_set = set(expected_schema)
 
-            result["added_columns"] = list(current_set - expected_set)
-            result["removed_columns"] = list(expected_set - current_set)
-            result["changed"] = (
-                len(result["added_columns"]) > 0 or len(result["removed_columns"]) > 0
-            )
+            added_columns = list(current_set - expected_set)
+            removed_columns = list(expected_set - current_set)
+            result["added_columns"] = added_columns
+            result["removed_columns"] = removed_columns
+            result["changed"] = len(added_columns) > 0 or len(removed_columns) > 0
 
         conn.close()
         return result
@@ -202,11 +240,18 @@ def validate_data_completeness(
         conn = duckdb.connect(str(duckdb_path), read_only=True)
 
         # Get row count
-        count = conn.execute(f"""
+        count_row = conn.execute(f"""
             SELECT COUNT(*)
             FROM "{schema}"."{source_name}"
-        """).fetchone()[0]
+        """).fetchone()
 
+        if count_row is None:
+            result["row_count"] = 0
+            result["has_data"] = False
+            conn.close()
+            return result
+
+        count = count_row[0]
         result["row_count"] = count
         result["has_data"] = count > 0
 
@@ -247,7 +292,7 @@ def print_validation_report(
     cursor_validation: dict[str, Any],
     schema_info: dict[str, Any],
     completeness: dict[str, Any],
-):
+) -> None:
     """
     Print a comprehensive validation report
 

--- a/dango/utils/data_validation.py
+++ b/dango/utils/data_validation.py
@@ -34,12 +34,13 @@ def validate_cursor_field(
             "issues": list
         }
     """
+    issues: list[str] = []
     result: dict[str, Any] = {
         "valid": False,
         "exists": False,
         "data_type": None,
         "sample_values": [],
-        "issues": [],
+        "issues": issues,
     }
 
     try:
@@ -53,18 +54,14 @@ def validate_cursor_field(
         """).fetchone()
 
         if table_exists_row is None:
-            issues_list = result["issues"]
-            assert isinstance(issues_list, list)
-            issues_list.append(f"Failed to check if table {schema}.{source_name} exists")
+            issues.append(f"Failed to check if table {schema}.{source_name} exists")
             conn.close()
             return result
 
         table_exists = table_exists_row[0]
 
         if not table_exists:
-            issues_list = result["issues"]
-            assert isinstance(issues_list, list)
-            issues_list.append(f"Table {schema}.{source_name} does not exist")
+            issues.append(f"Table {schema}.{source_name} does not exist")
             conn.close()
             return result
 
@@ -78,9 +75,7 @@ def validate_cursor_field(
         """).fetchone()
 
         if not column_info:
-            issues_list = result["issues"]
-            assert isinstance(issues_list, list)
-            issues_list.append(f"Cursor field '{cursor_field}' not found in table")
+            issues.append(f"Cursor field '{cursor_field}' not found in table")
             result["exists"] = False
             conn.close()
             return result
@@ -105,9 +100,7 @@ def validate_cursor_field(
         if isinstance(data_type, str) and not any(
             vtype in data_type.upper() for vtype in valid_types
         ):
-            issues_list = result["issues"]
-            assert isinstance(issues_list, list)
-            issues_list.append(
+            issues.append(
                 f"Cursor field has unexpected type '{data_type}'. "
                 f"Expected: {', '.join(valid_types)}"
             )
@@ -120,29 +113,21 @@ def validate_cursor_field(
         """).fetchone()
 
         if null_count_row is None:
-            issues_list = result["issues"]
-            assert isinstance(issues_list, list)
-            issues_list.append("Failed to check for NULL values in cursor field")
+            issues.append("Failed to check for NULL values in cursor field")
         else:
             null_count = null_count_row[0]
             if null_count > 0:
-                issues_list = result["issues"]
-                assert isinstance(issues_list, list)
-                issues_list.append(f"{null_count} NULL values found in cursor field")
+                issues.append(f"{null_count} NULL values found in cursor field")
 
         conn.close()
 
         # Overall validation
-        issues_list = result["issues"]
-        assert isinstance(issues_list, list)
-        result["valid"] = result["exists"] and len(issues_list) == 0
+        result["valid"] = result["exists"] and len(issues) == 0
 
         return result
 
     except Exception as e:
-        issues_list = result["issues"]
-        assert isinstance(issues_list, list)
-        issues_list.append(f"Validation error: {e}")
+        issues.append(f"Validation error: {e}")
         return result
 
 
@@ -171,9 +156,10 @@ def detect_schema_changes(
             "column_types": dict
         }
     """
-    result = {
+    current_columns: list[str] = []
+    result: dict[str, Any] = {
         "changed": False,
-        "current_columns": [],
+        "current_columns": current_columns,
         "added_columns": [],
         "removed_columns": [],
         "column_types": {},
@@ -190,13 +176,11 @@ def detect_schema_changes(
             ORDER BY ordinal_position
         """).fetchall()
 
-        result["current_columns"] = [col[0] for col in columns]
+        current_columns.extend(col[0] for col in columns)
         result["column_types"] = {col[0]: col[1] for col in columns}
 
         # Compare with expected schema if provided
         if expected_schema:
-            current_columns = result["current_columns"]
-            assert isinstance(current_columns, list)
             current_set = set(current_columns)
             expected_set = set(expected_schema)
 

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -121,24 +121,27 @@ def check_duckdb_health(duckdb_path: Path) -> dict[str, Any]:
         try:
             # Count tables by schema (including source-specific schemas like raw_stripe_test_1)
             # Exclude dlt internal tables (_dlt_*) as they are metadata, not user data
-            raw_tables = conn.execute("""
+            row = conn.execute("""
                 SELECT count(*)
                 FROM information_schema.tables
                 WHERE (table_schema='raw' OR table_schema LIKE 'raw_%')
                 AND table_name NOT LIKE '_dlt_%'
-            """).fetchone()[0]
+            """).fetchone()
+            raw_tables = row[0] if row else 0
 
-            staging_tables = conn.execute("""
+            row = conn.execute("""
                 SELECT count(*)
                 FROM information_schema.tables
                 WHERE table_schema='staging' OR table_schema LIKE 'staging_%'
-            """).fetchone()[0]
+            """).fetchone()
+            staging_tables = row[0] if row else 0
 
-            marts_tables = conn.execute("""
+            row = conn.execute("""
                 SELECT count(*)
                 FROM information_schema.tables
                 WHERE table_schema='marts' OR table_schema LIKE 'marts_%'
-            """).fetchone()[0]
+            """).fetchone()
+            marts_tables = row[0] if row else 0
 
             total_tables = raw_tables + staging_tables + marts_tables
 
@@ -206,7 +209,7 @@ def get_disk_usage_summary(project_root: Path) -> dict[str, Any]:
         return {"free_gb": 0, "total_gb": 0, "used_gb": 0, "used_pct": 0, "status": "unknown"}
 
 
-def print_health_summary(project_root: Path, duckdb_path: Path):
+def print_health_summary(project_root: Path, duckdb_path: Path) -> None:
     """
     Print a summary of platform health (for CLI display)
 

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -3,13 +3,16 @@
 Prevents concurrent dbt runs from UI, CLI, and sync operations to avoid DuckDB locking conflicts and data corruption.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys
+from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 import psutil
 
@@ -63,14 +66,14 @@ class DbtLock:
         self.lock_file_path = self.state_dir / "dbt.lock"
         self.lock_info_path = self.state_dir / "dbt.lock.json"
 
-        self._lock_file = None
+        self._lock_file: IO[str] | None = None
         self._acquired = False
 
     def _is_process_running(self, pid: int) -> bool:
         """Check if a process with the given PID is running."""
         try:
             process = psutil.Process(pid)
-            return process.is_running()
+            return bool(process.is_running())
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             return False
 
@@ -81,11 +84,12 @@ class DbtLock:
 
         try:
             with open(self.lock_info_path) as f:
-                return json.load(f)
+                result: dict[str, Any] = json.load(f)
+                return result
         except (OSError, json.JSONDecodeError):
             return None
 
-    def _write_lock_info(self):
+    def _write_lock_info(self) -> None:
         """Write lock information to the lock info file."""
         # Get hostname in a cross-platform way
         try:
@@ -198,7 +202,7 @@ class DbtLock:
 
             raise DbtLockError(message, lock_info=lock_info) from None
 
-    def release(self):
+    def release(self) -> None:
         """Release the lock."""
         if not self._acquired:
             return
@@ -229,23 +233,26 @@ class DbtLock:
         except OSError:
             pass
 
-    def __enter__(self):
+    def __enter__(self) -> DbtLock:
         """Context manager entry."""
         self.acquire()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
         """Context manager exit."""
         self.release()
-        return False
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Cleanup on deletion."""
         self.release()
 
 
 @contextmanager
-def dbt_lock(project_root: Path, source: str = "unknown", operation: str = "dbt operation"):
+def dbt_lock(
+    project_root: Path, source: str = "unknown", operation: str = "dbt operation"
+) -> Generator[DbtLock, None, None]:
     """
     Context manager for dbt lock.
 

--- a/dango/utils/dbt_status.py
+++ b/dango/utils/dbt_status.py
@@ -84,7 +84,8 @@ def _load_persistent_status(project_root: Path) -> dict[str, dict[str, Any]]:
 
     try:
         with open(status_path) as f:
-            return json.load(f)
+            result: dict[str, dict[str, Any]] = json.load(f)
+            return result
     except Exception:
         return {}
 

--- a/dango/utils/process.py
+++ b/dango/utils/process.py
@@ -18,7 +18,7 @@ def is_process_running(pid: int) -> bool:
     """
     try:
         # Use psutil for cross-platform compatibility
-        return psutil.pid_exists(pid)
+        return bool(psutil.pid_exists(pid))
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         return False
 

--- a/dango/utils/sync_history.py
+++ b/dango/utils/sync_history.py
@@ -15,7 +15,7 @@ def get_sync_history_file(project_root: Path, source_name: str) -> Path:
     return history_dir / f"{source_name}.json"
 
 
-def save_sync_history_entry(project_root: Path, source_name: str, entry: dict[str, Any]):
+def save_sync_history_entry(project_root: Path, source_name: str, entry: dict[str, Any]) -> None:
     """Save a sync history entry for a source"""
     history_file = get_sync_history_file(project_root, source_name)
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -184,13 +184,13 @@ app.include_router(metabase_proxy_router)
 
 # Application startup/shutdown events
 @app.on_event("startup")
-async def startup_event():
+async def startup_event() -> None:
     """Run on application startup."""
     logger.info("api_starting", project_root=str(get_project_root()))
 
 
 @app.on_event("shutdown")
-async def shutdown_event():
+async def shutdown_event() -> None:
     """Run on application shutdown."""
     logger.info("api_shutting_down")
 

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -13,7 +13,7 @@ class TableInfo(BaseModel):
 
     name: str
     row_count: int
-    schema: str
+    schema: str  # type: ignore[assignment]
 
 
 class SourceStatus(BaseModel):

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -13,7 +13,7 @@ class TableInfo(BaseModel):
 
     name: str
     row_count: int
-    schema: str  # type: ignore[assignment]
+    schema: str  # type: ignore[assignment]  # shadows BaseModel.schema() deprecated method
 
 
 class SourceStatus(BaseModel):

--- a/dango/web/routes/config.py
+++ b/dango/web/routes/config.py
@@ -16,7 +16,7 @@ router = APIRouter(tags=["config"])
 
 
 @router.get("/api/config")
-async def get_config():
+async def get_config() -> dict[str, object]:
     """Get Dango configuration (ports, URLs, etc.).
 
     Returns configuration needed by the frontend to build dynamic URLs
@@ -55,7 +55,7 @@ async def get_config():
 
 
 @router.get("/api/metabase-config")
-async def get_metabase_config():
+async def get_metabase_config() -> dict[str, object]:
     """Get Metabase configuration including database ID.
 
     Returns:

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -24,7 +24,7 @@ router = APIRouter(tags=["dbt"])
 
 
 @router.get("/api/dbt/models")
-async def list_dbt_models():
+async def list_dbt_models() -> dict[str, list]:
     """List all dbt models.
 
     Returns:
@@ -39,7 +39,9 @@ async def list_dbt_models():
 
 
 @router.post("/api/dbt/models/{model_name}/run")
-async def run_dbt_model(model_name: str, background_tasks: BackgroundTasks, cascade: bool = True):
+async def run_dbt_model(
+    model_name: str, background_tasks: BackgroundTasks, cascade: bool = True
+) -> dict[str, str | bool]:
     """Run a specific dbt model.
 
     Args:
@@ -85,7 +87,7 @@ async def run_dbt_model(model_name: str, background_tasks: BackgroundTasks, casc
     }
 
 
-async def run_dbt_model_task(model_name: str, cascade: bool):
+async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
     """Run dbt model in background."""
     from dango.utils import DbtLock, DbtLockError
     from dango.utils.dbt_status import update_model_status
@@ -243,7 +245,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool):
 
 @router.get("/manifest.json")
 @router.get("/catalog.json")
-async def dbt_docs_assets(request: Request):
+async def dbt_docs_assets(request: Request) -> Response:
     """Proxy dbt docs JSON assets.
 
     dbt docs JavaScript loads these files using absolute paths,
@@ -272,7 +274,7 @@ async def dbt_docs_assets(request: Request):
 
 @router.api_route("/dbt-docs/{path:path}", methods=["GET"])
 @router.api_route("/dbt-docs", methods=["GET"])
-async def dbt_docs_proxy(request: Request, path: str = ""):
+async def dbt_docs_proxy(request: Request, path: str = "") -> Response:
     """Reverse proxy for dbt docs with nav bar injection.
 
     Routes all requests to http://localhost:8081 and automatically

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -6,6 +6,7 @@ Health check and platform status endpoints.
 import asyncio
 import logging
 from datetime import datetime
+from typing import Any
 
 from fastapi import APIRouter
 
@@ -23,7 +24,7 @@ router = APIRouter(tags=["health"])
 
 
 @router.get("/api/status", response_model=ServiceHealth)
-async def get_status():
+async def get_status() -> ServiceHealth:
     """Get service health status.
 
     Returns health check for Dango API and related services (DuckDB, Metabase, dbt-docs)
@@ -55,7 +56,7 @@ async def get_status():
 
 
 @router.get("/api/watcher/status", response_model=WatcherStatus)
-async def get_watcher_status_api():
+async def get_watcher_status_api() -> WatcherStatus:
     """Get file watcher status.
 
     Returns information about the file watcher including:
@@ -104,7 +105,7 @@ async def get_watcher_status_api():
 
 
 @router.get("/api/health/platform")
-async def get_platform_health():
+async def get_platform_health() -> dict[str, Any]:
     """Get comprehensive platform health status.
 
     Returns:

--- a/dango/web/routes/logs.py
+++ b/dango/web/routes/logs.py
@@ -18,7 +18,7 @@ router = APIRouter(tags=["logs"])
 
 
 @router.get("/api/sources/{source_name}/logs", response_model=list[LogEntry])
-async def get_source_logs(source_name: str, limit: int = 100):
+async def get_source_logs(source_name: str, limit: int = 100) -> list[LogEntry]:
     """Get sync logs for a specific source.
 
     Args:
@@ -62,7 +62,7 @@ async def get_source_logs(source_name: str, limit: int = 100):
 
 
 @router.get("/api/logs")
-async def get_all_logs(limit: int = 1000):
+async def get_all_logs(limit: int = 1000) -> list[dict[str, object]]:
     """Get all activity logs.
 
     Args:

--- a/dango/web/routes/metabase_proxy.py
+++ b/dango/web/routes/metabase_proxy.py
@@ -4,7 +4,7 @@ Metabase reverse proxy routes with SSO session management.
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import yaml
@@ -21,7 +21,9 @@ router = APIRouter(tags=["metabase-proxy"])
 _metabase_session: dict[str, Any] = {}
 
 
-async def proxy_to_metabase(request: Request, target_path: str, session_id: str = None) -> Response:
+async def proxy_to_metabase(
+    request: Request, target_path: str, session_id: str | None = None
+) -> Response:
     """Proxy a request to Metabase.
 
     Args:
@@ -83,16 +85,18 @@ async def proxy_to_metabase(request: Request, target_path: str, session_id: str 
         return Response(content=f"Proxy error: {str(e)}", status_code=502)
 
 
-async def get_metabase_session() -> str:
+async def get_metabase_session() -> str | None:
     """Get or create Metabase session for auto-login.
 
     Returns:
-        Session ID for Metabase
+        Session ID for Metabase, or None if unable to create session
     """
     # Return cached session if valid
     if _metabase_session.get("id"):
         # TODO: Check if session is still valid
-        return _metabase_session["id"]
+        session_id = _metabase_session["id"]
+        if isinstance(session_id, str):
+            return session_id
 
     # Load credentials
     try:
@@ -130,12 +134,16 @@ async def get_metabase_session() -> str:
                 session_data = login_response.json()
                 session_id = session_data.get("id")
 
-                # Cache the session
-                _metabase_session["id"] = session_id
-                _metabase_session["email"] = admin_email
+                if session_id and isinstance(session_id, str):
+                    # Cache the session
+                    _metabase_session["id"] = session_id
+                    _metabase_session["email"] = admin_email
 
-                logger.info(f"Created Metabase session: {session_id[:8]}...")
-                return session_id
+                    logger.info(f"Created Metabase session: {session_id[:8]}...")
+                    return cast(str, session_id)
+                else:
+                    logger.error("Metabase login response missing valid session ID")
+                    return None
             else:
                 logger.error(f"Metabase login failed: {login_response.status_code}")
                 return None
@@ -151,20 +159,20 @@ async def get_metabase_session() -> str:
 
 
 @router.api_route("/api/health", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
-async def metabase_api_health(request: Request):
+async def metabase_api_health(request: Request) -> Response:
     """Proxy Metabase health check API."""
     session_id = await get_metabase_session()
     return await proxy_to_metabase(request, "/api/health", session_id)
 
 
 @router.api_route("/api/session", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
-async def metabase_api_session(request: Request):
+async def metabase_api_session(request: Request) -> Response:
     """Proxy Metabase session API."""
     return await proxy_to_metabase(request, "/api/session")
 
 
 @router.api_route("/api/user", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
-async def metabase_api_user(request: Request):
+async def metabase_api_user(request: Request) -> Response:
     """Proxy Metabase user API."""
     session_id = await get_metabase_session()
     return await proxy_to_metabase(request, "/api/user", session_id)
@@ -174,7 +182,7 @@ async def metabase_api_user(request: Request):
 @router.api_route(
     "/api/database/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
 )
-async def metabase_api_database(request: Request, path: str = ""):
+async def metabase_api_database(request: Request, path: str = "") -> Response:
     """Proxy Metabase database API."""
     session_id = await get_metabase_session()
     target_path = f"/api/database/{path}" if path else "/api/database"
@@ -182,19 +190,19 @@ async def metabase_api_database(request: Request, path: str = ""):
 
 
 @router.api_route("/app/{path:path}", methods=["GET"])
-async def metabase_app_assets(request: Request, path: str):
+async def metabase_app_assets(request: Request, path: str) -> Response:
     """Proxy Metabase app assets (JS, CSS, images, etc.)."""
     return await proxy_to_metabase(request, f"/app/{path}")
 
 
 @router.api_route("/public/{path:path}", methods=["GET"])
-async def metabase_public_assets(request: Request, path: str):
+async def metabase_public_assets(request: Request, path: str) -> Response:
     """Proxy Metabase public assets."""
     return await proxy_to_metabase(request, f"/public/{path}")
 
 
 @router.get("/styles.css")
-async def metabase_styles(request: Request):
+async def metabase_styles(request: Request) -> Response:
     """Proxy Metabase styles.css."""
     return await proxy_to_metabase(request, "/styles.css")
 
@@ -203,7 +211,7 @@ async def metabase_styles(request: Request):
     "/metabase/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
 )
 @router.api_route("/metabase", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
-async def metabase_proxy(request: Request, path: str = ""):
+async def metabase_proxy(request: Request, path: str = "") -> Response:
     """Reverse proxy for Metabase with automatic SSO.
 
     Routes all requests to http://localhost:3000 and automatically

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -26,7 +26,7 @@ router = APIRouter(tags=["sources"])
 
 
 @router.get("/api/sources", response_model=list[SourceStatus])
-async def get_sources():
+async def get_sources() -> list[SourceStatus]:
     """List all configured data sources with status.
 
     Returns:
@@ -46,7 +46,7 @@ async def get_sources():
 
 
 @router.get("/api/sources/{source_name}/details")
-async def get_source_details(source_name: str):
+async def get_source_details(source_name: str) -> dict[str, object]:
     """Get detailed information about a specific source.
 
     Args:

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -28,7 +28,7 @@ router = APIRouter(tags=["sync"])
 @router.post("/api/sources/{source_name}/sync", response_model=SyncResponse)
 async def trigger_sync(
     source_name: str, sync_request: SyncRequest, background_tasks: BackgroundTasks
-):
+) -> SyncResponse:
     """Trigger sync for a specific source.
 
     Args:
@@ -75,7 +75,7 @@ async def trigger_sync(
 
 async def run_sync_task(
     source_name: str, full_refresh: bool, start_date: str | None, end_date: str | None
-):
+) -> None:
     """Run sync task in background.
 
     This function imports and runs the dlt sync process, broadcasting updates via WebSocket

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -37,7 +37,7 @@ def _render_template(template_name: str, context: dict) -> HTMLResponse:
 
 
 @router.get("/")
-async def root(request: Request):
+async def root(request: Request) -> HTMLResponse:
     """Serve the dashboard UI."""
     return _render_template(
         "dashboard.html",
@@ -51,7 +51,7 @@ async def root(request: Request):
 
 
 @router.get("/health")
-async def health_page(request: Request):
+async def health_page(request: Request) -> HTMLResponse:
     """Serve the platform health page."""
     return _render_template(
         "health.html",
@@ -65,7 +65,7 @@ async def health_page(request: Request):
 
 
 @router.get("/logs")
-async def logs_page(request: Request):
+async def logs_page(request: Request) -> HTMLResponse:
     """Serve the logs page."""
     return _render_template(
         "logs.html",
@@ -79,13 +79,13 @@ async def logs_page(request: Request):
 
 
 @router.get("/api")
-async def api_info():
+async def api_info() -> dict[str, str]:
     """API information endpoint."""
     return {"message": "Dango API", "version": "0.1.0", "docs": "/api/docs", "websocket": "/ws"}
 
 
 @router.get("/api/docs", include_in_schema=False)
-async def custom_swagger_ui_html():
+async def custom_swagger_ui_html() -> HTMLResponse:
     """Swagger UI (default, no custom navbar)."""
     from fastapi.openapi.docs import get_swagger_ui_html
 
@@ -93,7 +93,7 @@ async def custom_swagger_ui_html():
 
 
 @router.get("/api/redoc", include_in_schema=False)
-async def custom_redoc_html():
+async def custom_redoc_html() -> HTMLResponse:
     """ReDoc (default, no custom navbar)."""
     from fastapi.openapi.docs import get_redoc_html
 

--- a/dango/web/routes/websocket.py
+++ b/dango/web/routes/websocket.py
@@ -18,21 +18,21 @@ router = APIRouter(tags=["websocket"])
 class ConnectionManager:
     """Manages WebSocket connections for real-time updates."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.active_connections: list[WebSocket] = []
 
-    async def connect(self, websocket: WebSocket):
+    async def connect(self, websocket: WebSocket) -> None:
         """Accept new WebSocket connection."""
         await websocket.accept()
         self.active_connections.append(websocket)
         logger.info(f"WebSocket connected. Total connections: {len(self.active_connections)}")
 
-    def disconnect(self, websocket: WebSocket):
+    def disconnect(self, websocket: WebSocket) -> None:
         """Remove WebSocket connection."""
         self.active_connections.remove(websocket)
         logger.info(f"WebSocket disconnected. Total connections: {len(self.active_connections)}")
 
-    async def broadcast(self, message: dict):
+    async def broadcast(self, message: dict) -> None:
         """Broadcast message to all connected clients and persist to logs."""
         # Persist to logs
         log_entry = {
@@ -76,7 +76,7 @@ ws_manager = ConnectionManager()
 
 
 @router.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket):
+async def websocket_endpoint(websocket: WebSocket) -> None:
     """WebSocket endpoint for real-time updates.
 
     Clients can connect to receive real-time updates about:

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -1,6 +1,6 @@
 # Exemption registry for files exceeding the 500-line soft limit (STANDARDS.md §2).
 # Consumed by scripts/check_file_sizes.py for CI and pre-commit checks.
-# Line counts captured at time of audit (2026-02-10) — informational, not enforced by script.
+# Line counts refreshed 2026-02-13 (TASK-092) — informational, not enforced by script.
 #
 # Categories:
 #   refactor — planned for refactoring in v1 (linked to a task)
@@ -18,63 +18,63 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/upload.py
-    lines: 664
+    lines: 680
     category: exempt
     reason: "CSV upload/list/delete endpoints. Extracted from web/app.py by TASK-085. DELETE endpoint alone has ~300 lines of DuckDB cleanup logic."
     review_by: "v1.1"
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 945
+    lines: 971
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
 
   - file: dango/cli/commands/auth.py
-    lines: 707
+    lines: 767
     category: exempt
     reason: "OAuth authentication commands (10 subcommands). Extracted from cli/main.py by TASK-005. One command per provider — file grows linearly with providers."
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 521
+    lines: 538
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. Sync command alone is ~200 lines of orchestration logic."
     review_by: "v1.1"
 
   # --- Exempt (stable, not modified in v1) ---
   - file: dango/ingestion/dlt_runner.py
-    lines: 1696
+    lines: 1759
     category: exempt
     reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage."
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
-    lines: 1440
+    lines: 1466
     category: exempt
     reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type."
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py
-    lines: 1225
+    lines: 1324
     category: exempt
     reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting."
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
-    lines: 1207
+    lines: 1142
     category: exempt
     reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations."
     review_by: "v1.1"
 
   - file: dango/visualization/dashboard_manager.py
-    lines: 1102
+    lines: 1113
     category: exempt
     reason: "Dashboard export/import operations. Tightly coupled to metabase.py API surface."
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 945
+    lines: 965
     category: exempt
     reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit."
     review_by: "v1.1"
@@ -82,37 +82,37 @@ exemptions:
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)
 
   - file: dango/oauth/providers.py
-    lines: 761
+    lines: 801
     category: exempt
     reason: "OAuth provider definitions (Google, Facebook, Shopify). Each provider is self-contained — file grows linearly with providers."
     review_by: "v1.1"
 
   - file: dango/ingestion/csv_loader.py
-    lines: 761
+    lines: 742
     category: exempt
     reason: "CSV loading with deduplication. Single-purpose module, stable."
     review_by: "v1.1"
 
   - file: dango/cli/validate.py
-    lines: 677
+    lines: 651
     category: exempt
     reason: "Validation commands (config, sources, connections). Each validator is independent."
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 560
+    lines: 577
     category: exempt
     reason: "DbtModelGenerator — generates dbt models from source configs. Stable, rarely modified."
     review_by: "v1.1"
 
   - file: dango/platform/watcher.py
-    lines: 531
+    lines: 506
     category: exempt
     reason: "File change detection for auto-sync. Event-driven logic, stable."
     review_by: "v1.1"
 
   - file: dango/cli/model_wizard.py
-    lines: 517
+    lines: 507
     category: exempt
     reason: "Interactive dbt model creation wizard. Sequential prompting, stable."
     review_by: "v1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ ignore_errors = true
 testpaths = ["tests"]
 pythonpath = ["."]
 markers = [
-    "unit: Unit tests (no I/O, no network, no database)",
+    "unit: Unit tests (no external services or network — tmp_path filesystem operations are allowed)",
     "integration: Integration tests (may use temp dirs, real files, DuckDB)",
 ]
 addopts = "--strict-markers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ dev = [
     "ruff>=0.6.0",
     "mypy>=1.11.0",
     "types-PyYAML>=6.0.0",
+    "types-requests>=2.31.0",
+    "types-psutil>=5.9.0",
+    "types-toml>=0.10.0",
+    "types-aiofiles>=23.2.0",
     "pre-commit>=3.6.0",
     "pip-audit>=2.7.0",
 ]
@@ -102,8 +106,11 @@ packages = [
     "dango.utils",
     "dango.visualization",
     "dango.web",
+    "dango.web.routes",
     "dango.oauth",      # OAuth management
     "dango.security",   # Token encryption
+    "dango.cli.commands",
+    "dango.cli.helpers",
 ]
 include-package-data = true
 
@@ -145,6 +152,15 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 exclude = ["dango/ingestion/dlt_sources/"]
+
+[[tool.mypy.overrides]]
+module = [
+    "inquirer",
+    "inquirer.*",
+    "googleapiclient",
+    "googleapiclient.*",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,30 @@ module = [
 ]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = [
+    # Exempt monolithic files (see docs/file-exemptions.yml)
+    # Full type checking deferred until refactoring or dedicated typing task
+    "dango.ingestion.dlt_runner",
+    "dango.ingestion.sources.registry",
+    "dango.ingestion.csv_loader",
+    "dango.cli.source_wizard",
+    "dango.cli.init",
+    "dango.cli.model_wizard",
+    "dango.cli.validate",
+    "dango.cli.commands.platform",
+    "dango.cli.commands.auth",
+    "dango.cli.commands.source",
+    "dango.visualization.metabase",
+    "dango.visualization.dashboard_manager",
+    "dango.transformation.generator",
+    "dango.platform.watcher",
+    "dango.oauth.providers",
+    "dango.web.helpers",
+    "dango.web.routes.upload",
+]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]


### PR DESCRIPTION
## Summary

- Achieve **0 mypy errors** across 85 checked source files (down from 420)
- Migrate 3 Pydantic V1 deprecations (`@validator` → `@field_validator`, `class Config` → `model_config`) — eliminates warnings on every test run
- Harden CI (mypy now blocks PRs) and pre-commit (mypy runs on every commit, not manual-only)
- Add type stubs (`types-requests`, `types-psutil`, `types-toml`, `types-aiofiles`) and fix `pyproject.toml` package list
- Add `ignore_errors = true` mypy overrides for 17 exempt monolithic files (from `docs/file-exemptions.yml`)
- Fix type errors in 40 non-exempt files: return type annotations, `None` checks, type narrowing, variable shadowing fixes
- Update unit test marker description to clarify `tmp_path` is allowed
- Refresh all 17 exempt file line counts in `docs/file-exemptions.yml`

## Test plan

- [x] `mypy dango/` — 0 errors (85 files checked)
- [x] `pytest` — 396 passed, 0 failed
- [x] `ruff check dango/` — all checks passed
- [x] No Pydantic deprecation warnings in test output
- [x] All pre-commit hooks pass
- [x] No `ValidationError` import shadowing verified (grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)