### PR TITLE
TASK-012: Add security utilities (password hashing + token generation)

### DIFF
--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -1,9 +1,10 @@
 """dango/auth/__init__.py
 
-Authentication and authorization data layer.
+User authentication and access control for Dango.
 
-Exports Pydantic models for users, sessions, and API keys, plus all
-CRUD functions for the auth SQLite database.
+Exports Pydantic models for users, sessions, and API keys, CRUD
+functions for the auth SQLite database, and pure security utility
+functions (password hashing, token generation, recovery codes).
 """
 
 from __future__ import annotations
@@ -29,6 +30,19 @@ from dango.auth.database import (
     update_user,
 )
 from dango.auth.models import APIKey, Role, Session, User, UserCreate, UserResponse, UserUpdate
+from dango.auth.security import (
+    check_password_strength,
+    generate_api_key,
+    generate_recovery_codes,
+    generate_session_token,
+    generate_temp_password,
+    get_key_prefix,
+    hash_api_key,
+    hash_password,
+    hash_recovery_code,
+    hash_token,
+    verify_password,
+)
 
 __all__ = [
     # Models
@@ -60,4 +74,16 @@ __all__ = [
     "get_api_key_by_hash",
     "list_user_api_keys",
     "revoke_api_key",
+    # Security utilities
+    "check_password_strength",
+    "generate_api_key",
+    "generate_recovery_codes",
+    "generate_session_token",
+    "generate_temp_password",
+    "get_key_prefix",
+    "hash_api_key",
+    "hash_password",
+    "hash_recovery_code",
+    "hash_token",
+    "verify_password",
 ]

--- a/dango/auth/security.py
+++ b/dango/auth/security.py
@@ -188,21 +188,21 @@ def hash_password(password: str) -> str:
     return _hasher.hash(password)
 
 
-def verify_password(password: str, hash: str) -> bool:
+def verify_password(password: str, password_hash: str) -> bool:
     """Verify a plain-text password against a bcrypt hash.
 
     Args:
         password: Plain-text password to check.
-        hash: Bcrypt hash to verify against.
+        password_hash: Bcrypt hash to verify against.
 
     Returns:
         ``True`` if the password matches, ``False`` otherwise.
 
     Raises:
-        pwdlib.exceptions.UnknownHashError: If *hash* is not a valid
-            bcrypt string (programming error, not user input).
+        pwdlib.exceptions.UnknownHashError: If *password_hash* is not a
+            valid bcrypt string (programming error, not user input).
     """
-    return _hasher.verify(password, hash)
+    return _hasher.verify(password, password_hash)
 
 
 def check_password_strength(password: str) -> list[str]:

--- a/dango/auth/security.py
+++ b/dango/auth/security.py
@@ -1,0 +1,358 @@
+"""dango/auth/security.py
+
+Pure security utility functions for Dango authentication.
+
+Provides password hashing (bcrypt via pwdlib), cryptographic token
+generation, API key management, temporary passwords, and TOTP recovery
+codes.  All functions are stateless and have no database or model
+dependencies — they are consumed by higher-level auth modules
+(sessions, CLI, Metabase sync).
+
+Password policy follows NIST SP 800-63B: minimum length + common
+password blocklist.  No complexity rules (digit/uppercase/special).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+from pwdlib import PasswordHash
+from pwdlib.hashers.bcrypt import BcryptHasher
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_hasher = PasswordHash((BcryptHasher(rounds=12),))
+
+_API_KEY_PREFIX = "dango_ak_"
+
+_MIN_PASSWORD_LENGTH = 8
+
+# Mixed case, no ambiguous characters (0, O, o, 1, l, I)
+_TEMP_PASSWORD_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"
+
+# Uppercase only, no ambiguous characters
+_RECOVERY_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+# ---------------------------------------------------------------------------
+# Common passwords (top ~1000 from SecLists, all lowercase, O(1) lookup)
+# ---------------------------------------------------------------------------
+
+# fmt: off
+_COMMON_PASSWORDS: frozenset[str] = frozenset({
+    "0000", "000000", "007007", "101010", "1111", "11111", "111111", "11111111",
+    "112233", "1212", "121212", "123123", "123321", "1234", "12345", "123456",
+    "1234567", "12345678", "123456789", "123654", "123abc", "123qwe", "1313", "131313",
+    "147147", "159753", "1969", "1q2w3e", "1q2w3e4r", "1qaz2wsx", "2000", "2112",
+    "212121", "2222", "222222", "232323", "242424", "252525", "3333", "333333",
+    "420420", "4321", "4444", "444444", "5150", "54321", "5555", "55555",
+    "555555", "654321", "6666", "666666", "6969", "696969", "69696969", "7777",
+    "777777", "7777777", "789456", "8675309", "87654321", "8888", "888888", "88888888",
+    "987654", "9999", "999999", "aaaa", "aaaaaa", "aaaaaaaa", "abc123", "abcd",
+    "abcd1234", "abcdef", "abcdefg", "access", "accord", "action", "adam", "adidas",
+    "admin", "airborne", "airplane", "alaska", "albert", "alex", "alexande", "alexis",
+    "alicia", "alison", "allison", "alpha", "alpha1", "alyssa", "amanda", "amateur",
+    "amber", "america", "american", "anderson", "andrea", "andrew", "angel", "angela",
+    "angels", "animal", "anthony", "apollo", "apple", "apples", "arizona", "arnold",
+    "arsenal", "arthur", "asdf", "asdfasdf", "asdfg", "asdfgh", "asdfghjk", "ashley",
+    "asshole", "assman", "august", "austin", "avalon", "azerty", "babes", "baby",
+    "babygirl", "badass", "badboy", "badger", "bailey", "balls", "bambam", "banana",
+    "bang", "barbara", "barney", "baseball", "bass", "bastard", "batman", "baxter",
+    "bbbbbb", "beach", "bear", "beatles", "beaver", "beavis", "beer", "benjamin",
+    "berlin", "bigboy", "bigcock", "bigdaddy", "bigdick", "bigdog", "bigmac", "bigman",
+    "bigred", "bigtits", "bill", "billy", "birdie", "bishop", "bitch", "bitches",
+    "biteme", "black", "blazer", "blink182", "blonde", "blowjob", "blowme", "blue",
+    "bobby", "bollocks", "bond007", "bondage", "bonnie", "boobies", "booboo", "boobs",
+    "booger", "boogie", "boomer", "booty", "boston", "bradley", "brandon", "brandy",
+    "braves", "brazil", "brenda", "brian", "britney", "brittany", "bronco", "broncos",
+    "brooke", "brooklyn", "brother", "brown", "brutus", "bubba", "bubba1", "bubbles",
+    "buddha", "buddy", "budlight", "buffalo", "bulldog", "bulldogs", "bullet", "bullshit",
+    "bunny", "burton", "buster", "butter", "butthead", "calvin", "camaro", "cameron",
+    "canada", "candy", "cannon", "captain", "cardinal", "carlos", "carmen", "carolina",
+    "caroline", "carrie", "carter", "cartman", "casper", "cassie", "catch22", "celtic",
+    "champion", "chance", "charles", "charlie", "cheese", "chelsea", "cherokee", "cherry",
+    "chester", "chevelle", "chevy", "chicago", "chicken", "chicks", "chopper", "chris",
+    "chris1", "christ", "christin", "chronic", "claire", "classic", "claudia", "clinton",
+    "cobra", "cocacola", "cock", "coffee", "college", "colorado", "compaq", "computer",
+    "connie", "connor", "control", "cookie", "cool", "cooper", "copper", "corvette",
+    "cougar", "courtney", "cowboy", "cowboys", "coyote", "crazy", "cream", "creative",
+    "cricket", "crystal", "cumming", "cumshot", "cunt", "daddy", "dakota", "dallas",
+    "dancer", "daniel", "danielle", "darkness", "dave", "david", "death", "debbie",
+    "december", "denise", "dennis", "denver", "destiny", "devils", "dexter", "diablo",
+    "diamond", "dick", "dickhead", "diesel", "digger", "digital", "dirty", "disney",
+    "doctor", "dodgers", "doggie", "dolphin", "dolphins", "domino", "donald", "donkey",
+    "douglas", "dragon", "dreamer", "dreams", "driver", "drowssap", "drummer", "ducati",
+    "dude", "duke", "duncan", "eagle", "eagle1", "eagles", "eatme", "eclipse",
+    "edward", "einstein", "electric", "elephant", "elizabet", "elvis", "eminem", "empire",
+    "enigma", "enjoy", "enter", "eric", "erotic", "eugene", "everton", "explorer",
+    "extreme", "falcon", "family", "fantasy", "fender", "ferrari", "fire", "fireman",
+    "fish", "fisher", "fishing", "flash", "florida", "flower", "flowers", "fluffy",
+    "flyers", "football", "ford", "forest", "forever", "france", "francis", "frank",
+    "frankie", "franklin", "freaky", "fred", "freddy", "free", "freedom", "freepass",
+    "freeuser", "friday", "friend", "friends", "froggy", "fuck", "fucked", "fucker",
+    "fucking", "fuckme", "fuckoff", "fuckyou", "gabriel", "galore", "gandalf", "garcia",
+    "garfield", "gateway", "gators", "gemini", "general", "genesis", "george", "georgia",
+    "giants", "gibson", "ginger", "girl", "girls", "goblue", "godzilla", "golden",
+    "golf", "golfer", "goober", "good", "gordon", "great", "green", "gregory",
+    "guinness", "guitar", "gunner", "hahaha", "hammer", "hannah", "happy", "happy1",
+    "hard", "hardcore", "hardon", "harley", "hawaii", "hawkeye", "head", "heather",
+    "heaven", "heka6w2", "hello", "hello1", "helpme", "hendrix", "hentai", "hitman",
+    "hobbes", "hockey", "homer", "honda", "honey", "hooker", "hooters", "horney",
+    "horny", "horse", "horses", "hotdog", "hotmail", "hotrod", "house", "houston",
+    "howard", "hummer", "hunter", "hunting", "iceman", "iloveyou", "indian", "infinity",
+    "inside", "internet", "ireland", "ironman", "iwantu", "jack", "jackass", "jackie",
+    "jackson", "jaguar", "jake", "james", "japan", "jasmine", "jason", "jasper",
+    "jeff", "jeffrey", "jennifer", "jenny", "jeremy", "jerry", "jessica", "jessie",
+    "jester", "jesus", "jimmy", "john", "johnny", "johnson", "jonathan", "jones",
+    "jordan", "jordan23", "joseph", "joshua", "juice", "junior", "jupiter", "justice",
+    "justin", "katana", "katie", "kawasaki", "kelly", "kermit", "kevin", "killer",
+    "kimberly", "king", "kitten", "kitty", "knight", "kodiak", "kramer", "kristen",
+    "lacrosse", "ladies", "lakers", "lasvegas", "lauren", "lawrence", "leather", "legend",
+    "lesbian", "leslie", "letmein", "letmein1", "liberty", "lickme", "lifehack", "light",
+    "lights", "lincoln", "lisa", "little", "liverpoo", "liverpool", "lizard", "london",
+    "long", "looking", "louise", "love", "lovely", "loveme", "lover", "loverboy",
+    "lovers", "lucky", "lucky1", "machine", "maddog", "madison", "madmax", "maggie",
+    "magic", "magnum", "marcus", "marina", "marine", "marines", "mark", "marlboro",
+    "marley", "marshall", "martin", "marvin", "maryjane", "master", "matrix", "matt",
+    "matthew", "mature", "maverick", "maximus", "maxwell", "melanie", "melissa", "member",
+    "mercedes", "mercury", "merlin", "metallic", "mexico", "michael", "michael1", "michelle",
+    "michigan", "mickey", "midnight", "mike", "miller", "mine", "mistress", "mitchell",
+    "molly", "monday", "money", "money1", "monica", "monkey", "monster", "montana",
+    "mookie", "moose", "morgan", "mother", "mountain", "mouse", "movie", "mozart",
+    "muffin", "murphy", "music", "mustang", "naked", "nascar", "natalie", "natasha",
+    "nathan", "naughty", "ncc1701", "ncc1701d", "nelson", "nemesis", "newport", "newyork",
+    "nicholas", "nicole", "nigger", "nintendo", "nipple", "nipples", "nirvana", "nissan",
+    "norman", "nothing", "november", "october", "oliver", "olivia", "online", "orange",
+    "oscar", "ou812", "packard", "packers", "pakistan", "pamela", "pantera", "panther",
+    "panthers", "panties", "paradise", "paris", "parker", "party", "pass", "passion",
+    "passport", "passw0rd", "password", "password1", "patches", "patricia", "patrick", "patriots",
+    "paul", "peaches", "peanut", "pearljam", "peekaboo", "penguin", "penis", "people",
+    "pepper", "pepsi", "perfect", "pervert", "peter", "phantom", "phoenix", "phpbb",
+    "picard", "pimp", "pimpin", "pirate", "platinum", "playboy", "player", "please",
+    "pokemon", "police", "pontiac", "poohbear", "pookie", "poop", "poopoo", "popcorn",
+    "popeye", "porn", "porno", "porsche", "power", "prince", "princess", "private",
+    "psycho", "pumpkin", "purple", "pussies", "pussy", "pussy1", "pussycat", "pyramid",
+    "qazwsx", "qqqqqq", "qwer", "qwert", "qwerty", "qwerty1", "qwertyui", "rabbit",
+    "rachel", "racing", "raider", "raiders", "rainbow", "ranger", "rangers", "raptor",
+    "rascal", "raven", "raymond", "rebecca", "red123", "reddog", "redhead", "redrum",
+    "redskins", "redsox", "redwings", "reggie", "remember", "richard", "robert", "rock",
+    "rocket", "rocks", "rocky", "roland", "rolltide", "rooster", "rosebud", "runner",
+    "rush2112", "russell", "russia", "ryan", "sabrina", "sailor", "saints", "samantha",
+    "sammy", "samson", "samsung", "samuel", "sandman", "sandra", "sandy", "sarah",
+    "saturn", "scarface", "school", "scooby", "scooter", "scorpio", "scorpion", "scotland",
+    "scott", "scotty", "secret", "security", "semperfi", "service", "sexsex", "sexy",
+    "shadow", "shaggy", "shannon", "sharon", "shaved", "shelby", "shit", "shithead",
+    "shooter", "shorty", "sierra", "silver", "simon", "simple", "simpson", "simpsons",
+    "single", "skipper", "skippy", "slayer", "slipknot", "slut", "sluts", "smith",
+    "smokey", "smooth", "snake", "snickers", "sniper", "snoopy", "snowball", "snowman",
+    "soccer", "softball", "sophie", "spanky", "sparky", "speedy", "spencer", "spider",
+    "spiderma", "spike", "spirit", "spitfire", "spooky", "sports", "spring", "squirt",
+    "srinivas", "stanley", "star", "stargate", "stars", "startrek", "starwars", "steelers",
+    "stella", "stephen", "steve", "steven", "stewart", "sticky", "stingray", "stinky",
+    "strike", "stupid", "sublime", "success", "suck", "sucker", "suckit", "suckme",
+    "sugar", "summer", "sunshine", "super", "superman", "surfer", "suzuki", "sweet",
+    "swimming", "swordfis", "sydney", "system", "tarheels", "tattoo", "taurus", "taylor",
+    "teen", "teens", "tennis", "teresa", "test", "test123", "tester", "testing",
+    "testtest", "texas", "theman", "therock", "thomas", "thumper", "thunder", "thx1138",
+    "tiffany", "tiger", "tiger1", "tigers", "tigger", "time", "timothy", "tinker",
+    "titanic", "tits", "tomcat", "tommy", "tony", "topgun", "toyota", "travis",
+    "trinity", "trooper", "trouble", "trucks", "trustno1", "tucker", "turkey", "turtle",
+    "united", "vagina", "vampire", "vanessa", "vegeta", "veronica", "victor", "victoria",
+    "video", "viking", "vikings", "vincent", "viper", "virginia", "vision", "voodoo",
+    "voyager", "walker", "walter", "wanker", "warrior", "water", "weasel", "welcome",
+    "westside", "whatever", "white", "whore", "whynot", "wildcat", "wildcats", "william",
+    "williams", "willie", "willow", "wilson", "windows", "winner", "winston", "winter",
+    "wizard", "wolf", "wolfgang", "wolfpack", "wolverin", "wolves", "wombat", "women",
+    "woody", "xavier", "xxxx", "xxxxx", "xxxxxx", "xxxxxxxx", "yamaha", "yankee",
+    "yankees", "yellow", "young", "zachary", "zombie", "zxcvbn", "zxcvbnm", "zzzzzz",
+})
+# fmt: on
+
+
+# ---------------------------------------------------------------------------
+# Password hashing (bcrypt, work factor 12)
+# ---------------------------------------------------------------------------
+
+
+def hash_password(password: str) -> str:
+    """Hash a password using bcrypt (work factor 12).
+
+    Args:
+        password: Plain-text password.
+
+    Returns:
+        Bcrypt hash string (``$2b$12$...``).
+    """
+    return _hasher.hash(password)
+
+
+def verify_password(password: str, hash: str) -> bool:
+    """Verify a plain-text password against a bcrypt hash.
+
+    Args:
+        password: Plain-text password to check.
+        hash: Bcrypt hash to verify against.
+
+    Returns:
+        ``True`` if the password matches, ``False`` otherwise.
+
+    Raises:
+        pwdlib.exceptions.UnknownHashError: If *hash* is not a valid
+            bcrypt string (programming error, not user input).
+    """
+    return _hasher.verify(password, hash)
+
+
+def check_password_strength(password: str) -> list[str]:
+    """Check password strength per NIST SP 800-63B guidelines.
+
+    Checks minimum length (8 characters) and common password blocklist.
+    Does **not** require digits, uppercase, or special characters.
+
+    Args:
+        password: Password to evaluate.
+
+    Returns:
+        List of issue descriptions.  Empty list means the password
+        passes all checks.
+    """
+    issues: list[str] = []
+    if len(password) < _MIN_PASSWORD_LENGTH:
+        issues.append(f"Password must be at least {_MIN_PASSWORD_LENGTH} characters")
+    if password.lower() in _COMMON_PASSWORDS:
+        issues.append("Password is too common")
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Session tokens (256-bit entropy, SHA-256 storage hash)
+# ---------------------------------------------------------------------------
+
+
+def generate_session_token() -> str:
+    """Generate a cryptographically secure session token.
+
+    Returns:
+        URL-safe base64 string (43 characters, 256-bit entropy).
+    """
+    return secrets.token_urlsafe(32)
+
+
+def hash_token(token: str) -> str:
+    """SHA-256 hash a token for database storage.
+
+    Args:
+        token: Raw token string.
+
+    Returns:
+        Hex-encoded SHA-256 digest (64 characters).
+    """
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# API keys (prefixed ``dango_ak_`` + SHA-256)
+# ---------------------------------------------------------------------------
+
+
+def generate_api_key() -> tuple[str, str]:
+    """Generate a new API key with the ``dango_ak_`` prefix.
+
+    Returns:
+        Tuple of ``(raw_key, sha256_hash)``.  The raw key is shown to
+        the user once; only the hash is stored in the database.
+    """
+    random_part = secrets.token_urlsafe(32)
+    raw_key = f"{_API_KEY_PREFIX}{random_part}"
+    return raw_key, hash_api_key(raw_key)
+
+
+def hash_api_key(key: str) -> str:
+    """SHA-256 hash an API key for database storage.
+
+    Args:
+        key: Full API key (including ``dango_ak_`` prefix).
+
+    Returns:
+        Hex-encoded SHA-256 digest (64 characters).
+    """
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+def get_key_prefix(key: str) -> str:
+    """Return a safe-to-display prefix of an API key.
+
+    Shows ``dango_ak_`` plus the first 3 characters of the random
+    portion — enough to identify a key without exposing the secret.
+
+    Args:
+        key: Full API key.
+
+    Returns:
+        First 12 characters of the key.
+    """
+    return key[:12]
+
+
+# ---------------------------------------------------------------------------
+# Temporary passwords
+# ---------------------------------------------------------------------------
+
+
+def generate_temp_password(length: int = 12) -> str:
+    """Generate a temporary password using unambiguous characters.
+
+    Excludes visually ambiguous characters (``0``, ``O``, ``o``,
+    ``1``, ``l``, ``I``) for readability when printed to a terminal.
+
+    Args:
+        length: Number of characters (default 12).
+
+    Returns:
+        Random alphanumeric string.
+    """
+    return "".join(secrets.choice(_TEMP_PASSWORD_CHARS) for _ in range(length))
+
+
+# ---------------------------------------------------------------------------
+# Recovery codes (TOTP 2FA backup)
+# ---------------------------------------------------------------------------
+
+
+def generate_recovery_codes(count: int = 8) -> list[str]:
+    """Generate formatted recovery codes for TOTP 2FA backup.
+
+    Each code is formatted as ``XXXX-XXXX`` using uppercase
+    alphanumeric characters (no ambiguous characters).
+
+    Args:
+        count: Number of codes to generate (default 8).
+
+    Returns:
+        List of recovery code strings.
+    """
+    codes: list[str] = []
+    for _ in range(count):
+        left = "".join(secrets.choice(_RECOVERY_CODE_CHARS) for _ in range(4))
+        right = "".join(secrets.choice(_RECOVERY_CODE_CHARS) for _ in range(4))
+        codes.append(f"{left}-{right}")
+    return codes
+
+
+def hash_recovery_code(code: str) -> str:
+    """Hash a recovery code for database storage.
+
+    Normalises the code by stripping dashes and converting to
+    uppercase before hashing, so ``ABCD-EFGH``, ``abcdefgh``,
+    and ``ABCDEFGH`` all produce the same hash.
+
+    Args:
+        code: Recovery code (with or without dashes, any case).
+
+    Returns:
+        Hex-encoded SHA-256 digest (64 characters).
+    """
+    normalised = code.replace("-", "").upper()
+    return hashlib.sha256(normalised.encode()).hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     # Security and encryption
     "keyring>=24.0.0",    # Secure credential storage in OS keychain
     "cryptography>=41.0.0",  # Token encryption
+    "pwdlib[bcrypt]>=0.3.0,<1.0",  # Password hashing (bcrypt)
     "toml>=0.10.2",       # TOML file parsing for .dlt/secrets.toml
 
     # Google API dependencies (for bundled Google Sheets source)
@@ -95,6 +96,7 @@ dango = "dango.cli.main:cli"
 [tool.setuptools]
 packages = [
     "dango",
+    "dango.auth",
     "dango.cli",
     "dango.config",
     "dango.ingestion",

--- a/tests/unit/test_auth_security.py
+++ b/tests/unit/test_auth_security.py
@@ -10,6 +10,7 @@ import re
 import time
 
 import pytest
+from pwdlib.exceptions import UnknownHashError
 
 from dango.auth.security import (
     _COMMON_PASSWORDS,
@@ -64,6 +65,10 @@ class TestPasswordHashing:
         password = "\u00e9\u00e8\u00ea\u00eb\u2603\U0001f600"
         hashed = hash_password(password)
         assert verify_password(password, hashed) is True
+
+    def test_invalid_hash_raises(self) -> None:
+        with pytest.raises(UnknownHashError):
+            verify_password("password", "not-a-bcrypt-hash")
 
 
 @pytest.mark.unit

--- a/tests/unit/test_auth_security.py
+++ b/tests/unit/test_auth_security.py
@@ -1,0 +1,280 @@
+"""tests/unit/test_auth_security.py
+
+Unit tests for dango.auth.security — password hashing, token generation,
+API keys, temporary passwords, and recovery codes.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from dango.auth.security import (
+    _COMMON_PASSWORDS,
+    _TEMP_PASSWORD_CHARS,
+    check_password_strength,
+    generate_api_key,
+    generate_recovery_codes,
+    generate_session_token,
+    generate_temp_password,
+    get_key_prefix,
+    hash_api_key,
+    hash_password,
+    hash_recovery_code,
+    hash_token,
+    verify_password,
+)
+
+
+@pytest.mark.unit
+class TestPasswordHashing:
+    """Tests for hash_password / verify_password."""
+
+    def test_bcrypt_format(self) -> None:
+        hashed = hash_password("correcthorsebatterystaple")
+        assert hashed.startswith("$2b$12$")
+
+    def test_verify_round_trip(self) -> None:
+        password = "my-secure-passphrase!"
+        hashed = hash_password(password)
+        assert verify_password(password, hashed) is True
+
+    def test_wrong_password_fails(self) -> None:
+        hashed = hash_password("real-password")
+        assert verify_password("wrong-password", hashed) is False
+
+    def test_random_salt(self) -> None:
+        h1 = hash_password("same-password")
+        h2 = hash_password("same-password")
+        assert h1 != h2
+
+    def test_timing_under_2s(self) -> None:
+        start = time.monotonic()
+        hash_password("benchmark-password")
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"Hash took {elapsed:.2f}s, expected <2s"
+
+    def test_empty_string(self) -> None:
+        hashed = hash_password("")
+        assert verify_password("", hashed) is True
+
+    def test_unicode_password(self) -> None:
+        password = "\u00e9\u00e8\u00ea\u00eb\u2603\U0001f600"
+        hashed = hash_password(password)
+        assert verify_password(password, hashed) is True
+
+
+@pytest.mark.unit
+class TestCheckPasswordStrength:
+    """Tests for check_password_strength (NIST SP 800-63B)."""
+
+    def test_strong_password_no_issues(self) -> None:
+        issues = check_password_strength("xK9!mQ2pL#nR")
+        assert issues == []
+
+    def test_too_short(self) -> None:
+        issues = check_password_strength("short")
+        assert any("at least 8" in i for i in issues)
+
+    def test_exactly_8_chars_passes_length(self) -> None:
+        issues = check_password_strength("abcdefxy")
+        assert not any("at least 8" in i for i in issues)
+
+    def test_7_chars_fails_length(self) -> None:
+        issues = check_password_strength("abcdefx")
+        assert any("at least 8" in i for i in issues)
+
+    def test_common_password_lowercase(self) -> None:
+        issues = check_password_strength("password")
+        assert any("too common" in i for i in issues)
+
+    def test_common_password_case_insensitive(self) -> None:
+        issues = check_password_strength("PASSWORD")
+        assert any("too common" in i for i in issues)
+
+    def test_common_password_mixed_case(self) -> None:
+        issues = check_password_strength("PaSsWoRd")
+        assert any("too common" in i for i in issues)
+
+    def test_both_issues(self) -> None:
+        issues = check_password_strength("admin")
+        assert len(issues) == 2
+        assert any("at least 8" in i for i in issues)
+        assert any("too common" in i for i in issues)
+
+    def test_empty_password(self) -> None:
+        issues = check_password_strength("")
+        assert any("at least 8" in i for i in issues)
+
+    def test_no_digit_requirement(self) -> None:
+        issues = check_password_strength("abcdefghij")
+        assert issues == []
+
+    def test_no_uppercase_requirement(self) -> None:
+        issues = check_password_strength("alllowercase")
+        assert issues == []
+
+    def test_no_special_char_requirement(self) -> None:
+        issues = check_password_strength("nospechars1234")
+        assert issues == []
+
+
+@pytest.mark.unit
+class TestSessionTokens:
+    """Tests for generate_session_token / hash_token."""
+
+    def test_token_length(self) -> None:
+        token = generate_session_token()
+        assert len(token) == 43
+
+    def test_url_safe_chars(self) -> None:
+        token = generate_session_token()
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", token)
+
+    def test_uniqueness(self) -> None:
+        tokens = {generate_session_token() for _ in range(100)}
+        assert len(tokens) == 100
+
+    def test_hash_sha256_format(self) -> None:
+        hashed = hash_token("test-token")
+        assert len(hashed) == 64
+        assert re.fullmatch(r"[0-9a-f]{64}", hashed)
+
+    def test_hash_deterministic(self) -> None:
+        assert hash_token("same") == hash_token("same")
+
+    def test_different_tokens_different_hashes(self) -> None:
+        t1 = generate_session_token()
+        t2 = generate_session_token()
+        assert hash_token(t1) != hash_token(t2)
+
+
+@pytest.mark.unit
+class TestAPIKeys:
+    """Tests for generate_api_key / hash_api_key / get_key_prefix."""
+
+    def test_prefix_format(self) -> None:
+        raw_key, _ = generate_api_key()
+        assert raw_key.startswith("dango_ak_")
+
+    def test_returns_tuple(self) -> None:
+        result = generate_api_key()
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_hash_matches(self) -> None:
+        raw_key, stored_hash = generate_api_key()
+        assert hash_api_key(raw_key) == stored_hash
+
+    def test_hash_sha256_format(self) -> None:
+        _, stored_hash = generate_api_key()
+        assert len(stored_hash) == 64
+        assert re.fullmatch(r"[0-9a-f]{64}", stored_hash)
+
+    def test_uniqueness(self) -> None:
+        keys = {generate_api_key()[0] for _ in range(100)}
+        assert len(keys) == 100
+
+    def test_prefix_is_12_chars(self) -> None:
+        raw_key, _ = generate_api_key()
+        prefix = get_key_prefix(raw_key)
+        assert len(prefix) == 12
+        assert prefix.startswith("dango_ak_")
+
+    def test_hash_deterministic(self) -> None:
+        key = "dango_ak_testkey123"
+        assert hash_api_key(key) == hash_api_key(key)
+
+
+@pytest.mark.unit
+class TestTempPasswords:
+    """Tests for generate_temp_password."""
+
+    def test_default_length(self) -> None:
+        pwd = generate_temp_password()
+        assert len(pwd) == 12
+
+    def test_custom_length(self) -> None:
+        pwd = generate_temp_password(length=20)
+        assert len(pwd) == 20
+
+    def test_no_ambiguous_chars(self) -> None:
+        ambiguous = set("0Oo1lI")
+        for _ in range(100):
+            pwd = generate_temp_password()
+            assert not ambiguous.intersection(pwd), f"Ambiguous char found in: {pwd}"
+
+    def test_only_allowed_chars(self) -> None:
+        allowed = set(_TEMP_PASSWORD_CHARS)
+        for _ in range(100):
+            pwd = generate_temp_password()
+            assert set(pwd).issubset(allowed), f"Unexpected char in: {pwd}"
+
+    def test_uniqueness(self) -> None:
+        passwords = {generate_temp_password() for _ in range(100)}
+        assert len(passwords) == 100
+
+
+@pytest.mark.unit
+class TestRecoveryCodes:
+    """Tests for generate_recovery_codes / hash_recovery_code."""
+
+    def test_default_count(self) -> None:
+        codes = generate_recovery_codes()
+        assert len(codes) == 8
+
+    def test_custom_count(self) -> None:
+        codes = generate_recovery_codes(count=4)
+        assert len(codes) == 4
+
+    def test_format(self) -> None:
+        codes = generate_recovery_codes()
+        for code in codes:
+            assert re.fullmatch(r"[A-Z0-9]{4}-[A-Z0-9]{4}", code), f"Bad format: {code}"
+
+    def test_no_ambiguous_chars(self) -> None:
+        ambiguous = set("0O1I")
+        for _ in range(10):
+            codes = generate_recovery_codes()
+            for code in codes:
+                chars = code.replace("-", "")
+                assert not ambiguous.intersection(chars), f"Ambiguous char in: {code}"
+
+    def test_all_unique(self) -> None:
+        codes = generate_recovery_codes(count=8)
+        assert len(set(codes)) == len(codes)
+
+    def test_hash_sha256_format(self) -> None:
+        hashed = hash_recovery_code("ABCD-EFGH")
+        assert len(hashed) == 64
+        assert re.fullmatch(r"[0-9a-f]{64}", hashed)
+
+    def test_hash_strips_dashes(self) -> None:
+        assert hash_recovery_code("ABCD-EFGH") == hash_recovery_code("ABCDEFGH")
+
+    def test_hash_case_insensitive(self) -> None:
+        assert hash_recovery_code("ABCD-EFGH") == hash_recovery_code("abcd-efgh")
+
+    def test_hash_deterministic(self) -> None:
+        assert hash_recovery_code("WXYZ-1234") == hash_recovery_code("WXYZ-1234")
+
+
+@pytest.mark.unit
+class TestCommonPasswordsList:
+    """Tests for the common passwords frozenset."""
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(_COMMON_PASSWORDS, frozenset)
+
+    def test_has_entries(self) -> None:
+        assert len(_COMMON_PASSWORDS) >= 900
+
+    def test_all_lowercase(self) -> None:
+        for pwd in _COMMON_PASSWORDS:
+            assert pwd == pwd.lower(), f"Non-lowercase entry: {pwd}"
+
+    def test_well_known_passwords_present(self) -> None:
+        for pwd in ("password", "123456", "qwerty", "admin", "letmein"):
+            assert pwd in _COMMON_PASSWORDS, f"Missing well-known password: {pwd}"


### PR DESCRIPTION
## Summary

- Create `dango/auth/security.py` with 11 pure security functions: password hashing (bcrypt, work factor 12), NIST SP 800-63B password strength check (length + 1000 common passwords blocklist), session tokens (256-bit entropy), API keys (`dango_ak_` prefix), temporary passwords (no ambiguous chars), and recovery codes (`XXXX-XXXX` format)
- Add `pwdlib[bcrypt]` dependency to `pyproject.toml` and register `dango.auth` package
- Add 50 unit tests across 7 test classes in `tests/unit/test_auth_security.py`

## Test plan

- [x] 50/50 unit tests pass (`pytest tests/unit/test_auth_security.py -v`)
- [x] 524/524 full test suite passes (no regressions)
- [x] ruff lint + format clean
- [x] mypy passes with no errors
- [x] STD-003 file headers valid
- [x] File size under 500-line limit (358 lines)
- [x] All pre-commit hooks pass
- [x] Bcrypt hash timing ~350ms (work factor 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)