### PR TITLE
Add OAuth token validation and pre-sync auth checks (TASK-009)

### DIFF
--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -128,7 +128,8 @@ def auth_status(ctx: click.Context) -> None:
             console.print("\n[red]⚠️  Expired OAuth Credentials:[/red]")
             for cred in expired:
                 console.print(f"  • {cred.account_info} ({cred.source_type})")
-                console.print(f"    [dim]Expired: {cred.expires_at.strftime('%Y-%m-%d')}[/dim]")
+                expiry_str = cred.expires_at.strftime("%Y-%m-%d") if cred.expires_at else "Unknown"
+                console.print(f"    [dim]Expired: {expiry_str}[/dim]")
                 console.print(
                     f"    [yellow]Re-authenticate: dango auth refresh {cred.source_type}[/yellow]\n"
                 )
@@ -140,7 +141,7 @@ def auth_status(ctx: click.Context) -> None:
                 days_left = cred.days_until_expiry()
                 console.print(f"  • {cred.account_info} ({cred.source_type})")
                 console.print(
-                    f"    [dim]Expires: {cred.expires_at.strftime('%Y-%m-%d')} ({days_left} days)[/dim]"
+                    f"    [dim]Expires: {cred.expires_at.strftime('%Y-%m-%d') if cred.expires_at else 'Unknown'} ({days_left} days)[/dim]"
                 )
                 console.print(
                     f"    [cyan]Re-authenticate: dango auth refresh {cred.source_type}[/cyan]\n"
@@ -361,6 +362,10 @@ def auth_google_sheets(ctx: click.Context) -> None:
             console.print("[red]Authentication failed[/red]")
             raise click.Abort()
 
+        console.print("\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,")
+        console.print("refresh tokens expire after 7 days. Publish your app for production use.")
+        console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
+
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         from dango.exceptions import is_debug_mode
@@ -399,6 +404,10 @@ def auth_google_analytics(ctx: click.Context) -> None:
             console.print("[red]Authentication failed[/red]")
             raise click.Abort()
 
+        console.print("\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,")
+        console.print("refresh tokens expire after 7 days. Publish your app for production use.")
+        console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
+
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         from dango.exceptions import is_debug_mode
@@ -436,6 +445,10 @@ def auth_google_ads(ctx: click.Context) -> None:
         if not oauth_name:
             console.print("[red]Authentication failed[/red]")
             raise click.Abort()
+
+        console.print("\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,")
+        console.print("refresh tokens expire after 7 days. Publish your app for production use.")
+        console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
@@ -549,19 +562,59 @@ def auth_check(ctx: click.Context) -> None:
                 if action:
                     console.print(f"    {action}")
 
+        # Live token validation
+        console.print("\n[bold]3. Live Token Validation[/bold]\n")
+
+        if credentials:
+            from dango.oauth.validation import validate_all_tokens
+
+            validation_results = validate_all_tokens(project_root)
+            has_google = False
+
+            for vr in validation_results:
+                if vr.provider == "google":
+                    has_google = True
+
+                if vr.valid:
+                    if vr.error_code == "network_error":
+                        console.print(f"  [yellow]?[/yellow] {vr.source_type} — {vr.message}")
+                    else:
+                        info = f" ({vr.account_info})" if vr.account_info else ""
+                        console.print(f"  [green]✓[/green] {vr.source_type} — Token valid{info}")
+                else:
+                    console.print(f"  [red]✗[/red] {vr.source_type} — {vr.message}")
+
+            # GCP Testing mode caveat
+            if has_google:
+                console.print(
+                    "\n  [dim]Note: If your GCP OAuth app is in 'Testing' mode, refresh tokens"
+                )
+                console.print("  expire after 7 days. Publish your app for permanent tokens.")
+                console.print(
+                    "  See: https://console.cloud.google.com/apis/credentials/consent[/dim]"
+                )
+        else:
+            console.print("  [dim]No tokens to validate[/dim]")
+
         # Summary and next steps
-        console.print("\n[bold]3. Summary[/bold]\n")
+        console.print("\n[bold]4. Summary[/bold]\n")
 
         if all_configured and credentials:
-            active_creds = [c for c in credentials if not c.is_expired()]
-            if active_creds:
+            # Use live validation results if available
+            if credentials:
+                valid_count = sum(1 for vr in validation_results if vr.valid)
+                invalid_count = sum(1 for vr in validation_results if not vr.valid)
+                if invalid_count == 0:
+                    console.print("  [green]✓ OAuth is fully configured[/green]")
+                    console.print("  [dim]You can add OAuth sources with: dango source add[/dim]")
+                else:
+                    console.print(
+                        f"  [yellow]⚠️  {invalid_count} token(s) need re-authentication[/yellow]"
+                    )
+                    console.print(f"  [dim]{valid_count} valid, {invalid_count} invalid[/dim]")
+            else:
                 console.print("  [green]✓ OAuth is fully configured[/green]")
                 console.print("  [dim]You can add OAuth sources with: dango source add[/dim]")
-            else:
-                console.print(
-                    "  [yellow]⚠️  OAuth credentials configured but tokens expired[/yellow]"
-                )
-                console.print("  [dim]Re-authenticate with: dango auth refresh <name>[/dim]")
         elif all_configured:
             console.print(
                 "  [yellow]⚠️  OAuth credentials configured but not yet authenticated[/yellow]"

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -600,21 +600,16 @@ def auth_check(ctx: click.Context) -> None:
         console.print("\n[bold]4. Summary[/bold]\n")
 
         if all_configured and credentials:
-            # Use live validation results if available
-            if credentials:
-                valid_count = sum(1 for vr in validation_results if vr.valid)
-                invalid_count = sum(1 for vr in validation_results if not vr.valid)
-                if invalid_count == 0:
-                    console.print("  [green]✓ OAuth is fully configured[/green]")
-                    console.print("  [dim]You can add OAuth sources with: dango source add[/dim]")
-                else:
-                    console.print(
-                        f"  [yellow]⚠️  {invalid_count} token(s) need re-authentication[/yellow]"
-                    )
-                    console.print(f"  [dim]{valid_count} valid, {invalid_count} invalid[/dim]")
-            else:
+            valid_count = sum(1 for vr in validation_results if vr.valid)
+            invalid_count = sum(1 for vr in validation_results if not vr.valid)
+            if invalid_count == 0:
                 console.print("  [green]✓ OAuth is fully configured[/green]")
                 console.print("  [dim]You can add OAuth sources with: dango source add[/dim]")
+            else:
+                console.print(
+                    f"  [yellow]⚠️  {invalid_count} token(s) need re-authentication[/yellow]"
+                )
+                console.print(f"  [dim]{valid_count} valid, {invalid_count} invalid[/dim]")
         elif all_configured:
             console.print(
                 "  [yellow]⚠️  OAuth credentials configured but not yet authenticated[/yellow]"

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -939,6 +939,43 @@ def status(ctx: click.Context) -> None:
         console.print(table)
         console.print()
 
+        # OAuth token health (stored metadata only — no API calls for fast output)
+        try:
+            from dango.oauth.storage import OAuthStorage
+
+            oauth_storage = OAuthStorage(project_root)
+            oauth_creds = oauth_storage.list()
+
+            if oauth_creds:
+                oauth_table = Table(
+                    title="OAuth Tokens", show_header=True, header_style="bold cyan"
+                )
+                oauth_table.add_column("Source", style="bold")
+                oauth_table.add_column("Status")
+                oauth_table.add_column("Account", style="dim")
+
+                has_warning = False
+                for cred in oauth_creds:
+                    if cred.is_expired():
+                        token_status = "[red]Expired[/red]"
+                        has_warning = True
+                    elif cred.is_expiring_soon():
+                        days_left = cred.days_until_expiry()
+                        token_status = f"[yellow]Expires in {days_left}d[/yellow]"
+                        has_warning = True
+                    else:
+                        token_status = "[green]Active[/green]"
+                    oauth_table.add_row(cred.source_type, token_status, cred.account_info)
+
+                console.print(oauth_table)
+                if has_warning:
+                    console.print(
+                        "  [yellow]Run 'dango auth check' for live token validation[/yellow]"
+                    )
+                console.print()
+        except Exception:
+            pass  # Don't let token display errors break status output
+
         # Print quick start commands
         any_running = fastapi_status["running"] or bool(docker_statuses)
         if not any_running:

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -478,6 +478,17 @@ def sync(
             console.print("[dim]Run without --dry-run to execute sync[/dim]")
             return
 
+        # Pre-sync OAuth token validation
+        from dango.exceptions import OAuthTokenExpiredError, OAuthTokenRevokedError
+        from dango.oauth.validation import validate_before_sync
+
+        for src in sources_to_sync:
+            try:
+                validate_before_sync(src.type.value, project_root)
+            except (OAuthTokenRevokedError, OAuthTokenExpiredError) as oauth_err:
+                console.print(f"\n[red]{oauth_err.user_message}[/red]")
+                raise click.Abort() from oauth_err
+
         # Run sync
         summary = run_sync(
             project_root=project_root,

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -39,6 +39,9 @@ __all__ = [
     "MigrationDiscoveryError",
     "MigrationApplicationError",
     "ConfigVersionError",
+    "OAuthError",
+    "OAuthTokenRevokedError",
+    "OAuthTokenExpiredError",
     "ValidationError",
     "InvalidSourceNameError",
     "InvalidDateFormatError",
@@ -229,6 +232,29 @@ class ConfigVersionError(DangoError):
     """Config file version is incompatible with running Dango."""
 
     _default_error_code = "DANGO-M004"
+
+
+# ---------------------------------------------------------------------------
+# OAuth exceptions  (DANGO-A***)
+# ---------------------------------------------------------------------------
+
+
+class OAuthError(DangoError):
+    """Base exception for OAuth errors."""
+
+    _default_error_code = "DANGO-A001"
+
+
+class OAuthTokenRevokedError(OAuthError):
+    """Token has been revoked or is no longer valid."""
+
+    _default_error_code = "DANGO-A002"
+
+
+class OAuthTokenExpiredError(OAuthError):
+    """Token has expired."""
+
+    _default_error_code = "DANGO-A003"
 
 
 # ---------------------------------------------------------------------------

--- a/dango/oauth/CLAUDE.md
+++ b/dango/oauth/CLAUDE.md
@@ -2,42 +2,50 @@
 
 ## Purpose
 
-Manages browser-based OAuth authentication flows, provider-specific token exchange, and credential persistence for dlt data sources.
+Manages browser-based OAuth authentication flows, provider-specific token exchange, credential persistence, and live token validation for dlt data sources.
 
 ## Files
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `__init__.py` | OAuth flow orchestration and local callback server | `OAuthManager`, `OAuthCallbackHandler`, `create_oauth_manager` |
+| `__init__.py` | OAuth flow orchestration and local callback server | `OAuthManager`, `OAuthCallbackHandler`, `create_oauth_manager`, re-exports from `validation.py` |
 | `providers.py` | Provider-specific OAuth implementations | `BaseOAuthProvider`, `GoogleOAuthProvider`, `FacebookOAuthProvider`, `ShopifyOAuthProvider` |
 | `router.py` | Routes OAuth requests to correct provider | `run_oauth_for_source`, `check_oauth_credentials_exist`, `OAUTH_PROVIDER_MAP` |
 | `storage.py` | Token persistence to `.dlt/secrets.toml` with metadata | `OAuthStorage`, `OAuthCredential` |
+| `validation.py` | Live token validation via API calls | `TokenValidationResult`, `validate_token`, `validate_all_tokens`, `validate_before_sync`, `validate_google_token`, `validate_facebook_token`, `validate_shopify_token` |
 
 ## Common Tasks
 
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
-| Add a new OAuth provider | `providers.py` (new class), `router.py` (`OAUTH_PROVIDER_MAP`) | Manual: `dango add` and select new source type |
+| Add a new OAuth provider | `providers.py` (new class), `router.py` (`OAUTH_PROVIDER_MAP`), `validation.py` (add validator) | Manual: `dango add` and select new source type |
 | Change token storage format | `storage.py` | Manual: verify `.dlt/secrets.toml` after auth |
 | Change callback server behavior | `__init__.py` (`OAuthCallbackHandler`) | Manual: run OAuth flow and check callback |
 | Check credential existence logic | `router.py` (`check_oauth_credentials_exist`) | Manual: `dango validate` after auth |
+| Add a new token validator | `validation.py` (new function + add to `_PROVIDER_VALIDATORS`) | `pytest tests/unit/test_oauth_validation.py` |
+| Test live token validation | `validation.py` | `pytest tests/unit/test_oauth_validation.py` |
 
 ## Dependencies
 
 **Imports from:**
 - `dango/config/credentials.py` — `CredentialManager` for reading/writing `.dlt/secrets.toml`
+- `dango/exceptions.py` — `OAuthTokenRevokedError`, `OAuthTokenExpiredError`
+- `requests` — HTTP calls in `validation.py` for live token checks
 
 **Used by:**
-- `dango/cli/main.py` — OAuth management commands (`dango auth`)
+- `dango/cli/commands/auth.py` — OAuth management commands (`dango auth check` uses `validate_all_tokens`)
+- `dango/cli/commands/source.py` — pre-sync validation (`validate_before_sync`)
+- `dango/cli/commands/platform.py` — token health in `dango status`
 - `dango/cli/source_wizard.py` — inline OAuth during `dango add`
 - `dango/cli/validate.py` — credential validation
 - `dango/ingestion/dlt_runner.py` — `OAuthStorage` for token expiry checks before sync
+- `dango/web/routes/sync.py` — pre-sync validation before web-triggered syncs
 
 ## Testing
 
-- **Unit:** None yet (will be `tests/unit/test_oauth.py`)
+- **Unit:** `pytest tests/unit/test_oauth_validation.py` (26 tests covering all validators, routing, pre-sync gate)
 - **Integration:** None yet (will be `tests/integration/test_oauth.py`)
-- **Manual:** `dango add` → select Google/Facebook/Shopify source → complete OAuth flow
+- **Manual:** `dango auth check` (live validation), `dango status` (token health)
 
 ## Don't Modify
 
@@ -46,3 +54,4 @@ Manages browser-based OAuth authentication flows, provider-specific token exchan
 | `providers.py` OAuth endpoints and scopes | Set by third-party APIs (Google, Facebook, Shopify); changes break authentication |
 | `storage.py` credential key structure | Must match dlt's expected secrets.toml format (e.g., `sources.{type}.credentials` for Google, flat keys for others) |
 | `router.py` `OAUTH_PROVIDER_MAP` keys | Source type keys must match `SourceType` enum values in `config/models.py` |
+| `validation.py` network error policy | Network errors return `valid=True` by design — don't block sync on transient API failures |

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -326,3 +326,10 @@ def create_oauth_manager(project_root: Path) -> OAuthManager:
         OAuthManager instance
     """
     return OAuthManager(project_root)
+
+
+# Re-export validation API
+from dango.oauth.validation import TokenValidationResult as TokenValidationResult  # noqa: E402
+from dango.oauth.validation import validate_all_tokens as validate_all_tokens  # noqa: E402
+from dango.oauth.validation import validate_before_sync as validate_before_sync  # noqa: E402
+from dango.oauth.validation import validate_token as validate_token  # noqa: E402

--- a/dango/oauth/validation.py
+++ b/dango/oauth/validation.py
@@ -1,0 +1,395 @@
+"""dango/oauth/validation.py
+
+Live token validation for OAuth credentials.
+
+Makes lightweight API calls to verify tokens actually work, rather than
+just checking stored metadata (expiry dates). Used by ``dango auth check``,
+pre-sync validation, and ``dango status``.
+
+Network error policy: if validation fails due to network issues
+(ConnectionError, Timeout), the token is given the benefit of the doubt
+(``valid=True``, ``error_code="network_error"``). Pre-sync validation
+does NOT raise on network errors — don't block sync just because a
+provider API is momentarily unreachable.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from dango.exceptions import OAuthTokenExpiredError, OAuthTokenRevokedError
+from dango.oauth.router import OAUTH_PROVIDER_MAP
+from dango.oauth.storage import OAuthCredential, OAuthStorage
+
+logger = logging.getLogger(__name__)
+
+# Google OAuth token endpoint
+_GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+_GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo"
+
+# Facebook Graph API
+_FACEBOOK_ME_URL = "https://graph.facebook.com/me"
+
+# Shopify API version (matches providers.py)
+_SHOPIFY_API_VERSION = "2024-01"
+
+# Request timeout in seconds
+_REQUEST_TIMEOUT = 10
+
+
+@dataclass
+class TokenValidationResult:
+    """Result of a live token validation check."""
+
+    source_type: str
+    provider: str
+    valid: bool
+    message: str
+    account_info: str = ""
+    expires_at: datetime | None = None
+    days_until_expiry: int | None = None
+    error_code: str | None = None  # "revoked", "expired", "network_error", "missing_credentials"
+
+
+def validate_google_token(credential: OAuthCredential) -> TokenValidationResult:
+    """Validate a Google OAuth credential by exchanging the refresh token.
+
+    1. POST refresh_token to Google's token endpoint to get a fresh access_token.
+    2. GET /oauth2/v1/userinfo with the access_token to verify it works.
+
+    Args:
+        credential: An OAuthCredential with Google credentials.
+
+    Returns:
+        TokenValidationResult with validation outcome.
+    """
+    creds = credential.credentials
+    client_id = creds.get("client_id")
+    client_secret = creds.get("client_secret")
+    refresh_token = creds.get("refresh_token")
+
+    if not all([client_id, client_secret, refresh_token]):
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=False,
+            message="Missing credentials (client_id, client_secret, or refresh_token)",
+            error_code="missing_credentials",
+        )
+
+    try:
+        # Step 1: Exchange refresh_token for access_token
+        token_response = requests.post(
+            _GOOGLE_TOKEN_URL,
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+
+        if token_response.status_code != 200:
+            error_data: dict[str, Any] = token_response.json()
+            error_type = error_data.get("error", "unknown")
+            if error_type == "invalid_grant":
+                return TokenValidationResult(
+                    source_type=credential.source_type,
+                    provider=credential.provider,
+                    valid=False,
+                    message=f"Token revoked. Re-authenticate: dango auth {credential.source_type}",
+                    error_code="revoked",
+                )
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=False,
+                message=f"Token exchange failed: {error_type}",
+                error_code="revoked",
+            )
+
+        access_token = token_response.json().get("access_token")
+
+        # Step 2: Verify access_token with userinfo endpoint
+        userinfo_response = requests.get(
+            _GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=_REQUEST_TIMEOUT,
+        )
+
+        if userinfo_response.status_code != 200:
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=False,
+                message="Access token verification failed",
+                error_code="revoked",
+            )
+
+        userinfo: dict[str, Any] = userinfo_response.json()
+        email = userinfo.get("email", "")
+
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=True,
+            message="Token valid",
+            account_info=email,
+            expires_at=credential.expires_at,
+            days_until_expiry=credential.days_until_expiry(),
+        )
+
+    except (requests.ConnectionError, requests.Timeout) as exc:
+        logger.debug(
+            "Network error validating Google token for %s: %s", credential.source_type, exc
+        )
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=True,
+            message="Could not reach Google API (network error)",
+            account_info=credential.account_info,
+            error_code="network_error",
+        )
+
+
+def validate_facebook_token(credential: OAuthCredential) -> TokenValidationResult:
+    """Validate a Facebook OAuth credential.
+
+    Checks stored expiry first, then calls GET /me to verify the token.
+
+    Args:
+        credential: An OAuthCredential with Facebook credentials.
+
+    Returns:
+        TokenValidationResult with validation outcome.
+    """
+    creds = credential.credentials
+    access_token = creds.get("access_token")
+
+    if not access_token:
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=False,
+            message="Missing access_token",
+            error_code="missing_credentials",
+        )
+
+    # Check stored expiry first
+    if credential.is_expired():
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=False,
+            message=f"Token expired. Re-authenticate: dango auth {credential.source_type}",
+            expires_at=credential.expires_at,
+            error_code="expired",
+        )
+
+    try:
+        response = requests.get(
+            _FACEBOOK_ME_URL,
+            params={"access_token": access_token},
+            timeout=_REQUEST_TIMEOUT,
+        )
+
+        if response.status_code == 200:
+            data: dict[str, Any] = response.json()
+            name = data.get("name", "")
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=True,
+                message="Token valid",
+                account_info=name or credential.account_info,
+                expires_at=credential.expires_at,
+                days_until_expiry=credential.days_until_expiry(),
+            )
+
+        # 401 or error response means revoked/invalid
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=False,
+            message=f"Token revoked. Re-authenticate: dango auth {credential.source_type}",
+            error_code="revoked",
+        )
+
+    except (requests.ConnectionError, requests.Timeout) as exc:
+        logger.debug(
+            "Network error validating Facebook token for %s: %s", credential.source_type, exc
+        )
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=True,
+            message="Could not reach Facebook API (network error)",
+            account_info=credential.account_info,
+            error_code="network_error",
+        )
+
+
+def validate_shopify_token(credential: OAuthCredential) -> TokenValidationResult:
+    """Validate a Shopify credential by calling the shop info endpoint.
+
+    Args:
+        credential: An OAuthCredential with Shopify credentials.
+
+    Returns:
+        TokenValidationResult with validation outcome.
+    """
+    creds = credential.credentials
+    access_token = creds.get("private_app_password")
+    shop_url = creds.get("shop_url")
+
+    if not access_token or not shop_url:
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=False,
+            message="Missing credentials (private_app_password or shop_url)",
+            error_code="missing_credentials",
+        )
+
+    try:
+        url = f"https://{shop_url}/admin/api/{_SHOPIFY_API_VERSION}/shop.json"
+        response = requests.get(
+            url,
+            headers={"X-Shopify-Access-Token": access_token},
+            timeout=_REQUEST_TIMEOUT,
+        )
+
+        if response.status_code == 200:
+            shop_data: dict[str, Any] = response.json()
+            shop_name = shop_data.get("shop", {}).get("name", "")
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=True,
+                message="Token valid",
+                account_info=f"{shop_name} ({shop_url})" if shop_name else shop_url,
+            )
+
+        # 401 or other error
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=False,
+            message="Token invalid. Re-authenticate: dango auth shopify",
+            error_code="revoked",
+        )
+
+    except (requests.ConnectionError, requests.Timeout) as exc:
+        logger.debug(
+            "Network error validating Shopify token for %s: %s", credential.source_type, exc
+        )
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=True,
+            message="Could not reach Shopify API (network error)",
+            account_info=credential.account_info,
+            error_code="network_error",
+        )
+
+
+# Provider → validator mapping
+_PROVIDER_VALIDATORS = {
+    "google": validate_google_token,
+    "facebook": validate_facebook_token,
+    "facebook_ads": validate_facebook_token,
+    "shopify": validate_shopify_token,
+}
+
+
+def validate_token(credential: OAuthCredential) -> TokenValidationResult:
+    """Validate a single OAuth credential by routing to the correct provider validator.
+
+    Args:
+        credential: The OAuth credential to validate.
+
+    Returns:
+        TokenValidationResult with validation outcome.
+    """
+    validator = _PROVIDER_VALIDATORS.get(credential.provider)
+    if validator is None:
+        return TokenValidationResult(
+            source_type=credential.source_type,
+            provider=credential.provider,
+            valid=True,
+            message=f"No validator for provider '{credential.provider}'",
+            account_info=credential.account_info,
+        )
+    return validator(credential)
+
+
+def validate_all_tokens(project_root: Path) -> list[TokenValidationResult]:
+    """Validate all stored OAuth tokens with live API calls.
+
+    Args:
+        project_root: Root of the Dango project.
+
+    Returns:
+        List of TokenValidationResult for each stored credential.
+    """
+    storage = OAuthStorage(project_root)
+    credentials = storage.list()
+    results: list[TokenValidationResult] = []
+    for cred in credentials:
+        result = validate_token(cred)
+        results.append(result)
+    return results
+
+
+def validate_before_sync(source_type: str, project_root: Path) -> None:
+    """Pre-sync gate: validate OAuth token if the source uses OAuth.
+
+    For non-OAuth sources, returns immediately. For OAuth sources, validates
+    the token and raises if revoked/expired. Network errors are silently
+    ignored (benefit of the doubt).
+
+    Args:
+        source_type: The source type value (e.g. "google_sheets").
+        project_root: Root of the Dango project.
+
+    Raises:
+        OAuthTokenRevokedError: If the token is revoked.
+        OAuthTokenExpiredError: If the token is expired.
+    """
+    # Only validate OAuth sources
+    if source_type not in OAUTH_PROVIDER_MAP:
+        return
+
+    storage = OAuthStorage(project_root)
+    credential = storage.get(source_type)
+
+    if credential is None:
+        # No stored credential — let dlt handle the missing credentials error
+        return
+
+    result = validate_token(credential)
+
+    # Silent pass on network errors
+    if result.error_code == "network_error":
+        return
+
+    if not result.valid:
+        if result.error_code == "expired":
+            raise OAuthTokenExpiredError(
+                result.message,
+                user_message=result.message,
+                context={"source_type": source_type, "provider": result.provider},
+            )
+        raise OAuthTokenRevokedError(
+            result.message,
+            user_message=result.message,
+            context={"source_type": source_type, "provider": result.provider},
+        )

