### PR TITLE
Add deferred auth schema fields (TASK-099)

### DIFF
--- a/dango/auth/database.py
+++ b/dango/auth/database.py
@@ -61,6 +61,9 @@ def _row_to_user(row: sqlite3.Row) -> User:
         oauth_id=row["oauth_id"],
         failed_login_attempts=row["failed_login_attempts"],
         locked_until=_datetime_from_str(row["locked_until"]),
+        metabase_user_id=row["metabase_user_id"],
+        must_change_password=_bool_from_int(row["must_change_password"]),
+        last_login=_datetime_from_str(row["last_login"]),
         created_at=_datetime_from_str(row["created_at"]),  # type: ignore[arg-type]
         updated_at=_datetime_from_str(row["updated_at"]),  # type: ignore[arg-type]
     )
@@ -77,6 +80,8 @@ def _row_to_session(row: sqlite3.Row) -> Session:
         created_at=_datetime_from_str(row["created_at"]),  # type: ignore[arg-type]
         expires_at=_datetime_from_str(row["expires_at"]),  # type: ignore[arg-type]
         last_activity=_datetime_from_str(row["last_activity"]),  # type: ignore[arg-type]
+        ip_address=row["ip_address"],
+        user_agent=row["user_agent"],
     )
 
 
@@ -87,6 +92,7 @@ def _row_to_api_key(row: sqlite3.Row) -> APIKey:
         user_id=row["user_id"],
         name=row["name"],
         key_hash=row["key_hash"],
+        key_prefix=row["key_prefix"],
         is_active=_bool_from_int(row["is_active"]),
         created_at=_datetime_from_str(row["created_at"]),  # type: ignore[arg-type]
         last_used_at=_datetime_from_str(row["last_used_at"]),
@@ -116,8 +122,9 @@ def create_user(db_path: Path, user: User) -> User:
                 id, email, password_hash, role, is_active,
                 totp_secret, totp_enabled, recovery_codes,
                 oauth_provider, oauth_id, failed_login_attempts, locked_until,
+                metabase_user_id, must_change_password, last_login,
                 created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 user.id,
@@ -132,6 +139,9 @@ def create_user(db_path: Path, user: User) -> User:
                 user.oauth_id,
                 user.failed_login_attempts,
                 _dt_to_str(user.locked_until),
+                user.metabase_user_id,
+                int(user.must_change_password),
+                _dt_to_str(user.last_login),
                 user.created_at.isoformat(),
                 user.updated_at.isoformat(),
             ),
