### PR TITLE
DOC-024: Phase 1 end-of-phase documentation sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
               │                                                            │
               │   config/     utils/      security/    templates/          │
               │   migrations/                                              │
-              │   exceptions.py* (Phase 2)    logging.py                  │
+              │   exceptions.py    logging.py                              │
               └───────────────────────────────────────────────────────────┘
                                         │
               ┌─────────────────────────┴──────────────────────────────────┐
@@ -67,12 +67,12 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 | Level | Role | Modules |
 |-------|------|---------|
-| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `migrations/`, `templates/`, `logging.py`, `exceptions.py`\* |
+| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `migrations/`, `templates/`, `logging.py`, `exceptions.py` |
 | 1 (core) | Imports Level 0 only | `oauth/`, `ingestion/`, `transformation/`, `auth/`\* |
 | 2 (platform) | Imports Level 0-1 | `platform/`, `web/`, `visualization/` |
 | 3 (ui) | Imports any level | `cli/` |
 
-\* = planned, not yet implemented (`exceptions.py`)
+\* = planned, not yet implemented
 
 **Three rules govern imports:**
 
@@ -295,10 +295,14 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 **Imports from:** `config/` (Level 0), `utils/` (Level 0), `ingestion/` (Level 1), `transformation/` (Level 1), `visualization/` (Level 2).
 
-### Planned Modules
+#### `exceptions.py`
+**Responsibility:** Centralized exception hierarchy for consistent error handling across modules.
 
-#### `exceptions.py` (Phase 2)
-Centralized exception hierarchy for consistent error handling across modules.
+**Public API:** `DangoError` base class and domain-specific subclasses: `ConfigError`, `IngestionError`, `InfrastructureError`, `MigrationError`, `OAuthError`, `ValidationError`, `WebAPIError`, and their specializations (e.g., `DbtLockError`, `OAuthTokenExpiredError`, `CSVSchemaMismatchError`).
+
+**Imports from:** None (Level 0).
+
+### Planned Modules
 
 #### `auth/` (Phase 2)
 User authentication and authorization — session management, roles, permissions.
@@ -338,7 +342,7 @@ User authentication and authorization — session management, roles, permissions
 ```
 User runs: dango sync [--source xyz]
 
-cli/main.py @cli.command("sync")
+cli/commands/source.py @click.command("sync")
   → utils/dbt_lock.py: dbt_lock() — acquire write lock
   → ingestion/dlt_runner.py: run_sync(project_root, source_names)
       → config/loader.py: ConfigLoader.load_config() — load sources.yml
@@ -357,7 +361,7 @@ cli/main.py @cli.command("sync")
 ```
 User runs: dango init
 
-cli/main.py @cli.command("init")
+cli/commands/project.py @click.command("init")
   → cli/wizard.py — interactive project setup
   → cli/init.py — create directory structure:
       .dango/, data/, data/uploads/, custom_sources/, dbt/models/...
@@ -387,7 +391,7 @@ cli/oauth.py
 ```
 User runs: dango start (first time)
 
-cli/main.py @cli.command("start")
+cli/commands/platform.py @click.command("start")
   → platform/docker.py: DockerManager.up() — start containers
   → visualization/metabase.py — auto-setup:
       → Create admin account (random password)
@@ -415,7 +419,7 @@ platform/watcher.py — detect file change (watchdog)
 ```
 POST /api/sources/{source_name}/sync
 
-web/app.py @app.post("/api/sources/{source_name}/sync")
+web/routes/sync.py @router.post("/api/sources/{source_name}/sync")
   → utils/dbt_lock.py: dbt_lock() — acquire write lock
   → ingestion/dlt_runner.py: run_sync() (in BackgroundTask)
   → WebSocket /ws — broadcast progress updates to connected clients
@@ -486,7 +490,7 @@ Three-tier storage:
 
 ## 10. API Design Principles
 