--- a/dango/oauth/validation.py
+++ b/dango/oauth/validation.py
@@ -54,7 +54,9 @@ class TokenValidationResult:
     account_info: str = ""
     expires_at: datetime | None = None
     days_until_expiry: int | None = None
-    error_code: str | None = None  # "revoked", "expired", "network_error", "missing_credentials"
+    error_code: str | None = (
+        None  # "revoked", "expired", "network_error", "server_error", "missing_credentials"
+    )
 
 
 def validate_google_token(credential: OAuthCredential) -> TokenValidationResult:
@@ -97,7 +99,20 @@ def validate_google_token(credential: OAuthCredential) -> TokenValidationResult:
         )
 
         if token_response.status_code != 200:
-            error_data: dict[str, Any] = token_response.json()
+            # Server errors (5xx) get benefit of the doubt
+            if token_response.status_code >= 500:
+                return TokenValidationResult(
+                    source_type=credential.source_type,
+                    provider=credential.provider,
+                    valid=True,
+                    message="Google API returned a server error",
+                    account_info=credential.account_info,
+                    error_code="server_error",
+                )
+            try:
+                error_data: dict[str, Any] = token_response.json()
+            except (ValueError, requests.JSONDecodeError):
+                error_data = {}
             error_type = error_data.get("error", "unknown")
             if error_type == "invalid_grant":
                 return TokenValidationResult(
@@ -115,7 +130,27 @@ def validate_google_token(credential: OAuthCredential) -> TokenValidationResult:
                 error_code="revoked",
             )
 
