### PR TITLE
TASK-010: Auth models, database schema, and CRUD operations

### DIFF
--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -1,0 +1,63 @@
+"""dango/auth/__init__.py
+
+Authentication and authorization data layer.
+
+Exports Pydantic models for users, sessions, and API keys, plus all
+CRUD functions for the auth SQLite database.
+"""
+
+from __future__ import annotations
+
+from dango.auth.database import (
+    cleanup_expired_sessions,
+    create_api_key,
+    create_session,
+    create_user,
+    deactivate_user,
+    delete_user,
+    get_api_key_by_hash,
+    get_session_by_token,
+    get_user_by_email,
+    get_user_by_id,
+    invalidate_all_user_sessions,
+    invalidate_session,
+    list_user_api_keys,
+    list_user_sessions,
+    list_users,
+    revoke_api_key,
+    update_session_activity,
+    update_user,
+)
+from dango.auth.models import APIKey, Role, Session, User, UserCreate, UserResponse, UserUpdate
+
+__all__ = [
+    # Models
+    "APIKey",
+    "Role",
+    "Session",
+    "User",
+    "UserCreate",
+    "UserResponse",
+    "UserUpdate",
+    # User CRUD
+    "create_user",
+    "get_user_by_email",
+    "get_user_by_id",
+    "list_users",
+    "update_user",
+    "deactivate_user",
+    "delete_user",
+    # Session CRUD
+    "create_session",
+    "get_session_by_token",
+    "update_session_activity",
+    "invalidate_session",
+    "invalidate_all_user_sessions",
+    "list_user_sessions",
+    "cleanup_expired_sessions",
+    # API key CRUD
+    "create_api_key",
+    "get_api_key_by_hash",
+    "list_user_api_keys",
+    "revoke_api_key",
+]