-The web module (`web/app.py`) exposes 19 REST endpoints, 1 WebSocket, and a Metabase reverse proxy.
+The web module (`web/routes/`) exposes 19 REST endpoints, 1 WebSocket, and a Metabase reverse proxy.
 
 **Current endpoints (all under `/api/`):**
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 Dango is an open-source data platform for small teams that integrates four production-grade tools into a single `pip install` + `dango start` workflow:
 
-- **dlt** (data load tool) for ingestion from 34 source types
+- **dlt** (data load tool) for ingestion from 33 source types
 - **DuckDB** as the embedded analytical warehouse
 - **dbt** for SQL-based data transformation
 - **Metabase** for dashboards and visualization
@@ -25,14 +25,14 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
               │                     Level 3 — UI                           │
               │                                                            │
               │   cli/                                                     │
-              │   (3927 lines)                                             │
+              │   (cli/commands/)                                          │
               └──────────┬─────────────────────────────────────────────────┘
                          │
               ┌──────────┴─────────────────────────────────────────────────┐
               │                  Level 2 — Platform                        │
               │                                                            │
               │   platform/        web/            visualization/          │
-              │   (Docker,         (2900 lines)    (Metabase)              │
+              │   (Docker,         (web/routes/)   (Metabase)              │
               │    watcher)                        auth/* (Phase 2)        │
               └──────────┬────────────────┬────────────────────────────────┘
                          │                │
@@ -49,7 +49,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
               │                  Level 0 — Base                            │
               │                                                            │
               │   config/     utils/      security/    templates/          │
-              │                                                            │
+              │   migrations/                                              │
               │   exceptions.py* (Phase 2)    logging.py                  │
               └───────────────────────────────────────────────────────────┘
                                         │
@@ -67,7 +67,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 | Level | Role | Modules |
 |-------|------|---------|
-| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `templates/`, `logging.py`, `exceptions.py`\* |
+| 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `migrations/`, `templates/`, `logging.py`, `exceptions.py`\* |
 | 1 (core) | Imports Level 0 only | `oauth/`, `ingestion/`, `transformation/`, `auth/`\* |
 | 2 (platform) | Imports Level 0-1 | `platform/`, `web/`, `visualization/` |
 | 3 (ui) | Imports any level | `cli/` |
@@ -90,7 +90,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 | File | Description |
 |------|-------------|
 | `__init__.py` | Re-exports all public symbols |
-| `models.py` | Pydantic models: `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType` (34 types), `DeduplicationStrategy`, `PlatformSettings`, source-specific configs |
+| `models.py` | Pydantic models: `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType` (33 types), `DeduplicationStrategy`, `PlatformSettings`, source-specific configs |
 | `loader.py` | `ConfigLoader` — finds project root, loads/saves `.dango/project.yml` and `.dango/sources.yml` |
 | `credentials.py` | `CredentialManager` — manages `.dlt/secrets.toml` and `.env` files |
 
@@ -152,6 +152,20 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 ---
 
+#### `migrations/`
+**Responsibility:** Database migration framework for managing schema changes across Dango versions.
+
+| File | Description |
+|------|-------------|
+| `__init__.py` | Public API: `apply_all_pending()`, `get_all_status()` |
+| `runner.py` | `MigrationRunner`, `MigrationInfo`, `MigrationStatus` — discovers, tracks, and applies migration scripts |
+
+**Public API:** `apply_all_pending(project_root)`, `get_all_status(project_root)`
+
+**Imports from:** None (Level 0). Uses pathlib, importlib.
+
+---
+
 #### `logging.py`
 **Responsibility:** Structured logging infrastructure (structlog wrapping stdlib). JSON to rotating log file, human-readable to stderr. Correlation ID support via contextvars.
 
@@ -162,14 +176,14 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 ### Level 1 — Core
 
 #### `ingestion/`
-**Responsibility:** Data loading from 34 source types into DuckDB via dlt pipelines and CSV loader.
+**Responsibility:** Data loading from 33 source types into DuckDB via dlt pipelines and CSV loader.
 
 | File | Description |
 |------|-------------|
 | `__init__.py` | Re-exports `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY` |
-| `dlt_runner.py` | `DltPipelineRunner` — orchestrates sync: load data, generate staging models, run dbt, refresh Metabase (1696 lines). Contains lazy imports from Level 1-2 modules. |
+| `dlt_runner.py` | `DltPipelineRunner` — orchestrates sync: load data, generate staging models, run dbt, refresh Metabase (1759 lines). Contains lazy imports from Level 1-2 modules. |
 | `csv_loader.py` | `CSVLoader` — incremental CSV loading with 4 dedup strategies, file metadata tracking |
-| `sources/registry.py` | `SOURCE_REGISTRY` — metadata dict for all 34 sources (auth type, params, setup guide, cost warnings) |
+| `sources/registry.py` | `SOURCE_REGISTRY` — metadata dict for all 33 sources (auth type, params, setup guide, cost warnings) |
 | `dlt_sources/` | 29 vendored dlt source integrations (third-party code, rarely modified) |
 
 **Public API:** `DltPipelineRunner`, `run_sync()`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata()`
@@ -246,7 +260,8 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 | File | Description |
 |------|-------------|
-| `main.py` | Main CLI entry point (3927 lines). Commands: `init`, `start`, `stop`, `status`, `sync`, `validate`, `rename`, `generate`, `serve`. Groups: `source`, `config`, `model`, `dbt`, `api`, `oauth`. |
+| `main.py` | Slim entry point (~88 lines) — registers command groups from `commands/` subpackage |
+| `commands/` | Command modules extracted from main.py by TASK-005: `platform.py` (start/stop/status), `source.py` (add/list/remove/sync), `auth.py` (OAuth management), `project.py` (init/rename/info), `transform.py` (run/docs/generate), etc. |
 | `init.py` | Project initialization wizard — creates directory structure, config files, Docker setup |
 | `wizard.py` | Interactive setup wizards |
 | `source_wizard.py` | Source configuration wizard |
@@ -271,11 +286,14 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 | File | Description |
 |------|-------------|
-| `app.py` | FastAPI application (2900 lines). 19 REST endpoints, 1 WebSocket, Metabase reverse proxy with SSO, dbt docs proxy. |
+| `app.py` | Slim entry point (~202 lines) — creates FastAPI app, registers routers from `routes/` |
+| `helpers.py` | Shared helpers: DuckDB queries, config loading, service health checks, log management |
+| `models.py` | Pydantic request/response DTOs |
+| `routes/` | Route modules extracted from app.py by TASK-085: `health.py`, `config.py`, `sources.py`, `sync.py`, `logs.py`, `dbt.py`, `upload.py`, `websocket.py`, `ui.py`, `metabase_proxy.py` |
 
 **Public API:** FastAPI `app` instance.
 
-**Imports from:** `config/` (Level 0), `utils/` (Level 0), `ingestion/` (Level 1), `transformation/` (Level 1), `visualization/` (Level 2). Also imports `cli/utils` (Level 3) — see Known Violations.
+**Imports from:** `config/` (Level 0), `utils/` (Level 0), `ingestion/` (Level 1), `transformation/` (Level 1), `visualization/` (Level 2).
 
 ### Planned Modules
 
@@ -492,9 +510,9 @@ The web module (`web/app.py`) exposes 19 REST endpoints, 1 WebSocket, and a Meta
 
 1. **New data source:** Add entry to `ingestion/sources/registry.py` (auth type, params, metadata). Optionally add OAuth provider in `oauth/providers.py` and dlt source in `ingestion/dlt_sources/`. The CLI auto-discovers sources from the registry.
 
-2. **New CLI command:** Add Click command in `cli/main.py`. After TASK-005, commands move to individual files in `cli/commands/`.
+2. **New CLI command:** Create a new command module in `cli/commands/` and register it in `cli/main.py` via `cli.add_command()`.
 
-3. **New API endpoint:** Add FastAPI route in `web/app.py`. After TASK-085, routes move to `web/routes/` subdirectory.
+3. **New API endpoint:** Add a FastAPI route in a new or existing module in `web/routes/` and register it in `web/app.py`.
 
 4. **New dbt dedup strategy:** Add template in `templates/dbt/`, enum value in `config/models.py` `DeduplicationStrategy`, and generation logic in `transformation/generator.py`.
 
@@ -516,9 +534,9 @@ The web module (`web/app.py`) exposes 19 REST endpoints, 1 WebSocket, and a Meta
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `cli/main.py` | 3927 | TASK-005 (split into `cli/commands/`) |
-| `web/app.py` | 2900 | TASK-085 (split into `web/routes/`) |
-| `ingestion/dlt_runner.py` | 1696 | Phase 3 (extract orchestration) |
+| ~~`cli/main.py`~~ | ~~3927~~ | ~~TASK-005~~ — **Done:** split into `cli/commands/`, main.py is now ~88 lines |
+| ~~`web/app.py`~~ | ~~2900~~ | ~~TASK-085~~ — **Done:** split into `web/routes/`, app.py is now ~202 lines |
+| `ingestion/dlt_runner.py` | 1759 | Phase 3 (extract orchestration) |
 
 ### Runtime Architecture
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -173,6 +173,15 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 **Imports from:** None (Level 0). Uses structlog + stdlib only.
 
+---
+
+#### `exceptions.py`
+**Responsibility:** Centralized exception hierarchy for consistent error handling across modules.
+
+**Public API:** `DangoError` base class and domain-specific subclasses: `ConfigError`, `IngestionError`, `InfrastructureError`, `MigrationError`, `OAuthError`, `ValidationError`, `WebAPIError`, and their specializations (e.g., `DbtLockError`, `OAuthTokenExpiredError`, `CSVSchemaMismatchError`).
+
+**Imports from:** None (Level 0).
+
 ### Level 1 — Core
 
 #### `ingestion/`
@@ -294,13 +303,6 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 **Public API:** FastAPI `app` instance.
 
 **Imports from:** `config/` (Level 0), `utils/` (Level 0), `ingestion/` (Level 1), `transformation/` (Level 1), `visualization/` (Level 2).
-
-#### `exceptions.py`
-**Responsibility:** Centralized exception hierarchy for consistent error handling across modules.
-
-**Public API:** `DangoError` base class and domain-specific subclasses: `ConfigError`, `IngestionError`, `InfrastructureError`, `MigrationError`, `OAuthError`, `ValidationError`, `WebAPIError`, and their specializations (e.g., `DbtLockError`, `OAuthTokenExpiredError`, `CSVSchemaMismatchError`).
-
-**Imports from:** None (Level 0).
 
 ### Planned Modules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,15 +64,15 @@ dango/                          # Python package source
 │   ├── main.py                 # Slim entry point (~86 lines) — registers commands
 │   ├── commands/               # Command modules (extracted from main.py by TASK-005)
 │   │   ├── __init__.py         # Package marker
-│   │   ├── auth.py             # auth group + 10 subcommands (707 lines)
+│   │   ├── auth.py             # auth group + 10 subcommands (815 lines)
 │   │   ├── config_cmd.py       # config group (validate/show)
 │   │   ├── dashboard.py        # dashboard group (provision)
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (955 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (1026 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (521 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (549 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   └── web.py              # web dev server
 │   ├── init.py                 # Project initialization wizard
@@ -102,15 +102,15 @@ dango/                          # Python package source
 │   │   ├── sync.py             # /api/sources/{name}/sync + run_sync_task()
 │   │   ├── logs.py             # /api/logs, /api/sources/{name}/logs
 │   │   ├── dbt.py              # /api/dbt/models, /api/dbt/models/{name}/run + dbt docs proxy
-│   │   ├── upload.py           # CSV upload/list/delete (664 lines)
+│   │   ├── upload.py           # CSV upload/list/delete (680 lines)
 │   │   ├── websocket.py        # ConnectionManager, ws_manager, /ws
 │   │   ├── ui.py               # /, /health, /logs, /api, /api/docs, /api/redoc
 │   │   └── metabase_proxy.py   # Metabase reverse proxy + SSO session
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
-│   ├── metabase.py             # Metabase API (1207 lines)
-│   └── dashboard_manager.py    # Dashboard export/import (1102 lines)
+│   ├── metabase.py             # Metabase API (1142 lines)
+│   └── dashboard_manager.py    # Dashboard export/import (1113 lines)
 │
 ├── platform/                   # Level 2 — Docker, network, file watcher
 │   ├── __main__.py             # Platform CLI entry point
@@ -121,19 +121,19 @@ dango/                          # Python package source
 │   └── watcher_runner.py       # Watcher subprocess runner
 │
 ├── ingestion/                  # Level 1 — Data loading
-│   ├── dlt_runner.py           # ⚠ 1696 lines — orchestrates full sync pipeline
-│   ├── csv_loader.py           # CSV loading with dedup (761 lines)
+│   ├── dlt_runner.py           # ⚠ 1759 lines — orchestrates full sync pipeline
+│   ├── csv_loader.py           # CSV loading with dedup (742 lines)
 │   ├── sources/
-│   │   └── registry.py         # Source metadata (1440 lines, 34 source types)
+│   │   └── registry.py         # Source metadata (1440 lines, 33 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
 │   ├── __init__.py             # run_dbt_models(), generate_dbt_docs()
-│   └── generator.py            # DbtModelGenerator (560 lines)
+│   └── generator.py            # DbtModelGenerator (577 lines)
 │
 ├── oauth/                      # Level 1 — OAuth flows
 │   ├── __init__.py             # OAuthManager
-│   ├── providers.py            # Google, Facebook, Shopify providers (761 lines)
+│   ├── providers.py            # Google, Facebook, Shopify providers (801 lines)
 │   ├── storage.py              # Credential CRUD in .dlt/secrets.toml
 │   └── router.py               # FastAPI OAuth callback endpoints
 │
@@ -197,23 +197,23 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `ingestion/dlt_runner.py` | 1696 | — (exempt, too risky) |
+| `ingestion/dlt_runner.py` | 1759 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 1440 | — (metadata-only) |
 | `cli/source_wizard.py` | 1324 | — |
-| `visualization/metabase.py` | 1207 | — |
-| `visualization/dashboard_manager.py` | 1102 | — |
+| `visualization/metabase.py` | 1142 | — |
+| `visualization/dashboard_manager.py` | 1113 | — |
+| `cli/commands/platform.py` | 1026 | — (extracted from main.py by TASK-005) |
 | `cli/init.py` | 965 | — |
-| `cli/commands/platform.py` | 955 | — (extracted from main.py by TASK-005) |
-| `oauth/providers.py` | 761 | — |
-| `ingestion/csv_loader.py` | 761 | — |
-| `cli/commands/auth.py` | 707 | — (extracted from main.py by TASK-005) |
-| `cli/validate.py` | 677 | — |
-| `transformation/generator.py` | 560 | — |
-| `platform/watcher.py` | 531 | — |
-| `cli/commands/source.py` | 521 | — (extracted from main.py by TASK-005) |
-| `cli/model_wizard.py` | 507 | — |
+| `cli/commands/auth.py` | 815 | — (extracted from main.py by TASK-005) |
+| `oauth/providers.py` | 801 | — |
 | `web/helpers.py` | 798 | — (extracted from app.py by TASK-085) |
-| `web/routes/upload.py` | 664 | — (extracted from app.py by TASK-085) |
+| `ingestion/csv_loader.py` | 742 | — |
+| `web/routes/upload.py` | 680 | — (extracted from app.py by TASK-085) |
+| `cli/validate.py` | 651 | — |
+| `transformation/generator.py` | 577 | — |
+| `cli/commands/source.py` | 549 | — (extracted from main.py by TASK-005) |
+| `platform/watcher.py` | 506 | — |
+| `cli/model_wizard.py` | 507 | — |
 
 ## Module Documentation Index
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ dango/                          # Python package source
 ├── logging.py                  # Level 0 — Structured logging (structlog + stdlib)
 ├── cli/                        # Level 3 — Click CLI (primary user interface)
 │   ├── __init__.py             # Shared Console instance
-│   ├── main.py                 # Slim entry point (~86 lines) — registers commands
+│   ├── main.py                 # Slim entry point (~88 lines) — registers commands
 │   ├── commands/               # Command modules (extracted from main.py by TASK-005)
 │   │   ├── __init__.py         # Package marker
 │   │   ├── auth.py             # auth group + 10 subcommands (815 lines)
@@ -212,8 +212,8 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/validate.py` | 651 | — |
 | `transformation/generator.py` | 577 | — |
 | `cli/commands/source.py` | 549 | — (extracted from main.py by TASK-005) |
-| `platform/watcher.py` | 506 | — |
 | `cli/model_wizard.py` | 507 | — |
+| `platform/watcher.py` | 506 | — |
 
 ## Module Documentation Index
 

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -21,7 +21,7 @@ class DeduplicationStrategy(str, Enum):
 
 
 class SourceType(str, Enum):
-    """Data source types - covers all 31 dlt verified sources + CSV + REST API"""
+    """Data source types — 33 source types (31 dlt verified sources + CSV + REST API)"""
 
     # Local/Custom
     CSV = "csv"

--- a/dango/oauth/CLAUDE.md
+++ b/dango/oauth/CLAUDE.md
@@ -12,7 +12,7 @@ Manages browser-based OAuth authentication flows, provider-specific token exchan
 | `providers.py` | Provider-specific OAuth implementations | `BaseOAuthProvider`, `GoogleOAuthProvider`, `FacebookOAuthProvider`, `ShopifyOAuthProvider` |
 | `router.py` | Routes OAuth requests to correct provider | `run_oauth_for_source`, `check_oauth_credentials_exist`, `OAUTH_PROVIDER_MAP` |
 | `storage.py` | Token persistence to `.dlt/secrets.toml` with metadata | `OAuthStorage`, `OAuthCredential` |
-| `validation.py` | Live token validation via API calls | `TokenValidationResult`, `validate_token`, `validate_all_tokens`, `validate_before_sync`, `validate_google_token`, `validate_facebook_token`, `validate_shopify_token` |
+| `validation.py` | Live token validation and refresh checking via API calls | `TokenValidationResult`, `validate_token`, `validate_all_tokens`, `validate_before_sync`, `validate_google_token`, `validate_facebook_token`, `validate_shopify_token` |
 
 ## Common Tasks
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -1,6 +1,6 @@
 # Exemption registry for files exceeding the 500-line soft limit (STANDARDS.md §2).
 # Consumed by scripts/check_file_sizes.py for CI and pre-commit checks.
-# Line counts refreshed 2026-02-13 (TASK-092) — informational, not enforced by script.
+# Line counts refreshed 2026-02-15 (DOC-024) — informational, not enforced by script.
 #
 # Categories:
 #   refactor — planned for refactoring in v1 (linked to a task)
@@ -25,19 +25,19 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 971
+    lines: 1026
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
 
   - file: dango/cli/commands/auth.py
-    lines: 767
+    lines: 815
     category: exempt
     reason: "OAuth authentication commands (10 subcommands). Extracted from cli/main.py by TASK-005. One command per provider — file grows linearly with providers."
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 538
+    lines: 549
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. Sync command alone is ~200 lines of orchestration logic."
     review_by: "v1.1"

--- a/tests/llm/navigation_test.md
+++ b/tests/llm/navigation_test.md
@@ -46,6 +46,8 @@ Provide the following to a fresh LLM session (e.g., a new Claude Code conversati
 
 **Batch mode:** For automated testing via `claude -p`, all 5 questions may be asked in a single prompt. For interactive sessions, ask one at a time to better simulate real developer behavior.
 
+**Environment setup:** When running `claude -p` from within an active Claude Code session, you must first run `unset CLAUDECODE` — otherwise it fails with "Claude Code cannot be launched inside another Claude Code session."
+
 ## Questions and Expected Answers
 
 ### Q1: "Where would you look to add a new CLI command?"
@@ -72,7 +74,7 @@ Provide the following to a fresh LLM session (e.g., a new Claude Code conversati
 
 **Expected navigation path:**
 - Root `CLAUDE.md` routing table → "OAuth / token flows → `dango/oauth/` → `oauth/CLAUDE.md`"
-- `oauth/CLAUDE.md` → Files table → `validation.py` ("Live token validation via API calls")
+- `oauth/CLAUDE.md` → Files table → `validation.py` ("Live token validation and refresh checking via API calls")
 - Supplementary: `ARCHITECTURE.md` §9 Secret Management → "OAuth tokens auto-refreshed by dlt at runtime (VAL-004)"
 
 **Expected key points in answer:**
@@ -81,7 +83,7 @@ Provide the following to a fresh LLM session (e.g., a new Claude Code conversati
 - Optionally note that dlt auto-refreshes Google tokens at runtime (from ARCHITECTURE.md)
 - Optionally mention `providers.py` for provider-specific OAuth implementations
 
-**Known documentation gap:** `oauth/CLAUDE.md` describes `validation.py` as "Live token validation via API calls" but does not use the word "refresh." A fresh LLM should still navigate to `oauth/` correctly via the routing table, but may not pinpoint the exact refresh mechanism. ARCHITECTURE.md §9 compensates with an explicit mention of dlt auto-refresh.
+**Documentation note:** `oauth/CLAUDE.md` describes `validation.py` as "Live token validation and refresh checking via API calls" (updated in DOC-024). ARCHITECTURE.md §9 also documents dlt auto-refresh (VAL-004).
 
 **Scoring:**
 | Score | Criteria |
@@ -178,15 +180,10 @@ Dry-run trace of each question through existing documentation, from a fresh LLM'
 
 **Trace:**
 1. Root `CLAUDE.md` routing table: "OAuth / token flows → `dango/oauth/` → `oauth/CLAUDE.md`"
-2. `oauth/CLAUDE.md` Files table lists `validation.py` as "Live token validation via API calls" with functions including `validate_google_token`, `validate_facebook_token`, `validate_shopify_token`
-3. `oauth/CLAUDE.md` does NOT use the word "refresh" anywhere
-4. `ARCHITECTURE.md` §9 Secret Management: "OAuth tokens auto-refreshed by dlt at runtime (VAL-004). Google tokens refresh automatically; Facebook tokens require manual re-auth every 60 days."
+2. `oauth/CLAUDE.md` Files table lists `validation.py` as "Live token validation and refresh checking via API calls" with functions including `validate_google_token`, `validate_facebook_token`, `validate_shopify_token`
+3. `ARCHITECTURE.md` §9 Secret Management: "OAuth tokens auto-refreshed by dlt at runtime (VAL-004). Google tokens refresh automatically; Facebook tokens require manual re-auth every 60 days."
 
-**Risk:** A fresh LLM will correctly navigate to `oauth/` via the routing table. It will find `validation.py` and `providers.py` as the relevant files. However, it may not connect "live token validation" with "token refresh" since the word "refresh" is absent from `oauth/CLAUDE.md`. ARCHITECTURE.md compensates if the LLM read it.
-
-**Verdict:** Navigable but not self-evident. The routing table gets you to the right module. ARCHITECTURE.md provides the refresh-specific context. A well-prepared LLM (one that read ARCHITECTURE.md as instructed) should score 1.0. One that only skimmed ARCHITECTURE.md might score 0.5. Expected score: 0.5 -- 1.0
-
-**Mitigation (if Q2 scores < 1.0 in real test):** Add "token refresh" to the `validation.py` description in `oauth/CLAUDE.md`. Change "Live token validation via API calls" to "Live token validation and refresh-token exchange via API calls."
+**Verdict:** Strong, unambiguous path. The word "refresh" now appears in `oauth/CLAUDE.md` (DOC-024 fix) and in ARCHITECTURE.md §9. Expected score: 1.0
 
 ### Q3 Simulation: "What files would you modify to add a new data source?"
 
@@ -225,14 +222,12 @@ Dry-run trace of each question through existing documentation, from a fresh LLM'
 | Q# | Expected Score | Confidence |
 |----|---------------|------------|
 | Q1 | 1.0 | High |
-| Q2 | 0.5 -- 1.0 | Medium (depends on ARCHITECTURE.md reading) |
+| Q2 | 1.0 | High (DOC-024 added "refresh" to oauth/CLAUDE.md) |
 | Q3 | 1.0 | High |
 | Q4 | 1.0 | High |
 | Q5 | 1.0 | High |
 
-**Predicted total:** 4.5 -- 5.0/5 (PASS or near-PASS)
-
-**Only risk:** Q2 depends on the LLM connecting "validation" with "refresh" and/or having read ARCHITECTURE.md §9. Mitigation is ready if needed.
+**Predicted total:** 5.0/5 (PASS)
 
 ## Results Log
 


### PR DESCRIPTION
## Summary

- Fix source count inconsistency: 34 → 33 across ARCHITECTURE.md (4 locations), CLAUDE.md tree structure, and `config/models.py` docstring
- Add `migrations/` module to ARCHITECTURE.md (system diagram, dependency table, module reference)
- Update ARCHITECTURE.md to reflect completed TASK-005/085 refactoring (cli/main.py and web/app.py are now slim entry points)
- Update monolithic files table line counts in CLAUDE.md to match actual values (16 files verified via `wc -l`)
- Add "refresh checking" keyword to `oauth/CLAUDE.md` validation.py description (closes TEST-000 Q2 fragility)
- Add `unset CLAUDECODE` prerequisite to `tests/llm/navigation_test.md`
- Update drifted line counts in `docs/file-exemptions.yml` (3 files)
- Update Q2 simulation in navigation_test.md to reflect closed documentation gap

## Files Changed

| File | Change |
|------|--------|
| `ARCHITECTURE.md` | Source count 34→33, add migrations/, update cli/ and web/ sections, extension points, monolithic files table |
| `CLAUDE.md` | Source count in tree, line counts in tree and monolithic table |
| `dango/config/models.py` | SourceType docstring fix |
| `dango/oauth/CLAUDE.md` | Add "refresh checking" to validation.py description |
| `docs/file-exemptions.yml` | Update 3 drifted line counts |
| `tests/llm/navigation_test.md` | Add CLAUDECODE prerequisite, update Q2 gap notes |

## Test plan

- [x] `grep -rn "34 source"` returns 0 hits outside vendored dlt_sources/
- [x] `grep "migrations" ARCHITECTURE.md` shows diagram, table, and module reference
- [x] `grep "refresh checking" dango/oauth/CLAUDE.md` matches
- [x] `grep "CLAUDECODE" tests/llm/navigation_test.md` matches
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)