### PR TITLE
Add database migration framework (TASK-087)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | Token encryption / keychain | `dango/security/` | [`dango/security/CLAUDE.md`](dango/security/CLAUDE.md) |
 | Shared utilities | `dango/utils/` | [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md) |
 | Logging / diagnostics | `dango/logging.py` | Module docstring |
+| Database migrations | `dango/migrations/` | [`dango/migrations/CLAUDE.md`](dango/migrations/CLAUDE.md) |
 | Docker / file watcher | `dango/platform/` | `dango/platform/CLAUDE.md` (Phase 3) |
 | Jinja2 templates / Dockerfiles | `dango/templates/` | [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md) |
 | Auth / users / sessions | `dango/auth/` | Not yet created (Phase 2) |
@@ -153,6 +154,10 @@ dango/                          # Python package source
 │   ├── dbt_status.py           # dbt model status tracking
 │   └── data_validation.py      # Data validation utilities
 │
+├── migrations/                 # Level 0 — Database migration framework
+│   ├── __init__.py             # Public API: apply_all_pending(), get_all_status()
+│   └── runner.py               # MigrationRunner, MigrationInfo, MigrationStatus
+│
 ├── security/                   # Level 0 — Token encryption
 │   └── token_storage.py        # SecureTokenStorage (OS keychain + Fernet)
 │
@@ -174,7 +179,7 @@ tests/
 
 | Level | Role | Modules |
 |-------|------|---------|
-| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `templates/`, `logging.py` |
+| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `migrations/`, `templates/`, `logging.py` |
 | 1 (core) | Imports Level 0 only | `oauth/`, `ingestion/`, `transformation/` |
 | 2 (platform) | Imports Level 0–1 | `platform/`, `web/`, `visualization/` |
 | 3 (ui) | Imports any level | `cli/` |
@@ -226,6 +231,7 @@ Module CLAUDE.md files provide per-module navigation, public API, and patterns.
 - [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md)
 - [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md)
 - [`dango/web/CLAUDE.md`](dango/web/CLAUDE.md)
+- [`dango/migrations/CLAUDE.md`](dango/migrations/CLAUDE.md)
 
 **Planned later phases:**
 - `dango/platform/CLAUDE.md` (Phase 3)

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -22,6 +22,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
+| `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
 | `init.py` (965 lines) | Project initialization wizard | `ProjectInitializer` |
@@ -64,6 +65,8 @@ dango (top-level group)
 │   ├── add, remove
 ├── dashboard (group)           ← commands/dashboard.py
 │   ├── provision
+├── migrate (group)             ← commands/migrate.py
+│   ├── status, run
 └── metabase (group)            ← commands/metabase_cmd.py
     ├── save, load, refresh
 ```

--- a/dango/cli/commands/migrate.py
+++ b/dango/cli/commands/migrate.py
@@ -83,9 +83,9 @@ def migrate_run(ctx: click.Context, db_name: str | None) -> None:
 
     try:
         if db_name:
-            from dango.migrations import _get_migrations_base_dir
+            from dango.migrations import get_migrations_base_dir
 
-            migrations_dir = _get_migrations_base_dir() / db_name
+            migrations_dir = get_migrations_base_dir() / db_name
             if not migrations_dir.is_dir():
                 console.print(f"[red]Error:[/red] No migration directory for '{db_name}'")
                 raise click.Abort()

--- a/dango/cli/commands/migrate.py
+++ b/dango/cli/commands/migrate.py
@@ -1,0 +1,113 @@
+"""dango/cli/commands/migrate.py
+
+CLI commands for database migration management (status, run).
+"""
+
+import click
+
+from dango.cli import console
+
+
+@click.group()
+@click.pass_context
+def migrate(ctx: click.Context) -> None:
+    """
+    Manage database migrations.
+
+    Commands:
+      dango migrate status   Show migration status for all databases
+      dango migrate run      Apply pending migrations
+    """
+    pass
+
+
+@migrate.command("status")
+@click.pass_context
+def migrate_status(ctx: click.Context) -> None:
+    """Show migration status for all databases."""
+    from rich.table import Table
+
+    from dango.migrations import get_all_status
+
+    from ..utils import require_project_context
+
+    project_root = require_project_context(ctx)
+    statuses = get_all_status(project_root)
+
+    if not statuses:
+        console.print("[dim]No migration databases found.[/dim]")
+        return
+
+    for ms in statuses:
+        table = Table(title=f"Database: {ms.db_name}", show_header=True)
+        table.add_column("Version", style="cyan", justify="right")
+        table.add_column("Description")
+        table.add_column("Status", justify="center")
+        table.add_column("Applied At")
+
+        for applied in ms.applied:
+            table.add_row(
+                str(applied.version),
+                applied.description,
+                "[green]applied[/green]",
+                applied.applied_at,
+            )
+        for pending in ms.pending:
+            table.add_row(
+                str(pending.version),
+                pending.description,
+                "[yellow]pending[/yellow]",
+                "",
+            )
+
+        console.print(table)
+        console.print(
+            f"  Current version: [cyan]{ms.current_version}[/cyan]  |  "
+            f"Applied: [green]{len(ms.applied)}[/green]  |  "
+            f"Pending: [yellow]{len(ms.pending)}[/yellow]"
+        )
+        console.print()
+
+
+@migrate.command("run")
+@click.option("--db", "db_name", default=None, help="Apply to a specific database only.")
+@click.pass_context
+def migrate_run(ctx: click.Context, db_name: str | None) -> None:
+    """Apply pending migrations."""
+    from dango.exceptions import MigrationError
+    from dango.migrations import MigrationRunner, apply_all_pending
+
+    from ..utils import require_project_context
+
+    project_root = require_project_context(ctx)
+
+    try:
+        if db_name:
+            from dango.migrations import _get_migrations_base_dir
+
+            migrations_dir = _get_migrations_base_dir() / db_name
+            if not migrations_dir.is_dir():
+                console.print(f"[red]Error:[/red] No migration directory for '{db_name}'")
+                raise click.Abort()
+
+            db_path = project_root / ".dango" / f"{db_name}.db"
+            runner = MigrationRunner(
+                db_path=db_path, db_name=db_name, migrations_dir=migrations_dir
+            )
+            applied = runner.apply_pending()
+            results = {db_name: applied}
+        else:
+            results = apply_all_pending(project_root)
+
+        total = sum(len(v) for v in results.values())
+        if total == 0:
+            console.print("[green]All databases are up to date.[/green]")
+        else:
+            for name, applied in results.items():
+                if applied:
+                    console.print(f"  [green]✓[/green] {name}: applied {len(applied)} migration(s)")
+                    for m in applied:
+                        console.print(f"    {m.version}: {m.description}")
+    except MigrationError as exc:
+        console.print(f"[red]Migration error:[/red] {exc}")
+        raise click.Abort() from exc

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -153,6 +153,24 @@ def start(ctx: click.Context) -> None:
         project_name = config.project.name
         platform_config = config.platform
 