-        access_token = token_response.json().get("access_token")
+        try:
+            token_data: dict[str, Any] = token_response.json()
+        except (ValueError, requests.JSONDecodeError):
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=True,
+                message="Could not parse token response",
+                account_info=credential.account_info,
+                error_code="server_error",
+            )
+        access_token = token_data.get("access_token")
+
+        if not access_token:
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=False,
+                message="Token exchange succeeded but no access_token returned",
+                error_code="revoked",
+            )
 
         # Step 2: Verify access_token with userinfo endpoint
         userinfo_response = requests.get(
@@ -123,6 +158,16 @@ def validate_google_token(credential: OAuthCredential) -> TokenValidationResult:
             headers={"Authorization": f"Bearer {access_token}"},
             timeout=_REQUEST_TIMEOUT,
         )
+
+        if userinfo_response.status_code >= 500:
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=True,
+                message="Google userinfo API returned a server error",
+                account_info=credential.account_info,
+                error_code="server_error",
+            )
 
         if userinfo_response.status_code != 200:
             return TokenValidationResult(
@@ -214,7 +259,18 @@ def validate_facebook_token(credential: OAuthCredential) -> TokenValidationResul
                 days_until_expiry=credential.days_until_expiry(),
             )
 
-        # 401 or error response means revoked/invalid
+        # Server errors (5xx) get benefit of the doubt
+        if response.status_code >= 500:
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=True,
+                message="Facebook API returned a server error",
+                account_info=credential.account_info,
+                error_code="server_error",
+            )
+
+        # 401 or client error means revoked/invalid
         return TokenValidationResult(
             source_type=credential.source_type,
             provider=credential.provider,
@@ -278,7 +334,18 @@ def validate_shopify_token(credential: OAuthCredential) -> TokenValidationResult
                 account_info=f"{shop_name} ({shop_url})" if shop_name else shop_url,
             )
 