--- a/dango/auth/database.py
+++ b/dango/auth/database.py
@@ -197,7 +197,7 @@ def update_user(db_path: Path, user_id: str, updates: UserUpdate) -> User:
         UserNotFoundError: If the user does not exist.
         UserExistsError: If the email update conflicts with an existing user.
     """
-    changes: dict[str, Any] = updates.model_dump(exclude_none=True)
+    changes: dict[str, Any] = updates.model_dump(exclude_unset=True)
     if not changes:
         user = get_user_by_id(db_path, user_id)
         if user is None:
@@ -207,7 +207,9 @@ def update_user(db_path: Path, user_id: str, updates: UserUpdate) -> User:
     # Convert Python types to SQLite-compatible values
     sql_values: dict[str, Any] = {}
     for key, value in changes.items():
-        if isinstance(value, bool):
+        if value is None:
+            sql_values[key] = None
+        elif isinstance(value, bool):
             sql_values[key] = int(value)
         elif isinstance(value, datetime):
             sql_values[key] = value.isoformat()

--- a/dango/auth/database.py
+++ b/dango/auth/database.py
@@ -1,0 +1,456 @@
+"""dango/auth/database.py
+
+Synchronous CRUD operations for users, sessions, and API keys.
+
+All functions take ``db_path: Path`` as their first argument and open
+short-lived connections internally. The underlying SQLite database uses
+WAL mode and foreign keys.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from dango.auth.models import APIKey, Role, Session, User, UserUpdate
+from dango.exceptions import UserExistsError, UserNotFoundError
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    """Open a SQLite connection with WAL mode and foreign keys enabled."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def _bool_from_int(value: int) -> bool:
+    """Convert SQLite integer (0/1) to Python bool."""
+    return bool(value)
+
+
+def _datetime_from_str(value: str | None) -> datetime | None:
+    """Parse an ISO 8601 timestamp string to a timezone-aware datetime."""
+    if value is None:
+        return None
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _row_to_user(row: sqlite3.Row) -> User:
+    """Convert a sqlite3.Row to a User model."""
+    return User(
+        id=row["id"],
+        email=row["email"],
+        password_hash=row["password_hash"],
+        role=Role(row["role"]),
+        is_active=_bool_from_int(row["is_active"]),
+        totp_secret=row["totp_secret"],
+        totp_enabled=_bool_from_int(row["totp_enabled"]),
+        recovery_codes=row["recovery_codes"],
+        oauth_provider=row["oauth_provider"],
+        oauth_id=row["oauth_id"],
+        failed_login_attempts=row["failed_login_attempts"],
+        locked_until=_datetime_from_str(row["locked_until"]),
+        created_at=_datetime_from_str(row["created_at"]),  # type: ignore[arg-type]
+        updated_at=_datetime_from_str(row["updated_at"]),  # type: ignore[arg-type]
+    )
+
+
+def _row_to_session(row: sqlite3.Row) -> Session:
+    """Convert a sqlite3.Row to a Session model."""
+    return Session(
+        id=row["id"],
+        user_id=row["user_id"],
+        token_hash=row["token_hash"],
+        is_active=_bool_from_int(row["is_active"]),
+        is_partial=_bool_from_int(row["is_partial"]),
+        created_at=_datetime_from_str(row["created_at"]),  # type: ignore[arg-type]
+        expires_at=_datetime_from_str(row["expires_at"]),  # type: ignore[arg-type]
+        last_activity=_datetime_from_str(row["last_activity"]),  # type: ignore[arg-type]
+    )
+
+
+def _row_to_api_key(row: sqlite3.Row) -> APIKey:
+    """Convert a sqlite3.Row to an APIKey model."""
+    return APIKey(
+        id=row["id"],
+        user_id=row["user_id"],
+        name=row["name"],
+        key_hash=row["key_hash"],
+        is_active=_bool_from_int(row["is_active"]),
+        created_at=_datetime_from_str(row["created_at"]),  # type: ignore[arg-type]
+        last_used_at=_datetime_from_str(row["last_used_at"]),
+        expires_at=_datetime_from_str(row["expires_at"]),
+    )
+
+
+def _dt_to_str(dt: datetime | None) -> str | None:
+    """Serialize a datetime to ISO 8601 string, or None."""
+    if dt is None:
+        return None
+    return dt.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# User CRUD
+# ---------------------------------------------------------------------------
+
+
+def create_user(db_path: Path, user: User) -> User:
+    """Insert a new user. Raises ``UserExistsError`` on duplicate email."""
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO users (
+                id, email, password_hash, role, is_active,
+                totp_secret, totp_enabled, recovery_codes,
+                oauth_provider, oauth_id, failed_login_attempts, locked_until,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user.id,
+                user.email,
+                user.password_hash,
+                user.role.value,
+                int(user.is_active),
+                user.totp_secret,
+                int(user.totp_enabled),
+                user.recovery_codes,
+                user.oauth_provider,
+                user.oauth_id,
+                user.failed_login_attempts,
+                _dt_to_str(user.locked_until),
+                user.created_at.isoformat(),
+                user.updated_at.isoformat(),
+            ),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError as exc:
+        if "UNIQUE" in str(exc) and "email" in str(exc):
+            raise UserExistsError(
+                f"A user with email '{user.email}' already exists",
+                context={"email": user.email},
+            ) from exc
+        raise  # pragma: no cover
+    finally:
+        conn.close()
+    return user
+
+
+def get_user_by_email(db_path: Path, email: str) -> User | None:
+    """Look up a user by email address. Returns None if not found."""
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM users WHERE email = ?", (email.strip().lower(),)
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_user(row)
+    finally:
+        conn.close()
+
+
+def get_user_by_id(db_path: Path, user_id: str) -> User | None:
+    """Look up a user by ID. Returns None if not found."""
+    conn = _connect(db_path)
+    try:
+        row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+        if row is None:
+            return None
+        return _row_to_user(row)
+    finally:
+        conn.close()
+
+
+def list_users(db_path: Path, *, active_only: bool = False) -> list[User]:
+    """Return all users, optionally filtering to active users only."""
+    conn = _connect(db_path)
+    try:
+        if active_only:
+            rows = conn.execute(
+                "SELECT * FROM users WHERE is_active = 1 ORDER BY created_at"
+            ).fetchall()
+        else:
+            rows = conn.execute("SELECT * FROM users ORDER BY created_at").fetchall()
+        return [_row_to_user(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def update_user(db_path: Path, user_id: str, updates: UserUpdate) -> User:
+    """Apply partial updates to a user.
+
+    Raises:
+        UserNotFoundError: If the user does not exist.
+        UserExistsError: If the email update conflicts with an existing user.
+    """
+    changes: dict[str, Any] = updates.model_dump(exclude_none=True)
+    if not changes:
+        user = get_user_by_id(db_path, user_id)
+        if user is None:
+            raise UserNotFoundError(f"User '{user_id}' not found", context={"user_id": user_id})
+        return user
+
+    # Convert Python types to SQLite-compatible values
+    sql_values: dict[str, Any] = {}
+    for key, value in changes.items():
+        if isinstance(value, bool):
+            sql_values[key] = int(value)
+        elif isinstance(value, datetime):
+            sql_values[key] = value.isoformat()
+        elif isinstance(value, Role):
+            sql_values[key] = value.value
+        else:
+            sql_values[key] = value
+
+    # Always update updated_at
+    sql_values["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    set_clause = ", ".join(f"{col} = ?" for col in sql_values)
+    values = list(sql_values.values()) + [user_id]
+
+    conn = _connect(db_path)
+    try:
+        try:
+            cursor = conn.execute(
+                f"UPDATE users SET {set_clause} WHERE id = ?",  # noqa: S608
+                values,
+            )
+        except sqlite3.IntegrityError as exc:
+            if "UNIQUE" in str(exc) and "email" in str(exc):
+                raise UserExistsError(
+                    f"A user with email '{changes.get('email')}' already exists",
+                    context={"email": changes.get("email", "")},
+                ) from exc
+            raise  # pragma: no cover
+        if cursor.rowcount == 0:
+            raise UserNotFoundError(f"User '{user_id}' not found", context={"user_id": user_id})
+        conn.commit()
+    finally:
+        conn.close()
+
+    user = get_user_by_id(db_path, user_id)
+    assert user is not None  # We just confirmed it exists
+    return user
+
+
+def deactivate_user(db_path: Path, user_id: str) -> User:
+    """Deactivate a user account. Raises ``UserNotFoundError`` if not found."""
+    return update_user(db_path, user_id, UserUpdate(is_active=False))
+
+
+def delete_user(db_path: Path, user_id: str) -> None:
+    """Hard-delete a user (CASCADE removes sessions and API keys).
+
+    Raises:
+        UserNotFoundError: If the user does not exist.
+    """
+    conn = _connect(db_path)
+    try:
+        cursor = conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        if cursor.rowcount == 0:
+            raise UserNotFoundError(f"User '{user_id}' not found", context={"user_id": user_id})
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Session CRUD
+# ---------------------------------------------------------------------------
+
+
+def create_session(db_path: Path, session: Session) -> Session:
+    """Insert a new session record."""
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                id, user_id, token_hash, is_active, is_partial,
+                created_at, expires_at, last_activity
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session.id,
+                session.user_id,
+                session.token_hash,
+                int(session.is_active),
+                int(session.is_partial),
+                session.created_at.isoformat(),
+                session.expires_at.isoformat(),
+                session.last_activity.isoformat(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return session
+
+
+def get_session_by_token(db_path: Path, token_hash: str) -> Session | None:
+    """Look up a session by its token hash. Returns None if not found."""
+    conn = _connect(db_path)
+    try:
+        row = conn.execute("SELECT * FROM sessions WHERE token_hash = ?", (token_hash,)).fetchone()
+        if row is None:
+            return None
+        return _row_to_session(row)
+    finally:
+        conn.close()
+
+
+def update_session_activity(db_path: Path, session_id: str) -> None:
+    """Update a session's last_activity timestamp to now."""
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE sessions SET last_activity = ? WHERE id = ?",
+            (now, session_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def invalidate_session(db_path: Path, session_id: str) -> None:
+    """Mark a single session as inactive."""
+    conn = _connect(db_path)
+    try:
+        conn.execute("UPDATE sessions SET is_active = 0 WHERE id = ?", (session_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def invalidate_all_user_sessions(db_path: Path, user_id: str) -> int:
+    """Mark all active sessions for a user as inactive. Returns count."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.execute(
+            "UPDATE sessions SET is_active = 0 WHERE user_id = ? AND is_active = 1",
+            (user_id,),
+        )
+        conn.commit()
+        return cursor.rowcount
+    finally:
+        conn.close()
+
+
+def list_user_sessions(db_path: Path, user_id: str, *, active_only: bool = True) -> list[Session]:
+    """List sessions for a user, optionally filtering to active only."""
+    conn = _connect(db_path)
+    try:
+        if active_only:
+            rows = conn.execute(
+                "SELECT * FROM sessions WHERE user_id = ? AND is_active = 1 ORDER BY created_at",
+                (user_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM sessions WHERE user_id = ? ORDER BY created_at",
+                (user_id,),
+            ).fetchall()
+        return [_row_to_session(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def cleanup_expired_sessions(db_path: Path) -> int:
+    """Delete expired sessions. Returns number of rows deleted."""
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _connect(db_path)
+    try:
+        cursor = conn.execute("DELETE FROM sessions WHERE expires_at < ?", (now,))
+        conn.commit()
+        return cursor.rowcount
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# API Key CRUD
+# ---------------------------------------------------------------------------
+
+
+def create_api_key(db_path: Path, api_key: APIKey) -> APIKey:
+    """Insert a new API key record."""
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO api_keys (
+                id, user_id, name, key_hash, is_active,
+                created_at, last_used_at, expires_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                api_key.id,
+                api_key.user_id,
+                api_key.name,
+                api_key.key_hash,
+                int(api_key.is_active),
+                api_key.created_at.isoformat(),
+                _dt_to_str(api_key.last_used_at),
+                _dt_to_str(api_key.expires_at),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return api_key
+
+
+def get_api_key_by_hash(db_path: Path, key_hash: str) -> APIKey | None:
+    """Look up an API key by its hash. Returns None if not found."""
+    conn = _connect(db_path)
+    try:
+        row = conn.execute("SELECT * FROM api_keys WHERE key_hash = ?", (key_hash,)).fetchone()
+        if row is None:
+            return None
+        return _row_to_api_key(row)
+    finally:
+        conn.close()
+
+
+def list_user_api_keys(db_path: Path, user_id: str, *, active_only: bool = True) -> list[APIKey]:
+    """List API keys for a user, optionally filtering to active only."""
+    conn = _connect(db_path)
+    try:
+        if active_only:
+            rows = conn.execute(
+                "SELECT * FROM api_keys WHERE user_id = ? AND is_active = 1 ORDER BY created_at",
+                (user_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM api_keys WHERE user_id = ? ORDER BY created_at",
+                (user_id,),
+            ).fetchall()
+        return [_row_to_api_key(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def revoke_api_key(db_path: Path, key_id: str) -> None:
+    """Mark an API key as inactive (revoked)."""
+    conn = _connect(db_path)
+    try:
+        conn.execute("UPDATE api_keys SET is_active = 0 WHERE id = ?", (key_id,))
+        conn.commit()
+    finally:
+        conn.close()

--- a/dango/auth/models.py
+++ b/dango/auth/models.py
@@ -71,7 +71,9 @@ class UserCreate(BaseModel):
 class UserUpdate(BaseModel):
     """Partial update model (all fields optional).
 
-    Use ``model_dump(exclude_none=True)`` to get only the fields that were set.
+    Use ``model_dump(exclude_unset=True)`` to get only the fields that were
+    explicitly passed. This allows setting nullable fields to ``None``
+    (e.g. clearing ``locked_until``) while still omitting untouched fields.
     """
 
     model_config = ConfigDict(from_attributes=True)

--- a/dango/auth/models.py
+++ b/dango/auth/models.py
@@ -1,0 +1,144 @@
+"""dango/auth/models.py
+
+Pydantic v2 models for the authentication and authorization system.
+
+Defines the data shapes for users, sessions, and API keys across four tiers:
+database records, creation input, partial update, and API-safe responses.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class Role(str, Enum):
+    """User roles with hierarchical permissions."""
+
+    ADMIN = "admin"
+    EDITOR = "editor"
+    VIEWER = "viewer"
+
+
+class User(BaseModel):
+    """Full user database record (includes sensitive fields)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    email: str
+    password_hash: str | None = None
+    role: Role = Role.VIEWER
+    is_active: bool = True
+    totp_secret: str | None = None
+    totp_enabled: bool = False
+    recovery_codes: str | None = None
+    oauth_provider: str | None = None
+    oauth_id: str | None = None
+    failed_login_attempts: int = 0
+    locked_until: datetime | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        """Lowercase and strip whitespace from email."""
+        return v.strip().lower()
+
+
+class UserCreate(BaseModel):
+    """Input validation for user creation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    email: str
+    password: str | None = None
+    role: Role = Role.VIEWER
+    oauth_provider: str | None = None
+    oauth_id: str | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        """Lowercase and strip whitespace from email."""
+        return v.strip().lower()
+
+
+class UserUpdate(BaseModel):
+    """Partial update model (all fields optional).
+
+    Use ``model_dump(exclude_none=True)`` to get only the fields that were set.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    email: str | None = None
+    password_hash: str | None = None
+    role: Role | None = None
+    is_active: bool | None = None
+    totp_secret: str | None = None
+    totp_enabled: bool | None = None
+    recovery_codes: str | None = None
+    oauth_provider: str | None = None
+    oauth_id: str | None = None
+    failed_login_attempts: int | None = None
+    locked_until: datetime | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def normalize_email(cls, v: str | None) -> str | None:
+        """Lowercase and strip whitespace from email if provided."""
+        if v is None:
+            return None
+        return v.strip().lower()
+
+
+class UserResponse(BaseModel):
+    """API-safe user representation (excludes sensitive fields)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    email: str
+    role: Role
+    is_active: bool
+    totp_enabled: bool
+    oauth_provider: str | None = None
+    failed_login_attempts: int = 0
+    locked_until: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class Session(BaseModel):
+    """Full session database record."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    user_id: str
+    token_hash: str
+    is_active: bool = True
+    is_partial: bool = False
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: datetime
+    last_activity: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class APIKey(BaseModel):
+    """Full API key database record."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    user_id: str
+    name: str
+    key_hash: str
+    is_active: bool = True
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_used_at: datetime | None = None
+    expires_at: datetime | None = None

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -47,6 +47,13 @@ __all__ = [
     "InvalidDateFormatError",
     "InvalidPortError",
     "WebAPIError",
+    "AuthenticationError",
+    "AuthorizationError",
+    "UserNotFoundError",
+    "UserExistsError",
+    "SessionExpiredError",
+    "AccountLockedError",
+    "AccountDeactivatedError",
     "is_debug_mode",
 ]
 
@@ -295,3 +302,50 @@ class WebAPIError(DangoError):
     """Base exception for web API errors."""
 
     _default_error_code = "DANGO-W001"
+
+
+# ---------------------------------------------------------------------------
+# Auth / Security exceptions  (DANGO-S***)
+# ---------------------------------------------------------------------------
+
+
+class AuthenticationError(DangoError):
+    """Authentication failed (invalid credentials, expired token, etc.)."""
+
+    _default_error_code = "DANGO-S001"
+
+
+class AuthorizationError(DangoError):
+    """Authenticated user lacks required permissions."""
+
+    _default_error_code = "DANGO-S002"
+
+
+class UserNotFoundError(DangoError):
+    """Referenced user does not exist."""
+
+    _default_error_code = "DANGO-S003"
+
+
+class UserExistsError(DangoError):
+    """A user with the given identifier already exists."""
+
+    _default_error_code = "DANGO-S004"
+
+
+class SessionExpiredError(AuthenticationError):
+    """Session has expired or exceeded its idle timeout."""
+
+    _default_error_code = "DANGO-S005"
+
+
+class AccountLockedError(AuthenticationError):
+    """Account is temporarily locked due to too many failed login attempts."""
+
+    _default_error_code = "DANGO-S006"
+
+
+class AccountDeactivatedError(AuthenticationError):
+    """Account has been deactivated by an administrator."""
+
+    _default_error_code = "DANGO-S007"

--- a/dango/migrations/auth/001_initial_auth.py
+++ b/dango/migrations/auth/001_initial_auth.py
@@ -33,8 +33,6 @@ def upgrade(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    conn.execute("CREATE INDEX idx_users_email ON users (email)")
-
     conn.execute(
         """
         CREATE TABLE sessions (
@@ -50,7 +48,6 @@ def upgrade(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    conn.execute("CREATE INDEX idx_sessions_token_hash ON sessions (token_hash)")
     conn.execute("CREATE INDEX idx_sessions_user_id ON sessions (user_id)")
     conn.execute("CREATE INDEX idx_sessions_expires_at ON sessions (expires_at)")
 
@@ -69,5 +66,4 @@ def upgrade(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    conn.execute("CREATE INDEX idx_api_keys_key_hash ON api_keys (key_hash)")
     conn.execute("CREATE INDEX idx_api_keys_user_id ON api_keys (user_id)")

--- a/dango/migrations/auth/001_initial_auth.py
+++ b/dango/migrations/auth/001_initial_auth.py
@@ -1,0 +1,73 @@
+"""dango/migrations/auth/001_initial_auth.py
+
+Create initial authentication tables: users, sessions, and api_keys.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+VERSION = 1
+DESCRIPTION = "Create initial auth tables"
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Create users, sessions, and api_keys tables with indexes."""
+    conn.execute(
+        """
+        CREATE TABLE users (
+            id                    TEXT PRIMARY KEY,
+            email                 TEXT NOT NULL UNIQUE,
+            password_hash         TEXT,
+            role                  TEXT NOT NULL DEFAULT 'viewer',
+            is_active             INTEGER NOT NULL DEFAULT 1,
+            totp_secret           TEXT,
+            totp_enabled          INTEGER NOT NULL DEFAULT 0,
+            recovery_codes        TEXT,
+            oauth_provider        TEXT,
+            oauth_id              TEXT,
+            failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+            locked_until          TEXT,
+            created_at            TEXT NOT NULL,
+            updated_at            TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_users_email ON users (email)")
+
+    conn.execute(
+        """
+        CREATE TABLE sessions (
+            id             TEXT PRIMARY KEY,
+            user_id        TEXT NOT NULL,
+            token_hash     TEXT NOT NULL UNIQUE,
+            is_active      INTEGER NOT NULL DEFAULT 1,
+            is_partial     INTEGER NOT NULL DEFAULT 0,
+            created_at     TEXT NOT NULL,
+            expires_at     TEXT NOT NULL,
+            last_activity  TEXT NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_sessions_token_hash ON sessions (token_hash)")
+    conn.execute("CREATE INDEX idx_sessions_user_id ON sessions (user_id)")
+    conn.execute("CREATE INDEX idx_sessions_expires_at ON sessions (expires_at)")
+
+    conn.execute(
+        """
+        CREATE TABLE api_keys (
+            id           TEXT PRIMARY KEY,
+            user_id      TEXT NOT NULL,
+            name         TEXT NOT NULL,
+            key_hash     TEXT NOT NULL UNIQUE,
+            is_active    INTEGER NOT NULL DEFAULT 1,
+            created_at   TEXT NOT NULL,
+            last_used_at TEXT,
+            expires_at   TEXT,
+            FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_api_keys_key_hash ON api_keys (key_hash)")
+    conn.execute("CREATE INDEX idx_api_keys_user_id ON api_keys (user_id)")

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -18,6 +18,10 @@ from fastapi.responses import JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from dango.exceptions import (
+    AccountDeactivatedError,
+    AccountLockedError,
+    AuthenticationError,
+    AuthorizationError,
     ConfigError,
     ConfigNotFoundError,
     ConfigValidationError,
@@ -29,7 +33,10 @@ from dango.exceptions import (
     InfrastructureError,
     IngestionError,
     ProjectNotFoundError,
+    SessionExpiredError,
     SyncTimeoutError,
+    UserExistsError,
+    UserNotFoundError,
     ValidationError,
     WebAPIError,
     is_debug_mode,
@@ -88,6 +95,14 @@ if static_dir.exists():
 
 # Map exception types to HTTP status codes
 _STATUS_MAP: dict[type[DangoError], int] = {
+    # Auth errors (most specific subclasses first for MRO walk)
+    SessionExpiredError: 401,
+    AccountLockedError: 423,
+    AccountDeactivatedError: 403,
+    AuthenticationError: 401,
+    AuthorizationError: 403,
+    UserNotFoundError: 404,
+    UserExistsError: 409,
     # Config errors
     ConfigNotFoundError: 404,
     ProjectNotFoundError: 404,

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -95,7 +95,7 @@ if static_dir.exists():
 
 # Map exception types to HTTP status codes
 _STATUS_MAP: dict[type[DangoError], int] = {
-    # Auth errors (most specific subclasses first for MRO walk)
+    # Auth errors (subclasses must be present so MRO walk finds them)
     SessionExpiredError: 401,
     AccountLockedError: 423,
     AccountDeactivatedError: 403,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ packages = [
     "dango.visualization",
     "dango.web",
     "dango.web.routes",
+    "dango.auth",       # Authentication & authorization
     "dango.oauth",      # OAuth management
     "dango.security",   # Token encryption
     "dango.migrations",

--- a/tests/unit/test_auth_database.py
+++ b/tests/unit/test_auth_database.py
@@ -1,0 +1,490 @@
+"""tests/unit/test_auth_database.py
+
+Tests for auth CRUD operations in dango/auth/database.py.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dango.auth.database import (
+    cleanup_expired_sessions,
+    create_api_key,
+    create_session,
+    create_user,
+    deactivate_user,
+    delete_user,
+    get_api_key_by_hash,
+    get_session_by_token,
+    get_user_by_email,
+    get_user_by_id,
+    invalidate_all_user_sessions,
+    invalidate_session,
+    list_user_api_keys,
+    list_user_sessions,
+    list_users,
+    revoke_api_key,
+    update_session_activity,
+    update_user,
+)
+from dango.auth.models import APIKey, Role, Session, User, UserUpdate
+from dango.exceptions import UserExistsError, UserNotFoundError
+from dango.migrations.runner import MigrationRunner
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database by running the migration."""
+    db_path = tmp_path / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(**overrides: Any) -> User:
+    """Build a User model with sensible defaults, applying overrides."""
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": "$2b$12$fakehash",
+        "role": Role.VIEWER,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+@pytest.mark.unit
+class TestCreateUser:
+    """Tests for create_user()."""
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        created = create_user(db, user)
+        assert created.id == user.id
+        assert created.email == "test@example.com"
+
+        fetched = get_user_by_id(db, user.id)
+        assert fetched is not None
+        assert fetched.email == user.email
+        assert fetched.password_hash == user.password_hash
+        assert fetched.role is Role.VIEWER
+        assert fetched.is_active is True
+
+    def test_duplicate_email_raises(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        create_user(db, _make_user(email="dup@example.com"))
+        with pytest.raises(UserExistsError, match="already exists"):
+            create_user(db, _make_user(email="dup@example.com"))
+
+    def test_preserves_all_fields(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        now = datetime.now(timezone.utc)
+        user = User(
+            email="full@example.com",
+            password_hash="hash",
+            role=Role.ADMIN,
+            is_active=False,
+            totp_secret="secret",
+            totp_enabled=True,
+            recovery_codes="r1,r2",
+            oauth_provider="google",
+            oauth_id="g-123",
+            failed_login_attempts=5,
+            locked_until=now,
+        )
+        create_user(db, user)
+        fetched = get_user_by_id(db, user.id)
+        assert fetched is not None
+        assert fetched.role is Role.ADMIN
+        assert fetched.is_active is False
+        assert fetched.totp_secret == "secret"
+        assert fetched.totp_enabled is True
+        assert fetched.recovery_codes == "r1,r2"
+        assert fetched.oauth_provider == "google"
+        assert fetched.oauth_id == "g-123"
+        assert fetched.failed_login_attempts == 5
+        assert fetched.locked_until is not None
+
+
+@pytest.mark.unit
+class TestGetUser:
+    """Tests for get_user_by_email() and get_user_by_id()."""
+
+    def test_by_email_found(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user(email="find@example.com")
+        create_user(db, user)
+        found = get_user_by_email(db, "find@example.com")
+        assert found is not None
+        assert found.id == user.id
+
+    def test_by_email_not_found(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert get_user_by_email(db, "nobody@example.com") is None
+
+    def test_by_email_case_insensitive(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user(email="case@example.com")
+        create_user(db, user)
+        found = get_user_by_email(db, "  CASE@EXAMPLE.COM  ")
+        assert found is not None
+        assert found.id == user.id
+
+    def test_by_id_found(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        found = get_user_by_id(db, user.id)
+        assert found is not None
+        assert found.email == user.email
+
+    def test_by_id_not_found(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert get_user_by_id(db, "nonexistent-id") is None
+
+
+@pytest.mark.unit
+class TestListUsers:
+    """Tests for list_users()."""
+
+    def test_empty(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert list_users(db) == []
+
+    def test_multiple_users(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        create_user(db, _make_user(email="a@example.com"))
+        create_user(db, _make_user(email="b@example.com"))
+        create_user(db, _make_user(email="c@example.com"))
+        users = list_users(db)
+        assert len(users) == 3
+
+    def test_active_only_filter(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        create_user(db, _make_user(email="active@example.com"))
+        inactive = _make_user(email="inactive@example.com")
+        create_user(db, inactive)
+        deactivate_user(db, inactive.id)
+
+        all_users = list_users(db)
+        assert len(all_users) == 2
+        active_users = list_users(db, active_only=True)
+        assert len(active_users) == 1
+        assert active_users[0].email == "active@example.com"
+
+
+@pytest.mark.unit
+class TestUpdateUser:
+    """Tests for update_user()."""
+
+    def test_partial_update(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        updated = update_user(db, user.id, UserUpdate(role=Role.EDITOR))
+        assert updated.role is Role.EDITOR
+        assert updated.email == user.email  # unchanged
+
+    def test_email_update(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        updated = update_user(db, user.id, UserUpdate(email="new@example.com"))
+        assert updated.email == "new@example.com"
+
+    def test_email_conflict_raises(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        create_user(db, _make_user(email="first@example.com"))
+        user2 = _make_user(email="second@example.com")
+        create_user(db, user2)
+        with pytest.raises(UserExistsError, match="already exists"):
+            update_user(db, user2.id, UserUpdate(email="first@example.com"))
+
+    def test_not_found_raises(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        with pytest.raises(UserNotFoundError, match="not found"):
+            update_user(db, "ghost", UserUpdate(role=Role.ADMIN))
+
+    def test_empty_update_returns_user(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        result = update_user(db, user.id, UserUpdate())
+        assert result.id == user.id
+
+    def test_empty_update_not_found_raises(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        with pytest.raises(UserNotFoundError):
+            update_user(db, "ghost", UserUpdate())
+
+    def test_updates_updated_at(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        original_updated = user.updated_at
+        updated = update_user(db, user.id, UserUpdate(role=Role.ADMIN))
+        assert updated.updated_at >= original_updated
+
+
+@pytest.mark.unit
+class TestDeactivateUser:
+    """Tests for deactivate_user()."""
+
+    def test_deactivates(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        result = deactivate_user(db, user.id)
+        assert result.is_active is False
+
+    def test_not_found_raises(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        with pytest.raises(UserNotFoundError):
+            deactivate_user(db, "ghost")
+
+
+@pytest.mark.unit
+class TestDeleteUser:
+    """Tests for delete_user()."""
+
+    def test_hard_delete(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        delete_user(db, user.id)
+        assert get_user_by_id(db, user.id) is None
+
+    def test_cascade_deletes_sessions(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        session = Session(
+            user_id=user.id,
+            token_hash="tok1",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        create_session(db, session)
+        delete_user(db, user.id)
+        assert get_session_by_token(db, "tok1") is None
+
+    def test_cascade_deletes_api_keys(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        key = APIKey(user_id=user.id, name="test-key", key_hash="kh1")
+        create_api_key(db, key)
+        delete_user(db, user.id)
+        assert get_api_key_by_hash(db, "kh1") is None
+
+    def test_not_found_raises(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        with pytest.raises(UserNotFoundError):
+            delete_user(db, "ghost")
+
+
+@pytest.mark.unit
+class TestSessionCRUD:
+    """Tests for session CRUD operations."""
+
+    def _make_session(self, user_id: str, token_hash: str = "hash1", **kw: Any) -> Session:
+        defaults: dict[str, Any] = {
+            "user_id": user_id,
+            "token_hash": token_hash,
+            "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        }
+        defaults.update(kw)
+        return Session(**defaults)
+
+    def test_create_and_get(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        session = self._make_session(user.id)
+        created = create_session(db, session)
+        assert created.id == session.id
+
+        fetched = get_session_by_token(db, session.token_hash)
+        assert fetched is not None
+        assert fetched.user_id == user.id
+        assert fetched.is_active is True
+
+    def test_get_nonexistent_returns_none(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert get_session_by_token(db, "nonexistent") is None
+
+    def test_update_activity(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        session = self._make_session(user.id)
+        create_session(db, session)
+        original_activity = session.last_activity
+
+        update_session_activity(db, session.id)
+        fetched = get_session_by_token(db, session.token_hash)
+        assert fetched is not None
+        assert fetched.last_activity >= original_activity
+
+    def test_invalidate_session(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        session = self._make_session(user.id)
+        create_session(db, session)
+        invalidate_session(db, session.id)
+
+        fetched = get_session_by_token(db, session.token_hash)
+        assert fetched is not None
+        assert fetched.is_active is False
+
+    def test_invalidate_all_user_sessions(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        s1 = self._make_session(user.id, token_hash="t1")
+        s2 = self._make_session(user.id, token_hash="t2")
+        create_session(db, s1)
+        create_session(db, s2)
+
+        count = invalidate_all_user_sessions(db, user.id)
+        assert count == 2
+        sessions = list_user_sessions(db, user.id, active_only=True)
+        assert len(sessions) == 0
+
+    def test_list_user_sessions(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        s1 = self._make_session(user.id, token_hash="t1")
+        s2 = self._make_session(user.id, token_hash="t2")
+        create_session(db, s1)
+        create_session(db, s2)
+        invalidate_session(db, s1.id)
+
+        active = list_user_sessions(db, user.id, active_only=True)
+        assert len(active) == 1
+        assert active[0].token_hash == "t2"
+
+        all_sessions = list_user_sessions(db, user.id, active_only=False)
+        assert len(all_sessions) == 2
+
+    def test_cleanup_expired_sessions(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+
+        # Create one expired and one valid session
+        expired = self._make_session(
+            user.id,
+            token_hash="expired",
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        valid = self._make_session(
+            user.id,
+            token_hash="valid",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        create_session(db, expired)
+        create_session(db, valid)
+
+        count = cleanup_expired_sessions(db)
+        assert count == 1
+        assert get_session_by_token(db, "expired") is None
+        assert get_session_by_token(db, "valid") is not None
+
+
+@pytest.mark.unit
+class TestAPIKeyCRUD:
+    """Tests for API key CRUD operations."""
+
+    def _make_api_key(self, user_id: str, **kw: Any) -> APIKey:
+        defaults: dict[str, Any] = {
+            "user_id": user_id,
+            "name": "Test Key",
+            "key_hash": "keyhash123",
+        }
+        defaults.update(kw)
+        return APIKey(**defaults)
+
+    def test_create_and_get(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        key = self._make_api_key(user.id)
+        created = create_api_key(db, key)
+        assert created.id == key.id
+
+        fetched = get_api_key_by_hash(db, key.key_hash)
+        assert fetched is not None
+        assert fetched.name == "Test Key"
+        assert fetched.user_id == user.id
+        assert fetched.is_active is True
+
+    def test_get_nonexistent_returns_none(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert get_api_key_by_hash(db, "nonexistent") is None
+
+    def test_list_user_api_keys(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        k1 = self._make_api_key(user.id, key_hash="kh1", name="Key 1")
+        k2 = self._make_api_key(user.id, key_hash="kh2", name="Key 2")
+        create_api_key(db, k1)
+        create_api_key(db, k2)
+        revoke_api_key(db, k1.id)
+
+        active = list_user_api_keys(db, user.id, active_only=True)
+        assert len(active) == 1
+        assert active[0].name == "Key 2"
+
+        all_keys = list_user_api_keys(db, user.id, active_only=False)
+        assert len(all_keys) == 2
+
+    def test_revoke_api_key(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        key = self._make_api_key(user.id)
+        create_api_key(db, key)
+        revoke_api_key(db, key.id)
+
+        fetched = get_api_key_by_hash(db, key.key_hash)
+        assert fetched is not None
+        assert fetched.is_active is False
+
+
+@pytest.mark.unit
+class TestDatabaseIntegrity:
+    """Tests for database-level constraints and behaviors."""
+
+    def test_wal_mode_enabled(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        # WAL mode is set per-connection by _connect(); verify via CRUD helper
+        from dango.auth.database import _connect
+
+        conn = _connect(db)
+        mode = conn.execute("PRAGMA journal_mode").fetchone()
+        conn.close()
+        assert mode is not None
+        assert mode[0] == "wal"
+
+    def test_foreign_keys_enabled(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        # Try inserting a session with a non-existent user_id
+        conn = sqlite3.connect(str(db))
+        conn.execute("PRAGMA foreign_keys=ON")
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO sessions (id, user_id, token_hash, is_active, is_partial, "
+                "created_at, expires_at, last_activity) "
+                "VALUES ('s1', 'nonexistent', 'hash', 1, 0, '2026-01-01', '2026-01-02', '2026-01-01')"
+            )
+        conn.close()

--- a/tests/unit/test_auth_database.py
+++ b/tests/unit/test_auth_database.py
@@ -110,6 +110,28 @@ class TestCreateUser:
         assert fetched.failed_login_attempts == 5
         assert fetched.locked_until is not None
 
+    def test_wal_mode_enabled(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        from dango.auth.database import _connect
+
+        conn = _connect(db)
+        mode = conn.execute("PRAGMA journal_mode").fetchone()
+        conn.close()
+        assert mode is not None
+        assert mode[0] == "wal"
+
+    def test_foreign_keys_reject_invalid_reference(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        conn = sqlite3.connect(str(db))
+        conn.execute("PRAGMA foreign_keys=ON")
+        sql = (
+            "INSERT INTO sessions (id,user_id,token_hash,is_active,is_partial,"
+            "created_at,expires_at,last_activity) VALUES (?,?,?,1,0,?,?,?)"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(sql, ("s1", "bad", "h", "2026-01-01", "2026-01-02", "2026-01-01"))
+        conn.close()
+
 
 @pytest.mark.unit
 class TestGetUser:
@@ -229,6 +251,25 @@ class TestUpdateUser:
         original_updated = user.updated_at
         updated = update_user(db, user.id, UserUpdate(role=Role.ADMIN))
         assert updated.updated_at >= original_updated
+
+    def test_update_locked_until_datetime(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        lock_time = datetime.now(timezone.utc) + timedelta(minutes=15)
+        updated = update_user(db, user.id, UserUpdate(locked_until=lock_time))
+        assert updated.locked_until is not None
+        # Compare with second precision (isoformat round-trip may lose microseconds)
+        assert abs((updated.locked_until - lock_time).total_seconds()) < 1
+
+    def test_clear_locked_until_to_none(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        lock_time = datetime.now(timezone.utc) + timedelta(minutes=15)
+        user = _make_user(locked_until=lock_time)
+        create_user(db, user)
+        assert get_user_by_id(db, user.id) is not None
+        updated = update_user(db, user.id, UserUpdate(locked_until=None))
+        assert updated.locked_until is None
 
 
 @pytest.mark.unit
@@ -457,34 +498,3 @@ class TestAPIKeyCRUD:
         fetched = get_api_key_by_hash(db, key.key_hash)
         assert fetched is not None
         assert fetched.is_active is False
-
-
-@pytest.mark.unit
-class TestDatabaseIntegrity:
-    """Tests for database-level constraints and behaviors."""
-
-    def test_wal_mode_enabled(self, tmp_path: Path) -> None:
-        db = _make_db(tmp_path)
-        # WAL mode is set per-connection by _connect(); verify via CRUD helper
-        from dango.auth.database import _connect
-
-        conn = _connect(db)
-        mode = conn.execute("PRAGMA journal_mode").fetchone()
-        conn.close()
-        assert mode is not None
-        assert mode[0] == "wal"
-
-    def test_foreign_keys_enabled(self, tmp_path: Path) -> None:
-        db = _make_db(tmp_path)
-        user = _make_user()
-        create_user(db, user)
-        # Try inserting a session with a non-existent user_id
-        conn = sqlite3.connect(str(db))
-        conn.execute("PRAGMA foreign_keys=ON")
-        with pytest.raises(sqlite3.IntegrityError):
-            conn.execute(
-                "INSERT INTO sessions (id, user_id, token_hash, is_active, is_partial, "
-                "created_at, expires_at, last_activity) "
-                "VALUES ('s1', 'nonexistent', 'hash', 1, 0, '2026-01-01', '2026-01-02', '2026-01-01')"
-            )
-        conn.close()

--- a/tests/unit/test_auth_models.py
+++ b/tests/unit/test_auth_models.py
@@ -1,0 +1,254 @@
+"""tests/unit/test_auth_models.py
+
+Tests for auth Pydantic models in dango/auth/models.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dango.auth.models import APIKey, Role, Session, User, UserCreate, UserResponse, UserUpdate
+
+
+@pytest.mark.unit
+class TestRole:
+    """Tests for the Role enum."""
+
+    def test_values(self) -> None:
+        assert Role.ADMIN.value == "admin"
+        assert Role.EDITOR.value == "editor"
+        assert Role.VIEWER.value == "viewer"
+
+    def test_is_str_subclass(self) -> None:
+        assert isinstance(Role.ADMIN, str)
+        assert Role.ADMIN == "admin"
+
+    def test_from_string(self) -> None:
+        assert Role("admin") is Role.ADMIN
+        assert Role("editor") is Role.EDITOR
+        assert Role("viewer") is Role.VIEWER
+
+    def test_invalid_role_raises(self) -> None:
+        with pytest.raises(ValueError, match="not a valid"):
+            Role("superadmin")
+
+
+@pytest.mark.unit
+class TestUser:
+    """Tests for the User model."""
+
+    def test_defaults(self) -> None:
+        user = User(email="test@example.com")
+        assert user.id  # UUID auto-generated
+        assert user.email == "test@example.com"
+        assert user.password_hash is None
+        assert user.role is Role.VIEWER
+        assert user.is_active is True
+        assert user.totp_secret is None
+        assert user.totp_enabled is False
+        assert user.recovery_codes is None
+        assert user.oauth_provider is None
+        assert user.oauth_id is None
+        assert user.failed_login_attempts == 0
+        assert user.locked_until is None
+        assert isinstance(user.created_at, datetime)
+        assert isinstance(user.updated_at, datetime)
+
+    def test_uuid_auto_generated(self) -> None:
+        user1 = User(email="a@example.com")
+        user2 = User(email="b@example.com")
+        assert user1.id != user2.id
+
+    def test_email_normalization(self) -> None:
+        user = User(email="  TEST@Example.COM  ")
+        assert user.email == "test@example.com"
+
+    def test_all_fields_explicit(self) -> None:
+        now = datetime.now(timezone.utc)
+        user = User(
+            id="custom-id",
+            email="admin@test.com",
+            password_hash="hashed",
+            role=Role.ADMIN,
+            is_active=False,
+            totp_secret="JBSWY3DPEHPK3PXP",
+            totp_enabled=True,
+            recovery_codes="code1,code2",
+            oauth_provider="google",
+            oauth_id="google-123",
+            failed_login_attempts=3,
+            locked_until=now,
+            created_at=now,
+            updated_at=now,
+        )
+        assert user.id == "custom-id"
+        assert user.password_hash == "hashed"
+        assert user.role is Role.ADMIN
+        assert user.is_active is False
+        assert user.totp_enabled is True
+        assert user.failed_login_attempts == 3
+
+
+@pytest.mark.unit
+class TestUserCreate:
+    """Tests for the UserCreate model."""
+
+    def test_required_email_only(self) -> None:
+        uc = UserCreate(email="user@example.com")
+        assert uc.email == "user@example.com"
+        assert uc.password is None
+        assert uc.role is Role.VIEWER
+        assert uc.oauth_provider is None
+        assert uc.oauth_id is None
+
+    def test_with_password(self) -> None:
+        uc = UserCreate(email="user@example.com", password="secret123")
+        assert uc.password == "secret123"
+
+    def test_with_role(self) -> None:
+        uc = UserCreate(email="admin@example.com", role=Role.ADMIN)
+        assert uc.role is Role.ADMIN
+
+    def test_email_normalization(self) -> None:
+        uc = UserCreate(email="  Admin@Test.COM  ")
+        assert uc.email == "admin@test.com"
+
+    def test_oauth_fields(self) -> None:
+        uc = UserCreate(
+            email="user@example.com",
+            oauth_provider="github",
+            oauth_id="gh-456",
+        )
+        assert uc.oauth_provider == "github"
+        assert uc.oauth_id == "gh-456"
+
+
+@pytest.mark.unit
+class TestUserUpdate:
+    """Tests for the UserUpdate model."""
+
+    def test_all_fields_optional(self) -> None:
+        uu = UserUpdate()
+        dump = uu.model_dump(exclude_none=True)
+        assert dump == {}
+
+    def test_partial_update_email(self) -> None:
+        uu = UserUpdate(email="new@example.com")
+        dump = uu.model_dump(exclude_none=True)
+        assert dump == {"email": "new@example.com"}
+
+    def test_partial_update_role(self) -> None:
+        uu = UserUpdate(role=Role.EDITOR)
+        dump = uu.model_dump(exclude_none=True)
+        assert dump == {"role": Role.EDITOR}
+
+    def test_email_normalization(self) -> None:
+        uu = UserUpdate(email="  UPPER@Test.COM  ")
+        assert uu.email == "upper@test.com"
+
+    def test_email_none_passes_through(self) -> None:
+        uu = UserUpdate(email=None)
+        assert uu.email is None
+
+    def test_multiple_fields(self) -> None:
+        uu = UserUpdate(email="new@test.com", role=Role.ADMIN, is_active=False)
+        dump = uu.model_dump(exclude_none=True)
+        assert dump["email"] == "new@test.com"
+        assert dump["role"] == Role.ADMIN
+        assert dump["is_active"] is False
+
+    def test_exclude_none_preserves_set_values(self) -> None:
+        uu = UserUpdate(failed_login_attempts=0, totp_enabled=False)
+        dump = uu.model_dump(exclude_none=True)
+        assert dump["failed_login_attempts"] == 0
+        assert dump["totp_enabled"] is False
+
+
+@pytest.mark.unit
+class TestUserResponse:
+    """Tests for the UserResponse model."""
+
+    def test_from_user_model(self) -> None:
+        user = User(email="test@example.com", password_hash="secret", totp_secret="totp123")
+        response = UserResponse.model_validate(user)
+        assert response.email == "test@example.com"
+        assert response.id == user.id
+        assert response.role is Role.VIEWER
+        assert response.is_active is True
+
+    def test_sensitive_fields_absent(self) -> None:
+        fields = set(UserResponse.model_fields.keys())
+        assert "password_hash" not in fields
+        assert "totp_secret" not in fields
+        assert "recovery_codes" not in fields
+        assert "oauth_id" not in fields
+
+    def test_safe_fields_present(self) -> None:
+        fields = set(UserResponse.model_fields.keys())
+        assert "id" in fields
+        assert "email" in fields
+        assert "role" in fields
+        assert "is_active" in fields
+        assert "totp_enabled" in fields
+        assert "oauth_provider" in fields
+        assert "created_at" in fields
+        assert "updated_at" in fields
+
+
+@pytest.mark.unit
+class TestSession:
+    """Tests for the Session model."""
+
+    def test_construction(self) -> None:
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        session = Session(user_id="user-1", token_hash="hash123", expires_at=expires)
+        assert session.id  # UUID auto-generated
+        assert session.user_id == "user-1"
+        assert session.token_hash == "hash123"
+        assert session.is_active is True
+        assert session.is_partial is False
+        assert isinstance(session.created_at, datetime)
+        assert session.expires_at == expires
+        assert isinstance(session.last_activity, datetime)
+
+    def test_partial_session(self) -> None:
+        expires = datetime.now(timezone.utc) + timedelta(minutes=5)
+        session = Session(
+            user_id="user-1",
+            token_hash="hash456",
+            expires_at=expires,
+            is_partial=True,
+        )
+        assert session.is_partial is True
+
+
+@pytest.mark.unit
+class TestAPIKey:
+    """Tests for the APIKey model."""
+
+    def test_construction(self) -> None:
+        key = APIKey(user_id="user-1", name="My Key", key_hash="keyhash123")
+        assert key.id  # UUID auto-generated
+        assert key.user_id == "user-1"
+        assert key.name == "My Key"
+        assert key.key_hash == "keyhash123"
+        assert key.is_active is True
+        assert isinstance(key.created_at, datetime)
+        assert key.last_used_at is None
+        assert key.expires_at is None
+
+    def test_with_expiry(self) -> None:
+        expires = datetime.now(timezone.utc) + timedelta(days=90)
+        key = APIKey(
+            user_id="user-1",
+            name="Expiring Key",
+            key_hash="keyhash456",
+            expires_at=expires,
+        )
+        assert key.expires_at == expires
+
+    def test_required_fields(self) -> None:
+        with pytest.raises(ValueError):
+            APIKey.model_validate({})  # missing user_id, name, key_hash

--- a/tests/unit/test_auth_models.py
+++ b/tests/unit/test_auth_models.py
@@ -131,17 +131,17 @@ class TestUserUpdate:
 
     def test_all_fields_optional(self) -> None:
         uu = UserUpdate()
-        dump = uu.model_dump(exclude_none=True)
+        dump = uu.model_dump(exclude_unset=True)
         assert dump == {}
 
     def test_partial_update_email(self) -> None:
         uu = UserUpdate(email="new@example.com")
-        dump = uu.model_dump(exclude_none=True)
+        dump = uu.model_dump(exclude_unset=True)
         assert dump == {"email": "new@example.com"}
 
     def test_partial_update_role(self) -> None:
         uu = UserUpdate(role=Role.EDITOR)
-        dump = uu.model_dump(exclude_none=True)
+        dump = uu.model_dump(exclude_unset=True)
         assert dump == {"role": Role.EDITOR}
 
     def test_email_normalization(self) -> None:
@@ -154,16 +154,22 @@ class TestUserUpdate:
 
     def test_multiple_fields(self) -> None:
         uu = UserUpdate(email="new@test.com", role=Role.ADMIN, is_active=False)
-        dump = uu.model_dump(exclude_none=True)
+        dump = uu.model_dump(exclude_unset=True)
         assert dump["email"] == "new@test.com"
         assert dump["role"] == Role.ADMIN
         assert dump["is_active"] is False
 
-    def test_exclude_none_preserves_set_values(self) -> None:
+    def test_exclude_unset_preserves_falsy_values(self) -> None:
         uu = UserUpdate(failed_login_attempts=0, totp_enabled=False)
-        dump = uu.model_dump(exclude_none=True)
+        dump = uu.model_dump(exclude_unset=True)
         assert dump["failed_login_attempts"] == 0
         assert dump["totp_enabled"] is False
+
+    def test_exclude_unset_preserves_explicit_none(self) -> None:
+        uu = UserUpdate(locked_until=None)
+        dump = uu.model_dump(exclude_unset=True)
+        assert "locked_until" in dump
+        assert dump["locked_until"] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -10,6 +10,10 @@ from typing import Any
 import pytest
 
 from dango.exceptions import (
+    AccountDeactivatedError,
+    AccountLockedError,
+    AuthenticationError,
+    AuthorizationError,
     ConfigError,
     ConfigNotFoundError,
     ConfigValidationError,
@@ -28,7 +32,10 @@ from dango.exceptions import (
     MigrationDiscoveryError,
     MigrationError,
     ProjectNotFoundError,
+    SessionExpiredError,
     SyncTimeoutError,
+    UserExistsError,
+    UserNotFoundError,
     ValidationError,
     WebAPIError,
     is_debug_mode,
@@ -110,6 +117,13 @@ class TestExceptionHierarchy:
             InvalidDateFormatError,
             InvalidPortError,
             WebAPIError,
+            AuthenticationError,
+            AuthorizationError,
+            UserNotFoundError,
+            UserExistsError,
+            SessionExpiredError,
+            AccountLockedError,
+            AccountDeactivatedError,
         ],
     )
     def test_all_inherit_from_dango_error(self, exc_class: type[DangoError]) -> None:
@@ -139,6 +153,15 @@ class TestExceptionHierarchy:
         assert issubclass(ConfigVersionError, DangoError)
         # ConfigVersionError is NOT a ConfigError — it's directly under DangoError
         assert not issubclass(ConfigVersionError, ConfigError)
+
+    def test_auth_hierarchy(self) -> None:
+        assert issubclass(SessionExpiredError, AuthenticationError)
+        assert issubclass(AccountLockedError, AuthenticationError)
+        assert issubclass(AccountDeactivatedError, AuthenticationError)
+        # These are independent — not under AuthenticationError
+        assert not issubclass(AuthorizationError, AuthenticationError)
+        assert not issubclass(UserNotFoundError, AuthenticationError)
+        assert not issubclass(UserExistsError, AuthenticationError)
 
     def test_validation_hierarchy(self) -> None:
         assert issubclass(InvalidSourceNameError, ValidationError)
@@ -174,6 +197,13 @@ class TestDefaultErrorCodes:
             (InvalidDateFormatError, "DANGO-V003"),
             (InvalidPortError, "DANGO-V004"),
             (WebAPIError, "DANGO-W001"),
+            (AuthenticationError, "DANGO-S001"),
+            (AuthorizationError, "DANGO-S002"),
+            (UserNotFoundError, "DANGO-S003"),
+            (UserExistsError, "DANGO-S004"),
+            (SessionExpiredError, "DANGO-S005"),
+            (AccountLockedError, "DANGO-S006"),
+            (AccountDeactivatedError, "DANGO-S007"),
         ],
     )
     def test_default_error_code(self, exc_class: type[DangoError], expected_code: str) -> None:


### PR DESCRIPTION
## Summary

- Add 7 auth exceptions (`DANGO-S001`–`S007`) with proper inheritance hierarchy to `exceptions.py` and wire them into `web/app.py` status map
- Create `dango/auth/` package with Pydantic v2 models (`Role`, `User`, `UserCreate`, `UserUpdate`, `UserResponse`, `Session`, `APIKey`), SQLite migration (`001_initial_auth` — 3 tables with indexes and foreign keys), and 18 sync CRUD functions (7 user, 7 session, 4 API key)
- Add 65 unit tests covering all models and CRUD operations; 531 total tests pass with 0 regressions

## Test plan

- [x] `mypy dango/auth/ dango/exceptions.py dango/web/app.py` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/unit/test_auth_models.py tests/unit/test_auth_database.py -v` — 65 pass
- [x] `pytest tests/unit/ -v` — 531 pass, 0 regressions
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)