+        # Auto-migrate databases
+        try:
+            from dango.migrations import apply_all_pending
+
+            migration_results = apply_all_pending(project_root)
+            for migration_db_name, migration_applied in migration_results.items():
+                if migration_applied:
+                    console.print(
+                        f"  Applied {len(migration_applied)} migration(s) to {migration_db_name}"
+                    )
+        except Exception as migration_exc:
+            from dango.exceptions import MigrationError
+
+            if isinstance(migration_exc, MigrationError):
+                console.print(f"[red]Migration error:[/red] {migration_exc}")
+                raise click.Abort() from migration_exc
+            raise
+
         # Ensure all dbt schemas exist (for Metabase visibility)
         from dango.utils.database import ensure_dbt_schemas
 

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -14,6 +14,7 @@ from dango.cli.commands.config_cmd import config
 from dango.cli.commands.dashboard import dashboard
 from dango.cli.commands.data import db, validate
 from dango.cli.commands.metabase_cmd import metabase
+from dango.cli.commands.migrate import migrate
 from dango.cli.commands.model import model
 from dango.cli.commands.platform import start, status, stop
 from dango.cli.commands.project import info, init, rename
@@ -75,6 +76,7 @@ cli.add_command(auth)
 cli.add_command(model)
 cli.add_command(dashboard)
 cli.add_command(metabase)
+cli.add_command(migrate)
 
 
 def main() -> None:

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -136,6 +136,8 @@ class ConfigLoader:
                 f"Invalid project configuration in {self.project_file}:\n{e}"
             ) from e
 
+    SUPPORTED_SOURCES_VERSIONS = {"1.0"}
+
     def load_sources_config(self) -> SourcesConfig:
         """
         Load sources configuration from sources.yml.
@@ -146,6 +148,7 @@ class ConfigLoader:
         Raises:
             ConfigNotFoundError: If file doesn't exist
             ConfigValidationError: If validation fails
+            ConfigVersionError: If version is unsupported
         """
         # sources.yml is optional - return empty config if not found
         if not self.sources_file.exists():
@@ -154,11 +157,26 @@ class ConfigLoader:
         data = self.load_yaml(self.sources_file)
 
         try:
-            return SourcesConfig(**data)
+            sources = SourcesConfig(**data)
         except ValidationError as e:
             raise ConfigValidationError(
                 f"Invalid sources configuration in {self.sources_file}:\n{e}"
             ) from e
+
+        if sources.version not in self.SUPPORTED_SOURCES_VERSIONS:
+            from dango.exceptions import ConfigVersionError
+
+            raise ConfigVersionError(
+                f"sources.yml version '{sources.version}' is not supported. "
+                f"Supported: {', '.join(sorted(self.SUPPORTED_SOURCES_VERSIONS))}. "
+                f"Upgrade Dango or run 'dango migrate run'.",
+                context={
+                    "file": str(self.sources_file),
+                    "version": sources.version,
+                },
+            )
+
+        return sources
 
     def load_config(self) -> DangoConfig:
         """

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -169,7 +169,7 @@ class ConfigLoader:
             raise ConfigVersionError(
                 f"sources.yml version '{sources.version}' is not supported. "
                 f"Supported: {', '.join(sorted(self.SUPPORTED_SOURCES_VERSIONS))}. "
-                f"Upgrade Dango or run 'dango migrate run'.",
+                f"Upgrade Dango to a version that supports this config format.",
                 context={
                     "file": str(self.sources_file),
                     "version": sources.version,
@@ -242,11 +242,15 @@ class ConfigLoader:
         """
         errors = []
 
+        from dango.exceptions import ConfigVersionError
+
         try:
             self.load_config()
         except ConfigNotFoundError as e:
             errors.append(str(e))
         except ConfigValidationError as e:
+            errors.append(str(e))
+        except ConfigVersionError as e:
             errors.append(str(e))
         except ConfigError as e:
             errors.append(str(e))

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -35,6 +35,10 @@ __all__ = [
     "DiskSpaceError",
     "DuckDBHealthError",
     "DbtLockError",
+    "MigrationError",
+    "MigrationDiscoveryError",
+    "MigrationApplicationError",
+    "ConfigVersionError",
     "ValidationError",
     "InvalidSourceNameError",
     "InvalidDateFormatError",
@@ -196,6 +200,35 @@ class DbtLockError(InfrastructureError):
             context=context,
             user_message=user_message,
         )
+
+
+# ---------------------------------------------------------------------------
+# Migration exceptions  (DANGO-M***)
+# ---------------------------------------------------------------------------
+
+
+class MigrationError(DangoError):
+    """Base exception for migration errors."""
+
+    _default_error_code = "DANGO-M001"
+
+
+class MigrationDiscoveryError(MigrationError):
+    """Migration files cannot be discovered or are malformed."""
+
+    _default_error_code = "DANGO-M002"
+
+
+class MigrationApplicationError(MigrationError):
+    """A migration failed during application."""
+
+    _default_error_code = "DANGO-M003"
+
+
+class ConfigVersionError(DangoError):
+    """Config file version is incompatible with running Dango."""
+
+    _default_error_code = "DANGO-M004"
 
 
 # ---------------------------------------------------------------------------