-        # 401 or other error
+        # Server errors (5xx) get benefit of the doubt
+        if response.status_code >= 500:
+            return TokenValidationResult(
+                source_type=credential.source_type,
+                provider=credential.provider,
+                valid=True,
+                message="Shopify API returned a server error",
+                account_info=credential.account_info,
+                error_code="server_error",
+            )
+
+        # 401 or client error means revoked/invalid
         return TokenValidationResult(
             source_type=credential.source_type,
             provider=credential.provider,
@@ -377,8 +444,8 @@ def validate_before_sync(source_type: str, project_root: Path) -> None:
 
     result = validate_token(credential)
 
-    # Silent pass on network errors
-    if result.error_code == "network_error":
+    # Silent pass on network errors and server errors
+    if result.error_code in ("network_error", "server_error"):
         return
 
     if not result.valid:
@@ -386,6 +453,16 @@ def validate_before_sync(source_type: str, project_root: Path) -> None:
             raise OAuthTokenExpiredError(
                 result.message,
                 user_message=result.message,
+                context={"source_type": source_type, "provider": result.provider},
+            )
+        if result.error_code == "missing_credentials":
+            msg = (
+                f"Incomplete OAuth credentials for {source_type}. "
+                f"Re-authenticate: dango auth {source_type}"
+            )
+            raise OAuthTokenRevokedError(
+                msg,
+                user_message=msg,
                 context={"source_type": source_type, "provider": result.provider},
             )
         raise OAuthTokenRevokedError(

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -150,6 +150,31 @@ async def run_sync_task(
         if not source_config:
             raise ValueError(f"Source '{source_name}' not found in configuration")
 
+        # Pre-sync OAuth token validation
+        from dango.exceptions import OAuthTokenExpiredError, OAuthTokenRevokedError
+        from dango.oauth.validation import validate_before_sync
+
+        try:
+            validate_before_sync(source_config.type.value, project_root)
+        except (OAuthTokenRevokedError, OAuthTokenExpiredError) as oauth_err:
+            await ws_manager.broadcast(
+                {
+                    "event": "sync_failed",
+                    "source": source_name,
+                    "message": oauth_err.user_message,
+                    "timestamp": datetime.now().isoformat(),
+                }
+            )
+            append_log_entry(
+                {
+                    "timestamp": datetime.now().isoformat(),
+                    "level": "error",
+                    "source": source_name,
+                    "message": f"OAuth validation failed: {oauth_err.user_message}",
+                }
+            )
+            return
+
         # Use the same run_sync function as CLI for consistent behavior
         # This ensures: data load -> dbt run -> docs generation -> Metabase sync
         from dango.ingestion import run_sync

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -119,6 +119,13 @@ exemptions:
 
 # Removed: dango/platform/network.py — now 486 lines, within limit (TASK-088)
 
+  # --- Test files (verbose by nature — each test class covers one public function) ---
+  - file: tests/unit/test_oauth_validation.py
+    lines: 580
+    category: exempt
+    reason: "35 tests covering all provider validators, routing, and pre-sync gate. Test methods are intentionally verbose for readability — each sets up mocks explicitly."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ module = [
     "dango.cli.model_wizard",
     "dango.cli.validate",
     "dango.cli.commands.platform",
-    "dango.cli.commands.auth",
+    # dango.cli.commands.auth — removed by TASK-009 (mypy errors fixed)
     "dango.cli.commands.source",
     "dango.visualization.metabase",
     "dango.visualization.dashboard_manager",

--- a/tests/factories/config_factories.py
+++ b/tests/factories/config_factories.py
@@ -3,6 +3,10 @@
 Each function returns a valid model instance with sensible defaults. All fields are overridable via keyword arguments.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from dango.config.models import (
     CSVSourceConfig,
     DangoConfig,
@@ -16,7 +20,7 @@ from dango.config.models import (
 )
 
 
-def make_stakeholder(**overrides) -> Stakeholder:
+def make_stakeholder(**overrides: Any) -> Stakeholder:
     """Create a valid Stakeholder instance."""
     defaults = {
         "name": "Test User",
@@ -26,7 +30,7 @@ def make_stakeholder(**overrides) -> Stakeholder:
     return Stakeholder(**{**defaults, **overrides})
 
 
-def make_project_context(**overrides) -> ProjectContext:
+def make_project_context(**overrides: Any) -> ProjectContext:
     """Create a valid ProjectContext instance."""
     defaults = {
         "name": "Test Analytics",
@@ -36,7 +40,7 @@ def make_project_context(**overrides) -> ProjectContext:
     return ProjectContext(**{**defaults, **overrides})
 
 
-def make_csv_source_config(**overrides) -> CSVSourceConfig:
+def make_csv_source_config(**overrides: Any) -> CSVSourceConfig:
     """Create a valid CSVSourceConfig instance."""
     defaults = {
         "directory": "data/test_csv",
@@ -44,7 +48,7 @@ def make_csv_source_config(**overrides) -> CSVSourceConfig:
     return CSVSourceConfig(**{**defaults, **overrides})
 
 
-def make_google_sheets_source_config(**overrides) -> GoogleSheetsSourceConfig:
+def make_google_sheets_source_config(**overrides: Any) -> GoogleSheetsSourceConfig:
     """Create a valid GoogleSheetsSourceConfig instance."""
     defaults = {
         "spreadsheet_url_or_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
@@ -53,13 +57,13 @@ def make_google_sheets_source_config(**overrides) -> GoogleSheetsSourceConfig:
     return GoogleSheetsSourceConfig(**{**defaults, **overrides})
 
 
-def make_data_source(source_type: SourceType = SourceType.CSV, **overrides) -> DataSource:
+def make_data_source(source_type: SourceType = SourceType.CSV, **overrides: Any) -> DataSource:
     """Create a valid DataSource instance with type-specific config.
 
     Automatically populates the type-specific config field for CSV and
     Google Sheets sources. Other types get no extra config by default.
     """
-    defaults = {
+    defaults: dict[str, Any] = {
         "name": "test_source",
         "type": source_type,
     }
@@ -71,7 +75,7 @@ def make_data_source(source_type: SourceType = SourceType.CSV, **overrides) -> D
     return DataSource(**{**defaults, **overrides})
 
 
-def make_sources_config(sources=None, **overrides) -> SourcesConfig:
+def make_sources_config(sources: list[DataSource] | None = None, **overrides: Any) -> SourcesConfig:
     """Create a valid SourcesConfig instance.
 
     Args:
@@ -86,7 +90,7 @@ def make_sources_config(sources=None, **overrides) -> SourcesConfig:
     return SourcesConfig(**{**defaults, **overrides})
 
 
-def make_platform_settings(**overrides) -> PlatformSettings:
+def make_platform_settings(**overrides: Any) -> PlatformSettings:
     """Create a PlatformSettings instance with Pydantic defaults."""
     return PlatformSettings(**overrides)
 
@@ -95,7 +99,7 @@ def make_dango_config(
     project: ProjectContext | None = None,
     sources: SourcesConfig | None = None,
     platform: PlatformSettings | None = None,
-    **overrides,
+    **overrides: Any,
 ) -> DangoConfig:
     """Create a valid DangoConfig instance.
 

--- a/tests/factories/oauth_factories.py
+++ b/tests/factories/oauth_factories.py
@@ -1,0 +1,85 @@
+"""tests/factories/oauth_factories.py
+
+Factory functions for creating test OAuth credentials.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from dango.oauth.storage import OAuthCredential
+
+
+def make_oauth_credential(
+    source_type: str = "google_sheets",
+    provider: str = "google",
+    **overrides: Any,
+) -> OAuthCredential:
+    """Create a valid OAuthCredential with sensible defaults."""
+    defaults: dict[str, Any] = {
+        "source_type": source_type,
+        "provider": provider,
+        "identifier": "test@example.com",
+        "account_info": "Test Account",
+        "credentials": {
+            "client_id": "test-client-id.apps.googleusercontent.com",
+            "client_secret": "test-client-secret",
+            "refresh_token": "test-refresh-token",
+        },
+        "created_at": datetime(2026, 1, 1),
+        "expires_at": None,
+        "last_refreshed": None,
+        "metadata": None,
+    }
+    defaults.update(overrides)
+    return OAuthCredential(**defaults)
+
+
+def make_google_credential(**overrides: Any) -> OAuthCredential:
+    """Create a Google OAuth credential."""
+    defaults: dict[str, Any] = {
+        "source_type": "google_sheets",
+        "provider": "google",
+        "identifier": "user@gmail.com",
+        "account_info": "user@gmail.com",
+        "credentials": {
+            "client_id": "123456.apps.googleusercontent.com",
+            "client_secret": "GOCSPX-secret",
+            "refresh_token": "1//0abc-refresh-token",
+        },
+    }
+    defaults.update(overrides)
+    return make_oauth_credential(**defaults)
+
+
+def make_facebook_credential(**overrides: Any) -> OAuthCredential:
+    """Create a Facebook OAuth credential."""
+    defaults: dict[str, Any] = {
+        "source_type": "facebook_ads",
+        "provider": "facebook_ads",
+        "identifier": "123456789",
+        "account_info": "Facebook Ads Account (123456789)",
+        "credentials": {
+            "access_token": "EAABsbCS1IXXZD-long-lived-token",
+        },
+        "expires_at": datetime.now() + timedelta(days=55),
+    }
+    defaults.update(overrides)
+    return make_oauth_credential(**defaults)
+
+
+def make_shopify_credential(**overrides: Any) -> OAuthCredential:
+    """Create a Shopify OAuth credential."""
+    defaults: dict[str, Any] = {
+        "source_type": "shopify",
+        "provider": "shopify",
+        "identifier": "mystore",
+        "account_info": "My Store (mystore.myshopify.com)",
+        "credentials": {
+            "private_app_password": "shpat_abcdef123456",
+            "shop_url": "mystore.myshopify.com",
+        },
+    }
+    defaults.update(overrides)
+    return make_oauth_credential(**defaults)

--- a/tests/unit/test_oauth_validation.py
+++ b/tests/unit/test_oauth_validation.py
@@ -1,0 +1,435 @@
+"""tests/unit/test_oauth_validation.py
+
+Tests for dango/oauth/validation.py — live token validation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import OAuthTokenExpiredError, OAuthTokenRevokedError
+from dango.oauth.validation import (
+    TokenValidationResult,
+    validate_all_tokens,
+    validate_before_sync,
+    validate_facebook_token,
+    validate_google_token,
+    validate_shopify_token,
+    validate_token,
+)
+from tests.factories.oauth_factories import (
+    make_facebook_credential,
+    make_google_credential,
+    make_oauth_credential,
+    make_shopify_credential,
+)
+
+
+@pytest.mark.unit
+class TestValidateGoogleToken:
+    """Tests for validate_google_token()."""
+
+    @patch("dango.oauth.validation.requests")
+    def test_valid_token(self, mock_requests: MagicMock) -> None:
+        """Valid refresh token returns valid result with email."""
+        # Mock token exchange
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {"access_token": "ya29.fresh-token"}
+
+        # Mock userinfo
+        userinfo_resp = MagicMock()
+        userinfo_resp.status_code = 200
+        userinfo_resp.json.return_value = {"email": "user@gmail.com", "name": "Test User"}
+
+        mock_requests.post.return_value = token_resp
+        mock_requests.get.return_value = userinfo_resp
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is True
+        assert result.account_info == "user@gmail.com"
+        assert result.error_code is None
+
+    @patch("dango.oauth.validation.requests")
+    def test_revoked_refresh_token(self, mock_requests: MagicMock) -> None:
+        """Revoked refresh token (invalid_grant) returns revoked result."""
+        token_resp = MagicMock()
+        token_resp.status_code = 400
+        token_resp.json.return_value = {
+            "error": "invalid_grant",
+            "error_description": "Token has been revoked.",
+        }
+        mock_requests.post.return_value = token_resp
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "revoked"
+        assert "Re-authenticate" in result.message
+
+    def test_missing_credentials(self) -> None:
+        """Missing client_id/secret/refresh_token returns missing_credentials."""
+        cred = make_google_credential(credentials={"client_id": "x"})
+        result = validate_google_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "missing_credentials"
+
+    @patch("dango.oauth.validation.requests")
+    def test_network_error_returns_valid(self, mock_requests: MagicMock) -> None:
+        """ConnectionError gives benefit of the doubt (valid=True, error_code=network_error)."""
+        import requests as real_requests
+
+        mock_requests.post.side_effect = real_requests.ConnectionError("DNS resolution failed")
+        mock_requests.ConnectionError = real_requests.ConnectionError
+        mock_requests.Timeout = real_requests.Timeout
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "network_error"
+
+    @patch("dango.oauth.validation.requests")
+    def test_userinfo_failure(self, mock_requests: MagicMock) -> None:
+        """Token exchange succeeds but userinfo fails → revoked."""
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {"access_token": "ya29.fresh-token"}
+
+        userinfo_resp = MagicMock()
+        userinfo_resp.status_code = 403
+
+        mock_requests.post.return_value = token_resp
+        mock_requests.get.return_value = userinfo_resp
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "revoked"
+
+
+@pytest.mark.unit
+class TestValidateFacebookToken:
+    """Tests for validate_facebook_token()."""
+
+    @patch("dango.oauth.validation.requests")
+    def test_valid_token(self, mock_requests: MagicMock) -> None:
+        """Valid token returns valid result."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"name": "John Doe", "id": "123456789"}
+        mock_requests.get.return_value = resp
+
+        cred = make_facebook_credential()
+        result = validate_facebook_token(cred)
+
+        assert result.valid is True
+        assert result.account_info == "John Doe"
+
+    def test_expired_token(self) -> None:
+        """Expired token (stored expiry in past) returns expired result."""
+        cred = make_facebook_credential(
+            expires_at=datetime.now() - timedelta(days=1),
+        )
+        result = validate_facebook_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "expired"
+
+    @patch("dango.oauth.validation.requests")
+    def test_revoked_token(self, mock_requests: MagicMock) -> None:
+        """401 from /me returns revoked result."""
+        resp = MagicMock()
+        resp.status_code = 401
+        mock_requests.get.return_value = resp
+
+        cred = make_facebook_credential()
+        result = validate_facebook_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "revoked"
+
+    def test_missing_access_token(self) -> None:
+        """Missing access_token returns missing_credentials."""
+        cred = make_facebook_credential(credentials={})
+        result = validate_facebook_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "missing_credentials"
+
+    @patch("dango.oauth.validation.requests")
+    def test_network_error_returns_valid(self, mock_requests: MagicMock) -> None:
+        """Network error gives benefit of the doubt."""
+        import requests as real_requests
+
+        mock_requests.get.side_effect = real_requests.Timeout("Connection timed out")
+        mock_requests.ConnectionError = real_requests.ConnectionError
+        mock_requests.Timeout = real_requests.Timeout
+
+        cred = make_facebook_credential()
+        result = validate_facebook_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "network_error"
+
+
+@pytest.mark.unit
+class TestValidateShopifyToken:
+    """Tests for validate_shopify_token()."""
+
+    @patch("dango.oauth.validation.requests")
+    def test_valid_token(self, mock_requests: MagicMock) -> None:
+        """Valid token returns shop name."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"shop": {"name": "My Awesome Store"}}
+        mock_requests.get.return_value = resp
+
+        cred = make_shopify_credential()
+        result = validate_shopify_token(cred)
+
+        assert result.valid is True
+        assert "My Awesome Store" in result.account_info
+
+    @patch("dango.oauth.validation.requests")
+    def test_invalid_token(self, mock_requests: MagicMock) -> None:
+        """401 from shop.json returns revoked result."""
+        resp = MagicMock()
+        resp.status_code = 401
+        mock_requests.get.return_value = resp
+
+        cred = make_shopify_credential()
+        result = validate_shopify_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "revoked"
+
+    def test_missing_credentials(self) -> None:
+        """Missing shop_url or password returns missing_credentials."""
+        cred = make_shopify_credential(credentials={"shop_url": "x.myshopify.com"})
+        result = validate_shopify_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "missing_credentials"
+
+    @patch("dango.oauth.validation.requests")
+    def test_network_error_returns_valid(self, mock_requests: MagicMock) -> None:
+        """Network error gives benefit of the doubt."""
+        import requests as real_requests
+
+        mock_requests.get.side_effect = real_requests.ConnectionError("Connection refused")
+        mock_requests.ConnectionError = real_requests.ConnectionError
+        mock_requests.Timeout = real_requests.Timeout
+
+        cred = make_shopify_credential()
+        result = validate_shopify_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "network_error"
+
+
+@pytest.mark.unit
+class TestValidateToken:
+    """Tests for validate_token() routing."""
+
+    @patch("dango.oauth.validation.requests")
+    def test_routes_google(self, mock_requests: MagicMock) -> None:
+        """Routes google provider to validate_google_token (returns valid)."""
+        # Mock successful token exchange + userinfo
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {"access_token": "ya29.test"}
+        userinfo_resp = MagicMock()
+        userinfo_resp.status_code = 200
+        userinfo_resp.json.return_value = {"email": "user@gmail.com"}
+        mock_requests.post.return_value = token_resp
+        mock_requests.get.return_value = userinfo_resp
+
+        cred = make_google_credential()
+        result = validate_token(cred)
+        assert result.valid is True
+        assert result.provider == "google"
+
+    @patch("dango.oauth.validation.requests")
+    def test_routes_facebook(self, mock_requests: MagicMock) -> None:
+        """Routes facebook_ads provider to validate_facebook_token."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"name": "Test", "id": "123"}
+        mock_requests.get.return_value = resp
+
+        cred = make_facebook_credential()
+        result = validate_token(cred)
+        assert result.valid is True
+        assert result.provider == "facebook_ads"
+
+    @patch("dango.oauth.validation.requests")
+    def test_routes_shopify(self, mock_requests: MagicMock) -> None:
+        """Routes shopify provider to validate_shopify_token."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"shop": {"name": "Test Shop"}}
+        mock_requests.get.return_value = resp
+
+        cred = make_shopify_credential()
+        result = validate_token(cred)
+        assert result.valid is True
+        assert result.provider == "shopify"
+
+    def test_unknown_provider(self) -> None:
+        """Unknown provider returns valid (no validator)."""
+        cred = make_oauth_credential(provider="unknown_provider")
+        result = validate_token(cred)
+        assert result.valid is True
+        assert "No validator" in result.message
+
+
+@pytest.mark.unit
+class TestValidateBeforeSync:
+    """Tests for validate_before_sync() pre-sync gate."""
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    @patch("dango.oauth.validation.validate_token")
+    def test_non_oauth_source_passes(
+        self, mock_validate: MagicMock, mock_storage_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Non-OAuth source (e.g. csv) passes immediately without validation."""
+        validate_before_sync("csv", tmp_path)
+        mock_validate.assert_not_called()
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    @patch("dango.oauth.validation.validate_token")
+    def test_valid_token_passes(
+        self, mock_validate: MagicMock, mock_storage_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Valid OAuth token passes without raising."""
+        mock_storage = MagicMock()
+        mock_storage.get.return_value = make_google_credential()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_validate.return_value = TokenValidationResult(
+            source_type="google_sheets", provider="google", valid=True, message="ok"
+        )
+
+        validate_before_sync("google_sheets", tmp_path)  # Should not raise
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    @patch("dango.oauth.validation.validate_token")
+    def test_revoked_token_raises(
+        self, mock_validate: MagicMock, mock_storage_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Revoked token raises OAuthTokenRevokedError."""
+        mock_storage = MagicMock()
+        mock_storage.get.return_value = make_google_credential()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_validate.return_value = TokenValidationResult(
+            source_type="google_sheets",
+            provider="google",
+            valid=False,
+            message="Token revoked",
+            error_code="revoked",
+        )
+
+        with pytest.raises(OAuthTokenRevokedError):
+            validate_before_sync("google_sheets", tmp_path)
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    @patch("dango.oauth.validation.validate_token")
+    def test_expired_token_raises(
+        self, mock_validate: MagicMock, mock_storage_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Expired token raises OAuthTokenExpiredError."""
+        mock_storage = MagicMock()
+        mock_storage.get.return_value = make_facebook_credential()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_validate.return_value = TokenValidationResult(
+            source_type="facebook_ads",
+            provider="facebook_ads",
+            valid=False,
+            message="Token expired",
+            error_code="expired",
+        )
+
+        with pytest.raises(OAuthTokenExpiredError):
+            validate_before_sync("facebook_ads", tmp_path)
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    @patch("dango.oauth.validation.validate_token")
+    def test_network_error_passes_silently(
+        self, mock_validate: MagicMock, mock_storage_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Network error does NOT raise — silent pass."""
+        mock_storage = MagicMock()
+        mock_storage.get.return_value = make_google_credential()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_validate.return_value = TokenValidationResult(
+            source_type="google_sheets",
+            provider="google",
+            valid=True,
+            message="Network error",
+            error_code="network_error",
+        )
+
+        validate_before_sync("google_sheets", tmp_path)  # Should not raise
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    def test_no_stored_credential_passes(self, mock_storage_cls: MagicMock, tmp_path: Path) -> None:
+        """Missing stored credential passes (let dlt handle it)."""
+        mock_storage = MagicMock()
+        mock_storage.get.return_value = None
+        mock_storage_cls.return_value = mock_storage
+
+        validate_before_sync("google_sheets", tmp_path)  # Should not raise
+
+
+@pytest.mark.unit
+class TestValidateAllTokens:
+    """Tests for validate_all_tokens()."""
+
+    @patch("dango.oauth.validation.validate_token")
+    @patch("dango.oauth.validation.OAuthStorage")
+    def test_validates_all_stored_tokens(
+        self, mock_storage_cls: MagicMock, mock_validate: MagicMock, tmp_path: Path
+    ) -> None:
+        """Validates each stored credential and returns results."""
+        creds = [make_google_credential(), make_facebook_credential()]
+        mock_storage = MagicMock()
+        mock_storage.list.return_value = creds
+        mock_storage_cls.return_value = mock_storage
+
+        mock_validate.side_effect = [
+            TokenValidationResult(
+                source_type="google_sheets", provider="google", valid=True, message="ok"
+            ),
+            TokenValidationResult(
+                source_type="facebook_ads", provider="facebook_ads", valid=False, message="revoked"
+            ),
+        ]
+
+        results = validate_all_tokens(tmp_path)
+
+        assert len(results) == 2
+        assert results[0].valid is True
+        assert results[1].valid is False
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    def test_empty_when_no_credentials(self, mock_storage_cls: MagicMock, tmp_path: Path) -> None:
+        """Returns empty list when no credentials stored."""
+        mock_storage = MagicMock()
+        mock_storage.list.return_value = []
+        mock_storage_cls.return_value = mock_storage
+
+        results = validate_all_tokens(tmp_path)
+        assert results == []

--- a/tests/unit/test_oauth_validation.py
+++ b/tests/unit/test_oauth_validation.py
@@ -116,6 +116,84 @@ class TestValidateGoogleToken:
         assert result.valid is False
         assert result.error_code == "revoked"
 
+    @patch("dango.oauth.validation.requests")
+    def test_non_json_error_response(self, mock_requests: MagicMock) -> None:
+        """Non-JSON error response (e.g. HTML 502) does not raise JSONDecodeError."""
+        token_resp = MagicMock()
+        token_resp.status_code = 400
+        token_resp.json.side_effect = ValueError("No JSON")
+        mock_requests.post.return_value = token_resp
+        mock_requests.JSONDecodeError = ValueError  # requests uses ValueError base
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "revoked"
+        assert "unknown" in result.message
+
+    @patch("dango.oauth.validation.requests")
+    def test_non_json_success_response(self, mock_requests: MagicMock) -> None:
+        """Non-JSON success response returns server_error with benefit of the doubt."""
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.side_effect = ValueError("No JSON")
+        mock_requests.post.return_value = token_resp
+        mock_requests.JSONDecodeError = ValueError
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "server_error"
+
+    @patch("dango.oauth.validation.requests")
+    def test_null_access_token(self, mock_requests: MagicMock) -> None:
+        """Token exchange returns null access_token → revoked."""
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {"access_token": None}
+        mock_requests.post.return_value = token_resp
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is False
+        assert result.error_code == "revoked"
+        assert "no access_token" in result.message
+
+    @patch("dango.oauth.validation.requests")
+    def test_token_endpoint_5xx_returns_server_error(self, mock_requests: MagicMock) -> None:
+        """5xx from token endpoint returns valid=True with server_error."""
+        token_resp = MagicMock()
+        token_resp.status_code = 502
+        mock_requests.post.return_value = token_resp
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "server_error"
+
+    @patch("dango.oauth.validation.requests")
+    def test_userinfo_5xx_returns_server_error(self, mock_requests: MagicMock) -> None:
+        """5xx from userinfo endpoint returns valid=True with server_error."""
+        token_resp = MagicMock()
+        token_resp.status_code = 200
+        token_resp.json.return_value = {"access_token": "ya29.fresh-token"}
+
+        userinfo_resp = MagicMock()
+        userinfo_resp.status_code = 503
+
+        mock_requests.post.return_value = token_resp
+        mock_requests.get.return_value = userinfo_resp
+
+        cred = make_google_credential()
+        result = validate_google_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "server_error"
+
 
 @pytest.mark.unit
 class TestValidateFacebookToken:
@@ -181,6 +259,19 @@ class TestValidateFacebookToken:
         assert result.valid is True
         assert result.error_code == "network_error"
 
+    @patch("dango.oauth.validation.requests")
+    def test_5xx_returns_server_error(self, mock_requests: MagicMock) -> None:
+        """5xx from Facebook API returns valid=True with server_error."""
+        resp = MagicMock()
+        resp.status_code = 500
+        mock_requests.get.return_value = resp
+
+        cred = make_facebook_credential()
+        result = validate_facebook_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "server_error"
+
 
 @pytest.mark.unit
 class TestValidateShopifyToken:
@@ -235,6 +326,19 @@ class TestValidateShopifyToken:
 
         assert result.valid is True
         assert result.error_code == "network_error"
+
+    @patch("dango.oauth.validation.requests")
+    def test_5xx_returns_server_error(self, mock_requests: MagicMock) -> None:
+        """5xx from Shopify API returns valid=True with server_error."""
+        resp = MagicMock()
+        resp.status_code = 503
+        mock_requests.get.return_value = resp
+
+        cred = make_shopify_credential()
+        result = validate_shopify_token(cred)
+
+        assert result.valid is True
+        assert result.error_code == "server_error"
 
 
 @pytest.mark.unit
@@ -390,6 +494,47 @@ class TestValidateBeforeSync:
         mock_storage = MagicMock()
         mock_storage.get.return_value = None
         mock_storage_cls.return_value = mock_storage
+
+        validate_before_sync("google_sheets", tmp_path)  # Should not raise
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    @patch("dango.oauth.validation.validate_token")
+    def test_missing_credentials_raises_with_clear_message(
+        self, mock_validate: MagicMock, mock_storage_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Missing credentials raises OAuthTokenRevokedError with helpful message."""
+        mock_storage = MagicMock()
+        mock_storage.get.return_value = make_google_credential()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_validate.return_value = TokenValidationResult(
+            source_type="google_sheets",
+            provider="google",
+            valid=False,
+            message="Missing credentials",
+            error_code="missing_credentials",
+        )
+
+        with pytest.raises(OAuthTokenRevokedError, match="Incomplete OAuth credentials"):
+            validate_before_sync("google_sheets", tmp_path)
+
+    @patch("dango.oauth.validation.OAuthStorage")
+    @patch("dango.oauth.validation.validate_token")
+    def test_server_error_passes_silently(
+        self, mock_validate: MagicMock, mock_storage_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Server error does NOT raise — silent pass like network errors."""
+        mock_storage = MagicMock()
+        mock_storage.get.return_value = make_google_credential()
+        mock_storage_cls.return_value = mock_storage
+
+        mock_validate.return_value = TokenValidationResult(
+            source_type="google_sheets",
+            provider="google",
+            valid=True,
+            message="Server error",
+            error_code="server_error",
+        )
 
         validate_before_sync("google_sheets", tmp_path)  # Should not raise
 


### PR DESCRIPTION
## Summary

- Adds live OAuth token validation — lightweight API calls to verify tokens actually work (Google refresh token exchange, Facebook `/me`, Shopify `shop.json`), rather than just checking stored metadata
- Validates in three places: `dango auth check` (live validation + GCP Testing caveat), pre-sync gate (CLI + web), and `dango status` (token health table)
- New exceptions: `OAuthError`, `OAuthTokenRevokedError`, `OAuthTokenExpiredError` (DANGO-A001–A003)
- Network error policy: tokens get benefit of the doubt on API failures (`valid=True`, `error_code="network_error"`) — pre-sync never blocks on transient network issues
- Fixed mypy errors in `cli/commands/auth.py`, removed from mypy exemptions
- Fixed pre-existing mypy errors in `tests/factories/config_factories.py`
- 26 new unit tests, all 456 unit tests passing

## Files changed

| File | Change |
|------|--------|
| `dango/oauth/validation.py` | **New** — core validation module (per-provider validators, routing, pre-sync gate) |
| `tests/factories/oauth_factories.py` | **New** — factory functions for test OAuth credentials |
| `tests/unit/test_oauth_validation.py` | **New** — 26 tests covering all validators, routing, pre-sync gate |
| `dango/exceptions.py` | Add OAuthError hierarchy (DANGO-A001–A003) |
| `dango/cli/commands/auth.py` | Live validation in `auth check`, GCP caveat on Google auth, mypy fixes |
| `dango/cli/commands/platform.py` | Token health table in `dango status` |
| `dango/cli/commands/source.py` | Pre-sync OAuth validation before `run_sync()` |
| `dango/web/routes/sync.py` | Pre-sync OAuth validation before web-triggered syncs |
| `dango/oauth/__init__.py` | Re-export validation API |
| `dango/oauth/CLAUDE.md` | Add validation.py to module docs |
| `pyproject.toml` | Remove `cli.commands.auth` from mypy exemptions |
| `tests/factories/config_factories.py` | Fix pre-existing mypy errors (type annotations) |

## Test plan

- [x] All 26 new validation tests pass
- [x] All 456 unit tests pass (no regressions)
- [x] mypy clean on all new and modified files
- [x] ruff lint + format clean
- [x] All pre-commit hooks pass
- [ ] Manual: `dango auth check` shows live validation results
- [ ] Manual: `dango status` shows token health table
- [ ] Manual: `dango sync --source <oauth_source>` with revoked token shows clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)