### PR TITLE
Add per-user Metabase session bridging (TASK-019)

### DIFF
--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -46,6 +46,12 @@ from dango.auth.lockout import (
     reset_failed_logins,
     unlock_account,
 )
+from dango.auth.metabase_bridge import (
+    bridge_metabase_login,
+    bridge_metabase_logout,
+    ensure_metabase_synced,
+    get_metabase_url,
+)
 from dango.auth.metabase_sync import (
     deactivate_metabase_user,
     decrypt_metabase_password,
@@ -152,6 +158,11 @@ __all__ = [
     "record_failed_login",
     "reset_failed_logins",
     "unlock_account",
+    # Metabase bridge (async session bridging)
+    "bridge_metabase_login",
+    "bridge_metabase_logout",
+    "ensure_metabase_synced",
+    "get_metabase_url",
     # Metabase sync
     "deactivate_metabase_user",
     "decrypt_metabase_password",

--- a/dango/auth/metabase_bridge.py
+++ b/dango/auth/metabase_bridge.py
@@ -1,0 +1,152 @@
+"""dango/auth/metabase_bridge.py
+
+Async Metabase session bridging for per-user SSO.
+
+Provides functions to create and destroy Metabase sessions using a user's
+encrypted Metabase password, and to ensure a user is synced to Metabase
+before first login.  All functions catch exceptions and return
+``None``/``False`` — Metabase being unreachable never blocks Dango auth.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+
+from dango.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10.0
+
+
+def _load_metabase_url(project_root: Path) -> str | None:
+    """Read the Metabase URL from ``.dango/metabase.yml``.
+
+    Returns ``None`` if the file is missing or the key is absent.
+    """
+    path = project_root / ".dango" / "metabase.yml"
+    if not path.exists():
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            data: dict[str, Any] = yaml.safe_load(f)
+        url = data.get("metabase_url")
+        return str(url) if url else None
+    except Exception:
+        logger.debug("Failed to load metabase URL", exc_info=True)
+        return None
+
+
+async def get_metabase_url(project_root: Path) -> str | None:
+    """Return the configured Metabase URL (async wrapper).
+
+    Reads ``.dango/metabase.yml`` via ``asyncio.to_thread`` so that the
+    blocking file I/O does not stall the event loop.
+    """
+    return await asyncio.to_thread(_load_metabase_url, project_root)
+
+
+async def bridge_metabase_login(
+    user: User,
+    project_root: Path,
+    metabase_url: str | None = None,
+) -> str | None:
+    """Create a Metabase session for *user* using their encrypted password.
+
+    Returns the Metabase session ID on success, or ``None`` if bridging
+    cannot proceed (no credentials, Metabase down, etc.).
+    """
+    try:
+        if user.metabase_password_enc is None or user.metabase_user_id is None:
+            logger.debug("Metabase bridge skip: no credentials for %s", user.email)
+            return None
+
+        if metabase_url is None:
+            metabase_url = await get_metabase_url(project_root)
+        if metabase_url is None:
+            logger.debug("Metabase bridge skip: no URL configured")
+            return None
+
+        from dango.auth.metabase_sync import decrypt_metabase_password
+
+        password = decrypt_metabase_password(user.metabase_password_enc, project_root)
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                f"{metabase_url}/api/session",
+                json={"username": user.email, "password": password},
+            )
+
+        if resp.status_code == 200:
+            session_id = resp.json().get("id")
+            if isinstance(session_id, str) and session_id:
+                logger.info("Metabase bridge login for %s: %s...", user.email, session_id[:8])
+                return session_id
+
+        logger.warning(
+            "Metabase bridge login failed for %s (HTTP %s)", user.email, resp.status_code
+        )
+        return None
+
+    except Exception:
+        logger.warning("Metabase bridge login error for %s", user.email, exc_info=True)
+        return None
+
+
+async def bridge_metabase_logout(
+    session_id: str,
+    project_root: Path,
+    metabase_url: str | None = None,
+) -> bool:
+    """Invalidate a Metabase session (server-side DELETE).
+
+    Returns ``True`` if Metabase confirmed the session was deleted.
+    """
+    try:
+        if metabase_url is None:
+            metabase_url = await get_metabase_url(project_root)
+        if metabase_url is None:
+            return False
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.delete(
+                f"{metabase_url}/api/session",
+                headers={"X-Metabase-Session": session_id},
+            )
+
+        if resp.status_code in (200, 204):
+            logger.info("Metabase bridge logout: %s...", session_id[:8])
+            return True
+
+        logger.warning("Metabase bridge logout failed (HTTP %s)", resp.status_code)
+        return False
+
+    except Exception:
+        logger.warning("Metabase bridge logout error", exc_info=True)
+        return False
+
+
+async def ensure_metabase_synced(
+    db_path: Path,
+    user_id: str,
+    project_root: Path,
+    metabase_url: str,
+) -> None:
+    """Sync a Dango user to Metabase in a background thread.
+
+    Wraps the synchronous ``sync_user_to_metabase`` so it can be called
+    from async code without blocking the event loop.  Exceptions are
+    caught and logged — this function never raises.
+    """
+    try:
+        from dango.auth.metabase_sync import sync_user_to_metabase
+
+        await asyncio.to_thread(sync_user_to_metabase, db_path, user_id, project_root, metabase_url)
+    except Exception:
+        logger.warning("Metabase sync on startup failed for user %s", user_id, exc_info=True)

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -267,6 +267,19 @@ async def startup_event() -> None:
                 console.print()
                 console.print(format_credentials_panel(user.email, password))
                 console.print()
+
+                # Sync newly created admin to Metabase (if Metabase is running)
+                try:
+                    from dango.auth.metabase_bridge import (
+                        ensure_metabase_synced,
+                        get_metabase_url,
+                    )
+
+                    mb_url = await get_metabase_url(project_root)
+                    if mb_url is not None:
+                        await ensure_metabase_synced(db_path, user.id, project_root, mb_url)
+                except Exception:
+                    logger.debug("metabase_sync_on_admin_create_skipped", exc_info=True)
     except Exception:
         logger.warning("first_run_admin_check_failed", exc_info=True)
 

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -210,6 +210,27 @@ async def login(request: Request) -> JSONResponse:
         }
     )
     _set_session_cookie(response, raw_token, request)
+
+    # Bridge Metabase session — re-read user for fresh metabase fields
+    try:
+        from dango.auth.metabase_bridge import bridge_metabase_login
+
+        project_root: Path = request.app.state.project_root
+        fresh_user = get_user_by_email(db_path, user.email)
+        if fresh_user is not None:
+            mb_session = await bridge_metabase_login(fresh_user, project_root)
+            if mb_session is not None:
+                response.set_cookie(
+                    key="metabase.SESSION",
+                    value=mb_session,
+                    path="/",
+                    httponly=True,
+                    samesite="lax",
+                    secure=is_secure_request(request.scope),
+                )
+    except Exception:
+        logger.debug("metabase_bridge_on_login_failed", exc_info=True)
+
     return response
 
 
@@ -229,6 +250,17 @@ async def logout(request: Request) -> JSONResponse:
         session = get_session_by_token(db_path, token_hash)
         if session:
             invalidate_session(db_path, session.id)
+
+    # Invalidate Metabase session (server-side)
+    mb_session_id = request.cookies.get("metabase.SESSION")
+    if mb_session_id:
+        try:
+            from dango.auth.metabase_bridge import bridge_metabase_logout
+
+            project_root: Path = request.app.state.project_root
+            await bridge_metabase_logout(mb_session_id, project_root)
+        except Exception:
+            logger.debug("metabase_bridge_on_logout_failed", exc_info=True)
 
     log_auth_event(
         AuditEvent.LOGOUT,

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -211,23 +211,21 @@ async def login(request: Request) -> JSONResponse:
     )
     _set_session_cookie(response, raw_token, request)
 
-    # Bridge Metabase session — re-read user for fresh metabase fields
+    # Bridge Metabase session (uses user's encrypted Metabase password)
     try:
         from dango.auth.metabase_bridge import bridge_metabase_login
 
         project_root: Path = request.app.state.project_root
-        fresh_user = get_user_by_email(db_path, user.email)
-        if fresh_user is not None:
-            mb_session = await bridge_metabase_login(fresh_user, project_root)
-            if mb_session is not None:
-                response.set_cookie(
-                    key="metabase.SESSION",
-                    value=mb_session,
-                    path="/",
-                    httponly=True,
-                    samesite="lax",
-                    secure=is_secure_request(request.scope),
-                )
+        mb_session = await bridge_metabase_login(user, project_root)
+        if mb_session is not None:
+            response.set_cookie(
+                key="metabase.SESSION",
+                value=mb_session,
+                path="/",
+                httponly=True,
+                samesite="lax",
+                secure=is_secure_request(request.scope),
+            )
     except Exception:
         logger.debug("metabase_bridge_on_login_failed", exc_info=True)
 

--- a/dango/web/routes/metabase_proxy.py
+++ b/dango/web/routes/metabase_proxy.py
@@ -1,156 +1,178 @@
 """dango/web/routes/metabase_proxy.py
 
-Metabase reverse proxy routes with SSO session management.
+Metabase reverse proxy routes with per-user session bridging.
+
+Each Dango user's Metabase session cookie (``metabase.SESSION``) is stored
+on the browser.  When a proxied request receives a 401 from Metabase, the
+proxy transparently re-bridges by decrypting the user's Metabase password
+and creating a new Metabase session.
 """
 
 import logging
-from typing import Any, cast
+from pathlib import Path
+from typing import Any
 
 import httpx
 import yaml
 from fastapi import APIRouter, Request
 from fastapi.responses import Response
 
-from dango.web.helpers import get_project_root
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["metabase-proxy"])
 
-# Store Metabase session for SSO
-_metabase_session: dict[str, Any] = {}
+_MB_SESSION_COOKIE = "metabase.SESSION"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_metabase_url(project_root: Path) -> str:
+    """Read the Metabase URL from ``.dango/metabase.yml``, defaulting to localhost."""
+    path = project_root / ".dango" / "metabase.yml"
+    if path.exists():
+        try:
+            with open(path, encoding="utf-8") as f:
+                data: dict[str, Any] = yaml.safe_load(f)
+            url = data.get("metabase_url")
+            if url:
+                return str(url)
+        except Exception:
+            logger.debug("metabase_proxy_url_load_failed", exc_info=True)
+    return "http://localhost:3000"
+
+
+def _get_project_root(request: Request) -> Path:
+    """Resolve project root from app state."""
+    from dango.web.helpers import get_project_root
+
+    root: Path | None = getattr(request.app.state, "project_root", None)
+    if root is not None:
+        return root
+    return get_project_root()
+
+
+def _get_user_mb_session(request: Request) -> str | None:
+    """Extract the user's ``metabase.SESSION`` cookie from the request."""
+    return request.cookies.get(_MB_SESSION_COOKIE)
+
+
+async def _rebridge_if_needed(request: Request, metabase_url: str) -> str | None:
+    """Create a fresh Metabase session for the current user.
+
+    Called when a proxied request gets a 401 from Metabase.  Returns the
+    new Metabase session ID, or ``None`` if re-bridging fails.
+    """
+    user = getattr(request.state, "user", None)
+    if user is None:
+        return None
+    try:
+        from dango.auth.metabase_bridge import bridge_metabase_login
+
+        project_root = _get_project_root(request)
+        return await bridge_metabase_login(user, project_root, metabase_url)
+    except Exception:
+        logger.warning("metabase_rebridge_failed", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Core proxy function
+# ---------------------------------------------------------------------------
 
 
 async def proxy_to_metabase(
-    request: Request, target_path: str, session_id: str | None = None
+    request: Request,
+    target_path: str,
+    session_id: str | None = None,
+    metabase_url: str | None = None,
 ) -> Response:
-    """Proxy a request to Metabase.
+    """Proxy a request to Metabase with per-user session bridging.
 
     Args:
         request: The incoming FastAPI request
         target_path: The path to proxy to on Metabase (e.g., "/api/health")
         session_id: Optional Metabase session ID for auth
+        metabase_url: Optional Metabase base URL
 
     Returns:
         Response from Metabase
     """
-    metabase_url = "http://localhost:3000"
-    target_url = f"{metabase_url}{target_path}"
+    project_root = _get_project_root(request)
+    if metabase_url is None:
+        metabase_url = _get_metabase_url(project_root)
 
+    target_url = f"{metabase_url}{target_path}"
     if request.url.query:
         target_url += f"?{request.url.query}"
 
-    logger.debug(f"Proxying to Metabase: {request.method} {target_url}")
+    logger.debug("Proxying to Metabase: %s %s", request.method, target_url)
 
     # Prepare headers
-    headers = {}
+    headers: dict[str, str] = {}
     for key, value in request.headers.items():
-        if key.lower() not in ["host", "connection", "content-length"]:
+        if key.lower() not in ("host", "connection", "content-length"):
             headers[key] = value
 
-    # Add session cookie if provided
-    if session_id:
-        existing_cookies = headers.get("cookie", "")
-        if existing_cookies:
-            headers["cookie"] = f"{existing_cookies}; metabase.SESSION={session_id}"
-        else:
-            headers["cookie"] = f"metabase.SESSION={session_id}"
-
     # Get request body if present
-    body = None
-    if request.method in ["POST", "PUT", "PATCH"]:
+    body: bytes | None = None
+    if request.method in ("POST", "PUT", "PATCH"):
         body = await request.body()
 
-    # Make proxy request
     try:
-        async with httpx.AsyncClient(follow_redirects=False, timeout=30.0) as client:
-            proxy_response = await client.request(
-                method=request.method, url=target_url, headers=headers, content=body
-            )
+        response = await _do_proxy(target_url, request.method, headers, body, session_id)
 
-            # Build response headers
-            response_headers = {}
-            for key, value in proxy_response.headers.items():
-                if key.lower() not in ["content-encoding", "transfer-encoding", "content-length"]:
-                    response_headers[key] = value
+        # Re-bridge on 401 (session expired)
+        if response.status_code == 401 and session_id is not None:
+            new_session = await _rebridge_if_needed(request, metabase_url)
+            if new_session is not None:
+                response = await _do_proxy(target_url, request.method, headers, body, new_session)
+                if response.status_code != 401:
+                    # Attach the new session cookie to the response
+                    final = _build_response(response)
+                    final.set_cookie(key=_MB_SESSION_COOKIE, value=new_session, path="/")
+                    return final
 
-            return Response(
-                content=proxy_response.content,
-                status_code=proxy_response.status_code,
-                headers=response_headers,
-            )
+        return _build_response(response)
 
     except Exception as e:
-        logger.error(f"Metabase proxy error for {target_path}: {e}")
-        return Response(content=f"Proxy error: {str(e)}", status_code=502)
+        logger.error("Metabase proxy error for %s: %s", target_path, e)
+        return Response(content=f"Proxy error: {e}", status_code=502)
 
 
-async def get_metabase_session() -> str | None:
-    """Get or create Metabase session for auto-login.
+async def _do_proxy(
+    url: str,
+    method: str,
+    headers: dict[str, str],
+    body: bytes | None,
+    session_id: str | None,
+) -> httpx.Response:
+    """Execute the actual HTTP request to Metabase."""
+    proxy_headers = dict(headers)
+    if session_id:
+        existing_cookies = proxy_headers.get("cookie", "")
+        if existing_cookies:
+            proxy_headers["cookie"] = f"{existing_cookies}; {_MB_SESSION_COOKIE}={session_id}"
+        else:
+            proxy_headers["cookie"] = f"{_MB_SESSION_COOKIE}={session_id}"
 
-    Returns:
-        Session ID for Metabase, or None if unable to create session
-    """
-    # Return cached session if valid
-    if _metabase_session.get("id"):
-        # TODO: Check if session is still valid
-        session_id = _metabase_session["id"]
-        if isinstance(session_id, str):
-            return session_id
+    async with httpx.AsyncClient(follow_redirects=False, timeout=30.0) as client:
+        return await client.request(method=method, url=url, headers=proxy_headers, content=body)
 
-    # Load credentials
-    try:
-        project_root = get_project_root()
-        metabase_config_file = project_root / ".dango" / "metabase.yml"
 
-        if not metabase_config_file.exists():
-            logger.error("Metabase config not found")
-            return None
-
-        with open(metabase_config_file, encoding="utf-8") as f:
-            metabase_config = yaml.safe_load(f)
-
-        admin_email = metabase_config.get("admin", {}).get("email")
-        admin_password = metabase_config.get("admin", {}).get("password")
-
-        if not admin_email or not admin_password:
-            logger.error("Metabase credentials not found in config")
-            return None
-
-    except Exception as e:
-        logger.error(f"Failed to load Metabase config: {e}")
-        return None
-
-    # Create new session by logging in
-    try:
-        async with httpx.AsyncClient() as client:
-            login_response = await client.post(
-                "http://localhost:3000/api/session",
-                json={"username": admin_email, "password": admin_password},
-                timeout=10.0,
-            )
-
-            if login_response.status_code == 200:
-                session_data = login_response.json()
-                session_id = session_data.get("id")
-
-                if session_id and isinstance(session_id, str):
-                    # Cache the session
-                    _metabase_session["id"] = session_id
-                    _metabase_session["email"] = admin_email
-
-                    logger.info(f"Created Metabase session: {session_id[:8]}...")
-                    return cast(str, session_id)
-                else:
-                    logger.error("Metabase login response missing valid session ID")
-                    return None
-            else:
-                logger.error(f"Metabase login failed: {login_response.status_code}")
-                return None
-
-    except Exception as e:
-        logger.error(f"Error creating Metabase session: {e}")
-        return None
+def _build_response(proxy_response: httpx.Response) -> Response:
+    """Build a FastAPI Response from an httpx response."""
+    response_headers: dict[str, str] = {}
+    for key, value in proxy_response.headers.items():
+        if key.lower() not in ("content-encoding", "transfer-encoding", "content-length"):
+            response_headers[key] = value
+    return Response(
+        content=proxy_response.content,
+        status_code=proxy_response.status_code,
+        headers=response_headers,
+    )
 
 
 # ==============================================================================
@@ -161,7 +183,7 @@ async def get_metabase_session() -> str | None:
 @router.api_route("/api/health", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
 async def metabase_api_health(request: Request) -> Response:
     """Proxy Metabase health check API."""
-    session_id = await get_metabase_session()
+    session_id = _get_user_mb_session(request)
     return await proxy_to_metabase(request, "/api/health", session_id)
 
 
@@ -174,7 +196,7 @@ async def metabase_api_session(request: Request) -> Response:
 @router.api_route("/api/user", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
 async def metabase_api_user(request: Request) -> Response:
     """Proxy Metabase user API."""
-    session_id = await get_metabase_session()
+    session_id = _get_user_mb_session(request)
     return await proxy_to_metabase(request, "/api/user", session_id)
 
 
@@ -184,7 +206,7 @@ async def metabase_api_user(request: Request) -> Response:
 )
 async def metabase_api_database(request: Request, path: str = "") -> Response:
     """Proxy Metabase database API."""
-    session_id = await get_metabase_session()
+    session_id = _get_user_mb_session(request)
     target_path = f"/api/database/{path}" if path else "/api/database"
     return await proxy_to_metabase(request, target_path, session_id)
 
@@ -212,68 +234,16 @@ async def metabase_styles(request: Request) -> Response:
 )
 @router.api_route("/metabase", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
 async def metabase_proxy(request: Request, path: str = "") -> Response:
-    """Reverse proxy for Metabase with automatic SSO.
+    """Reverse proxy for Metabase with per-user session bridging.
 
-    Routes all requests to http://localhost:3000 and automatically
-    handles authentication by injecting session cookies.
+    Routes all requests to the configured Metabase URL and uses the
+    user's ``metabase.SESSION`` cookie for authentication.  On 401,
+    attempts to re-bridge the session transparently.
     """
-    metabase_url = "http://localhost:3000"
+    project_root = _get_project_root(request)
+    metabase_url = _get_metabase_url(project_root)
 
-    # Build target URL
-    if path:
-        target_url = f"{metabase_url}/{path}"
-    else:
-        target_url = metabase_url
+    target_path = f"/{path}" if path else "/"
+    session_id = _get_user_mb_session(request)
 
-    if request.url.query:
-        target_url += f"?{request.url.query}"
-
-    logger.info(f"Proxying: {request.method} {target_url}")
-
-    # Get or create Metabase session
-    session_id = await get_metabase_session()
-
-    # Prepare headers
-    headers = {}
-    for key, value in request.headers.items():
-        # Skip headers that should not be forwarded
-        if key.lower() not in ["host", "connection", "content-length"]:
-            headers[key] = value
-
-    # Add session cookie if we have one
-    if session_id:
-        # Add to Cookie header
-        existing_cookies = headers.get("cookie", "")
-        if existing_cookies:
-            headers["cookie"] = f"{existing_cookies}; metabase.SESSION={session_id}"
-        else:
-            headers["cookie"] = f"metabase.SESSION={session_id}"
-
-    # Get request body if present
-    body = None
-    if request.method in ["POST", "PUT", "PATCH"]:
-        body = await request.body()
-
-    # Make proxy request
-    try:
-        async with httpx.AsyncClient(follow_redirects=False, timeout=30.0) as client:
-            proxy_response = await client.request(
-                method=request.method, url=target_url, headers=headers, content=body
-            )
-
-            # Build response
-            response_headers = {}
-            for key, value in proxy_response.headers.items():
-                # Skip headers that cause issues
-                if key.lower() not in ["content-encoding", "transfer-encoding", "content-length"]:
-                    response_headers[key] = value
-
-            # Return proxy response without modification (no nav bar injection)
-            content = proxy_response.content
-            return Response(
-                content=content, status_code=proxy_response.status_code, headers=response_headers
-            )
-
-    except Exception as e:
-        logger.error(f"Proxy error: {e}")
-        return Response(content=f"Proxy error: {str(e)}", status_code=502)
+    return await proxy_to_metabase(request, target_path, session_id, metabase_url)

--- a/dango/web/routes/metabase_proxy.py
+++ b/dango/web/routes/metabase_proxy.py
@@ -17,6 +17,8 @@ import yaml
 from fastapi import APIRouter, Request
 from fastapi.responses import Response
 
+from dango.web.middleware.auth import is_secure_request
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["metabase-proxy"])
@@ -132,14 +134,21 @@ async def proxy_to_metabase(
                 if response.status_code != 401:
                     # Attach the new session cookie to the response
                     final = _build_response(response)
-                    final.set_cookie(key=_MB_SESSION_COOKIE, value=new_session, path="/")
+                    final.set_cookie(
+                        key=_MB_SESSION_COOKIE,
+                        value=new_session,
+                        path="/",
+                        httponly=True,
+                        samesite="lax",
+                        secure=is_secure_request(request.scope),
+                    )
                     return final
 
         return _build_response(response)
 
-    except Exception as e:
-        logger.error("Metabase proxy error for %s: %s", target_path, e)
-        return Response(content=f"Proxy error: {e}", status_code=502)
+    except Exception:
+        logger.error("Metabase proxy error for %s", target_path, exc_info=True)
+        return Response(content="Failed to connect to Metabase", status_code=502)
 
 
 async def _do_proxy(
@@ -152,9 +161,19 @@ async def _do_proxy(
     """Execute the actual HTTP request to Metabase."""
     proxy_headers = dict(headers)
     if session_id:
+        # Strip any existing metabase.SESSION from forwarded cookies to avoid duplicates
         existing_cookies = proxy_headers.get("cookie", "")
         if existing_cookies:
-            proxy_headers["cookie"] = f"{existing_cookies}; {_MB_SESSION_COOKIE}={session_id}"
+            parts = [
+                c.strip()
+                for c in existing_cookies.split(";")
+                if not c.strip().startswith(f"{_MB_SESSION_COOKIE}=")
+            ]
+            filtered = "; ".join(parts)
+            if filtered:
+                proxy_headers["cookie"] = f"{filtered}; {_MB_SESSION_COOKIE}={session_id}"
+            else:
+                proxy_headers["cookie"] = f"{_MB_SESSION_COOKIE}={session_id}"
         else:
             proxy_headers["cookie"] = f"{_MB_SESSION_COOKIE}={session_id}"
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -119,6 +119,13 @@ exemptions:
 
 # Removed: dango/platform/network.py — now 486 lines, within limit (TASK-088)
 
+  # --- Auth web routes (Metabase bridging hooks added by TASK-019) ---
+  - file: dango/web/routes/auth.py
+    lines: 532
+    category: refactor
+    reason: "Login/logout endpoints + API key CRUD + page routes. Grew past 500 with TASK-019 Metabase bridging hooks. Split into auth_api.py + auth_pages.py planned for TASK-095."
+    review_by: "TASK-095"
+
   # --- Test files (verbose by nature — each test class covers one public function) ---
   - file: tests/unit/test_oauth_validation.py
     lines: 580

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -121,7 +121,7 @@ exemptions:
 
   # --- Auth web routes (Metabase bridging hooks added by TASK-019) ---
   - file: dango/web/routes/auth.py
-    lines: 532
+    lines: 530
     category: refactor
     reason: "Login/logout endpoints + API key CRUD + page routes. Grew past 500 with TASK-019 Metabase bridging hooks. Split into auth_api.py + auth_pages.py planned for TASK-095."
     review_by: "TASK-095"

--- a/tests/unit/test_metabase_bridge.py
+++ b/tests/unit/test_metabase_bridge.py
@@ -1,0 +1,261 @@
+"""tests/unit/test_metabase_bridge.py
+
+Tests for async Metabase session bridging in dango/auth/metabase_bridge.py.
+All Metabase HTTP calls are mocked via ``unittest.mock.patch``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from dango.auth.metabase_bridge import (
+    _load_metabase_url,
+    bridge_metabase_login,
+    bridge_metabase_logout,
+    ensure_metabase_synced,
+    get_metabase_url,
+)
+from dango.auth.models import Role, User
+
+# Lazy imports in metabase_bridge.py mean we must patch at the origin module.
+_DECRYPT_TARGET = "dango.auth.metabase_sync.decrypt_metabase_password"
+_SYNC_TARGET = "dango.auth.metabase_sync.sync_user_to_metabase"
+_HTTPX_CLIENT = "dango.auth.metabase_bridge.httpx.AsyncClient"
+
+
+def _mb_yml(tmp_path: Path, url: str = "http://metabase:3000") -> Path:
+    """Write a minimal metabase.yml and return the project root."""
+    d = tmp_path / ".dango"
+    d.mkdir(exist_ok=True)
+    (d / "metabase.yml").write_text(
+        yaml.safe_dump({"metabase_url": url, "admin": {"email": "a@b.c", "password": "pw"}})
+    )
+    return tmp_path
+
+
+def _make_user(**kw: Any) -> User:
+    """Build a User model with Metabase fields populated."""
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": "$2b$12$fake",
+        "role": Role.EDITOR,
+        "metabase_user_id": 42,
+        "metabase_password_enc": "encrypted_blob",
+    }
+    defaults.update(kw)
+    return User(**defaults)
+
+
+def _mock_httpx_client(
+    method: str, response: MagicMock | None = None, side_effect: Exception | None = None
+) -> AsyncMock:
+    """Create a mock httpx.AsyncClient context manager."""
+    mock_client = AsyncMock()
+    if side_effect is not None:
+        setattr(mock_client, method, AsyncMock(side_effect=side_effect))
+    else:
+        setattr(mock_client, method, AsyncMock(return_value=response))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _resp(status: int = 200, data: dict[str, Any] | None = None) -> MagicMock:
+    """Build a mock httpx response."""
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = data if data is not None else {}
+    return r
+
+
+# ---------------------------------------------------------------------------
+# _load_metabase_url / get_metabase_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoadMetabaseUrl:
+    """Tests for _load_metabase_url (sync) and get_metabase_url (async)."""
+
+    def test_file_exists(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path, "http://metabase:3000")
+        assert _load_metabase_url(root) == "http://metabase:3000"
+
+    def test_file_missing(self, tmp_path: Path) -> None:
+        assert _load_metabase_url(tmp_path) is None
+
+    def test_missing_key(self, tmp_path: Path) -> None:
+        d = tmp_path / ".dango"
+        d.mkdir()
+        (d / "metabase.yml").write_text(yaml.safe_dump({"admin": {}}))
+        assert _load_metabase_url(tmp_path) is None
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        d = tmp_path / ".dango"
+        d.mkdir()
+        (d / "metabase.yml").write_text("{{invalid")
+        assert _load_metabase_url(tmp_path) is None
+
+    def test_async_wrapper(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        result = asyncio.run(get_metabase_url(root))
+        assert result == "http://metabase:3000"
+
+
+# ---------------------------------------------------------------------------
+# bridge_metabase_login
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBridgeMetabaseLogin:
+    """Tests for bridge_metabase_login."""
+
+    def _run(self, coro: Any) -> Any:
+        return asyncio.run(coro)
+
+    def test_success(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        user = _make_user()
+        mock_client = _mock_httpx_client("post", _resp(200, {"id": "sess-abc-123"}))
+
+        with (
+            patch(_DECRYPT_TARGET, return_value="mb_pw"),
+            patch(_HTTPX_CLIENT, return_value=mock_client),
+        ):
+            result = self._run(bridge_metabase_login(user, root))
+            assert result == "sess-abc-123"
+            mock_client.post.assert_called_once()
+
+    def test_no_credentials(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        user = _make_user(metabase_password_enc=None)
+        result = self._run(bridge_metabase_login(user, root))
+        assert result is None
+
+    def test_no_metabase_user_id(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        user = _make_user(metabase_user_id=None)
+        result = self._run(bridge_metabase_login(user, root))
+        assert result is None
+
+    def test_no_url(self, tmp_path: Path) -> None:
+        user = _make_user()
+        result = self._run(bridge_metabase_login(user, tmp_path))
+        assert result is None
+
+    def test_metabase_401(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        user = _make_user()
+        mock_client = _mock_httpx_client("post", _resp(401))
+
+        with (
+            patch(_DECRYPT_TARGET, return_value="pw"),
+            patch(_HTTPX_CLIENT, return_value=mock_client),
+        ):
+            result = self._run(bridge_metabase_login(user, root))
+            assert result is None
+
+    def test_network_error(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        user = _make_user()
+        mock_client = _mock_httpx_client("post", side_effect=ConnectionError("refused"))
+
+        with (
+            patch(_DECRYPT_TARGET, return_value="pw"),
+            patch(_HTTPX_CLIENT, return_value=mock_client),
+        ):
+            result = self._run(bridge_metabase_login(user, root))
+            assert result is None
+
+    def test_decrypt_error(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        user = _make_user()
+
+        with patch(_DECRYPT_TARGET, side_effect=ValueError("bad key")):
+            result = self._run(bridge_metabase_login(user, root))
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# bridge_metabase_logout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBridgeMetabaseLogout:
+    """Tests for bridge_metabase_logout."""
+
+    def _run(self, coro: Any) -> Any:
+        return asyncio.run(coro)
+
+    def test_success_204(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        mock_client = _mock_httpx_client("delete", _resp(204))
+
+        with patch(_HTTPX_CLIENT, return_value=mock_client):
+            result = self._run(bridge_metabase_logout("sess-123", root))
+            assert result is True
+
+    def test_success_200(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        mock_client = _mock_httpx_client("delete", _resp(200))
+
+        with patch(_HTTPX_CLIENT, return_value=mock_client):
+            result = self._run(bridge_metabase_logout("sess-123", root))
+            assert result is True
+
+    def test_failure_500(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        mock_client = _mock_httpx_client("delete", _resp(500))
+
+        with patch(_HTTPX_CLIENT, return_value=mock_client):
+            result = self._run(bridge_metabase_logout("sess-123", root))
+            assert result is False
+
+    def test_no_url(self, tmp_path: Path) -> None:
+        result = self._run(bridge_metabase_logout("sess-123", tmp_path))
+        assert result is False
+
+    def test_network_error(self, tmp_path: Path) -> None:
+        root = _mb_yml(tmp_path)
+        mock_client = _mock_httpx_client("delete", side_effect=ConnectionError("refused"))
+
+        with patch(_HTTPX_CLIENT, return_value=mock_client):
+            result = self._run(bridge_metabase_logout("sess-123", root))
+            assert result is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_metabase_synced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEnsureMetabaseSynced:
+    """Tests for ensure_metabase_synced."""
+
+    def _run(self, coro: Any) -> Any:
+        return asyncio.run(coro)
+
+    def test_calls_sync(self, tmp_path: Path) -> None:
+        with patch(_SYNC_TARGET) as mock_sync:
+            self._run(
+                ensure_metabase_synced(tmp_path / "auth.db", "user-1", tmp_path, "http://mb:3000")
+            )
+            mock_sync.assert_called_once_with(
+                tmp_path / "auth.db", "user-1", tmp_path, "http://mb:3000"
+            )
+
+    def test_exception_swallowed(self, tmp_path: Path) -> None:
+        with patch(_SYNC_TARGET, side_effect=RuntimeError("boom")):
+            # Should not raise
+            self._run(
+                ensure_metabase_synced(tmp_path / "auth.db", "user-1", tmp_path, "http://mb:3000")
+            )

--- a/tests/unit/test_web_metabase_proxy.py
+++ b/tests/unit/test_web_metabase_proxy.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -21,10 +22,15 @@ from dango.auth.sessions import create_session
 from dango.migrations.runner import MigrationRunner
 from dango.web.middleware.auth import COOKIE_NAME
 from dango.web.routes.auth import router as auth_router
+from dango.web.routes.metabase_proxy import router as proxy_router
 
 # Lazy imports in auth.py mean we patch at the origin module.
 _BRIDGE_LOGIN = "dango.auth.metabase_bridge.bridge_metabase_login"
 _BRIDGE_LOGOUT = "dango.auth.metabase_bridge.bridge_metabase_logout"
+# Proxy internals — patched directly on the module since they are not lazy-imported.
+_DO_PROXY = "dango.web.routes.metabase_proxy._do_proxy"
+_REBRIDGE = "dango.web.routes.metabase_proxy._rebridge_if_needed"
+_GET_MB_URL = "dango.web.routes.metabase_proxy._get_metabase_url"
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +135,7 @@ class TestLoginMetabaseBridge:
 
         assert resp.status_code == 200
         assert COOKIE_NAME in resp.cookies
+        assert "metabase.SESSION" not in resp.cookies
 
 
 # ---------------------------------------------------------------------------
@@ -196,3 +203,94 @@ class TestLogoutMetabaseBridge:
             )
 
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Proxy re-bridge on 401
+# ---------------------------------------------------------------------------
+
+
+def _httpx_response(status: int = 200, body: bytes = b"ok") -> httpx.Response:
+    """Build a minimal httpx.Response for proxy mock returns."""
+    return httpx.Response(status_code=status, content=body)
+
+
+def _make_proxy_app(tmp_path: Path) -> FastAPI:
+    """Create a FastAPI app with proxy routes and a fake authenticated user."""
+    app = FastAPI()
+    app.state.project_root = tmp_path
+
+    user = MagicMock()
+    user.email = "proxy@example.com"
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    app.include_router(proxy_router)
+    return app
+
+
+@pytest.mark.unit
+class TestProxyRebridge:
+    """Tests for the re-bridge-on-401 pattern in the Metabase proxy."""
+
+    def test_401_rebridge_retry_succeeds(self, tmp_path: Path) -> None:
+        """On 401, proxy re-bridges and retries; new cookie is set."""
+        app = _make_proxy_app(tmp_path)
+        client = TestClient(app, raise_server_exceptions=False)
+        client.cookies.set("metabase.SESSION", "old-sess")
+
+        first_resp = _httpx_response(401)
+        retry_resp = _httpx_response(200, b"dashboard data")
+
+        with (
+            patch(_DO_PROXY, new_callable=AsyncMock, side_effect=[first_resp, retry_resp]),
+            patch(_REBRIDGE, new_callable=AsyncMock, return_value="new-sess-id"),
+            patch(_GET_MB_URL, return_value="http://mb:3000"),
+        ):
+            resp = client.get("/metabase/api/card")
+
+        assert resp.status_code == 200
+        assert resp.text == "dashboard data"
+        assert "metabase.SESSION" in resp.cookies
+        assert resp.cookies["metabase.SESSION"] == "new-sess-id"
+
+    def test_401_rebridge_fails_returns_401(self, tmp_path: Path) -> None:
+        """On 401, if re-bridge fails, the original 401 is returned."""
+        app = _make_proxy_app(tmp_path)
+        client = TestClient(app, raise_server_exceptions=False)
+        client.cookies.set("metabase.SESSION", "old-sess")
+
+        first_resp = _httpx_response(401, b"Unauthorized")
+
+        with (
+            patch(_DO_PROXY, new_callable=AsyncMock, return_value=first_resp),
+            patch(_REBRIDGE, new_callable=AsyncMock, return_value=None),
+            patch(_GET_MB_URL, return_value="http://mb:3000"),
+        ):
+            resp = client.get("/metabase/api/card")
+
+        assert resp.status_code == 401
+        assert "metabase.SESSION" not in resp.cookies
+
+    def test_200_no_rebridge(self, tmp_path: Path) -> None:
+        """On 200, no re-bridge is attempted."""
+        app = _make_proxy_app(tmp_path)
+        client = TestClient(app, raise_server_exceptions=False)
+        client.cookies.set("metabase.SESSION", "valid-sess")
+
+        ok_resp = _httpx_response(200, b"ok")
+
+        with (
+            patch(_DO_PROXY, new_callable=AsyncMock, return_value=ok_resp) as mock_proxy,
+            patch(_REBRIDGE, new_callable=AsyncMock) as mock_rebridge,
+            patch(_GET_MB_URL, return_value="http://mb:3000"),
+        ):
+            resp = client.get("/metabase/api/card")
+
+        assert resp.status_code == 200
+        mock_proxy.assert_called_once()
+        mock_rebridge.assert_not_called()

--- a/tests/unit/test_web_metabase_proxy.py
+++ b/tests/unit/test_web_metabase_proxy.py
@@ -1,0 +1,198 @@
+"""tests/unit/test_web_metabase_proxy.py
+
+Tests for Metabase session bridging integration in login/logout endpoints
+and proxy re-bridge logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dango.auth import database as db
+from dango.auth.models import Role, User
+from dango.auth.security import hash_password
+from dango.auth.sessions import create_session
+from dango.migrations.runner import MigrationRunner
+from dango.web.middleware.auth import COOKIE_NAME
+from dango.web.routes.auth import router as auth_router
+
+# Lazy imports in auth.py mean we patch at the origin module.
+_BRIDGE_LOGIN = "dango.auth.metabase_bridge.bridge_metabase_login"
+_BRIDGE_LOGOUT = "dango.auth.metabase_bridge.bridge_metabase_logout"
+
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database at the standard project path."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir(exist_ok=True)
+    db_path = dango_dir / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(
+    db_path: Path,
+    email: str = "test@example.com",
+    password: str = "securepassword123",
+    role: Role = Role.EDITOR,
+    **overrides: Any,
+) -> User:
+    """Create and persist a user, returning the model."""
+    defaults: dict[str, Any] = {
+        "email": email,
+        "password_hash": hash_password(password),
+        "role": role,
+    }
+    defaults.update(overrides)
+    user = User(**defaults)
+    db.create_user(db_path, user)
+    return user
+
+
+def _make_auth_app(db_path: Path) -> FastAPI:
+    """Create a FastAPI app with auth routes."""
+    app = FastAPI()
+    app.state.project_root = db_path.parent.parent
+    app.include_router(auth_router)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Login + Metabase bridge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoginMetabaseBridge:
+    """Tests for Metabase session bridging during login."""
+
+    def test_login_bridges_metabase_session(self, tmp_path: Path) -> None:
+        """Successful login sets metabase.SESSION cookie when bridge succeeds."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path, metabase_user_id=42, metabase_password_enc="encrypted")
+        app = _make_auth_app(db_path)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch(_BRIDGE_LOGIN, new_callable=AsyncMock, return_value="mb-sess-xyz"):
+            resp = client.post(
+                "/api/auth/login",
+                json={"email": "test@example.com", "password": "securepassword123"},
+            )
+
+        assert resp.status_code == 200
+        assert COOKIE_NAME in resp.cookies
+        assert "metabase.SESSION" in resp.cookies
+        assert resp.cookies["metabase.SESSION"] == "mb-sess-xyz"
+
+    def test_login_succeeds_when_metabase_down(self, tmp_path: Path) -> None:
+        """Login succeeds even if Metabase bridge fails — no metabase cookie."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)
+        app = _make_auth_app(db_path)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch(_BRIDGE_LOGIN, new_callable=AsyncMock, return_value=None):
+            resp = client.post(
+                "/api/auth/login",
+                json={"email": "test@example.com", "password": "securepassword123"},
+            )
+
+        assert resp.status_code == 200
+        assert COOKIE_NAME in resp.cookies
+        assert "metabase.SESSION" not in resp.cookies
+
+    def test_login_succeeds_when_no_metabase_account(self, tmp_path: Path) -> None:
+        """User without Metabase credentials gets no Metabase cookie."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)  # no metabase_user_id or metabase_password_enc
+        app = _make_auth_app(db_path)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # bridge_metabase_login checks user.metabase_password_enc before calling httpx
+        resp = client.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+
+        assert resp.status_code == 200
+        assert COOKIE_NAME in resp.cookies
+
+
+# ---------------------------------------------------------------------------
+# Logout + Metabase bridge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLogoutMetabaseBridge:
+    """Tests for Metabase session teardown during logout."""
+
+    def _setup_logged_in(self, tmp_path: Path) -> tuple[TestClient, Path, User]:
+        """Return a test client with a user session pre-established."""
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        app = _make_auth_app(db_path)
+
+        @app.middleware("http")
+        async def set_user(request: Any, call_next: Any) -> Any:
+            request.state.user = user
+            request.state.auth_method = "session"
+            return await call_next(request)
+
+        raw_token, _sess = create_session(db_path, user.id)
+        client = TestClient(app, raise_server_exceptions=False)
+        client.cookies.set(COOKIE_NAME, raw_token)
+        return client, db_path, user
+
+    def test_logout_deletes_metabase_session(self, tmp_path: Path) -> None:
+        """Logout with metabase.SESSION cookie calls bridge_metabase_logout."""
+        client, db_path, user = self._setup_logged_in(tmp_path)
+        client.cookies.set("metabase.SESSION", "mb-sess-abc")
+
+        with patch(_BRIDGE_LOGOUT, new_callable=AsyncMock, return_value=True) as mock_logout:
+            resp = client.post(
+                "/api/auth/logout",
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+
+        assert resp.status_code == 200
+        mock_logout.assert_called_once()
+
+    def test_logout_without_metabase_cookie(self, tmp_path: Path) -> None:
+        """Logout without metabase.SESSION does not attempt bridge logout."""
+        client, db_path, user = self._setup_logged_in(tmp_path)
+
+        with patch(_BRIDGE_LOGOUT, new_callable=AsyncMock) as mock_logout:
+            resp = client.post(
+                "/api/auth/logout",
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+
+        assert resp.status_code == 200
+        mock_logout.assert_not_called()
+
+    def test_logout_succeeds_when_bridge_fails(self, tmp_path: Path) -> None:
+        """Logout succeeds even if Metabase session deletion fails."""
+        client, db_path, user = self._setup_logged_in(tmp_path)
+        client.cookies.set("metabase.SESSION", "mb-sess-abc")
+
+        with patch(_BRIDGE_LOGOUT, new_callable=AsyncMock, side_effect=ConnectionError("refused")):
+            resp = client.post(
+                "/api/auth/logout",
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- **New `dango/auth/metabase_bridge.py`** (152 lines): async functions for creating/destroying per-user Metabase sessions using encrypted passwords stored in auth.db
- **Refactored `metabase_proxy.py`** (279→249 lines): removed shared admin session cache + `get_metabase_session()`, replaced with per-user cookie-based sessions + transparent re-bridge on 401
- **Login endpoint**: bridges Metabase session after successful auth, sets `metabase.SESSION` cookie
- **Logout endpoint**: invalidates Metabase session server-side via DELETE before clearing cookie
- **Startup event**: syncs newly created admin user to Metabase when Metabase is available
- **25 new tests** across 2 test files (19 bridge unit + 6 login/logout integration)

## Files Changed

| File | Before | After | Action |
|------|--------|-------|--------|
| `dango/auth/metabase_bridge.py` | — | 152 | **NEW** |
| `dango/web/routes/metabase_proxy.py` | 279 | 249 | Refactored (smaller!) |
| `dango/web/routes/auth.py` | 500 | 532 | +bridging hooks |
| `dango/web/app.py` | 285 | 297 | +startup sync |
| `dango/auth/__init__.py` | 183 | 194 | +re-exports |
| `docs/file-exemptions.yml` | 138 | 145 | +auth.py exemption |
| `tests/unit/test_metabase_bridge.py` | — | 261 | **NEW** |
| `tests/unit/test_web_metabase_proxy.py` | — | 198 | **NEW** |

## Test plan

- [x] `ruff check` passes on all modified files
- [x] `ruff format --check` passes on all files
- [x] `mypy` passes on all modified source files
- [x] All 25 new tests pass
- [x] Full unit suite (943 tests) passes with no regressions
- [x] STD-003 headers on all new files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)