--- a/dango/migrations/CLAUDE.md
+++ b/dango/migrations/CLAUDE.md
@@ -1,0 +1,85 @@
+# migrations/
+
+## Purpose
+
+Incremental database migration framework for Dango's SQLite databases. Each subsystem (auth, scheduler, etc.) has its own subdirectory with independently versioned migration files. Migrations run automatically on `dango start` and can be managed manually via `dango migrate status` and `dango migrate run`.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` | Public API and subdirectory orchestration | `apply_all_pending()`, `get_all_status()` |
+| `runner.py` | Core migration engine | `MigrationRunner`, `MigrationInfo`, `MigrationStatus`, `AppliedMigration` |
+
+## Migration Subdirectories
+
+Each subdirectory represents a database. Convention: `auth/` maps to `.dango/auth.db`.
+
+```
+migrations/
+├── __init__.py     # Public API
+├── runner.py       # Core engine
+├── CLAUDE.md       # This file
+└── auth/           # Created by TASK-011 (Phase 2)
+    ├── 001_initial_auth.py
+    └── 002_add_sessions.py
+```
+
+## Migration File Contract
+
+```python
+"""dango/migrations/auth/001_initial_auth.py
+
+Create initial auth tables.
+"""
+from __future__ import annotations
+import sqlite3
+
+VERSION = 1              # Must match NNN in filename
+DESCRIPTION = "Create initial auth tables"
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Apply this migration. Do not call conn.commit()."""
+    conn.execute("CREATE TABLE IF NOT EXISTS users (...)")
+```
+
+Rules:
+- Filename: `NNN_description.py` (zero-padded, e.g., `001`, `002`)
+- `VERSION` int must match filename prefix
+- `DESCRIPTION` string for status output
+- `upgrade(conn)` receives an active connection inside a runner-managed transaction
+- No `downgrade()` function
+- `__init__.py` files are ignored during discovery
+- Subdirectories are NOT Python packages
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new migration | Create `NNN_*.py` in the appropriate subdirectory | `pytest tests/unit/test_migrations.py` |
+| Add a new database | Create a new subdirectory under `migrations/` | `dango migrate status` |
+| Check migration status | Run `dango migrate status` | — |
+| Apply migrations manually | Run `dango migrate run` or `dango migrate run --db auth` | — |
+
+## Dependencies
+
+**Imports from:**
+- `dango.exceptions` — `MigrationError`, `MigrationDiscoveryError`, `MigrationApplicationError`
+- stdlib only: `sqlite3`, `importlib.util`, `pathlib`, `dataclasses`, `re`, `datetime`
+
+**Used by:**
+- `dango/cli/commands/platform.py` — auto-migrate on `dango start`
+- `dango/cli/commands/migrate.py` — manual CLI commands
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_migrations.py -v`
+- **Manual:** `dango migrate status`, `dango migrate run`
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `_migrations` table schema | Applied migrations reference this schema; changing it breaks existing databases |
+| `NNN_*.py` filename convention | Discovery relies on the regex pattern `^\d{3,}_.+\.py$` |
+| Applied migration files | Once applied, migration files must not be altered (version is recorded in DB) |

--- a/dango/migrations/__init__.py
+++ b/dango/migrations/__init__.py
@@ -1,0 +1,110 @@
+"""dango/migrations/__init__.py
+
+Database migration framework for Dango.
+
+Provides incremental schema migrations for SQLite databases used by
+subsystems (auth, scheduler, etc.). Each subsystem has its own
+subdirectory under ``dango/migrations/`` with independently versioned
+migration files.
+
+Public API::
+
+    from dango.migrations import apply_all_pending, get_all_status
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .runner import (
+    AppliedMigration,
+    MigrationInfo,
+    MigrationRunner,
+    MigrationStatus,
+)
+
+__all__ = [
+    "apply_all_pending",
+    "get_all_status",
+    "AppliedMigration",
+    "MigrationInfo",
+    "MigrationRunner",
+    "MigrationStatus",
+]
+
+
+def _get_migrations_base_dir() -> Path:
+    """Return the directory containing migration subdirectories."""
+    return Path(__file__).parent
+
+
+def apply_all_pending(project_root: Path) -> dict[str, list[MigrationInfo]]:
+    """Discover all migration subdirectories and apply pending migrations.
+
+    Convention: database ``'auth'`` maps to ``<project_root>/.dango/auth.db``.
+    Subdirectories without migration files are skipped.
+
+    Args:
+        project_root: Root of the Dango project.
+
+    Returns:
+        Mapping of database name to list of applied migrations.
+    """
+    base_dir = _get_migrations_base_dir()
+    results: dict[str, list[MigrationInfo]] = {}
+
+    for subdir in sorted(base_dir.iterdir()):
+        if not subdir.is_dir():
+            continue
+        if subdir.name.startswith("__"):
+            continue
+
+        # Check if the subdirectory has any Python migration files
+        py_files = [
+            f
+            for f in subdir.iterdir()
+            if f.is_file() and f.suffix == ".py" and f.name != "__init__.py"
+        ]
+        if not py_files:
+            continue
+
+        db_path = project_root / ".dango" / f"{subdir.name}.db"
+        runner = MigrationRunner(db_path=db_path, db_name=subdir.name, migrations_dir=subdir)
+        applied = runner.apply_pending()
+        results[subdir.name] = applied
+
+    return results
+
+
+def get_all_status(project_root: Path) -> list[MigrationStatus]:
+    """Get migration status for all known databases.
+
+    Args:
+        project_root: Root of the Dango project.
+
+    Returns:
+        List of ``MigrationStatus`` objects, one per database.
+    """
+    base_dir = _get_migrations_base_dir()
+    statuses: list[MigrationStatus] = []
+
+    for subdir in sorted(base_dir.iterdir()):
+        if not subdir.is_dir():
+            continue
+        if subdir.name.startswith("__"):
+            continue
+
+        # Check if the subdirectory has any Python migration files
+        py_files = [
+            f
+            for f in subdir.iterdir()
+            if f.is_file() and f.suffix == ".py" and f.name != "__init__.py"
+        ]
+        if not py_files:
+            continue
+
+        db_path = project_root / ".dango" / f"{subdir.name}.db"
+        runner = MigrationRunner(db_path=db_path, db_name=subdir.name, migrations_dir=subdir)
+        statuses.append(runner.status())
+
+    return statuses

--- a/dango/migrations/__init__.py
+++ b/dango/migrations/__init__.py
@@ -26,6 +26,7 @@ from .runner import (
 __all__ = [
     "apply_all_pending",
     "get_all_status",
+    "get_migrations_base_dir",
     "AppliedMigration",
     "MigrationInfo",
     "MigrationRunner",
@@ -33,7 +34,7 @@ __all__ = [
 ]
 
 
-def _get_migrations_base_dir() -> Path:
+def get_migrations_base_dir() -> Path:
     """Return the directory containing migration subdirectories."""
     return Path(__file__).parent
 
@@ -50,7 +51,7 @@ def apply_all_pending(project_root: Path) -> dict[str, list[MigrationInfo]]:
     Returns:
         Mapping of database name to list of applied migrations.
     """
-    base_dir = _get_migrations_base_dir()
+    base_dir = get_migrations_base_dir()
     results: dict[str, list[MigrationInfo]] = {}
 
     for subdir in sorted(base_dir.iterdir()):
@@ -85,7 +86,7 @@ def get_all_status(project_root: Path) -> list[MigrationStatus]:
     Returns:
         List of ``MigrationStatus`` objects, one per database.
     """
-    base_dir = _get_migrations_base_dir()
+    base_dir = get_migrations_base_dir()
     statuses: list[MigrationStatus] = []
 
     for subdir in sorted(base_dir.iterdir()):

--- a/dango/migrations/runner.py
+++ b/dango/migrations/runner.py
@@ -1,0 +1,266 @@
+"""dango/migrations/runner.py
+
+Core migration engine for applying schema migrations to SQLite databases.
+
+Each database (auth, scheduler, etc.) has its own migration subdirectory
+under ``dango/migrations/`` with independently versioned migration files.
+The runner discovers, validates, and applies pending migrations within
+transactions, recording each applied version in a ``_migrations`` table.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+from dango.exceptions import MigrationApplicationError, MigrationDiscoveryError
+
+# Pattern: NNN_description.py (e.g., 001_initial_auth.py)
+_MIGRATION_FILE_RE = re.compile(r"^(\d{3,})_.+\.py$")
+
+
+@dataclass(frozen=True)
+class MigrationInfo:
+    """A discovered migration file ready to apply."""
+
+    version: int
+    description: str
+    file_path: Path
+
+
+@dataclass(frozen=True)
+class AppliedMigration:
+    """A migration that has already been applied."""
+
+    version: int
+    description: str
+    applied_at: str
+
+
+@dataclass(frozen=True)
+class MigrationStatus:
+    """Full status of a single database's migrations."""
+
+    db_name: str
+    db_path: Path
+    current_version: int
+    applied: list[AppliedMigration] = field(default_factory=list)
+    pending: list[MigrationInfo] = field(default_factory=list)
+
+
+def _load_migration_module(file_path: Path) -> ModuleType:
+    """Load a migration file as a Python module."""
+    spec = importlib.util.spec_from_file_location(file_path.stem, file_path)
+    if spec is None or spec.loader is None:
+        msg = f"Cannot load migration file: {file_path}"
+        raise MigrationDiscoveryError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+class MigrationRunner:
+    """Discovers and applies migrations for a single database.
+
+    Args:
+        db_path: Path to the SQLite database file.
+        db_name: Logical name (e.g. ``"auth"``).
+        migrations_dir: Directory containing ``NNN_*.py`` migration files.
+    """
+
+    def __init__(self, db_path: Path, db_name: str, migrations_dir: Path) -> None:
+        self.db_path = db_path
+        self.db_name = db_name
+        self.migrations_dir = migrations_dir
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a connection, creating the database file if needed."""
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        return sqlite3.connect(str(self.db_path))
+
+    def ensure_migrations_table(self, conn: sqlite3.Connection) -> None:
+        """Create the ``_migrations`` tracking table if it does not exist."""
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS _migrations (
+                version     INTEGER PRIMARY KEY,
+                description TEXT NOT NULL,
+                applied_at  TEXT NOT NULL
+            )
+            """
+        )
+
+    def get_applied_versions(self) -> list[int]:
+        """Return sorted list of already-applied migration versions."""
+        conn = self._connect()
+        try:
+            self.ensure_migrations_table(conn)
+            rows = conn.execute("SELECT version FROM _migrations ORDER BY version").fetchall()
+            return [row[0] for row in rows]
+        finally:
+            conn.close()
+
+    def discover_migrations(self) -> list[MigrationInfo]:
+        """Scan the migrations directory for valid migration files.
+
+        Returns:
+            Sorted list of ``MigrationInfo`` objects.
+
+        Raises:
+            MigrationDiscoveryError: On duplicate versions or malformed files.
+        """
+        if not self.migrations_dir.exists():
+            return []
+
+        migrations: list[MigrationInfo] = []
+        seen_versions: dict[int, Path] = {}
+
+        for path in sorted(self.migrations_dir.iterdir()):
+            if not path.is_file() or path.suffix != ".py":
+                continue
+            if path.name == "__init__.py":
+                continue
+
+            match = _MIGRATION_FILE_RE.match(path.name)
+            if not match:
+                continue
+
+            filename_version = int(match.group(1))
+
+            module = _load_migration_module(path)
+
+            # Validate required attributes
+            for attr in ("VERSION", "DESCRIPTION", "upgrade"):
+                if not hasattr(module, attr):
+                    msg = f"Migration {path.name} is missing required attribute '{attr}'"
+                    raise MigrationDiscoveryError(msg)
+
+            version = module.VERSION
+            if not isinstance(version, int):
+                msg = f"Migration {path.name}: VERSION must be an int, got {type(version).__name__}"
+                raise MigrationDiscoveryError(msg)
+
+            if version != filename_version:
+                msg = (
+                    f"Migration {path.name}: VERSION={version} does not match "
+                    f"filename prefix {filename_version}"
+                )
+                raise MigrationDiscoveryError(msg)
+
+            if not isinstance(module.DESCRIPTION, str):
+                msg = f"Migration {path.name}: DESCRIPTION must be a str"
+                raise MigrationDiscoveryError(msg)
+
+            if not callable(module.upgrade):
+                msg = f"Migration {path.name}: upgrade must be callable"
+                raise MigrationDiscoveryError(msg)
+
+            if version in seen_versions:
+                msg = (
+                    f"Duplicate migration version {version}: "
+                    f"{seen_versions[version].name} and {path.name}"
+                )
+                raise MigrationDiscoveryError(msg)
+
+            seen_versions[version] = path
+            migrations.append(
+                MigrationInfo(
+                    version=version,
+                    description=module.DESCRIPTION,
+                    file_path=path,
+                )
+            )
+
+        return sorted(migrations, key=lambda m: m.version)
+
+    def get_pending(self) -> list[MigrationInfo]:
+        """Return migrations that have not yet been applied."""
+        applied = set(self.get_applied_versions())
+        return [m for m in self.discover_migrations() if m.version not in applied]
+
+    def apply_one(self, migration: MigrationInfo) -> None:
+        """Apply a single migration inside a transaction.
+
+        Raises:
+            MigrationApplicationError: If the migration's ``upgrade()`` fails.
+        """
+        conn = self._connect()
+        try:
+            self.ensure_migrations_table(conn)
+            conn.execute("BEGIN")
+            try:
+                module = _load_migration_module(migration.file_path)
+                module.upgrade(conn)
+
+                now = datetime.now(timezone.utc).isoformat()
+                conn.execute(
+                    "INSERT INTO _migrations (version, description, applied_at) VALUES (?, ?, ?)",
+                    (migration.version, migration.description, now),
+                )
+                conn.commit()
+            except Exception as exc:
+                conn.rollback()
+                msg = (
+                    f"Migration {migration.version} ({migration.description}) "
+                    f"failed for {self.db_name}: {exc}"
+                )
+                raise MigrationApplicationError(
+                    msg,
+                    context={
+                        "db_name": self.db_name,
+                        "version": migration.version,
+                        "description": migration.description,
+                    },
+                ) from exc
+        finally:
+            conn.close()
+
+    def apply_pending(self) -> list[MigrationInfo]:
+        """Apply all pending migrations in version order.
+
+        Returns:
+            List of migrations that were applied.
+
+        Raises:
+            MigrationApplicationError: On failure (subsequent migrations are skipped).
+        """
+        pending = self.get_pending()
+        applied: list[MigrationInfo] = []
+        for migration in pending:
+            self.apply_one(migration)
+            applied.append(migration)
+        return applied
+
+    def current_version(self) -> int:
+        """Return the highest applied migration version, or 0 if none."""
+        versions = self.get_applied_versions()
+        return versions[-1] if versions else 0
+
+    def status(self) -> MigrationStatus:
+        """Return full migration status for this database."""
+        conn = self._connect()
+        try:
+            self.ensure_migrations_table(conn)
+            rows = conn.execute(
+                "SELECT version, description, applied_at FROM _migrations ORDER BY version"
+            ).fetchall()
+            applied = [
+                AppliedMigration(version=r[0], description=r[1], applied_at=r[2]) for r in rows
+            ]
+        finally:
+            conn.close()
+
+        pending = self.get_pending()
+
+        return MigrationStatus(
+            db_name=self.db_name,
+            db_path=self.db_path,
+            current_version=self.current_version(),
+            applied=applied,
+            pending=pending,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ packages = [
     "dango.web.routes",
     "dango.oauth",      # OAuth management
     "dango.security",   # Token encryption
+    "dango.migrations",
     "dango.cli.commands",
     "dango.cli.helpers",
 ]

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -3,12 +3,17 @@
 Tests for the unified exception hierarchy in dango/exceptions.py.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
 from dango.exceptions import (
     ConfigError,
     ConfigNotFoundError,
     ConfigValidationError,
+    ConfigVersionError,
     CSVSchemaMismatchError,
     DangoError,
     DbtLockError,
@@ -19,6 +24,9 @@ from dango.exceptions import (
     InvalidDateFormatError,
     InvalidPortError,
     InvalidSourceNameError,
+    MigrationApplicationError,
+    MigrationDiscoveryError,
+    MigrationError,
     ProjectNotFoundError,
     SyncTimeoutError,
     ValidationError,
@@ -31,45 +39,45 @@ from dango.exceptions import (
 class TestDangoErrorBase:
     """Tests for DangoError base class."""
 
-    def test_basic_construction(self):
+    def test_basic_construction(self) -> None:
         exc = DangoError("something broke")
         assert str(exc) == "something broke"
         assert exc.error_code == "DANGO-G000"
         assert exc.context == {}
         assert exc.user_message == "something broke"
 
-    def test_explicit_error_code(self):
+    def test_explicit_error_code(self) -> None:
         exc = DangoError("oops", error_code="DANGO-X999")
         assert exc.error_code == "DANGO-X999"
 
-    def test_context_dict(self):
-        ctx = {"path": "/tmp/test", "size": 42}
+    def test_context_dict(self) -> None:
+        ctx: dict[str, Any] = {"path": "/tmp/test", "size": 42}
         exc = DangoError("fail", context=ctx)
         assert exc.context == ctx
 
-    def test_user_message_override(self):
+    def test_user_message_override(self) -> None:
         exc = DangoError("internal detail", user_message="Something went wrong.")
         assert exc.user_message == "Something went wrong."
         assert str(exc) == "internal detail"
 
-    def test_user_message_defaults_to_message(self):
+    def test_user_message_defaults_to_message(self) -> None:
         exc = DangoError("the message")
         assert exc.user_message == "the message"
 
-    def test_empty_message(self):
+    def test_empty_message(self) -> None:
         exc = DangoError()
         assert str(exc) == ""
         assert exc.user_message == ""
 
-    def test_catchable_as_exception(self):
+    def test_catchable_as_exception(self) -> None:
         exc = DangoError("test")
         assert isinstance(exc, Exception)
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         exc = DangoError("oops", error_code="DANGO-X001")
         assert repr(exc) == "DangoError('oops', error_code='DANGO-X001')"
 
-    def test_explicit_empty_user_message(self):
+    def test_explicit_empty_user_message(self) -> None:
         exc = DangoError("internal", user_message="")
         assert exc.user_message == ""
         assert str(exc) == "internal"
@@ -93,6 +101,10 @@ class TestExceptionHierarchy:
             DiskSpaceError,
             DuckDBHealthError,
             DbtLockError,
+            MigrationError,
+            MigrationDiscoveryError,
+            MigrationApplicationError,
+            ConfigVersionError,
             ValidationError,
             InvalidSourceNameError,
             InvalidDateFormatError,
@@ -100,26 +112,35 @@ class TestExceptionHierarchy:
             WebAPIError,
         ],
     )
-    def test_all_inherit_from_dango_error(self, exc_class):
+    def test_all_inherit_from_dango_error(self, exc_class: type[DangoError]) -> None:
         assert issubclass(exc_class, DangoError)
         exc = exc_class("test")
         assert isinstance(exc, DangoError)
 
-    def test_config_hierarchy(self):
+    def test_config_hierarchy(self) -> None:
         assert issubclass(ConfigNotFoundError, ConfigError)
         assert issubclass(ConfigValidationError, ConfigError)
         assert issubclass(ProjectNotFoundError, ConfigError)
 
-    def test_ingestion_hierarchy(self):
+    def test_ingestion_hierarchy(self) -> None:
         assert issubclass(SyncTimeoutError, IngestionError)
         assert issubclass(CSVSchemaMismatchError, IngestionError)
 
-    def test_infrastructure_hierarchy(self):
+    def test_infrastructure_hierarchy(self) -> None:
         assert issubclass(DiskSpaceError, InfrastructureError)
         assert issubclass(DuckDBHealthError, InfrastructureError)
         assert issubclass(DbtLockError, InfrastructureError)
 
-    def test_validation_hierarchy(self):
+    def test_migration_hierarchy(self) -> None:
+        assert issubclass(MigrationDiscoveryError, MigrationError)
+        assert issubclass(MigrationApplicationError, MigrationError)
+
+    def test_config_version_hierarchy(self) -> None:
+        assert issubclass(ConfigVersionError, DangoError)
+        # ConfigVersionError is NOT a ConfigError — it's directly under DangoError
+        assert not issubclass(ConfigVersionError, ConfigError)
+
+    def test_validation_hierarchy(self) -> None:
         assert issubclass(InvalidSourceNameError, ValidationError)
         assert issubclass(InvalidDateFormatError, ValidationError)
         assert issubclass(InvalidPortError, ValidationError)
@@ -144,6 +165,10 @@ class TestDefaultErrorCodes:
             (DiskSpaceError, "DANGO-U002"),
             (DuckDBHealthError, "DANGO-U003"),
             (DbtLockError, "DANGO-U004"),
+            (MigrationError, "DANGO-M001"),
+            (MigrationDiscoveryError, "DANGO-M002"),
+            (MigrationApplicationError, "DANGO-M003"),
+            (ConfigVersionError, "DANGO-M004"),
             (ValidationError, "DANGO-V001"),
             (InvalidSourceNameError, "DANGO-V002"),
             (InvalidDateFormatError, "DANGO-V003"),
@@ -151,11 +176,11 @@ class TestDefaultErrorCodes:
             (WebAPIError, "DANGO-W001"),
         ],
     )
-    def test_default_error_code(self, exc_class, expected_code):
+    def test_default_error_code(self, exc_class: type[DangoError], expected_code: str) -> None:
         exc = exc_class("test")
         assert exc.error_code == expected_code
 
-    def test_explicit_code_overrides_default(self):
+    def test_explicit_code_overrides_default(self) -> None:
         exc = ConfigError("test", error_code="DANGO-C999")
         assert exc.error_code == "DANGO-C999"
 
@@ -164,30 +189,30 @@ class TestDefaultErrorCodes:
 class TestDbtLockErrorCompat:
     """Tests for DbtLockError backward compatibility."""
 
-    def test_lock_info_param(self):
-        info = {"pid": 123, "source": "cli"}
+    def test_lock_info_param(self) -> None:
+        info: dict[str, Any] = {"pid": 123, "source": "cli"}
         exc = DbtLockError("locked", lock_info=info)
         assert exc.lock_info == info
         assert exc.error_code == "DANGO-U004"
 
-    def test_lock_info_defaults_to_none(self):
+    def test_lock_info_defaults_to_none(self) -> None:
         exc = DbtLockError("locked")
         assert exc.lock_info is None
 
-    def test_lock_info_with_context(self):
+    def test_lock_info_with_context(self) -> None:
         exc = DbtLockError("locked", lock_info={"pid": 1}, context={"op": "sync"})
         assert exc.lock_info == {"pid": 1}
         # lock_info is merged into context; explicit context keys take precedence
         assert exc.context == {"pid": 1, "op": "sync"}
 
-    def test_lock_info_merged_into_context(self):
-        info = {"pid": 123, "source": "cli", "operation": "sync"}
+    def test_lock_info_merged_into_context(self) -> None:
+        info: dict[str, Any] = {"pid": 123, "source": "cli", "operation": "sync"}
         exc = DbtLockError("locked", lock_info=info)
         # lock_info keys appear in context for API debug responses
         assert exc.context["pid"] == 123
         assert exc.context["source"] == "cli"
 
-    def test_lock_info_none_context_empty(self):
+    def test_lock_info_none_context_empty(self) -> None:
         exc = DbtLockError("locked")
         assert exc.lock_info is None
         assert exc.context == {}
@@ -197,35 +222,35 @@ class TestDbtLockErrorCompat:
 class TestIsDebugMode:
     """Tests for is_debug_mode() function."""
 
-    def test_not_set(self, monkeypatch):
+    def test_not_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DANGO_DEBUG", raising=False)
         assert is_debug_mode() is False
 
-    def test_set_to_1(self, monkeypatch):
+    def test_set_to_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DANGO_DEBUG", "1")
         assert is_debug_mode() is True
 
-    def test_set_to_true(self, monkeypatch):
+    def test_set_to_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DANGO_DEBUG", "true")
         assert is_debug_mode() is True
 
-    def test_set_to_yes(self, monkeypatch):
+    def test_set_to_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DANGO_DEBUG", "yes")
         assert is_debug_mode() is True
 
-    def test_set_to_TRUE_uppercase(self, monkeypatch):
+    def test_set_to_TRUE_uppercase(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DANGO_DEBUG", "TRUE")
         assert is_debug_mode() is True
 
-    def test_set_to_0(self, monkeypatch):
+    def test_set_to_0(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DANGO_DEBUG", "0")
         assert is_debug_mode() is False
 
-    def test_set_to_empty(self, monkeypatch):
+    def test_set_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DANGO_DEBUG", "")
         assert is_debug_mode() is False
 
-    def test_set_to_random_string(self, monkeypatch):
+    def test_set_to_random_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DANGO_DEBUG", "maybe")
         assert is_debug_mode() is False
 
@@ -234,7 +259,7 @@ class TestIsDebugMode:
 class TestBackwardCompatImports:
     """Tests that re-export shims return the same class objects."""
 
-    def test_config_exceptions_reexport(self):
+    def test_config_exceptions_reexport(self) -> None:
         from dango.config.exceptions import ConfigError as CE1
         from dango.config.exceptions import ConfigNotFoundError as CNFE1
         from dango.config.exceptions import ConfigValidationError as CVE1
@@ -245,12 +270,12 @@ class TestBackwardCompatImports:
         assert CVE1 is ConfigValidationError
         assert PNFE1 is ProjectNotFoundError
 
-    def test_utils_dbt_lock_reexport(self):
+    def test_utils_dbt_lock_reexport(self) -> None:
         from dango.utils.dbt_lock import DbtLockError as DLE1
 
         assert DLE1 is DbtLockError
 
-    def test_utils_init_reexport(self):
+    def test_utils_init_reexport(self) -> None:
         from dango.utils import DbtLockError as DLE2
 
         assert DLE2 is DbtLockError

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -296,7 +296,7 @@ class TestApplyAllPending:
     def _patch_base(self, monkeypatch: pytest.MonkeyPatch, base: Path) -> None:
         import dango.migrations as mig_mod
 
-        monkeypatch.setattr(mig_mod, "_get_migrations_base_dir", lambda: base)
+        monkeypatch.setattr(mig_mod, "get_migrations_base_dir", lambda: base)
 
     def test_no_subdirectories(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         self._patch_base(monkeypatch, tmp_path)
@@ -340,7 +340,7 @@ class TestGetAllStatus:
 
         base = tmp_path / "mig"
         base.mkdir()
-        monkeypatch.setattr(mig_mod, "_get_migrations_base_dir", lambda: base)
+        monkeypatch.setattr(mig_mod, "get_migrations_base_dir", lambda: base)
         auth_dir = base / "auth"
         auth_dir.mkdir()
         _write_migration(auth_dir, 1, "Auth init")
@@ -375,3 +375,17 @@ class TestConfigVersionCheck:
         loader = ConfigLoader(tmp_path)
         with pytest.raises(ConfigVersionError, match="99.0"):
             loader.load_sources_config()
+
+    def test_validate_config_catches_version_error(self, tmp_path: Path) -> None:
+        from dango.config.loader import ConfigLoader
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "project.yml").write_text(
+            "project:\n  name: test\n  created_by: tester\n  purpose: testing\n"
+        )
+        (dango_dir / "sources.yml").write_text("version: '99.0'\nsources: []\n")
+        loader = ConfigLoader(tmp_path)
+        is_valid, errors = loader.validate_config()
+        assert not is_valid
+        assert any("99.0" in e for e in errors)

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -1,0 +1,377 @@
+"""tests/unit/test_migrations.py
+
+Tests for the database migration framework in dango/migrations/.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from dango.exceptions import MigrationApplicationError, MigrationDiscoveryError
+from dango.migrations import (
+    MigrationInfo,
+    MigrationRunner,
+    MigrationStatus,
+    apply_all_pending,
+    get_all_status,
+)
+from dango.migrations.runner import AppliedMigration
+
+
+def _write_migration(directory: Path, version: int, description: str, sql: str = "") -> Path:
+    """Create a properly formatted migration file."""
+    prefix = f"{version:03d}"
+    slug = description.lower().replace(" ", "_")
+    path = directory / f"{prefix}_{slug}.py"
+    stmt = f"conn.execute({sql!r})" if sql else "pass"
+    path.write_text(
+        textwrap.dedent(f"""\
+        from __future__ import annotations
+        import sqlite3
+        VERSION = {version}
+        DESCRIPTION = {description!r}
+        def upgrade(conn: sqlite3.Connection) -> None:
+            {stmt}
+    """)
+    )
+    return path
+
+
+def _make_runner(tmp_path: Path) -> tuple[Path, Path, MigrationRunner]:
+    """Create migrations dir, db_path, and runner."""
+    mdir = tmp_path / "migrations"
+    mdir.mkdir()
+    db_path = tmp_path / "test.db"
+    runner = MigrationRunner(db_path=db_path, db_name="test", migrations_dir=mdir)
+    return mdir, db_path, runner
+
+
+@pytest.mark.unit
+class TestDataclasses:
+    """Tests for MigrationInfo and AppliedMigration dataclasses."""
+
+    def test_migration_info_construction(self, tmp_path: Path) -> None:
+        info = MigrationInfo(version=1, description="test", file_path=tmp_path / "001_test.py")
+        assert info.version == 1
+        assert info.description == "test"
+
+    def test_migration_info_frozen(self, tmp_path: Path) -> None:
+        info = MigrationInfo(version=1, description="test", file_path=tmp_path / "001_test.py")
+        with pytest.raises(AttributeError):
+            info.version = 2  # type: ignore[misc]
+
+    def test_applied_migration_construction(self) -> None:
+        am = AppliedMigration(version=1, description="test", applied_at="2026-01-01")
+        assert am.version == 1
+        assert am.applied_at == "2026-01-01"
+
+    def test_applied_migration_frozen(self) -> None:
+        am = AppliedMigration(version=1, description="test", applied_at="2026-01-01")
+        with pytest.raises(AttributeError):
+            am.version = 2  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestMigrationDiscovery:
+    """Tests for MigrationRunner.discover_migrations()."""
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        assert runner.discover_migrations() == []
+
+    def test_nonexistent_directory(self, tmp_path: Path) -> None:
+        runner = MigrationRunner(
+            db_path=tmp_path / "test.db", db_name="test", migrations_dir=tmp_path / "nope"
+        )
+        assert runner.discover_migrations() == []
+
+    def test_single_migration(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "Create users", "CREATE TABLE users (id INTEGER)")
+        found = runner.discover_migrations()
+        assert len(found) == 1
+        assert found[0].version == 1
+        assert found[0].description == "Create users"
+
+    def test_multiple_migrations_sorted(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 3, "Third")
+        _write_migration(mdir, 1, "First")
+        _write_migration(mdir, 2, "Second")
+        assert [m.version for m in runner.discover_migrations()] == [1, 2, 3]
+
+    def test_skips_init_py_and_non_python(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        (mdir / "__init__.py").write_text("")
+        (mdir / "README.md").write_text("docs")
+        _write_migration(mdir, 1, "Real migration")
+        assert len(runner.discover_migrations()) == 1
+
+    def test_duplicate_version_raises(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "First")
+        (mdir / "001_duplicate.py").write_text(
+            'VERSION = 1\nDESCRIPTION = "Dup"\ndef upgrade(c): pass\n'
+        )
+        with pytest.raises(MigrationDiscoveryError, match="Duplicate migration version"):
+            runner.discover_migrations()
+
+    def test_missing_version_attr_raises(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        (mdir / "001_bad.py").write_text('DESCRIPTION = "x"\ndef upgrade(c): pass\n')
+        with pytest.raises(MigrationDiscoveryError, match="missing required attribute 'VERSION'"):
+            runner.discover_migrations()
+
+    def test_missing_description_attr_raises(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        (mdir / "001_bad.py").write_text("VERSION = 1\ndef upgrade(c): pass\n")
+        with pytest.raises(
+            MigrationDiscoveryError, match="missing required attribute 'DESCRIPTION'"
+        ):
+            runner.discover_migrations()
+
+    def test_missing_upgrade_func_raises(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        (mdir / "001_bad.py").write_text('VERSION = 1\nDESCRIPTION = "x"\n')
+        with pytest.raises(MigrationDiscoveryError, match="missing required attribute 'upgrade'"):
+            runner.discover_migrations()
+
+    def test_version_mismatch_raises(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        (mdir / "001_bad.py").write_text(
+            'VERSION = 2\nDESCRIPTION = "wrong"\ndef upgrade(c): pass\n'
+        )
+        with pytest.raises(MigrationDiscoveryError, match="does not match filename prefix"):
+            runner.discover_migrations()
+
+
+@pytest.mark.unit
+class TestMigrationRunner:
+    """Tests for MigrationRunner apply/status operations."""
+
+    def test_creates_migrations_table(self, tmp_path: Path) -> None:
+        _, db_path, runner = _make_runner(tmp_path)
+        assert runner.get_applied_versions() == []
+        conn = sqlite3.connect(str(db_path))
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'"
+        ).fetchall()
+        conn.close()
+        assert len(tables) == 1
+
+    def test_apply_single_migration(self, tmp_path: Path) -> None:
+        mdir, db_path, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "Create table", "CREATE TABLE users (id INTEGER PRIMARY KEY)")
+        applied = runner.apply_pending()
+        assert len(applied) == 1
+        assert applied[0].version == 1
+        conn = sqlite3.connect(str(db_path))
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='users'"
+        ).fetchall()
+        conn.close()
+        assert len(tables) == 1
+
+    def test_apply_multiple_in_order(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "Create users", "CREATE TABLE users (id INTEGER)")
+        _write_migration(mdir, 2, "Create roles", "CREATE TABLE roles (id INTEGER, name TEXT)")
+        applied = runner.apply_pending()
+        assert [m.version for m in applied] == [1, 2]
+        assert runner.current_version() == 2
+
+    def test_skips_already_applied(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "Create table", "CREATE TABLE users (id INTEGER)")
+        runner.apply_pending()
+        _write_migration(mdir, 2, "Add column", "ALTER TABLE users ADD COLUMN name TEXT")
+        applied = runner.apply_pending()
+        assert len(applied) == 1
+        assert applied[0].version == 2
+
+    def test_records_version_and_timestamp(self, tmp_path: Path) -> None:
+        mdir, db_path, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "Test migration")
+        runner.apply_pending()
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT version, description, applied_at FROM _migrations").fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == 1
+        assert rows[0][1] == "Test migration"
+        assert rows[0][2]  # timestamp not empty
+
+    def test_failed_migration_rolls_back(self, tmp_path: Path) -> None:
+        mdir, db_path, runner = _make_runner(tmp_path)
+        (mdir / "001_bad.py").write_text(
+            textwrap.dedent("""\
+            VERSION = 1
+            DESCRIPTION = "Will fail"
+            def upgrade(conn):
+                conn.execute("CREATE TABLE foo (id INTEGER)")
+                raise RuntimeError("boom")
+        """)
+        )
+        with pytest.raises(MigrationApplicationError, match="boom"):
+            runner.apply_pending()
+        conn = sqlite3.connect(str(db_path))
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='foo'"
+        ).fetchall()
+        conn.close()
+        assert len(tables) == 0
+        assert runner.current_version() == 0
+
+    def test_partial_failure_stops(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "Good", "CREATE TABLE good (id INTEGER)")
+        (mdir / "002_bad.py").write_text(
+            textwrap.dedent("""\
+            VERSION = 2
+            DESCRIPTION = "Bad"
+            def upgrade(conn):
+                raise RuntimeError("fail")
+        """)
+        )
+        _write_migration(mdir, 3, "Never reached")
+        with pytest.raises(MigrationApplicationError):
+            runner.apply_pending()
+        assert runner.current_version() == 1
+        assert runner.get_applied_versions() == [1]
+
+    def test_current_version_zero_when_none(self, tmp_path: Path) -> None:
+        _, _, runner = _make_runner(tmp_path)
+        assert runner.current_version() == 0
+
+    def test_status_returns_full_info(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "Applied")
+        _write_migration(mdir, 2, "Pending")
+        runner.apply_one(runner.discover_migrations()[0])
+        status = runner.status()
+        assert isinstance(status, MigrationStatus)
+        assert status.db_name == "test"
+        assert status.current_version == 1
+        assert len(status.applied) == 1
+        assert len(status.pending) == 1
+        assert status.pending[0].version == 2
+
+
+@pytest.mark.unit
+class TestMigrationRunnerEdgeCases:
+    """Edge case tests for MigrationRunner."""
+
+    def test_nonexistent_db_path_creates_file(self, tmp_path: Path) -> None:
+        mdir = tmp_path / "migrations"
+        mdir.mkdir()
+        db_path = tmp_path / "subdir" / "test.db"
+        _write_migration(mdir, 1, "Init", "CREATE TABLE t (id INTEGER)")
+        runner = MigrationRunner(db_path=db_path, db_name="test", migrations_dir=mdir)
+        runner.apply_pending()
+        assert db_path.exists()
+        assert runner.current_version() == 1
+
+    def test_gaps_in_versions_allowed(self, tmp_path: Path) -> None:
+        mdir, _, runner = _make_runner(tmp_path)
+        _write_migration(mdir, 1, "First")
+        _write_migration(mdir, 5, "Fifth")
+        applied = runner.apply_pending()
+        assert [m.version for m in applied] == [1, 5]
+        assert runner.current_version() == 5
+
+    def test_no_migration_files_is_noop(self, tmp_path: Path) -> None:
+        _, _, runner = _make_runner(tmp_path)
+        assert runner.apply_pending() == []
+        assert runner.current_version() == 0
+
+
+@pytest.mark.unit
+class TestApplyAllPending:
+    """Tests for the apply_all_pending() public API."""
+
+    def _patch_base(self, monkeypatch: pytest.MonkeyPatch, base: Path) -> None:
+        import dango.migrations as mig_mod
+
+        monkeypatch.setattr(mig_mod, "_get_migrations_base_dir", lambda: base)
+
+    def test_no_subdirectories(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_base(monkeypatch, tmp_path)
+        assert apply_all_pending(tmp_path) == {}
+
+    def test_applies_to_all_databases(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        base = tmp_path / "mig"
+        base.mkdir()
+        self._patch_base(monkeypatch, base)
+        auth_dir = base / "auth"
+        auth_dir.mkdir()
+        _write_migration(auth_dir, 1, "Auth init", "CREATE TABLE users (id INTEGER)")
+        sched_dir = base / "scheduler"
+        sched_dir.mkdir()
+        _write_migration(sched_dir, 1, "Sched init", "CREATE TABLE jobs (id INTEGER)")
+        project = tmp_path / "project"
+        (project / ".dango").mkdir(parents=True)
+        result = apply_all_pending(project)
+        assert len(result["auth"]) == 1
+        assert len(result["scheduler"]) == 1
+        assert (project / ".dango" / "auth.db").exists()
+        assert (project / ".dango" / "scheduler.db").exists()
+
+    def test_skips_pycache_and_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        base = tmp_path / "mig"
+        base.mkdir()
+        self._patch_base(monkeypatch, base)
+        (base / "__pycache__").mkdir()
+        (base / "empty_db").mkdir()
+        assert apply_all_pending(tmp_path) == {}
+
+
+@pytest.mark.unit
+class TestGetAllStatus:
+    """Tests for the get_all_status() public API."""
+
+    def test_returns_statuses(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import dango.migrations as mig_mod
+
+        base = tmp_path / "mig"
+        base.mkdir()
+        monkeypatch.setattr(mig_mod, "_get_migrations_base_dir", lambda: base)
+        auth_dir = base / "auth"
+        auth_dir.mkdir()
+        _write_migration(auth_dir, 1, "Auth init")
+        project = tmp_path / "project"
+        (project / ".dango").mkdir(parents=True)
+        statuses = get_all_status(project)
+        assert len(statuses) == 1
+        assert statuses[0].db_name == "auth"
+        assert len(statuses[0].pending) == 1
+
+
+@pytest.mark.unit
+class TestConfigVersionCheck:
+    """Tests for config version validation in loader."""
+
+    def test_supported_version_passes(self, tmp_path: Path) -> None:
+        from dango.config.loader import ConfigLoader
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "sources.yml").write_text("version: '1.0'\nsources: []\n")
+        loader = ConfigLoader(tmp_path)
+        assert loader.load_sources_config().version == "1.0"
+
+    def test_unsupported_version_raises(self, tmp_path: Path) -> None:
+        from dango.config.loader import ConfigLoader
+        from dango.exceptions import ConfigVersionError
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "sources.yml").write_text("version: '99.0'\nsources: []\n")
+        loader = ConfigLoader(tmp_path)
+        with pytest.raises(ConfigVersionError, match="99.0"):
+            loader.load_sources_config()


### PR DESCRIPTION
## Summary

- Introduces incremental SQLite migration framework for subsystem databases (auth, scheduler, etc.)
- New `dango/migrations/` package with `MigrationRunner` engine — discovers, validates, and applies `NNN_*.py` migration files per-database subdirectory
- New CLI commands: `dango migrate status` and `dango migrate run [--db name]`
- New M-series exceptions: `MigrationError`, `MigrationDiscoveryError`, `MigrationApplicationError`, `ConfigVersionError`
- Auto-migrates on `dango start` (after config load, before DB operations)
- Config version validation in `load_sources_config()` — rejects unsupported `sources.yml` versions
- 32 unit tests covering discovery, application, transaction rollback, edge cases, and public API
- Fixes pre-existing mypy annotations in `test_exceptions.py`

## Test plan

- [x] `pytest tests/unit/test_migrations.py tests/unit/test_exceptions.py -v` — 105 pass
- [x] `pytest` — 438 pass, zero regressions
- [x] All pre-commit hooks pass (ruff lint, ruff format, mypy, headers, docstrings, file sizes)
- [ ] `dango migrate status` smoke test in a real project (should show no databases when no migrations exist)
- [ ] Manual test: edit `sources.yml` to `version: "99.0"` → verify `ConfigVersionError` on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)