@@ -283,8 +293,9 @@ def create_session(db_path: Path, session: Session) -> Session:
             """
             INSERT INTO sessions (
                 id, user_id, token_hash, is_active, is_partial,
-                created_at, expires_at, last_activity
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                created_at, expires_at, last_activity,
+                ip_address, user_agent
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -295,6 +306,8 @@ def create_session(db_path: Path, session: Session) -> Session:
                 session.created_at.isoformat(),
                 session.expires_at.isoformat(),
                 session.last_activity.isoformat(),
+                session.ip_address,
+                session.user_agent,
             ),
         )
         conn.commit()
@@ -396,15 +409,16 @@ def create_api_key(db_path: Path, api_key: APIKey) -> APIKey:
         conn.execute(
             """
             INSERT INTO api_keys (
-                id, user_id, name, key_hash, is_active,
+                id, user_id, name, key_hash, key_prefix, is_active,
                 created_at, last_used_at, expires_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 api_key.id,
                 api_key.user_id,
                 api_key.name,
                 api_key.key_hash,
+                api_key.key_prefix,
                 int(api_key.is_active),
                 api_key.created_at.isoformat(),
                 _dt_to_str(api_key.last_used_at),

--- a/dango/auth/models.py
+++ b/dango/auth/models.py
@@ -40,6 +40,9 @@ class User(BaseModel):
     oauth_id: str | None = None
     failed_login_attempts: int = 0
     locked_until: datetime | None = None
+    metabase_user_id: int | None = None
+    must_change_password: bool = False
+    last_login: datetime | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -89,6 +92,9 @@ class UserUpdate(BaseModel):
     oauth_id: str | None = None
     failed_login_attempts: int | None = None
     locked_until: datetime | None = None
+    metabase_user_id: int | None = None
+    must_change_password: bool | None = None
+    last_login: datetime | None = None
 
     @field_validator("email", mode="before")
     @classmethod
@@ -112,6 +118,8 @@ class UserResponse(BaseModel):
     oauth_provider: str | None = None
     failed_login_attempts: int = 0
     locked_until: datetime | None = None
+    must_change_password: bool = False
+    last_login: datetime | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -129,6 +137,8 @@ class Session(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime
     last_activity: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    ip_address: str | None = None
+    user_agent: str | None = None
 
 
 class APIKey(BaseModel):
@@ -140,6 +150,7 @@ class APIKey(BaseModel):
     user_id: str
     name: str
     key_hash: str
+    key_prefix: str = ""
     is_active: bool = True
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_used_at: datetime | None = None

--- a/dango/migrations/auth/002_complete_auth_schema.py
+++ b/dango/migrations/auth/002_complete_auth_schema.py
@@ -1,0 +1,25 @@
+"""dango/migrations/auth/002_complete_auth_schema.py
+
+Add deferred fields: metabase_user_id, must_change_password, last_login,
+ip_address, user_agent, key_prefix.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+VERSION = 2
+DESCRIPTION = "Add deferred auth schema fields"
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Add deferred fields to users, sessions, and api_keys tables."""
+    # Users table
+    conn.execute("ALTER TABLE users ADD COLUMN metabase_user_id INTEGER")
+    conn.execute("ALTER TABLE users ADD COLUMN must_change_password INTEGER NOT NULL DEFAULT 0")
+    conn.execute("ALTER TABLE users ADD COLUMN last_login TEXT")
+    # Sessions table
+    conn.execute("ALTER TABLE sessions ADD COLUMN ip_address TEXT")
+    conn.execute("ALTER TABLE sessions ADD COLUMN user_agent TEXT")
+    # API keys table
+    conn.execute("ALTER TABLE api_keys ADD COLUMN key_prefix TEXT NOT NULL DEFAULT ''")

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -120,6 +120,12 @@ exemptions:
 # Removed: dango/platform/network.py — now 486 lines, within limit (TASK-088)
 
   # --- Test files (verbose by nature — each test class covers one public function) ---
+  - file: tests/unit/test_auth_database.py
+    lines: 520
+    category: exempt
+    reason: "At limit from TASK-010; TASK-099 adds 6-field round-trip tests. TEST-002 will split into multiple files."
+    review_by: "v1.0"
+
   - file: tests/unit/test_oauth_validation.py
     lines: 580
     category: exempt

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -121,7 +121,7 @@ exemptions:
 
   # --- Test files (verbose by nature — each test class covers one public function) ---
   - file: tests/unit/test_auth_database.py
-    lines: 520
+    lines: 546
     category: exempt
     reason: "At limit from TASK-010; TASK-099 adds 6-field round-trip tests. TEST-002 will split into multiple files."
     review_by: "v1.0"

--- a/tests/unit/test_auth_database.py
+++ b/tests/unit/test_auth_database.py
@@ -96,6 +96,9 @@ class TestCreateUser:
             oauth_id="g-123",
             failed_login_attempts=5,
             locked_until=now,
+            metabase_user_id=42,
+            must_change_password=True,
+            last_login=now,
         )
         create_user(db, user)
         fetched = get_user_by_id(db, user.id)
@@ -109,6 +112,9 @@ class TestCreateUser:
         assert fetched.oauth_id == "g-123"
         assert fetched.failed_login_attempts == 5
         assert fetched.locked_until is not None
+        assert fetched.metabase_user_id == 42
+        assert fetched.must_change_password is True
+        assert fetched.last_login is not None
 
     def test_wal_mode_enabled(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)
@@ -438,6 +444,22 @@ class TestSessionCRUD:
         assert get_session_by_token(db, "expired") is None
         assert get_session_by_token(db, "valid") is not None
 
+    def test_session_with_metadata(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        session = self._make_session(
+            user.id,
+            token_hash="meta1",
+            ip_address="10.0.0.1",
+            user_agent="TestAgent/1.0",
+        )
+        create_session(db, session)
+        fetched = get_session_by_token(db, "meta1")
+        assert fetched is not None
+        assert fetched.ip_address == "10.0.0.1"
+        assert fetched.user_agent == "TestAgent/1.0"
+
 
 @pytest.mark.unit
 class TestAPIKeyCRUD:
@@ -498,3 +520,13 @@ class TestAPIKeyCRUD:
         fetched = get_api_key_by_hash(db, key.key_hash)
         assert fetched is not None
         assert fetched.is_active is False
+
+    def test_api_key_with_prefix(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        key = self._make_api_key(user.id, key_hash="pfx1", key_prefix="dango_ak_abc12")
+        create_api_key(db, key)
+        fetched = get_api_key_by_hash(db, "pfx1")
+        assert fetched is not None
+        assert fetched.key_prefix == "dango_ak_abc12"

--- a/tests/unit/test_auth_database.py
+++ b/tests/unit/test_auth_database.py
@@ -268,6 +268,20 @@ class TestUpdateUser:
         # Compare with second precision (isoformat round-trip may lose microseconds)
         assert abs((updated.locked_until - lock_time).total_seconds()) < 1
 
+    def test_update_new_schema_fields(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        now = datetime.now(timezone.utc)
+        updated = update_user(
+            db,
+            user.id,
+            UserUpdate(metabase_user_id=7, must_change_password=True, last_login=now),
+        )
+        assert updated.metabase_user_id == 7
+        assert updated.must_change_password is True
+        assert updated.last_login is not None
+
     def test_clear_locked_until_to_none(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)
         lock_time = datetime.now(timezone.utc) + timedelta(minutes=15)

--- a/tests/unit/test_auth_models.py
+++ b/tests/unit/test_auth_models.py
@@ -53,6 +53,9 @@ class TestUser:
         assert user.oauth_id is None
         assert user.failed_login_attempts == 0
         assert user.locked_until is None
+        assert user.metabase_user_id is None
+        assert user.must_change_password is False
+        assert user.last_login is None
         assert isinstance(user.created_at, datetime)
         assert isinstance(user.updated_at, datetime)
 
@@ -80,6 +83,9 @@ class TestUser:
             oauth_id="google-123",
             failed_login_attempts=3,
             locked_until=now,
+            metabase_user_id=42,
+            must_change_password=True,
+            last_login=now,
             created_at=now,
             updated_at=now,
         )
@@ -89,6 +95,9 @@ class TestUser:
         assert user.is_active is False
         assert user.totp_enabled is True
         assert user.failed_login_attempts == 3
+        assert user.metabase_user_id == 42
+        assert user.must_change_password is True
+        assert user.last_login == now
 
 
 @pytest.mark.unit
@@ -171,6 +180,14 @@ class TestUserUpdate:
         assert "locked_until" in dump
         assert dump["locked_until"] is None
 
+    def test_new_schema_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        uu = UserUpdate(metabase_user_id=7, must_change_password=True, last_login=now)
+        dump = uu.model_dump(exclude_unset=True)
+        assert dump["metabase_user_id"] == 7
+        assert dump["must_change_password"] is True
+        assert dump["last_login"] == now
+
 
 @pytest.mark.unit
 class TestUserResponse:
@@ -190,6 +207,7 @@ class TestUserResponse:
         assert "totp_secret" not in fields
         assert "recovery_codes" not in fields
         assert "oauth_id" not in fields
+        assert "metabase_user_id" not in fields
 
     def test_safe_fields_present(self) -> None:
         fields = set(UserResponse.model_fields.keys())
@@ -199,6 +217,8 @@ class TestUserResponse:
         assert "is_active" in fields
         assert "totp_enabled" in fields
         assert "oauth_provider" in fields
+        assert "must_change_password" in fields
+        assert "last_login" in fields
         assert "created_at" in fields
         assert "updated_at" in fields
 
@@ -218,6 +238,20 @@ class TestSession:
         assert isinstance(session.created_at, datetime)
         assert session.expires_at == expires
         assert isinstance(session.last_activity, datetime)
+        assert session.ip_address is None
+        assert session.user_agent is None
+
+    def test_with_ip_and_user_agent(self) -> None:
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        session = Session(
+            user_id="user-1",
+            token_hash="hash789",
+            expires_at=expires,
+            ip_address="192.168.1.1",
+            user_agent="Mozilla/5.0",
+        )
+        assert session.ip_address == "192.168.1.1"
+        assert session.user_agent == "Mozilla/5.0"
 
     def test_partial_session(self) -> None:
         expires = datetime.now(timezone.utc) + timedelta(minutes=5)
@@ -240,10 +274,20 @@ class TestAPIKey:
         assert key.user_id == "user-1"
         assert key.name == "My Key"
         assert key.key_hash == "keyhash123"
+        assert key.key_prefix == ""
         assert key.is_active is True
         assert isinstance(key.created_at, datetime)
         assert key.last_used_at is None
         assert key.expires_at is None
+
+    def test_with_key_prefix(self) -> None:
+        key = APIKey(
+            user_id="user-1",
+            name="Prefixed Key",
+            key_hash="keyhash789",
+            key_prefix="dango_ak_abc",
+        )
+        assert key.key_prefix == "dango_ak_abc"
 
     def test_with_expiry(self) -> None:
         expires = datetime.now(timezone.utc) + timedelta(days=90)


### PR DESCRIPTION
## Summary
- Adds 6 fields deferred from TASK-010 to prevent merge conflicts during Batch 2 parallelism: `metabase_user_id`, `must_change_password`, `last_login` (users), `ip_address`, `user_agent` (sessions), `key_prefix` (api_keys)
- Includes migration `002_complete_auth_schema.py`, model updates, CRUD updates, and round-trip tests for all new fields
- Adds `test_auth_database.py` to file exemptions (532 lines — TEST-002 will split)

## Test plan
- [x] All 124 auth tests pass (models + database + security)
- [x] Full test suite passes (614 tests)
- [x] mypy clean on all changed files
- [x] ruff lint + format clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)