### PR TITLE
TASK-014: Session management and API key lifecycle

### DIFF
--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -2,10 +2,11 @@
 
 User authentication and access control for Dango.
 
-Exports Pydantic models for users, sessions, and API keys, CRUD
-functions for the auth SQLite database, pure security utility
-functions (password hashing, token generation, recovery codes),
-role-based permission checking, and audit logging for security events.
+Exports Pydantic models for users, sessions, and API keys, low-level
+database CRUD, higher-level session/API key lifecycle functions (from
+``sessions.py``), pure security utility functions (password hashing,
+token generation, recovery codes), role-based permission checking,
+and audit logging for security events.
 """
 
 from __future__ import annotations
@@ -17,9 +18,6 @@ from dango.auth.audit import (
     query_audit_log,
 )
 from dango.auth.database import (
-    cleanup_expired_sessions,
-    create_api_key,
-    create_session,
     create_user,
     deactivate_user,
     delete_user,
@@ -27,12 +25,10 @@ from dango.auth.database import (
     get_session_by_token,
     get_user_by_email,
     get_user_by_id,
-    invalidate_all_user_sessions,
-    invalidate_session,
     list_user_api_keys,
     list_user_sessions,
     list_users,
-    revoke_api_key,
+    update_api_key_last_used,
     update_session_activity,
     update_user,
 )
@@ -58,6 +54,21 @@ from dango.auth.security import (
     hash_token,
     verify_password,
 )
+from dango.auth.sessions import (
+    DEFAULT_IDLE_TIMEOUT_MINUTES,
+    DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES,
+    DEFAULT_SESSION_MAX_DAYS,
+    cleanup_expired_sessions,
+    create_api_key,
+    create_session,
+    invalidate_all_sessions,
+    invalidate_session,
+    list_api_keys,
+    revoke_api_key,
+    validate_api_key,
+    validate_partial_session,
+    validate_session,
+)
 
 __all__ = [
     # Audit logging
@@ -73,7 +84,11 @@ __all__ = [
     "UserCreate",
     "UserResponse",
     "UserUpdate",
-    # User CRUD
+    # Constants
+    "DEFAULT_IDLE_TIMEOUT_MINUTES",
+    "DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES",
+    "DEFAULT_SESSION_MAX_DAYS",
+    # User CRUD (database.py)
     "create_user",
     "get_user_by_email",
     "get_user_by_id",
@@ -81,19 +96,26 @@ __all__ = [
     "update_user",
     "deactivate_user",
     "delete_user",
-    # Session CRUD
+    # Session lifecycle (sessions.py)
     "create_session",
+    "validate_session",
+    "validate_partial_session",
+    "invalidate_session",
+    "invalidate_all_sessions",
+    "cleanup_expired_sessions",
+    # Low-level session access (database.py)
     "get_session_by_token",
     "update_session_activity",
-    "invalidate_session",
-    "invalidate_all_user_sessions",
     "list_user_sessions",
-    "cleanup_expired_sessions",
-    # API key CRUD
+    # API key lifecycle (sessions.py)
     "create_api_key",
+    "validate_api_key",
+    "revoke_api_key",
+    "list_api_keys",
+    # Low-level API key access (database.py)
     "get_api_key_by_hash",
     "list_user_api_keys",
-    "revoke_api_key",
+    "update_api_key_last_used",
     # Permissions
     "PERMISSIONS",
     "ROLE_PERMISSIONS",

--- a/dango/auth/database.py
+++ b/dango/auth/database.py
@@ -470,3 +470,17 @@ def revoke_api_key(db_path: Path, key_id: str) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def update_api_key_last_used(db_path: Path, key_id: str) -> None:
+    """Update an API key's last_used_at timestamp to now."""
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE api_keys SET last_used_at = ? WHERE id = ?",
+            (now, key_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()

--- a/dango/auth/sessions.py
+++ b/dango/auth/sessions.py
@@ -134,14 +134,14 @@ def validate_session(
         db.invalidate_session(db_path, session.id)
         return None
 
-    # Sliding window — update last_activity
-    db.update_session_activity(db_path, session.id)
-
-    # Check user is active
+    # Check user is active (before updating activity timestamp —
+    # don't record "last activity" for failed auth attempts)
     user = db.get_user_by_id(db_path, session.user_id)
     if user is None or not user.is_active:
         return None
 
+    # Sliding window — update last_activity
+    db.update_session_activity(db_path, session.id)
     return user
 
 
@@ -268,14 +268,14 @@ def validate_api_key(db_path: Path, key: str) -> User | None:
     if api_key.expires_at is not None and now >= api_key.expires_at:
         return None
 
-    # Update last_used_at
-    db.update_api_key_last_used(db_path, api_key.id)
-
-    # Check user is active
+    # Check user is active (before updating last_used —
+    # don't record usage for failed auth attempts)
     user = db.get_user_by_id(db_path, api_key.user_id)
     if user is None or not user.is_active:
         return None
 
+    # Update last_used_at
+    db.update_api_key_last_used(db_path, api_key.id)
     return user
 
 

--- a/dango/auth/sessions.py
+++ b/dango/auth/sessions.py
@@ -1,0 +1,289 @@
+"""dango/auth/sessions.py
+
+Session management and API key lifecycle orchestration.
+
+Composes security utilities (token generation, hashing) with database
+CRUD to provide complete session and API key workflows.  All timeout
+policy enforcement lives here; ``database.py`` handles raw persistence
+only.
+
+Downstream consumers: auth middleware (TASK-015), CLI auth commands
+(TASK-013), unit tests (TEST-002).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from dango.auth import database as db
+from dango.auth import security
+from dango.auth.models import APIKey, Session, User
+
+# ---------------------------------------------------------------------------
+# Default timeout constants (overridable per-call)
+# ---------------------------------------------------------------------------
+
+DEFAULT_IDLE_TIMEOUT_MINUTES: int = 60
+"""Idle timeout — invalidate session after this many minutes of inactivity."""
+
+DEFAULT_SESSION_MAX_DAYS: int = 30
+"""Absolute timeout — session expires this many days after creation."""
+
+DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES: int = 5
+"""Partial session timeout — for 2FA intermediate state."""
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+
+def create_session(
+    db_path: Path,
+    user_id: str,
+    *,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
+    session_max_days: int = DEFAULT_SESSION_MAX_DAYS,
+    is_partial: bool = False,
+    partial_timeout_minutes: int = DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES,
+) -> tuple[str, Session]:
+    """Create a new session and return ``(raw_token, session)``.
+
+    The raw token is shown to the caller once (set as cookie);
+    only the SHA-256 hash is persisted in the database.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        user_id: ID of the user this session belongs to.
+        ip_address: Optional client IP address.
+        user_agent: Optional client User-Agent string.
+        session_max_days: Absolute session lifetime in days.
+        is_partial: If ``True``, creates a short-lived partial session
+            for 2FA intermediate state.
+        partial_timeout_minutes: Lifetime for partial sessions in minutes.
+
+    Returns:
+        Tuple of ``(raw_token, Session)``.
+    """
+    now = datetime.now(timezone.utc)
+    raw_token = security.generate_session_token()
+    token_hash = security.hash_token(raw_token)
+
+    if is_partial:
+        expires_at = now + timedelta(minutes=partial_timeout_minutes)
+    else:
+        expires_at = now + timedelta(days=session_max_days)
+
+    session = Session(
+        user_id=user_id,
+        token_hash=token_hash,
+        is_active=True,
+        is_partial=is_partial,
+        created_at=now,
+        expires_at=expires_at,
+        last_activity=now,
+        ip_address=ip_address,
+        user_agent=user_agent,
+    )
+    db.create_session(db_path, session)
+    return raw_token, session
+
+
+def validate_session(
+    db_path: Path,
+    token: str,
+    *,
+    idle_timeout_minutes: int = DEFAULT_IDLE_TIMEOUT_MINUTES,
+) -> User | None:
+    """Validate a session token and return the associated user.
+
+    Enforces absolute expiry, idle timeout, active status, non-partial
+    requirement, and user active status.  On success, updates the
+    session's sliding-window ``last_activity`` timestamp.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        token: Raw session token (from cookie).
+        idle_timeout_minutes: Maximum minutes of inactivity before
+            the session is considered expired.
+
+    Returns:
+        The ``User`` if the session is valid, or ``None``.
+    """
+    now = datetime.now(timezone.utc)
+    token_hash = security.hash_token(token)
+
+    session = db.get_session_by_token(db_path, token_hash)
+    if session is None:
+        return None
+    if not session.is_active:
+        return None
+    if session.is_partial:
+        return None
+
+    # Absolute timeout
+    if now >= session.expires_at:
+        db.invalidate_session(db_path, session.id)
+        return None
+
+    # Idle timeout
+    idle_delta = timedelta(minutes=idle_timeout_minutes)
+    if now - session.last_activity > idle_delta:
+        db.invalidate_session(db_path, session.id)
+        return None
+
+    # Sliding window — update last_activity
+    db.update_session_activity(db_path, session.id)
+
+    # Check user is active
+    user = db.get_user_by_id(db_path, session.user_id)
+    if user is None or not user.is_active:
+        return None
+
+    return user
+
+
+def validate_partial_session(
+    db_path: Path,
+    token: str,
+) -> User | None:
+    """Validate a partial session token (2FA intermediate state).
+
+    Unlike ``validate_session``, this *requires* ``is_partial=True``
+    and does **not** apply idle timeout or update ``last_activity``.
+    Only absolute expiry and active-status checks apply.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        token: Raw session token.
+
+    Returns:
+        The ``User`` if the partial session is valid, or ``None``.
+    """
+    now = datetime.now(timezone.utc)
+    token_hash = security.hash_token(token)
+
+    session = db.get_session_by_token(db_path, token_hash)
+    if session is None:
+        return None
+    if not session.is_active:
+        return None
+    if not session.is_partial:
+        return None
+
+    # Absolute timeout only
+    if now >= session.expires_at:
+        db.invalidate_session(db_path, session.id)
+        return None
+
+    # Check user is active
+    user = db.get_user_by_id(db_path, session.user_id)
+    if user is None or not user.is_active:
+        return None
+
+    return user
+
+
+def invalidate_session(db_path: Path, session_id: str) -> None:
+    """Mark a single session as inactive."""
+    db.invalidate_session(db_path, session_id)
+
+
+def invalidate_all_sessions(db_path: Path, user_id: str) -> int:
+    """Invalidate all active sessions for a user. Returns count."""
+    return db.invalidate_all_user_sessions(db_path, user_id)
+
+
+def cleanup_expired_sessions(db_path: Path) -> int:
+    """Delete expired sessions. Returns number of rows deleted."""
+    return db.cleanup_expired_sessions(db_path)
+
+
+# ---------------------------------------------------------------------------
+# API key lifecycle
+# ---------------------------------------------------------------------------
+
+
+def create_api_key(
+    db_path: Path,
+    user_id: str,
+    name: str,
+    *,
+    expires_at: datetime | None = None,
+) -> tuple[str, APIKey]:
+    """Create a new API key and return ``(raw_key, api_key)``.
+
+    The raw key (prefixed ``dango_ak_``) is shown to the user once;
+    only the SHA-256 hash is stored in the database.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        user_id: ID of the user this key belongs to.
+        name: Human-readable name for the key.
+        expires_at: Optional expiry datetime (``None`` = never expires).
+
+    Returns:
+        Tuple of ``(raw_key, APIKey)``.
+    """
+    raw_key, key_hash = security.generate_api_key()
+    key_prefix = security.get_key_prefix(raw_key)
+
+    api_key = APIKey(
+        user_id=user_id,
+        name=name,
+        key_hash=key_hash,
+        key_prefix=key_prefix,
+        is_active=True,
+        expires_at=expires_at,
+    )
+    db.create_api_key(db_path, api_key)
+    return raw_key, api_key
+
+
+def validate_api_key(db_path: Path, key: str) -> User | None:
+    """Validate an API key and return the associated user.
+
+    Checks active status, expiry, and user active status.  On success,
+    updates the key's ``last_used_at`` timestamp.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        key: Full API key string (including ``dango_ak_`` prefix).
+
+    Returns:
+        The ``User`` if the key is valid, or ``None``.
+    """
+    now = datetime.now(timezone.utc)
+    key_hash = security.hash_api_key(key)
+
+    api_key = db.get_api_key_by_hash(db_path, key_hash)
+    if api_key is None:
+        return None
+    if not api_key.is_active:
+        return None
+
+    # Expiry check (None = never expires)
+    if api_key.expires_at is not None and now >= api_key.expires_at:
+        return None
+
+    # Update last_used_at
+    db.update_api_key_last_used(db_path, api_key.id)
+
+    # Check user is active
+    user = db.get_user_by_id(db_path, api_key.user_id)
+    if user is None or not user.is_active:
+        return None
+
+    return user
+
+
+def revoke_api_key(db_path: Path, key_id: str) -> None:
+    """Revoke an API key (mark as inactive)."""
+    db.revoke_api_key(db_path, key_id)
+
+
+def list_api_keys(db_path: Path, user_id: str) -> list[APIKey]:
+    """List active API keys for a user."""
+    return db.list_user_api_keys(db_path, user_id, active_only=True)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -121,9 +121,9 @@ exemptions:
 
   # --- Test files (verbose by nature — each test class covers one public function) ---
   - file: tests/unit/test_auth_database.py
-    lines: 546
+    lines: 560
     category: exempt
-    reason: "At limit from TASK-010; TASK-099 adds 6-field round-trip tests. TEST-002 will split into multiple files."
+    reason: "At limit from TASK-010; TASK-014 adds update_api_key_last_used test. TEST-002 will split into multiple files."
     review_by: "v1.0"
 
   - file: tests/unit/test_oauth_validation.py

--- a/tests/unit/test_auth_api_keys.py
+++ b/tests/unit/test_auth_api_keys.py
@@ -1,0 +1,198 @@
+"""tests/unit/test_auth_api_keys.py
+
+Tests for API key lifecycle management in dango/auth/sessions.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dango.auth import database as db
+from dango.auth.models import Role, User
+from dango.auth.security import hash_api_key
+from dango.auth.sessions import (
+    create_api_key,
+    list_api_keys,
+    revoke_api_key,
+    validate_api_key,
+)
+from dango.migrations.runner import MigrationRunner
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database by running the migration."""
+    db_path = tmp_path / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(**overrides: Any) -> User:
+    """Build a User model with sensible defaults, applying overrides."""
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": "$2b$12$fakehash",
+        "role": Role.VIEWER,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _setup_user(db_path: Path, **overrides: Any) -> User:
+    """Create and persist a user, returning the model."""
+    user = _make_user(**overrides)
+    db.create_user(db_path, user)
+    return user
+
+
+@pytest.mark.unit
+class TestCreateAPIKey:
+    """Tests for create_api_key()."""
+
+    def test_returns_raw_key_and_model(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, api_key = create_api_key(db_path, user.id, "My Key")
+        assert isinstance(raw_key, str)
+        assert api_key.name == "My Key"
+        assert api_key.user_id == user.id
+
+    def test_dango_ak_prefix(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, _ = create_api_key(db_path, user.id, "Key")
+        assert raw_key.startswith("dango_ak_")
+
+    def test_hash_stored_not_raw(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, api_key = create_api_key(db_path, user.id, "Key")
+        assert api_key.key_hash == hash_api_key(raw_key)
+        assert api_key.key_hash != raw_key
+
+    def test_prefix_set(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, api_key = create_api_key(db_path, user.id, "Key")
+        assert api_key.key_prefix == raw_key[:12]
+
+    def test_with_expiry(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        exp = datetime.now(timezone.utc) + timedelta(days=90)
+        _, api_key = create_api_key(db_path, user.id, "Key", expires_at=exp)
+        assert api_key.expires_at is not None
+        assert abs((api_key.expires_at - exp).total_seconds()) < 2
+
+    def test_without_expiry(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, api_key = create_api_key(db_path, user.id, "Key")
+        assert api_key.expires_at is None
+
+
+@pytest.mark.unit
+class TestValidateAPIKey:
+    """Tests for validate_api_key()."""
+
+    def test_happy_path_returns_user(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, _ = create_api_key(db_path, user.id, "Key")
+        result = validate_api_key(db_path, raw_key)
+        assert result is not None
+        assert result.id == user.id
+
+    def test_updates_last_used(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, api_key = create_api_key(db_path, user.id, "Key")
+        assert api_key.last_used_at is None
+        validate_api_key(db_path, raw_key)
+        fetched = db.get_api_key_by_hash(db_path, api_key.key_hash)
+        assert fetched is not None
+        assert fetched.last_used_at is not None
+
+    def test_invalid_key_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        assert validate_api_key(db_path, "dango_ak_bogus") is None
+
+    def test_revoked_key_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, api_key = create_api_key(db_path, user.id, "Key")
+        revoke_api_key(db_path, api_key.id)
+        assert validate_api_key(db_path, raw_key) is None
+
+    def test_expired_key_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        raw_key, _ = create_api_key(db_path, user.id, "Key", expires_at=past)
+        assert validate_api_key(db_path, raw_key) is None
+
+    def test_no_expiry_always_valid(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, _ = create_api_key(db_path, user.id, "Key")
+        assert validate_api_key(db_path, raw_key) is not None
+
+    def test_deactivated_user_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, _ = create_api_key(db_path, user.id, "Key")
+        db.deactivate_user(db_path, user.id)
+        assert validate_api_key(db_path, raw_key) is None
+
+
+@pytest.mark.unit
+class TestRevokeAPIKey:
+    """Tests for revoke_api_key()."""
+
+    def test_revokes_target(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_key, api_key = create_api_key(db_path, user.id, "Key")
+        revoke_api_key(db_path, api_key.id)
+        assert validate_api_key(db_path, raw_key) is None
+
+    def test_others_unaffected(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, key1 = create_api_key(db_path, user.id, "Key 1")
+        raw2, _ = create_api_key(db_path, user.id, "Key 2")
+        revoke_api_key(db_path, key1.id)
+        assert validate_api_key(db_path, raw2) is not None
+
+
+@pytest.mark.unit
+class TestListAPIKeys:
+    """Tests for list_api_keys()."""
+
+    def test_lists_active(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        create_api_key(db_path, user.id, "Key 1")
+        create_api_key(db_path, user.id, "Key 2")
+        keys = list_api_keys(db_path, user.id)
+        assert len(keys) == 2
+
+    def test_excludes_revoked(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, key1 = create_api_key(db_path, user.id, "Key 1")
+        create_api_key(db_path, user.id, "Key 2")
+        revoke_api_key(db_path, key1.id)
+        keys = list_api_keys(db_path, user.id)
+        assert len(keys) == 1
+        assert keys[0].name == "Key 2"
+
+    def test_empty_for_no_keys(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        assert list_api_keys(db_path, user.id) == []

--- a/tests/unit/test_auth_database.py
+++ b/tests/unit/test_auth_database.py
@@ -29,6 +29,7 @@ from dango.auth.database import (
     list_user_sessions,
     list_users,
     revoke_api_key,
+    update_api_key_last_used,
     update_session_activity,
     update_user,
 )
@@ -544,3 +545,16 @@ class TestAPIKeyCRUD:
         fetched = get_api_key_by_hash(db, "pfx1")
         assert fetched is not None
         assert fetched.key_prefix == "dango_ak_abc12"
+
+    def test_update_last_used(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user()
+        create_user(db, user)
+        key = self._make_api_key(user.id)
+        create_api_key(db, key)
+        assert get_api_key_by_hash(db, key.key_hash) is not None
+        assert get_api_key_by_hash(db, key.key_hash).last_used_at is None  # type: ignore[union-attr]
+        update_api_key_last_used(db, key.id)
+        fetched = get_api_key_by_hash(db, key.key_hash)
+        assert fetched is not None
+        assert fetched.last_used_at is not None

--- a/tests/unit/test_auth_sessions.py
+++ b/tests/unit/test_auth_sessions.py
@@ -1,0 +1,366 @@
+"""tests/unit/test_auth_sessions.py
+
+Tests for session lifecycle management in dango/auth/sessions.py.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from dango.auth import database as db
+from dango.auth.models import Role, User
+from dango.auth.security import hash_token
+from dango.auth.sessions import (
+    DEFAULT_IDLE_TIMEOUT_MINUTES,
+    DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES,
+    DEFAULT_SESSION_MAX_DAYS,
+    cleanup_expired_sessions,
+    create_session,
+    invalidate_all_sessions,
+    invalidate_session,
+    validate_partial_session,
+    validate_session,
+)
+from dango.migrations.runner import MigrationRunner
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database by running the migration."""
+    db_path = tmp_path / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(**overrides: Any) -> User:
+    """Build a User model with sensible defaults, applying overrides."""
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": "$2b$12$fakehash",
+        "role": Role.VIEWER,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _setup_user(db_path: Path, **overrides: Any) -> User:
+    """Create and persist a user, returning the model."""
+    user = _make_user(**overrides)
+    db.create_user(db_path, user)
+    return user
+
+
+@pytest.mark.unit
+class TestCreateSession:
+    """Tests for create_session()."""
+
+    def test_returns_raw_token_and_session(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        assert isinstance(raw_token, str)
+        assert len(raw_token) > 0
+        assert session.user_id == user.id
+
+    def test_token_hash_matches(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        assert session.token_hash == hash_token(raw_token)
+
+    def test_default_expiry(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(db_path, user.id)
+        expected = session.created_at + timedelta(days=DEFAULT_SESSION_MAX_DAYS)
+        assert abs((session.expires_at - expected).total_seconds()) < 2
+
+    def test_custom_expiry(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(db_path, user.id, session_max_days=7)
+        expected = session.created_at + timedelta(days=7)
+        assert abs((session.expires_at - expected).total_seconds()) < 2
+
+    def test_ip_and_user_agent_stored(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(
+            db_path, user.id, ip_address="10.0.0.1", user_agent="TestAgent/1.0"
+        )
+        assert session.ip_address == "10.0.0.1"
+        assert session.user_agent == "TestAgent/1.0"
+
+    def test_is_active_by_default(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(db_path, user.id)
+        assert session.is_active is True
+
+    def test_partial_session_short_expiry(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(db_path, user.id, is_partial=True)
+        expected = session.created_at + timedelta(minutes=DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES)
+        assert abs((session.expires_at - expected).total_seconds()) < 2
+        assert session.is_partial is True
+
+    def test_session_persisted_in_db(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        fetched = db.get_session_by_token(db_path, hash_token(raw_token))
+        assert fetched is not None
+        assert fetched.id == session.id
+
+
+@pytest.mark.unit
+class TestValidateSession:
+    """Tests for validate_session()."""
+
+    def test_happy_path_returns_user(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, _ = create_session(db_path, user.id)
+        result = validate_session(db_path, raw_token)
+        assert result is not None
+        assert result.id == user.id
+
+    def test_sliding_window_updates_last_activity(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        original_activity = session.last_activity
+        time.sleep(0.05)
+        validate_session(db_path, raw_token)
+        fetched = db.get_session_by_token(db_path, session.token_hash)
+        assert fetched is not None
+        assert fetched.last_activity >= original_activity
+
+    def test_invalid_token_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        assert validate_session(db_path, "totally-bogus-token") is None
+
+    def test_inactive_session_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        db.invalidate_session(db_path, session.id)
+        assert validate_session(db_path, raw_token) is None
+
+    def test_partial_session_rejected(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, _ = create_session(db_path, user.id, is_partial=True)
+        assert validate_session(db_path, raw_token) is None
+
+    def test_absolute_timeout_invalidates(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        past_expiry = session.expires_at + timedelta(seconds=1)
+        with patch("dango.auth.sessions.datetime") as mock_dt:
+            mock_dt.now.return_value = past_expiry
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = validate_session(db_path, raw_token)
+        assert result is None
+        fetched = db.get_session_by_token(db_path, session.token_hash)
+        assert fetched is not None
+        assert fetched.is_active is False
+
+    def test_idle_timeout_default_invalidates(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        past_idle = session.last_activity + timedelta(minutes=DEFAULT_IDLE_TIMEOUT_MINUTES + 1)
+        with patch("dango.auth.sessions.datetime") as mock_dt:
+            mock_dt.now.return_value = past_idle
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = validate_session(db_path, raw_token)
+        assert result is None
+        fetched = db.get_session_by_token(db_path, session.token_hash)
+        assert fetched is not None
+        assert fetched.is_active is False
+
+    def test_idle_timeout_custom(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        past_idle = session.last_activity + timedelta(minutes=11)
+        with patch("dango.auth.sessions.datetime") as mock_dt:
+            mock_dt.now.return_value = past_idle
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = validate_session(db_path, raw_token, idle_timeout_minutes=10)
+        assert result is None
+
+    def test_deactivated_user_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, _ = create_session(db_path, user.id)
+        db.deactivate_user(db_path, user.id)
+        assert validate_session(db_path, raw_token) is None
+
+    def test_orphaned_session_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, _ = create_session(db_path, user.id)
+        db.delete_user(db_path, user.id)
+        assert validate_session(db_path, raw_token) is None
+
+    def test_multiple_concurrent_sessions(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        token1, _ = create_session(db_path, user.id)
+        token2, _ = create_session(db_path, user.id)
+        assert validate_session(db_path, token1) is not None
+        assert validate_session(db_path, token2) is not None
+
+    def test_within_idle_timeout_succeeds(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        within_idle = session.last_activity + timedelta(minutes=DEFAULT_IDLE_TIMEOUT_MINUTES - 1)
+        with patch("dango.auth.sessions.datetime") as mock_dt:
+            mock_dt.now.return_value = within_idle
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = validate_session(db_path, raw_token)
+        assert result is not None
+        assert result.id == user.id
+
+
+@pytest.mark.unit
+class TestValidatePartialSession:
+    """Tests for validate_partial_session()."""
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, _ = create_session(db_path, user.id, is_partial=True)
+        result = validate_partial_session(db_path, raw_token)
+        assert result is not None
+        assert result.id == user.id
+
+    def test_rejects_non_partial(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, _ = create_session(db_path, user.id, is_partial=False)
+        assert validate_partial_session(db_path, raw_token) is None
+
+    def test_expired_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id, is_partial=True)
+        past_expiry = session.expires_at + timedelta(seconds=1)
+        with patch("dango.auth.sessions.datetime") as mock_dt:
+            mock_dt.now.return_value = past_expiry
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = validate_partial_session(db_path, raw_token)
+        assert result is None
+
+    def test_inactive_returns_none(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id, is_partial=True)
+        db.invalidate_session(db_path, session.id)
+        assert validate_partial_session(db_path, raw_token) is None
+
+    def test_does_not_update_last_activity(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id, is_partial=True)
+        original = session.last_activity
+        time.sleep(0.05)
+        validate_partial_session(db_path, raw_token)
+        fetched = db.get_session_by_token(db_path, session.token_hash)
+        assert fetched is not None
+        assert abs((fetched.last_activity - original).total_seconds()) < 1
+
+
+@pytest.mark.unit
+class TestInvalidateSession:
+    """Tests for invalidate_session()."""
+
+    def test_invalidates_target(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        raw_token, session = create_session(db_path, user.id)
+        invalidate_session(db_path, session.id)
+        assert validate_session(db_path, raw_token) is None
+
+    def test_leaves_others_untouched(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        token1, session1 = create_session(db_path, user.id)
+        token2, _ = create_session(db_path, user.id)
+        invalidate_session(db_path, session1.id)
+        assert validate_session(db_path, token1) is None
+        assert validate_session(db_path, token2) is not None
+
+
+@pytest.mark.unit
+class TestInvalidateAllSessions:
+    """Tests for invalidate_all_sessions()."""
+
+    def test_invalidates_all_for_user(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        token1, _ = create_session(db_path, user.id)
+        token2, _ = create_session(db_path, user.id)
+        invalidate_all_sessions(db_path, user.id)
+        assert validate_session(db_path, token1) is None
+        assert validate_session(db_path, token2) is None
+
+    def test_returns_count(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        create_session(db_path, user.id)
+        create_session(db_path, user.id)
+        count = invalidate_all_sessions(db_path, user.id)
+        assert count == 2
+
+    def test_other_users_unaffected(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user1 = _setup_user(db_path, email="u1@example.com")
+        user2 = _setup_user(db_path, email="u2@example.com")
+        create_session(db_path, user1.id)
+        token2, _ = create_session(db_path, user2.id)
+        invalidate_all_sessions(db_path, user1.id)
+        assert validate_session(db_path, token2) is not None
+
+
+@pytest.mark.unit
+class TestCleanupExpiredSessions:
+    """Tests for cleanup_expired_sessions()."""
+
+    def test_deletes_expired(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(db_path, user.id, is_partial=True, partial_timeout_minutes=0)
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        from dango.auth.database import _connect
+
+        conn = _connect(db_path)
+        conn.execute(
+            "UPDATE sessions SET expires_at = ? WHERE id = ?",
+            (past.isoformat(), session.id),
+        )
+        conn.commit()
+        conn.close()
+        count = cleanup_expired_sessions(db_path)
+        assert count == 1
+        assert db.get_session_by_token(db_path, session.token_hash) is None
+
+    def test_keeps_active(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(db_path, user.id)
+        count = cleanup_expired_sessions(db_path)
+        assert count == 0
+        assert db.get_session_by_token(db_path, session.token_hash) is not None

--- a/tests/unit/test_auth_sessions.py
+++ b/tests/unit/test_auth_sessions.py
@@ -5,6 +5,7 @@ Tests for session lifecycle management in dango/auth/sessions.py.
 
 from __future__ import annotations
 
+import sqlite3
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -111,6 +112,13 @@ class TestCreateSession:
         expected = session.created_at + timedelta(minutes=DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES)
         assert abs((session.expires_at - expected).total_seconds()) < 2
         assert session.is_partial is True
+
+    def test_partial_session_custom_timeout(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _setup_user(db_path)
+        _, session = create_session(db_path, user.id, is_partial=True, partial_timeout_minutes=2)
+        expected = session.created_at + timedelta(minutes=2)
+        assert abs((session.expires_at - expected).total_seconds()) < 2
 
     def test_session_persisted_in_db(self, tmp_path: Path) -> None:
         db_path = _make_db(tmp_path)
@@ -344,9 +352,7 @@ class TestCleanupExpiredSessions:
         user = _setup_user(db_path)
         _, session = create_session(db_path, user.id, is_partial=True, partial_timeout_minutes=0)
         past = datetime.now(timezone.utc) - timedelta(hours=1)
-        from dango.auth.database import _connect
-
-        conn = _connect(db_path)
+        conn = sqlite3.connect(str(db_path))
         conn.execute(
             "UPDATE sessions SET expires_at = ? WHERE id = ?",
             (past.isoformat(), session.id),


### PR DESCRIPTION
## Summary
- Creates `dango/auth/sessions.py` (289 lines) — higher-level orchestration layer composing `security.py` utilities with `database.py` CRUD for complete session and API key lifecycle management
- Adds `update_api_key_last_used()` to `database.py` (+14 lines → 486 total)
- Updates `__init__.py` exports to route through `sessions.py` for higher-level ops while keeping low-level DB access available
- 50 new tests across `test_auth_sessions.py` (374 lines) and `test_auth_api_keys.py` (198 lines)

### Key functions
- **Session lifecycle:** `create_session`, `validate_session`, `validate_partial_session`, `invalidate_session`, `invalidate_all_sessions`, `cleanup_expired_sessions`
- **API key lifecycle:** `create_api_key`, `validate_api_key`, `revoke_api_key`, `list_api_keys`
- **Timeout constants:** `DEFAULT_IDLE_TIMEOUT_MINUTES` (60), `DEFAULT_SESSION_MAX_DAYS` (30), `DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES` (5)

### Design decisions
- Functions accept optional timeout parameters with defaults (config wiring deferred to TASK-015 middleware)
- Partial session support included proactively for TASK-096 (2FA)
- `validate_session` enforces: absolute expiry, idle timeout, non-partial, user active check, sliding window update
- `validate_partial_session` enforces: absolute expiry, active check — no idle timeout or sliding window

## Test plan
- [x] All 50 new tests pass (`pytest tests/unit/test_auth_sessions.py tests/unit/test_auth_api_keys.py -v`)
- [x] All 42 existing auth database tests pass (no regressions)
- [x] Full unit suite passes (657 passed)
- [x] ruff lint + format clean
- [x] mypy clean
- [x] All pre-commit hooks pass
- [x] All files under 500-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)