### PR TITLE
Add CLI auth commands, admin setup, and auth toggle (TASK-013)

### DIFF
--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -9,6 +9,14 @@ functions (password hashing, token generation, recovery codes).
 
 from __future__ import annotations
 
+from dango.auth.admin import (
+    ensure_admin,
+    format_credentials_panel,
+    get_auth_config_path,
+    get_auth_db_path,
+    is_auth_enabled,
+    set_auth_enabled,
+)
 from dango.auth.database import (
     cleanup_expired_sessions,
     create_api_key,
@@ -45,6 +53,13 @@ from dango.auth.security import (
 )
 
 __all__ = [
+    # Admin utilities
+    "ensure_admin",
+    "format_credentials_panel",
+    "get_auth_config_path",
+    "get_auth_db_path",
+    "is_auth_enabled",
+    "set_auth_enabled",
     # Models
     "APIKey",
     "Role",

--- a/dango/auth/admin.py
+++ b/dango/auth/admin.py
@@ -1,0 +1,124 @@
+"""dango/auth/admin.py
+
+Business logic for admin management and auth configuration.
+
+Provides helpers for reading/writing the auth toggle in ``.dango/auth.yml``,
+creating the first admin user on startup, and formatting credential output
+for the terminal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from rich.panel import Panel
+
+from dango.auth.database import create_user, list_users
+from dango.auth.models import Role, User
+from dango.auth.security import generate_temp_password, hash_password
+from dango.config.loader import ConfigLoader
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def get_auth_db_path(project_root: Path) -> Path:
+    """Return path to ``.dango/auth.db``."""
+    return project_root / ".dango" / "auth.db"
+
+
+def get_auth_config_path(project_root: Path) -> Path:
+    """Return path to ``.dango/auth.yml``."""
+    return project_root / ".dango" / "auth.yml"
+
+
+# ---------------------------------------------------------------------------
+# Auth toggle (reads/writes .dango/auth.yml)
+# ---------------------------------------------------------------------------
+
+
+def is_auth_enabled(project_root: Path) -> bool:
+    """Read enabled flag from ``.dango/auth.yml``.
+
+    Returns ``False`` if the file is missing or has no ``enabled`` key.
+    """
+    config_path = get_auth_config_path(project_root)
+    if not config_path.exists():
+        return False
+    loader = ConfigLoader(project_root)
+    data: dict[str, Any] = loader.load_yaml(config_path)
+    return bool(data.get("enabled", False))
+
+
+def set_auth_enabled(project_root: Path, *, enabled: bool) -> None:
+    """Write enabled flag to ``.dango/auth.yml``.
+
+    Preserves any other keys already present in the file.
+    """
+    config_path = get_auth_config_path(project_root)
+    loader = ConfigLoader(project_root)
+
+    data: dict[str, Any] = {}
+    if config_path.exists():
+        data = loader.load_yaml(config_path)
+
+    data["enabled"] = enabled
+    loader.save_yaml(data, config_path)
+
+
+# ---------------------------------------------------------------------------
+# Admin bootstrapping
+# ---------------------------------------------------------------------------
+
+
+def ensure_admin(
+    db_path: Path,
+    email: str = "admin@localhost",
+) -> tuple[User, str] | None:
+    """Create an admin user if none exists.
+
+    Returns ``(user, raw_password)`` if a new admin was created, or
+    ``None`` if an admin already exists.
+    """
+    users = list_users(db_path, active_only=True)
+    admins = [u for u in users if u.role == Role.ADMIN]
+    if admins:
+        return None
+
+    password = generate_temp_password()
+    user = User(
+        email=email,
+        password_hash=hash_password(password),
+        role=Role.ADMIN,
+        must_change_password=True,
+    )
+    create_user(db_path, user)
+    return user, password
+
+
+# ---------------------------------------------------------------------------
+# Credential display
+# ---------------------------------------------------------------------------
+
+
+def format_credentials_panel(
+    email: str,
+    password: str,
+    *,
+    title: str = "Admin account created",
+) -> Panel:
+    """Return a Rich ``Panel`` displaying credentials.
+
+    The panel is formatted for terminal output with clear instructions
+    to save the temporary password.
+    """
+    content = (
+        f"[bold]Email:[/bold]    {email}\n"
+        f"[bold]Password:[/bold] {password}\n"
+        "\n"
+        "[dim]Save this password — it will not be shown again.[/dim]\n"
+        "[dim]The user must change it on first login.[/dim]"
+    )
+    return Panel(content, title=f"[green]{title}[/green]", border_style="green")

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -15,7 +15,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
 | `commands/source.py` (521 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
 | `commands/platform.py` (955 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
-| `commands/auth.py` (~20 lines) | `auth` group placeholder (Phase 2 user management) | `auth` |
+| `commands/auth.py` (488 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
 | `commands/oauth.py` (815 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
 | `commands/transform.py` (326 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
 | `commands/data.py` (360 lines) | `db` group (`status`, `clean`) + `validate` | `db`, `validate()` |
@@ -59,7 +59,10 @@ dango (top-level group)
 │   ├── validate, show
 ├── db (group)                  ← commands/data.py
 │   ├── status, clean
-├── auth (group)                ← commands/auth.py (Phase 2 placeholder)
+├── auth (group)                ← commands/auth.py
+│   ├── enable, disable, add-user, list-users, reset-password,
+│   │   deactivate-user, reactivate-user, delete-user, status,
+│   │   unlock, audit, recover
 ├── oauth (group)               ← commands/oauth.py
 │   ├── status, setup, check, list, remove, refresh,
 │   │   facebook_ads, google_sheets, google_analytics, google_ads

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -70,7 +70,8 @@ def auth_enable(ctx: click.Context) -> None:
             print_info("Authentication is already enabled.")
             return
 
-        set_auth_enabled(project_root, enabled=True)
+        # Create admin before enabling so a failure doesn't leave auth
+        # enabled with no admin user.
         db_path = get_auth_db_path(project_root)
         if db_path.exists():
             email = click.prompt("Admin email", default="admin@localhost")
@@ -82,6 +83,7 @@ def auth_enable(ctx: click.Context) -> None:
                 console.print()
             else:
                 print_info("Admin account already exists.")
+        set_auth_enabled(project_root, enabled=True)
         print_success("Authentication enabled.")
     except click.Abort:
         raise
@@ -159,6 +161,8 @@ def auth_list_users(ctx: click.Context) -> None:
     from dango.auth.database import list_users
 
     try:
+        from datetime import datetime, timezone
+
         _, db_path = _get_db_path(ctx)
         users = list_users(db_path)
         if not users:
@@ -166,6 +170,7 @@ def auth_list_users(ctx: click.Context) -> None:
             console.print("[dim]Use 'dango auth add-user <email>' to create one.[/dim]")
             return
 
+        now = datetime.now(timezone.utc)
         table = Table(title=f"Users ({len(users)})", show_header=True)
         table.add_column("Email", style="cyan")
         table.add_column("Role", style="blue")
@@ -175,7 +180,7 @@ def auth_list_users(ctx: click.Context) -> None:
         for user in users:
             if not user.is_active:
                 status = "[red]Inactive[/red]"
-            elif user.locked_until is not None:
+            elif user.locked_until is not None and user.locked_until > now:
                 status = "[yellow]Locked[/yellow]"
             else:
                 status = "[green]Active[/green]"
@@ -347,6 +352,8 @@ def auth_status(ctx: click.Context) -> None:
     from dango.cli.utils import require_project_context
 
     try:
+        from datetime import datetime, timezone
+
         project_root = require_project_context(ctx)
         enabled = is_auth_enabled(project_root)
         lines: list[str] = []
@@ -360,12 +367,13 @@ def auth_status(ctx: click.Context) -> None:
             from dango.auth.database import list_users
             from dango.auth.models import Role
 
+            now = datetime.now(timezone.utc)
             users = list_users(db_path)
             active = [u for u in users if u.is_active]
             admins = [u for u in active if u.role == Role.ADMIN]
             editors = [u for u in active if u.role == Role.EDITOR]
             viewers = [u for u in active if u.role == Role.VIEWER]
-            locked = [u for u in users if u.locked_until is not None]
+            locked = [u for u in users if u.locked_until is not None and u.locked_until > now]
             inactive = [u for u in users if not u.is_active]
             lines.append(f"[bold]Users:[/bold] {len(active)} active")
             lines.append(

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -1,11 +1,19 @@
 """dango/cli/commands/auth.py
 
-User authentication and access management commands (Phase 2).
+User authentication and access management commands.
 
-OAuth credential management has moved to ``dango oauth``.
+Provides CLI subcommands for enabling/disabling auth, managing users
+(add, list, deactivate, reactivate, delete, reset-password, unlock),
+querying the audit log, and emergency admin recovery.
 """
 
+from __future__ import annotations
+
+from pathlib import Path
+
 import click
+
+from dango.cli import console
 
 
 @click.group()
@@ -13,8 +21,468 @@ import click
 def auth(ctx: click.Context) -> None:
     """Manage user authentication and access.
 
-    Commands for login, logout, user management, and role assignment
-    will be added in Phase 2. For OAuth credential management, use
-    ``dango oauth``.
+    Enable or disable authentication, create and manage users, reset
+    passwords, and query the audit log.  For OAuth credential management
+    (Google, Facebook, Shopify), use ``dango oauth``.
     """
-    pass
+
+
+def _get_db_path(ctx: click.Context) -> tuple[Path, Path]:
+    """Return (project_root, db_path) or abort if auth.db missing."""
+    from dango.auth.admin import get_auth_db_path
+    from dango.cli.utils import print_error, require_project_context
+
+    project_root = require_project_context(ctx)
+    db_path = get_auth_db_path(project_root)
+    if not db_path.exists():
+        print_error("Auth database not found. Run 'dango start' or 'dango migrate run' first.")
+        raise click.Abort()
+    return project_root, db_path
+
+
+def _handle_error(exc: Exception) -> None:
+    """Print error and show traceback in debug mode."""
+    console.print(f"[red]Error:[/red] {exc}")
+    from dango.exceptions import is_debug_mode
+
+    if is_debug_mode():
+        import traceback
+
+        console.print(traceback.format_exc())
+
+
+@auth.command("enable")
+@click.pass_context
+def auth_enable(ctx: click.Context) -> None:
+    """Enable authentication for this project."""
+    from dango.auth.admin import (
+        ensure_admin,
+        format_credentials_panel,
+        get_auth_db_path,
+        is_auth_enabled,
+        set_auth_enabled,
+    )
+    from dango.cli.utils import print_info, print_success, require_project_context
+
+    try:
+        project_root = require_project_context(ctx)
+        if is_auth_enabled(project_root):
+            print_info("Authentication is already enabled.")
+            return
+
+        set_auth_enabled(project_root, enabled=True)
+        db_path = get_auth_db_path(project_root)
+        if db_path.exists():
+            email = click.prompt("Admin email", default="admin@localhost")
+            result = ensure_admin(db_path, email=email)
+            if result is not None:
+                user, password = result
+                console.print()
+                console.print(format_credentials_panel(user.email, password))
+                console.print()
+            else:
+                print_info("Admin account already exists.")
+        print_success("Authentication enabled.")
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("disable")
+@click.pass_context
+def auth_disable(ctx: click.Context) -> None:
+    """Disable authentication for this project."""
+    from dango.auth.admin import is_auth_enabled, set_auth_enabled
+    from dango.cli.utils import confirm, print_info, print_warning, require_project_context
+
+    try:
+        project_root = require_project_context(ctx)
+        if not is_auth_enabled(project_root):
+            print_info("Authentication is already disabled.")
+            return
+        if not confirm("Disabling auth removes all access control. Continue?"):
+            return
+        set_auth_enabled(project_root, enabled=False)
+        print_warning("Authentication disabled. All endpoints are now public.")
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("add-user")
+@click.argument("email")
+@click.option("--role", type=click.Choice(["admin", "editor", "viewer"]), default="viewer")
+@click.pass_context
+def auth_add_user(ctx: click.Context, email: str, role: str) -> None:
+    """Create a new user with a temporary password."""
+    from dango.auth.admin import format_credentials_panel
+    from dango.auth.database import create_user
+    from dango.auth.models import Role, User
+    from dango.auth.security import generate_temp_password, hash_password
+    from dango.exceptions import UserExistsError
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        password = generate_temp_password()
+        user = User(
+            email=email,
+            password_hash=hash_password(password),
+            role=Role(role),
+            must_change_password=True,
+        )
+        create_user(db_path, user)
+        console.print()
+        console.print(format_credentials_panel(user.email, password, title="User created"))
+        console.print()
+    except click.Abort:
+        raise
+    except UserExistsError:
+        from dango.cli.utils import print_error
+
+        print_error(f"A user with email '{email.strip().lower()}' already exists.")
+        raise click.Abort() from None
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("list-users")
+@click.pass_context
+def auth_list_users(ctx: click.Context) -> None:
+    """List all users."""
+    from rich.table import Table
+
+    from dango.auth.database import list_users
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        users = list_users(db_path)
+        if not users:
+            console.print("[dim]No users found.[/dim]")
+            console.print("[dim]Use 'dango auth add-user <email>' to create one.[/dim]")
+            return
+
+        table = Table(title=f"Users ({len(users)})", show_header=True)
+        table.add_column("Email", style="cyan")
+        table.add_column("Role", style="blue")
+        table.add_column("Status")
+        table.add_column("Last Login", style="dim")
+        table.add_column("Created", style="dim")
+        for user in users:
+            if not user.is_active:
+                status = "[red]Inactive[/red]"
+            elif user.locked_until is not None:
+                status = "[yellow]Locked[/yellow]"
+            else:
+                status = "[green]Active[/green]"
+            last_login = user.last_login.strftime("%Y-%m-%d %H:%M") if user.last_login else "Never"
+            table.add_row(
+                user.email,
+                user.role.value,
+                status,
+                last_login,
+                user.created_at.strftime("%Y-%m-%d"),
+            )
+        console.print()
+        console.print(table)
+        console.print()
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("reset-password")
+@click.argument("email")
+@click.pass_context
+def auth_reset_password(ctx: click.Context, email: str) -> None:
+    """Generate a new temporary password for a user."""
+    from dango.auth.admin import format_credentials_panel
+    from dango.auth.database import get_user_by_email, invalidate_all_user_sessions, update_user
+    from dango.auth.models import UserUpdate
+    from dango.auth.security import generate_temp_password, hash_password
+    from dango.cli.utils import print_error
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        user = get_user_by_email(db_path, email)
+        if user is None:
+            print_error(f"User '{email}' not found.")
+            raise click.Abort()
+
+        password = generate_temp_password()
+        update_user(
+            db_path,
+            user.id,
+            UserUpdate(password_hash=hash_password(password), must_change_password=True),
+        )
+        invalidate_all_user_sessions(db_path, user.id)
+        console.print()
+        console.print(format_credentials_panel(user.email, password, title="Password reset"))
+        console.print()
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("deactivate-user")
+@click.argument("email")
+@click.pass_context
+def auth_deactivate_user(ctx: click.Context, email: str) -> None:
+    """Deactivate a user account (soft disable)."""
+    from dango.auth.database import (
+        deactivate_user,
+        get_user_by_email,
+        invalidate_all_user_sessions,
+        list_users,
+    )
+    from dango.auth.models import Role
+    from dango.cli.utils import print_error, print_success
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        user = get_user_by_email(db_path, email)
+        if user is None:
+            print_error(f"User '{email}' not found.")
+            raise click.Abort()
+        if user.role == Role.ADMIN:
+            active_admins = [
+                u for u in list_users(db_path, active_only=True) if u.role == Role.ADMIN
+            ]
+            if len(active_admins) <= 1:
+                print_error("Cannot deactivate the only active admin.")
+                raise click.Abort()
+        deactivate_user(db_path, user.id)
+        invalidate_all_user_sessions(db_path, user.id)
+        print_success(f"User '{user.email}' deactivated.")
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("reactivate-user")
+@click.argument("email")
+@click.pass_context
+def auth_reactivate_user(ctx: click.Context, email: str) -> None:
+    """Reactivate a deactivated user account."""
+    from dango.auth.database import get_user_by_email, update_user
+    from dango.auth.models import UserUpdate
+    from dango.cli.utils import print_error, print_info, print_success
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        user = get_user_by_email(db_path, email)
+        if user is None:
+            print_error(f"User '{email}' not found.")
+            raise click.Abort()
+        if user.is_active:
+            print_info(f"User '{user.email}' is already active.")
+            return
+        update_user(db_path, user.id, UserUpdate(is_active=True))
+        print_success(f"User '{user.email}' reactivated.")
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("delete-user")
+@click.argument("email")
+@click.pass_context
+def auth_delete_user(ctx: click.Context, email: str) -> None:
+    """Permanently delete a user (cannot be undone)."""
+    from dango.auth.database import delete_user, get_user_by_email, list_users
+    from dango.auth.models import Role
+    from dango.cli.utils import confirm, print_error, print_success, print_warning
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        user = get_user_by_email(db_path, email)
+        if user is None:
+            print_error(f"User '{email}' not found.")
+            raise click.Abort()
+        if user.role == Role.ADMIN:
+            active_admins = [
+                u for u in list_users(db_path, active_only=True) if u.role == Role.ADMIN
+            ]
+            if len(active_admins) <= 1:
+                print_error("Cannot delete the only active admin.")
+                raise click.Abort()
+        if not confirm(f"Permanently delete user '{user.email}'? This cannot be undone."):
+            return
+        try:
+            from dango.auth.metabase_sync import cleanup_metabase_user  # type: ignore[import-not-found]  # noqa: I001,E501
+
+            cleanup_metabase_user(db_path, user)
+        except ImportError:
+            pass  # TASK-018 not yet available
+        except Exception:
+            print_warning("Metabase cleanup failed (user will still be deleted).")
+        delete_user(db_path, user.id)
+        print_success(f"User '{user.email}' deleted.")
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("status")
+@click.pass_context
+def auth_status(ctx: click.Context) -> None:
+    """Show authentication status."""
+    from rich.panel import Panel
+
+    from dango.auth.admin import get_auth_db_path, is_auth_enabled
+    from dango.cli.utils import require_project_context
+
+    try:
+        project_root = require_project_context(ctx)
+        enabled = is_auth_enabled(project_root)
+        lines: list[str] = []
+        if enabled:
+            lines.append("[green]Authentication:[/green] Enabled")
+        else:
+            lines.append("[yellow]Authentication:[/yellow] Disabled")
+
+        db_path = get_auth_db_path(project_root)
+        if db_path.exists():
+            from dango.auth.database import list_users
+            from dango.auth.models import Role
+
+            users = list_users(db_path)
+            active = [u for u in users if u.is_active]
+            admins = [u for u in active if u.role == Role.ADMIN]
+            editors = [u for u in active if u.role == Role.EDITOR]
+            viewers = [u for u in active if u.role == Role.VIEWER]
+            locked = [u for u in users if u.locked_until is not None]
+            inactive = [u for u in users if not u.is_active]
+            lines.append(f"[bold]Users:[/bold] {len(active)} active")
+            lines.append(
+                f"  Admins: {len(admins)}  Editors: {len(editors)}  Viewers: {len(viewers)}"
+            )
+            if inactive:
+                lines.append(f"  [dim]Inactive: {len(inactive)}[/dim]")
+            if locked:
+                lines.append(f"  [yellow]Locked: {len(locked)}[/yellow]")
+        else:
+            lines.append("[dim]Auth database not initialized.[/dim]")
+            lines.append("[dim]Run 'dango start' or 'dango migrate run' first.[/dim]")
+        console.print()
+        console.print(Panel("\n".join(lines), title="Auth Status", border_style="blue"))
+        console.print()
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("unlock")
+@click.argument("email")
+@click.pass_context
+def auth_unlock(ctx: click.Context, email: str) -> None:
+    """Unlock a locked-out user account."""
+    from dango.auth.database import get_user_by_email, update_user
+    from dango.auth.models import UserUpdate
+    from dango.cli.utils import print_error, print_info, print_success
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        user = get_user_by_email(db_path, email)
+        if user is None:
+            print_error(f"User '{email}' not found.")
+            raise click.Abort()
+        if user.locked_until is None and user.failed_login_attempts == 0:
+            print_info(f"User '{user.email}' is not locked.")
+            return
+        update_user(
+            db_path,
+            user.id,
+            UserUpdate(failed_login_attempts=0, locked_until=None),
+        )
+        print_success(f"User '{user.email}' unlocked.")
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("audit")
+@click.option("--since", type=str, default=None, help="Filter events after date (YYYY-MM-DD).")
+@click.option("--type", "event_type", type=str, default=None, help="Filter by event type.")
+@click.option("--limit", type=int, default=50, help="Max events to show.")
+@click.pass_context
+def auth_audit(
+    ctx: click.Context,
+    since: str | None,
+    event_type: str | None,
+    limit: int,
+) -> None:
+    """Query the authentication audit log."""
+    from dango.cli.utils import print_info
+
+    try:
+        _get_db_path(ctx)  # Validate project + db exists
+        try:
+            from dango.auth.audit import query_audit_log  # type: ignore[import-not-found]
+
+            query_audit_log(since=since, event_type=event_type, limit=limit)
+        except ImportError:
+            print_info("Audit logging is not yet available (TASK-089).")
+            print_info("This command will work once the audit module is implemented.")
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("recover")
+@click.pass_context
+def auth_recover(ctx: click.Context) -> None:
+    """Create a recovery admin account (emergency use)."""
+    from dango.auth.admin import format_credentials_panel
+    from dango.auth.database import create_user
+    from dango.auth.models import Role, User
+    from dango.auth.security import generate_temp_password, hash_password
+    from dango.cli.utils import print_warning
+    from dango.exceptions import UserExistsError
+
+    try:
+        _, db_path = _get_db_path(ctx)
+        email = click.prompt("Recovery admin email", default="recovery@localhost")
+        password = generate_temp_password()
+        user = User(
+            email=email,
+            password_hash=hash_password(password),
+            role=Role.ADMIN,
+            must_change_password=True,
+        )
+        try:
+            create_user(db_path, user)
+        except UserExistsError:
+            from dango.cli.utils import print_error
+
+            print_error(f"A user with email '{email.strip().lower()}' already exists.")
+            raise click.Abort() from None
+        print_warning("Recovery admin created. Delete this account after regaining access.")
+        console.print()
+        console.print(format_credentials_panel(user.email, password, title="Recovery admin"))
+        console.print()
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -8,7 +8,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `app.py` | Entry point: `create_app()`, middleware, router registration, lifecycle events, global exception handlers (`DangoError` → structured JSON, generic `Exception` → 500) | `create_app()`, `app` (global FastAPI instance), `dango_error_handler()`, `unhandled_error_handler()` |
+| `app.py` | Entry point: `create_app()`, middleware, router registration, lifecycle events (incl. first-run admin creation), global exception handlers (`DangoError` → structured JSON, generic `Exception` → 500) | `create_app()`, `app` (global FastAPI instance), `startup_event()`, `dango_error_handler()`, `unhandled_error_handler()` |
 | `models.py` | Pydantic request/response DTOs | `TableInfo`, `SourceStatus`, `ServiceHealth`, `SyncRequest`, `SyncResponse`, `LogEntry`, `WatcherStatus` |
 | `helpers.py` | Shared helpers: DuckDB queries, config loading, service health, logging | `get_project_root()`, `load_sources_config()`, `get_duckdb_path()`, `get_dbt_models()`, `mask_sensitive_config()`, `get_source_freshness()`, `append_log_entry()`, `load_all_logs()`, `check_service_status_async()`, `get_platform_health_data()`, `get_source_status_data()` |
 | `__init__.py` | Public exports | `app` module |

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -201,7 +201,27 @@ app.include_router(metabase_proxy_router)
 @app.on_event("startup")
 async def startup_event() -> None:
     """Run on application startup."""
-    logger.info("api_starting", project_root=str(get_project_root()))
+    project_root = get_project_root()
+    logger.info("api_starting", project_root=str(project_root))
+
+    # First-run admin creation (non-interactive)
+    try:
+        import os
+
+        from dango.auth.admin import ensure_admin, format_credentials_panel, get_auth_db_path
+        from dango.cli.utils import console
+
+        db_path = get_auth_db_path(project_root)
+        if db_path.exists():
+            email = os.environ.get("DANGO_ADMIN_EMAIL", "admin@localhost")
+            result = ensure_admin(db_path, email=email)
+            if result is not None:
+                user, password = result
+                console.print()
+                console.print(format_credentials_panel(user.email, password))
+                console.print()
+    except Exception:
+        logger.warning("first_run_admin_check_failed", exc_info=True)
 
 
 @app.on_event("shutdown")

--- a/tests/unit/test_auth_admin.py
+++ b/tests/unit/test_auth_admin.py
@@ -1,0 +1,198 @@
+"""tests/unit/test_auth_admin.py
+
+Tests for admin business logic in dango/auth/admin.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dango.auth.admin import (
+    ensure_admin,
+    format_credentials_panel,
+    get_auth_config_path,
+    get_auth_db_path,
+    is_auth_enabled,
+    set_auth_enabled,
+)
+from dango.auth.models import Role, User
+from dango.migrations.runner import MigrationRunner
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database by running migrations."""
+    db_path = tmp_path / ".dango" / "auth.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(**overrides: Any) -> User:
+    """Build a User model with sensible defaults."""
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": "$2b$12$fakehash",
+        "role": Role.VIEWER,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+@pytest.mark.unit
+class TestGetAuthDbPath:
+    """Test get_auth_db_path helper."""
+
+    def test_returns_expected_path(self, tmp_path: Path) -> None:
+        result = get_auth_db_path(tmp_path)
+        assert result == tmp_path / ".dango" / "auth.db"
+
+    def test_path_is_absolute(self, tmp_path: Path) -> None:
+        result = get_auth_db_path(tmp_path)
+        assert result.is_absolute()
+
+
+@pytest.mark.unit
+class TestGetAuthConfigPath:
+    """Test get_auth_config_path helper."""
+
+    def test_returns_expected_path(self, tmp_path: Path) -> None:
+        result = get_auth_config_path(tmp_path)
+        assert result == tmp_path / ".dango" / "auth.yml"
+
+
+@pytest.mark.unit
+class TestIsAuthEnabled:
+    """Test is_auth_enabled reading auth.yml."""
+
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None:
+        assert is_auth_enabled(tmp_path) is False
+
+    def test_empty_file_returns_false(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".dango" / "auth.yml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("")
+        assert is_auth_enabled(tmp_path) is False
+
+    def test_enabled_true(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".dango" / "auth.yml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("enabled: true\n")
+        assert is_auth_enabled(tmp_path) is True
+
+    def test_enabled_false(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".dango" / "auth.yml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("enabled: false\n")
+        assert is_auth_enabled(tmp_path) is False
+
+
+@pytest.mark.unit
+class TestSetAuthEnabled:
+    """Test set_auth_enabled writing auth.yml."""
+
+    def test_creates_file(self, tmp_path: Path) -> None:
+        set_auth_enabled(tmp_path, enabled=True)
+        config_path = tmp_path / ".dango" / "auth.yml"
+        assert config_path.exists()
+        assert is_auth_enabled(tmp_path) is True
+
+    def test_updates_existing(self, tmp_path: Path) -> None:
+        set_auth_enabled(tmp_path, enabled=True)
+        assert is_auth_enabled(tmp_path) is True
+        set_auth_enabled(tmp_path, enabled=False)
+        assert is_auth_enabled(tmp_path) is False
+
+    def test_preserves_other_keys(self, tmp_path: Path) -> None:
+        import yaml
+
+        config_path = tmp_path / ".dango" / "auth.yml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("enabled: false\ncustom_key: hello\n")
+
+        set_auth_enabled(tmp_path, enabled=True)
+
+        with open(config_path) as f:
+            data: dict[str, Any] = yaml.safe_load(f)
+        assert data["enabled"] is True
+        assert data["custom_key"] == "hello"
+
+
+@pytest.mark.unit
+class TestEnsureAdmin:
+    """Test ensure_admin creating admin when needed."""
+
+    def test_creates_admin_when_none_exist(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        result = ensure_admin(db_path, email="admin@test.com")
+
+        assert result is not None
+        user, password = result
+        assert user.email == "admin@test.com"
+        assert user.role == Role.ADMIN
+        assert user.must_change_password is True
+        assert len(password) == 12
+
+    def test_skips_when_admin_exists(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        from dango.auth.database import create_user
+
+        admin = _make_user(email="existing@test.com", role=Role.ADMIN)
+        create_user(db_path, admin)
+
+        result = ensure_admin(db_path, email="new@test.com")
+        assert result is None
+
+    def test_default_email(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        result = ensure_admin(db_path)
+        assert result is not None
+        user, _ = result
+        assert user.email == "admin@localhost"
+
+    def test_email_normalized(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        result = ensure_admin(db_path, email="  Admin@Test.COM  ")
+        assert result is not None
+        user, _ = result
+        assert user.email == "admin@test.com"
+
+    def test_ignores_inactive_admins(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        from dango.auth.database import create_user, deactivate_user
+
+        admin = _make_user(email="old@test.com", role=Role.ADMIN)
+        create_user(db_path, admin)
+        deactivate_user(db_path, admin.id)
+
+        result = ensure_admin(db_path, email="new@test.com")
+        assert result is not None
+        user, _ = result
+        assert user.email == "new@test.com"
+
+
+@pytest.mark.unit
+class TestFormatCredentialsPanel:
+    """Test format_credentials_panel output."""
+
+    def test_contains_email(self) -> None:
+        panel = format_credentials_panel("user@test.com", "temppass123")
+        rendered = panel.renderable
+        assert "user@test.com" in str(rendered)
+
+    def test_contains_password(self) -> None:
+        panel = format_credentials_panel("user@test.com", "temppass123")
+        rendered = panel.renderable
+        assert "temppass123" in str(rendered)
+
+    def test_custom_title(self) -> None:
+        panel = format_credentials_panel("u@t.com", "p", title="Custom Title")
+        assert "Custom Title" in str(panel.title)
+
+    def test_default_title(self) -> None:
+        panel = format_credentials_panel("u@t.com", "p")
+        assert "Admin account created" in str(panel.title)

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -216,6 +216,37 @@ class TestAuthResetPassword:
         assert result.exit_code == 0
         assert "user@test.com" in result.output
 
+    def test_reset_changes_hash_and_invalidates_sessions(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        db_path = project_root / ".dango" / "auth.db"
+        user = _add_user(project_root, email="user@test.com")
+        old_hash = user.password_hash
+
+        # Create a session for the user
+        from datetime import datetime, timedelta, timezone
+
+        from dango.auth.database import create_session, get_user_by_email, list_user_sessions
+        from dango.auth.models import Session
+
+        session = Session(
+            user_id=user.id,
+            token_hash="fakehash123",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        create_session(db_path, session)
+        assert len(list_user_sessions(db_path, user.id)) == 1
+
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "reset-password", "user@test.com"])
+        assert result.exit_code == 0
+
+        updated = get_user_by_email(db_path, "user@test.com")
+        assert updated is not None
+        assert updated.password_hash != old_hash
+        assert updated.must_change_password is True
+        assert len(list_user_sessions(db_path, user.id, active_only=True)) == 0
+
     def test_reset_nonexistent_user(self, tmp_path: Path) -> None:
         project_root = _setup_project(tmp_path)
         runner = CliRunner()
@@ -235,6 +266,16 @@ class TestAuthDeactivateUser:
         runner = CliRunner()
         with patch("dango.cli.utils.find_project_root", return_value=project_root):
             result = runner.invoke(cli, ["auth", "deactivate-user", "user@test.com"])
+        assert result.exit_code == 0
+        assert "deactivated" in result.output.lower()
+
+    def test_deactivate_admin_when_another_exists(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="admin1@test.com", role=Role.ADMIN)
+        _add_user(project_root, email="admin2@test.com", role=Role.ADMIN)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "deactivate-user", "admin1@test.com"])
         assert result.exit_code == 0
         assert "deactivated" in result.output.lower()
 
@@ -328,6 +369,18 @@ class TestAuthDeleteUser:
 @pytest.mark.unit
 class TestAuthStatus:
     """Tests for 'dango auth status'."""
+
+    def test_status_no_db(self, tmp_path: Path) -> None:
+        """Status works when auth.db doesn't exist yet."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "project.yml").write_text("project:\n  name: test\n")
+        # No auth.db created
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=tmp_path):
+            result = runner.invoke(cli, ["auth", "status"])
+        assert result.exit_code == 0
+        assert "not initialized" in result.output.lower()
 
     def test_status_disabled(self, tmp_path: Path) -> None:
         project_root = _setup_project(tmp_path)

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -1,0 +1,418 @@
+"""tests/unit/test_cli_auth.py
+
+CLI command tests for dango/cli/commands/auth.py using CliRunner.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.auth.database import create_user
+from dango.auth.models import Role, User
+from dango.cli.main import cli
+from dango.migrations.runner import MigrationRunner
+
+
+def _setup_project(tmp_path: Path) -> Path:
+    """Create a minimal dango project with auth.db."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "project.yml").write_text("project:\n  name: test\n")
+
+    db_path = dango_dir / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return tmp_path
+
+
+def _make_user(**overrides: Any) -> User:
+    """Build a User model with sensible defaults."""
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": "$2b$12$fakehashfakehashfakehashfakehashfakehashfakehashfakeh",
+        "role": Role.VIEWER,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _add_user(tmp_path: Path, **overrides: Any) -> User:
+    """Insert a user into the project's auth.db."""
+    db_path = tmp_path / ".dango" / "auth.db"
+    user = _make_user(**overrides)
+    create_user(db_path, user)
+    return user
+
+
+@pytest.mark.unit
+class TestAuthHelp:
+    """Auth group --help shows all subcommands."""
+
+    def test_help_lists_subcommands(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["auth", "--help"])
+        assert result.exit_code == 0
+        for cmd in [
+            "enable",
+            "disable",
+            "add-user",
+            "list-users",
+            "reset-password",
+            "deactivate-user",
+            "reactivate-user",
+            "delete-user",
+            "status",
+            "unlock",
+            "audit",
+            "recover",
+        ]:
+            assert cmd in result.output, f"Subcommand '{cmd}' not in --help"
+
+
+@pytest.mark.unit
+class TestAuthEnable:
+    """Tests for 'dango auth enable'."""
+
+    def test_enable_creates_config(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "enable"], input="admin@localhost\n")
+        assert result.exit_code == 0
+        assert "enabled" in result.output.lower()
+
+    def test_enable_already_enabled(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        config_path = project_root / ".dango" / "auth.yml"
+        config_path.write_text("enabled: true\n")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "enable"])
+        assert result.exit_code == 0
+        assert "already enabled" in result.output.lower()
+
+    def test_enable_creates_admin(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "enable"], input="admin@test.com\n")
+        assert result.exit_code == 0
+        assert "admin@test.com" in result.output
+
+    def test_enable_skips_admin_if_exists(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="admin@test.com", role=Role.ADMIN)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "enable"], input="admin@localhost\n")
+        assert result.exit_code == 0
+        assert "already exists" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthDisable:
+    """Tests for 'dango auth disable'."""
+
+    def test_disable_with_confirmation(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        (project_root / ".dango" / "auth.yml").write_text("enabled: true\n")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "disable"], input="y\n")
+        assert result.exit_code == 0
+        assert "disabled" in result.output.lower()
+
+    def test_disable_already_disabled(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "disable"])
+        assert result.exit_code == 0
+        assert "already disabled" in result.output.lower()
+
+    def test_disable_aborted(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        (project_root / ".dango" / "auth.yml").write_text("enabled: true\n")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "disable"], input="n\n")
+        assert result.exit_code == 0
+        # Auth should still be enabled
+        from dango.auth.admin import is_auth_enabled
+
+        assert is_auth_enabled(project_root) is True
+
+
+@pytest.mark.unit
+class TestAuthAddUser:
+    """Tests for 'dango auth add-user'."""
+
+    def test_add_user_default_role(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "add-user", "new@test.com"])
+        assert result.exit_code == 0
+        assert "new@test.com" in result.output
+
+    def test_add_user_with_role(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "add-user", "ed@test.com", "--role", "editor"])
+        assert result.exit_code == 0
+        assert "ed@test.com" in result.output
+
+    def test_add_duplicate_user(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="dup@test.com")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "add-user", "dup@test.com"])
+        assert result.exit_code != 0
+        assert "already exists" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthListUsers:
+    """Tests for 'dango auth list-users'."""
+
+    def test_empty_list(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "list-users"])
+        assert result.exit_code == 0
+        assert "no users" in result.output.lower()
+
+    def test_list_with_users(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="alice@test.com", role=Role.ADMIN)
+        _add_user(project_root, email="bob@test.com", role=Role.VIEWER)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "list-users"])
+        assert result.exit_code == 0
+        assert "alice@test.com" in result.output
+        assert "bob@test.com" in result.output
+
+
+@pytest.mark.unit
+class TestAuthResetPassword:
+    """Tests for 'dango auth reset-password'."""
+
+    def test_reset_existing_user(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "reset-password", "user@test.com"])
+        assert result.exit_code == 0
+        assert "user@test.com" in result.output
+
+    def test_reset_nonexistent_user(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "reset-password", "gone@test.com"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthDeactivateUser:
+    """Tests for 'dango auth deactivate-user'."""
+
+    def test_deactivate_user(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com", role=Role.VIEWER)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "deactivate-user", "user@test.com"])
+        assert result.exit_code == 0
+        assert "deactivated" in result.output.lower()
+
+    def test_deactivate_last_admin_blocked(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="admin@test.com", role=Role.ADMIN)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "deactivate-user", "admin@test.com"])
+        assert result.exit_code != 0
+        assert "only active admin" in result.output.lower()
+
+    def test_deactivate_nonexistent(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "deactivate-user", "nope@test.com"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthReactivateUser:
+    """Tests for 'dango auth reactivate-user'."""
+
+    def test_reactivate_inactive_user(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        user = _add_user(project_root, email="user@test.com")
+        from dango.auth.database import deactivate_user
+
+        deactivate_user(project_root / ".dango" / "auth.db", user.id)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "reactivate-user", "user@test.com"])
+        assert result.exit_code == 0
+        assert "reactivated" in result.output.lower()
+
+    def test_reactivate_already_active(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "reactivate-user", "user@test.com"])
+        assert result.exit_code == 0
+        assert "already active" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthDeleteUser:
+    """Tests for 'dango auth delete-user'."""
+
+    def test_delete_with_confirmation(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "delete-user", "user@test.com"], input="y\n")
+        assert result.exit_code == 0
+        assert "deleted" in result.output.lower()
+
+    def test_delete_aborted(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "delete-user", "user@test.com"], input="n\n")
+        assert result.exit_code == 0
+        # User should still exist
+        from dango.auth.database import get_user_by_email
+
+        assert get_user_by_email(project_root / ".dango" / "auth.db", "user@test.com") is not None
+
+    def test_delete_last_admin_blocked(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="admin@test.com", role=Role.ADMIN)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "delete-user", "admin@test.com"], input="y\n")
+        assert result.exit_code != 0
+        assert "only active admin" in result.output.lower()
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "delete-user", "nope@test.com"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthStatus:
+    """Tests for 'dango auth status'."""
+
+    def test_status_disabled(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "status"])
+        assert result.exit_code == 0
+        assert "disabled" in result.output.lower()
+
+    def test_status_enabled_with_users(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        (project_root / ".dango" / "auth.yml").write_text("enabled: true\n")
+        _add_user(project_root, email="admin@test.com", role=Role.ADMIN)
+        _add_user(project_root, email="viewer@test.com", role=Role.VIEWER)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "status"])
+        assert result.exit_code == 0
+        assert "enabled" in result.output.lower()
+        assert "2 active" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthUnlock:
+    """Tests for 'dango auth unlock'."""
+
+    def test_unlock_locked_user(self, tmp_path: Path) -> None:
+        from datetime import datetime, timezone
+
+        project_root = _setup_project(tmp_path)
+        user = _add_user(project_root, email="locked@test.com")
+        from dango.auth.database import update_user
+        from dango.auth.models import UserUpdate
+
+        update_user(
+            project_root / ".dango" / "auth.db",
+            user.id,
+            UserUpdate(failed_login_attempts=5, locked_until=datetime.now(timezone.utc)),
+        )
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "unlock", "locked@test.com"])
+        assert result.exit_code == 0
+        assert "unlocked" in result.output.lower()
+
+    def test_unlock_not_locked(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "unlock", "user@test.com"])
+        assert result.exit_code == 0
+        assert "not locked" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthRecover:
+    """Tests for 'dango auth recover'."""
+
+    def test_recover_creates_admin(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "recover"], input="recovery@test.com\n")
+        assert result.exit_code == 0
+        assert "recovery@test.com" in result.output
+
+    def test_recover_duplicate_email(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="existing@test.com")
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "recover"], input="existing@test.com\n")
+        assert result.exit_code != 0
+        assert "already exists" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestAuthAudit:
+    """Tests for 'dango auth audit'."""
+
+    def test_audit_graceful_when_module_missing(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "audit"])
+        assert result.exit_code == 0
+        assert "not yet available" in result.output.lower()

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -97,11 +97,25 @@ class TestCliCommandRegistration:
             assert cmd in result.output, f"OAuth subcommand '{cmd}' missing"
 
     def test_auth_subcommands(self) -> None:
-        """Auth group (placeholder) responds to --help."""
+        """Auth group has all expected subcommands."""
         runner = CliRunner()
         result = runner.invoke(cli, ["auth", "--help"])
         assert result.exit_code == 0
-        assert "authentication" in result.output.lower()
+        for cmd in [
+            "enable",
+            "disable",
+            "add-user",
+            "list-users",
+            "reset-password",
+            "deactivate-user",
+            "reactivate-user",
+            "delete-user",
+            "status",
+            "unlock",
+            "audit",
+            "recover",
+        ]:
+            assert cmd in result.output, f"Auth subcommand '{cmd}' missing"
 
     def test_db_subcommands(self) -> None:
         """DB group has status and clean subcommands."""


### PR DESCRIPTION
## Summary

- Implements 12 `dango auth` CLI subcommands: `enable`, `disable`, `add-user`, `list-users`, `reset-password`, `deactivate-user`, `reactivate-user`, `delete-user`, `status`, `unlock`, `audit`, `recover`
- Creates `dango/auth/admin.py` business logic module (auth config toggle via `.dango/auth.yml`, admin bootstrapping, credential panel display)
- Adds first-run admin creation to `web/app.py` startup event (non-interactive, uses `DANGO_ADMIN_EMAIL` env var)
- 62 new tests (665 total passing), mypy clean, ruff clean, all files under 500-line limit

## Test plan

- [x] `pytest tests/unit/test_auth_admin.py` — 19 tests for admin.py business logic
- [x] `pytest tests/unit/test_cli_auth.py` — 31 tests for all CLI subcommands via CliRunner
- [x] `pytest tests/unit/test_cli_commands.py` — Updated smoke test verifies all 12 subcommands in `--help`
- [x] `pytest -x` — Full suite (665 passed)
- [x] `mypy` — Clean on all modified files
- [x] `ruff check` + `ruff format --check` — Clean
- [x] `wc -l` — auth.py 488 lines, admin.py 124 lines (both under 500)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)