### PR TITLE
Add OAuth social login (Google + GitHub) (TASK-095)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ build/
 .dlt/secrets.toml
 *.pem
 *.key
+
+# Dango runtime data
+.dango/

--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -33,6 +33,7 @@ from dango.auth.database import (
     get_session_by_token,
     get_user_by_email,
     get_user_by_id,
+    get_user_by_oauth,
     list_user_api_keys,
     list_user_sessions,
     list_users,
@@ -57,6 +58,14 @@ from dango.auth.metabase_sync import (
     sync_user_to_metabase,
 )
 from dango.auth.models import APIKey, Role, Session, User, UserCreate, UserResponse, UserUpdate
+from dango.auth.oauth_login import (
+    OAuthLoginError,
+    OAuthLoginProvider,
+    OAuthUserInfo,
+    generate_oauth_state,
+    get_configured_providers,
+    get_provider,
+)
 from dango.auth.permissions import (
     PERMISSIONS,
     ROLE_PERMISSIONS,
@@ -123,6 +132,7 @@ __all__ = [
     "create_user",
     "get_user_by_email",
     "get_user_by_id",
+    "get_user_by_oauth",
     "list_users",
     "update_user",
     "deactivate_user",
@@ -168,6 +178,13 @@ __all__ = [
     "get_permissions",
     "has_permission",
     "require_permission",
+    # OAuth login
+    "OAuthLoginError",
+    "OAuthLoginProvider",
+    "OAuthUserInfo",
+    "generate_oauth_state",
+    "get_configured_providers",
+    "get_provider",
     # Security utilities
     "check_password_strength",
     "generate_api_key",

--- a/dango/auth/database.py
+++ b/dango/auth/database.py
@@ -188,6 +188,21 @@ def get_user_by_id(db_path: Path, user_id: str) -> User | None:
         conn.close()
 
 
+def get_user_by_oauth(db_path: Path, provider: str, oauth_id: str) -> User | None:
+    """Look up a user by OAuth provider and provider-assigned ID."""
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM users WHERE oauth_provider = ? AND oauth_id = ?",
+            (provider, oauth_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_user(row)
+    finally:
+        conn.close()
+
+
 def list_users(db_path: Path, *, active_only: bool = False) -> list[User]:
     """Return all users, optionally filtering to active users only."""
     conn = _connect(db_path)

--- a/dango/auth/oauth_login.py
+++ b/dango/auth/oauth_login.py
@@ -1,0 +1,297 @@
+"""dango/auth/oauth_login.py
+
+OAuth social login provider abstraction.
+
+Defines a provider interface (``OAuthLoginProvider``) and concrete
+implementations for Google and GitHub.  Route handlers in
+``web/routes/auth.py`` use these providers to drive the authorization
+code flow without knowing provider-specific details.
+"""
+
+from __future__ import annotations
+
+import secrets
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+from dango.config.models import OAuthProviderConfig
+
+_HTTP_TIMEOUT: float = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OAuthUserInfo:
+    """User identity returned by an OAuth provider after code exchange."""
+
+    provider: str
+    provider_id: str
+    email: str
+    name: str | None
+
+
+class OAuthLoginError(Exception):
+    """Raised when an OAuth login flow fails (caught by route handlers)."""
+
+
+# ---------------------------------------------------------------------------
+# Provider ABC
+# ---------------------------------------------------------------------------
+
+
+class OAuthLoginProvider(ABC):
+    """Base class for OAuth social login providers."""
+
+    name: str
+    display_name: str
+    icon_svg: str
+
+    def __init__(self, config: OAuthProviderConfig) -> None:
+        self._client_id = config.client_id
+        self._client_secret = config.client_secret
+
+    @abstractmethod
+    def get_authorization_url(self, redirect_uri: str, state: str) -> str:
+        """Build the provider's authorization URL for the redirect."""
+
+    @abstractmethod
+    async def exchange_code(self, code: str, redirect_uri: str) -> OAuthUserInfo:
+        """Exchange an authorization code for user info."""
+
+
+# ---------------------------------------------------------------------------
+# Google
+# ---------------------------------------------------------------------------
+
+# fmt: off
+_GOOGLE_ICON_SVG = (
+    '<svg viewBox="0 0 24 24" width="20" height="20">'
+    '<path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/>'
+    '<path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>'
+    '<path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>'
+    '<path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>'
+    '</svg>'
+)
+# fmt: on
+
+
+class GoogleOAuthProvider(OAuthLoginProvider):
+    """Google OAuth 2.0 login provider."""
+
+    name = "google"
+    display_name = "Google"
+    icon_svg = _GOOGLE_ICON_SVG
+
+    _AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+    _TOKEN_URL = "https://oauth2.googleapis.com/token"
+    _USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+    def get_authorization_url(self, redirect_uri: str, state: str) -> str:
+        """Build Google authorization URL."""
+        params = {
+            "client_id": self._client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": "openid email profile",
+            "state": state,
+            "access_type": "online",
+            "prompt": "select_account",
+        }
+        return f"{self._AUTH_URL}?{urlencode(params)}"
+
+    async def exchange_code(self, code: str, redirect_uri: str) -> OAuthUserInfo:
+        """Exchange Google authorization code for user info."""
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            # Exchange code for access token
+            token_resp = await client.post(
+                self._TOKEN_URL,
+                data={
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "code": code,
+                    "grant_type": "authorization_code",
+                    "redirect_uri": redirect_uri,
+                },
+            )
+            if token_resp.status_code != 200:
+                raise OAuthLoginError("Failed to exchange Google authorization code")
+
+            token_data: dict[str, Any] = token_resp.json()
+            access_token = token_data.get("access_token")
+            if not access_token:
+                raise OAuthLoginError("No access token in Google response")
+
+            # Fetch user info
+            user_resp = await client.get(
+                self._USERINFO_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if user_resp.status_code != 200:
+                raise OAuthLoginError("Failed to fetch Google user info")
+
+            user_data: dict[str, Any] = user_resp.json()
+            email = user_data.get("email")
+            if not email:
+                raise OAuthLoginError("No email in Google user info")
+
+            return OAuthUserInfo(
+                provider="google",
+                provider_id=str(user_data.get("id", "")),
+                email=email,
+                name=user_data.get("name"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# GitHub
+# ---------------------------------------------------------------------------
+
+# fmt: off
+_GITHUB_ICON_SVG = (
+    '<svg viewBox="0 0 24 24" width="20" height="20">'
+    '<path fill="currentColor" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z"/>'
+    '</svg>'
+)
+# fmt: on
+
+
+class GitHubOAuthProvider(OAuthLoginProvider):
+    """GitHub OAuth login provider."""
+
+    name = "github"
+    display_name = "GitHub"
+    icon_svg = _GITHUB_ICON_SVG
+
+    _AUTH_URL = "https://github.com/login/oauth/authorize"
+    _TOKEN_URL = "https://github.com/login/oauth/access_token"
+    _USER_URL = "https://api.github.com/user"
+    _EMAILS_URL = "https://api.github.com/user/emails"
+
+    def get_authorization_url(self, redirect_uri: str, state: str) -> str:
+        """Build GitHub authorization URL."""
+        params = {
+            "client_id": self._client_id,
+            "redirect_uri": redirect_uri,
+            "scope": "user:email",
+            "state": state,
+        }
+        return f"{self._AUTH_URL}?{urlencode(params)}"
+
+    async def exchange_code(self, code: str, redirect_uri: str) -> OAuthUserInfo:
+        """Exchange GitHub authorization code for user info."""
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            # Exchange code for access token
+            token_resp = await client.post(
+                self._TOKEN_URL,
+                data={
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                },
+                headers={"Accept": "application/json"},
+            )
+            if token_resp.status_code != 200:
+                raise OAuthLoginError("Failed to exchange GitHub authorization code")
+
+            token_data: dict[str, Any] = token_resp.json()
+            access_token = token_data.get("access_token")
+            if not access_token:
+                raise OAuthLoginError("No access token in GitHub response")
+
+            auth_headers = {"Authorization": f"Bearer {access_token}"}
+
+            # Fetch user profile
+            user_resp = await client.get(self._USER_URL, headers=auth_headers)
+            if user_resp.status_code != 200:
+                raise OAuthLoginError("Failed to fetch GitHub user info")
+
+            user_data: dict[str, Any] = user_resp.json()
+            email = user_data.get("email")
+
+            # Fallback: fetch primary verified email from /user/emails
+            if not email:
+                email = await self._fetch_primary_email(client, auth_headers)
+
+            if not email:
+                raise OAuthLoginError(
+                    "No verified email found on your GitHub account. "
+                    "Please add a verified email to GitHub and try again."
+                )
+
+            return OAuthUserInfo(
+                provider="github",
+                provider_id=str(user_data.get("id", "")),
+                email=email,
+                name=user_data.get("name") or user_data.get("login"),
+            )
+
+    async def _fetch_primary_email(
+        self,
+        client: httpx.AsyncClient,
+        headers: dict[str, str],
+    ) -> str | None:
+        """Fetch the user's primary verified email from GitHub /user/emails."""
+        resp = await client.get(self._EMAILS_URL, headers=headers)
+        if resp.status_code != 200:
+            return None
+        emails: list[dict[str, Any]] = resp.json()
+        # Find primary + verified email
+        for entry in emails:
+            if entry.get("primary") and entry.get("verified"):
+                return entry.get("email")
+        # Fallback: any verified email
+        for entry in emails:
+            if entry.get("verified"):
+                return entry.get("email")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Registry and helpers
+# ---------------------------------------------------------------------------
+
+_PROVIDERS: dict[str, type[OAuthLoginProvider]] = {
+    "google": GoogleOAuthProvider,
+    "github": GitHubOAuthProvider,
+}
+
+
+def get_provider(name: str, config: OAuthProviderConfig) -> OAuthLoginProvider:
+    """Instantiate an OAuth provider by name.
+
+    Raises:
+        OAuthLoginError: If the provider name is not recognized.
+    """
+    provider_cls = _PROVIDERS.get(name)
+    if provider_cls is None:
+        raise OAuthLoginError(f"Unknown OAuth provider: {name}")
+    return provider_cls(config)
+
+
+def get_configured_providers(
+    provider_configs: dict[str, OAuthProviderConfig],
+) -> list[OAuthLoginProvider]:
+    """Return instantiated providers for all configured entries.
+
+    Silently skips unknown provider names (logged at debug level).
+    """
+    providers: list[OAuthLoginProvider] = []
+    for name, config in provider_configs.items():
+        provider_cls = _PROVIDERS.get(name)
+        if provider_cls is not None:
+            providers.append(provider_cls(config))
+    return providers
+
+
+def generate_oauth_state() -> str:
+    """Generate a cryptographically random CSRF state token."""
+    return secrets.token_urlsafe(32)

--- a/dango/auth/oauth_login.py
+++ b/dango/auth/oauth_login.py
@@ -109,45 +109,50 @@ class GoogleOAuthProvider(OAuthLoginProvider):
 
     async def exchange_code(self, code: str, redirect_uri: str) -> OAuthUserInfo:
         """Exchange Google authorization code for user info."""
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            # Exchange code for access token
-            token_resp = await client.post(
-                self._TOKEN_URL,
-                data={
-                    "client_id": self._client_id,
-                    "client_secret": self._client_secret,
-                    "code": code,
-                    "grant_type": "authorization_code",
-                    "redirect_uri": redirect_uri,
-                },
-            )
-            if token_resp.status_code != 200:
-                raise OAuthLoginError("Failed to exchange Google authorization code")
+        try:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                # Exchange code for access token
+                token_resp = await client.post(
+                    self._TOKEN_URL,
+                    data={
+                        "client_id": self._client_id,
+                        "client_secret": self._client_secret,
+                        "code": code,
+                        "grant_type": "authorization_code",
+                        "redirect_uri": redirect_uri,
+                    },
+                )
+                if token_resp.status_code != 200:
+                    raise OAuthLoginError("Failed to exchange Google authorization code")
 
-            token_data: dict[str, Any] = token_resp.json()
-            access_token = token_data.get("access_token")
-            if not access_token:
-                raise OAuthLoginError("No access token in Google response")
+                token_data: dict[str, Any] = token_resp.json()
+                access_token = token_data.get("access_token")
+                if not access_token:
+                    raise OAuthLoginError("No access token in Google response")
 
-            # Fetch user info
-            user_resp = await client.get(
-                self._USERINFO_URL,
-                headers={"Authorization": f"Bearer {access_token}"},
-            )
-            if user_resp.status_code != 200:
-                raise OAuthLoginError("Failed to fetch Google user info")
+                # Fetch user info
+                user_resp = await client.get(
+                    self._USERINFO_URL,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                )
+                if user_resp.status_code != 200:
+                    raise OAuthLoginError("Failed to fetch Google user info")
 
-            user_data: dict[str, Any] = user_resp.json()
-            email = user_data.get("email")
-            if not email:
-                raise OAuthLoginError("No email in Google user info")
+                user_data: dict[str, Any] = user_resp.json()
+                email = user_data.get("email")
+                if not email:
+                    raise OAuthLoginError("No email in Google user info")
 
-            return OAuthUserInfo(
-                provider="google",
-                provider_id=str(user_data.get("id", "")),
-                email=email,
-                name=user_data.get("name"),
-            )
+                return OAuthUserInfo(
+                    provider="google",
+                    provider_id=str(user_data.get("id", "")),
+                    email=email,
+                    name=user_data.get("name"),
+                )
+        except OAuthLoginError:
+            raise
+        except httpx.HTTPError as exc:
+            raise OAuthLoginError("Failed to connect to Google") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -187,52 +192,57 @@ class GitHubOAuthProvider(OAuthLoginProvider):
 
     async def exchange_code(self, code: str, redirect_uri: str) -> OAuthUserInfo:
         """Exchange GitHub authorization code for user info."""
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            # Exchange code for access token
-            token_resp = await client.post(
-                self._TOKEN_URL,
-                data={
-                    "client_id": self._client_id,
-                    "client_secret": self._client_secret,
-                    "code": code,
-                    "redirect_uri": redirect_uri,
-                },
-                headers={"Accept": "application/json"},
-            )
-            if token_resp.status_code != 200:
-                raise OAuthLoginError("Failed to exchange GitHub authorization code")
-
-            token_data: dict[str, Any] = token_resp.json()
-            access_token = token_data.get("access_token")
-            if not access_token:
-                raise OAuthLoginError("No access token in GitHub response")
-
-            auth_headers = {"Authorization": f"Bearer {access_token}"}
-
-            # Fetch user profile
-            user_resp = await client.get(self._USER_URL, headers=auth_headers)
-            if user_resp.status_code != 200:
-                raise OAuthLoginError("Failed to fetch GitHub user info")
-
-            user_data: dict[str, Any] = user_resp.json()
-            email = user_data.get("email")
-
-            # Fallback: fetch primary verified email from /user/emails
-            if not email:
-                email = await self._fetch_primary_email(client, auth_headers)
-
-            if not email:
-                raise OAuthLoginError(
-                    "No verified email found on your GitHub account. "
-                    "Please add a verified email to GitHub and try again."
+        try:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                # Exchange code for access token
+                token_resp = await client.post(
+                    self._TOKEN_URL,
+                    data={
+                        "client_id": self._client_id,
+                        "client_secret": self._client_secret,
+                        "code": code,
+                        "redirect_uri": redirect_uri,
+                    },
+                    headers={"Accept": "application/json"},
                 )
+                if token_resp.status_code != 200:
+                    raise OAuthLoginError("Failed to exchange GitHub authorization code")
 
-            return OAuthUserInfo(
-                provider="github",
-                provider_id=str(user_data.get("id", "")),
-                email=email,
-                name=user_data.get("name") or user_data.get("login"),
-            )
+                token_data: dict[str, Any] = token_resp.json()
+                access_token = token_data.get("access_token")
+                if not access_token:
+                    raise OAuthLoginError("No access token in GitHub response")
+
+                auth_headers = {"Authorization": f"Bearer {access_token}"}
+
+                # Fetch user profile
+                user_resp = await client.get(self._USER_URL, headers=auth_headers)
+                if user_resp.status_code != 200:
+                    raise OAuthLoginError("Failed to fetch GitHub user info")
+
+                user_data: dict[str, Any] = user_resp.json()
+                email = user_data.get("email")
+
+                # Fallback: fetch primary verified email from /user/emails
+                if not email:
+                    email = await self._fetch_primary_email(client, auth_headers)
+
+                if not email:
+                    raise OAuthLoginError(
+                        "No verified email found on your GitHub account. "
+                        "Please add a verified email to GitHub and try again."
+                    )
+
+                return OAuthUserInfo(
+                    provider="github",
+                    provider_id=str(user_data.get("id", "")),
+                    email=email,
+                    name=user_data.get("name") or user_data.get("login"),
+                )
+        except OAuthLoginError:
+            raise
+        except httpx.HTTPError as exc:
+            raise OAuthLoginError("Failed to connect to GitHub") from exc
 
     async def _fetch_primary_email(
         self,
@@ -282,7 +292,7 @@ def get_configured_providers(
 ) -> list[OAuthLoginProvider]:
     """Return instantiated providers for all configured entries.
 
-    Silently skips unknown provider names (logged at debug level).
+    Silently skips unknown provider names.
     """
     providers: list[OAuthLoginProvider] = []
     for name, config in provider_configs.items():

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -456,6 +456,13 @@ class AccountLockoutConfig(BaseModel):
     lockout_minutes: int = Field(default=15, description="Lockout duration in minutes")
 
 
+class OAuthProviderConfig(BaseModel):
+    """Credentials for a single OAuth login provider."""
+
+    client_id: str = Field(description="OAuth client ID")
+    client_secret: str = Field(description="OAuth client secret")
+
+
 class AuthConfig(BaseModel):
     """Authentication configuration."""
 
@@ -464,6 +471,10 @@ class AuthConfig(BaseModel):
     session_max_days: int = Field(default=30, description="Maximum session lifetime in days")
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     lockout: AccountLockoutConfig = Field(default_factory=AccountLockoutConfig)
+    oauth_providers: dict[str, OAuthProviderConfig] = Field(
+        default_factory=dict,
+        description="OAuth login providers keyed by name (google, github)",
+    )
 
 
 class DangoConfig(BaseModel):

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -589,6 +589,7 @@ async def _resolve_oauth_user(
     # 1. Look up by OAuth identity
     user = get_user_by_oauth(db_path, user_info.provider, user_info.provider_id)
 
+    need_auto_link = False
     if user is None:
         # 2. Look up by email
         user = get_user_by_email(db_path, user_info.email)
@@ -605,15 +606,7 @@ async def _resolve_oauth_user(
                 return _login_error_redirect(
                     "This email is already linked to a different login provider"
                 )
-            # Auto-link: set oauth_provider and oauth_id
-            update_user(
-                db_path,
-                user.id,
-                UserUpdate(
-                    oauth_provider=user_info.provider,
-                    oauth_id=user_info.provider_id,
-                ),
-            )
+            need_auto_link = True
 
     if user is None:
         # 4. No account found
@@ -625,7 +618,7 @@ async def _resolve_oauth_user(
         )
         return _login_error_redirect("No account found for this email. Contact your administrator.")
 
-    # Check active
+    # Check active before any writes
     if not user.is_active:
         log_auth_event(
             AuditEvent.LOGIN_FAILURE,
@@ -635,6 +628,23 @@ async def _resolve_oauth_user(
             details={"provider": user_info.provider, "reason": "inactive"},
         )
         return _login_error_redirect("Your account has been deactivated")
+
+    # Auto-link after all validation passes
+    if need_auto_link:
+        update_user(
+            db_path,
+            user.id,
+            UserUpdate(
+                oauth_provider=user_info.provider,
+                oauth_id=user_info.provider_id,
+            ),
+        )
+        logger.info(
+            "oauth_account_linked",
+            user_id=user.id,
+            email=user.email,
+            provider=user_info.provider,
+        )
 
     # Success — create session
     reset_failed_logins(db_path, user.email)
@@ -685,7 +695,6 @@ async def login_page(request: Request) -> HTMLResponse:
     oauth_providers = [
         {"name": p.name, "display_name": p.display_name, "icon_svg": p.icon_svg} for p in providers
     ]
-    login_error = request.query_params.get("error", "")
     return _render_template(
         "login.html",
         {
@@ -694,7 +703,6 @@ async def login_page(request: Request) -> HTMLResponse:
             "current_page": "login",
             "subtitle": "Login",
             "oauth_providers": oauth_providers,
-            "login_error": login_error,
         },
     )
 

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from pydantic import ValidationError
 
 import dango
@@ -23,12 +24,20 @@ from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.database import (
     get_session_by_token,
     get_user_by_email,
+    get_user_by_oauth,
     list_user_api_keys,
     list_user_sessions,
     update_user,
 )
 from dango.auth.lockout import check_account_locked, record_failed_login, reset_failed_logins
 from dango.auth.models import User, UserResponse, UserUpdate
+from dango.auth.oauth_login import (
+    OAuthLoginError,
+    OAuthUserInfo,
+    generate_oauth_state,
+    get_configured_providers,
+    get_provider,
+)
 from dango.auth.security import (
     check_password_strength,
     hash_password,
@@ -42,7 +51,7 @@ from dango.auth.sessions import (
     invalidate_session,
     revoke_api_key,
 )
-from dango.config.models import AuthConfig
+from dango.config.models import AuthConfig, OAuthProviderConfig
 from dango.logging import get_logger
 from dango.web.middleware.auth import COOKIE_NAME, is_secure_request
 from dango.web.models import (
@@ -121,6 +130,26 @@ def _get_current_token_hash(request: Request) -> str | None:
     if cookie_token is None:
         return None
     return hash_token(cookie_token)
+
+
+def _get_oauth_config(request: Request) -> dict[str, OAuthProviderConfig]:
+    """Load OAuth provider configs from project config."""
+    auth_config = _get_auth_config(request)
+    if auth_config is None:
+        return {}
+    return auth_config.oauth_providers
+
+
+def _build_redirect_uri(request: Request, provider_name: str) -> str:
+    """Build the OAuth callback URL for a provider."""
+    scheme = request.url.scheme
+    host = request.headers.get("host", "localhost:8800")
+    return f"{scheme}://{host}/api/auth/oauth/{provider_name}/callback"
+
+
+def _login_error_redirect(message: str) -> RedirectResponse:
+    """Redirect to login page with an error message in query params."""
+    return RedirectResponse(url=f"/login?error={quote(message)}", status_code=302)
 
 
 # ---------------------------------------------------------------------------
@@ -468,6 +497,182 @@ async def revoke_key(key_id: str, request: Request) -> JSONResponse:
 
 
 # ---------------------------------------------------------------------------
+# OAuth social login
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/auth/oauth/{provider_name}/login")
+async def oauth_login(provider_name: str, request: Request) -> RedirectResponse:
+    """Redirect the user to the OAuth provider's authorization page."""
+    oauth_configs = _get_oauth_config(request)
+    provider_config = oauth_configs.get(provider_name)
+    if provider_config is None:
+        return _login_error_redirect(f"OAuth provider '{provider_name}' is not configured")
+
+    try:
+        provider = get_provider(provider_name, provider_config)
+    except OAuthLoginError:
+        return _login_error_redirect(f"OAuth provider '{provider_name}' is not configured")
+
+    state = generate_oauth_state()
+    redirect_uri = _build_redirect_uri(request, provider_name)
+    auth_url = provider.get_authorization_url(redirect_uri, state)
+
+    response = RedirectResponse(url=auth_url, status_code=302)
+    response.set_cookie(
+        key="dango_oauth_state",
+        value=state,
+        path="/api/auth/oauth/",
+        httponly=True,
+        samesite="lax",
+        max_age=600,
+        secure=is_secure_request(request.scope),
+    )
+    return response
+
+
+@router.get("/api/auth/oauth/{provider_name}/callback")
+async def oauth_callback(provider_name: str, request: Request) -> RedirectResponse:
+    """Handle the OAuth callback from the provider."""
+    # Check for provider-side error
+    error_param = request.query_params.get("error")
+    if error_param:
+        return _login_error_redirect("Login was cancelled or denied by the provider")
+
+    # Validate required params
+    code = request.query_params.get("code")
+    state = request.query_params.get("state")
+    if not code or not state:
+        return _login_error_redirect("Invalid OAuth callback (missing code or state)")
+
+    # CSRF: validate state matches cookie
+    cookie_state = request.cookies.get("dango_oauth_state")
+    if not cookie_state or cookie_state != state:
+        return _login_error_redirect("OAuth state mismatch (possible CSRF)")
+
+    # Exchange code for user info
+    oauth_configs = _get_oauth_config(request)
+    provider_config = oauth_configs.get(provider_name)
+    if provider_config is None:
+        return _login_error_redirect(f"OAuth provider '{provider_name}' is not configured")
+
+    try:
+        provider = get_provider(provider_name, provider_config)
+        redirect_uri = _build_redirect_uri(request, provider_name)
+        user_info = await provider.exchange_code(code, redirect_uri)
+    except OAuthLoginError as exc:
+        logger.warning("oauth_exchange_failed", provider=provider_name, error=str(exc))
+        return _login_error_redirect("Failed to complete OAuth login")
+
+    # Resolve user and create session
+    response = await _resolve_oauth_user(request, user_info)
+    response.delete_cookie("dango_oauth_state", path="/api/auth/oauth/")
+    return response
+
+
+async def _resolve_oauth_user(
+    request: Request,
+    user_info: OAuthUserInfo,
+) -> RedirectResponse:
+    """Resolve an OAuth user to a local account and create a session.
+
+    Resolution order:
+    1. Exact match by ``oauth_provider`` + ``oauth_id`` → login.
+    2. Match by email with no existing OAuth link → auto-link and login.
+    3. Match by email linked to a *different* provider → reject.
+    4. No match → reject (admin must pre-create the user).
+    """
+
+    db_path = _get_db_path(request)
+    ip = _get_client_ip(request)
+
+    # 1. Look up by OAuth identity
+    user = get_user_by_oauth(db_path, user_info.provider, user_info.provider_id)
+
+    if user is None:
+        # 2. Look up by email
+        user = get_user_by_email(db_path, user_info.email)
+        if user is not None:
+            if user.oauth_provider is not None and user.oauth_provider != user_info.provider:
+                # 3. Already linked to a different provider
+                log_auth_event(
+                    AuditEvent.LOGIN_FAILURE,
+                    user_id=user.id,
+                    email=user_info.email,
+                    ip=ip,
+                    details={"provider": user_info.provider, "reason": "different_provider_linked"},
+                )
+                return _login_error_redirect(
+                    "This email is already linked to a different login provider"
+                )
+            # Auto-link: set oauth_provider and oauth_id
+            update_user(
+                db_path,
+                user.id,
+                UserUpdate(
+                    oauth_provider=user_info.provider,
+                    oauth_id=user_info.provider_id,
+                ),
+            )
+
+    if user is None:
+        # 4. No account found
+        log_auth_event(
+            AuditEvent.LOGIN_FAILURE,
+            email=user_info.email,
+            ip=ip,
+            details={"provider": user_info.provider, "reason": "no_account"},
+        )
+        return _login_error_redirect("No account found for this email. Contact your administrator.")
+
+    # Check active
+    if not user.is_active:
+        log_auth_event(
+            AuditEvent.LOGIN_FAILURE,
+            user_id=user.id,
+            email=user_info.email,
+            ip=ip,
+            details={"provider": user_info.provider, "reason": "inactive"},
+        )
+        return _login_error_redirect("Your account has been deactivated")
+
+    # Success — create session
+    reset_failed_logins(db_path, user.email)
+    auth_config = _get_auth_config(request)
+    session_max_days = auth_config.session_max_days if auth_config else 30
+
+    raw_token, _session = create_session(
+        db_path,
+        user.id,
+        ip_address=ip,
+        user_agent=_get_user_agent(request),
+        session_max_days=session_max_days,
+    )
+    update_user(db_path, user.id, UserUpdate(last_login=datetime.now(timezone.utc)))
+    log_auth_event(
+        AuditEvent.LOGIN_SUCCESS,
+        user_id=user.id,
+        email=user.email,
+        ip=ip,
+        details={"provider": user_info.provider},
+    )
+
+    # Redirect to setup if must_change_password, otherwise home
+    # TASK-019 will add Metabase session bridging at this point
+    target = "/setup" if user.must_change_password else "/"
+    response = RedirectResponse(url=target, status_code=302)
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=raw_token,
+        path="/",
+        httponly=True,
+        samesite="lax",
+        secure=is_secure_request(request.scope),
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
 # Page routes
 # ---------------------------------------------------------------------------
 
@@ -475,6 +680,12 @@ async def revoke_key(key_id: str, request: Request) -> JSONResponse:
 @router.get("/login")
 async def login_page(request: Request) -> HTMLResponse:
     """Render the login page."""
+    oauth_configs = _get_oauth_config(request)
+    providers = get_configured_providers(oauth_configs)
+    oauth_providers = [
+        {"name": p.name, "display_name": p.display_name, "icon_svg": p.icon_svg} for p in providers
+    ]
+    login_error = request.query_params.get("error", "")
     return _render_template(
         "login.html",
         {
@@ -482,6 +693,8 @@ async def login_page(request: Request) -> HTMLResponse:
             "version": dango.__version__,
             "current_page": "login",
             "subtitle": "Login",
+            "oauth_providers": oauth_providers,
+            "login_error": login_error,
         },
     )
 

--- a/dango/web/templates/login.html
+++ b/dango/web/templates/login.html
@@ -46,8 +46,28 @@
                 </button>
             </form>
 
-            <!-- Placeholder for OAuth buttons (TASK-095) -->
-            <div id="oauth-buttons" class="hidden mt-4"></div>
+            {% if oauth_providers %}
+            <div class="mt-6">
+                <div class="relative">
+                    <div class="absolute inset-0 flex items-center">
+                        <div class="w-full border-t border-gray-300"></div>
+                    </div>
+                    <div class="relative flex justify-center text-sm">
+                        <span class="px-2 bg-white text-gray-500">or continue with</span>
+                    </div>
+                </div>
+
+                <div class="mt-4 space-y-2">
+                    {% for provider in oauth_providers %}
+                    <a href="/api/auth/oauth/{{ provider.name }}/login"
+                       class="w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 rounded-md bg-white hover:bg-gray-50 text-sm font-medium text-gray-700 transition-colors">
+                        {{ provider.icon_svg | safe }}
+                        <span>Continue with {{ provider.display_name }}</span>
+                    </a>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
         </div>
 
         <p class="text-center text-xs text-gray-400 mt-6">Dango v{{ version }}</p>
@@ -59,8 +79,9 @@
 <script>
 function loginForm() {
     return {
-        email: '', password: '', error: '', loading: false,
-        locked: false, lockoutRemaining: 0, _timer: null,
+        email: '', password: '',
+        error: new URLSearchParams(window.location.search).get('error') || '',
+        loading: false, locked: false, lockoutRemaining: 0, _timer: null,
         async submit() {
             this.loading = true;
             this.error = '';

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -23,6 +23,19 @@ exemptions:
     reason: "CSV upload/list/delete endpoints. Extracted from web/app.py by TASK-085. DELETE endpoint alone has ~300 lines of DuckDB cleanup logic."
     review_by: "v1.1"
 
+  # --- Phase 2 auth additions ---
+  - file: dango/web/routes/auth.py
+    lines: 713
+    category: exempt
+    reason: "TASK-095 added OAuth social login endpoints (+120 lines over TASK-016 base). TASK-096 will move page routes to routes/ui.py, reducing by ~26 lines."
+    review_by: "v1.1"
+
+  - file: dango/auth/database.py
+    lines: 504
+    category: exempt
+    reason: "TASK-095 added get_user_by_oauth() (+14 lines). Marginally over limit."
+    review_by: "v1.1"
+
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
     lines: 1026
@@ -124,6 +137,12 @@ exemptions:
     lines: 580
     category: exempt
     reason: "35 tests covering all provider validators, routing, and pre-sync gate. Test methods are intentionally verbose for readability — each sets up mocks explicitly."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_auth_database.py
+    lines: 504
+    category: exempt
+    reason: "TASK-095 added get_user_by_oauth tests (+4 tests). Marginally over limit."
     review_by: "v1.1"
 
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -25,7 +25,7 @@ exemptions:
 
   # --- Phase 2 auth additions ---
   - file: dango/web/routes/auth.py
-    lines: 713
+    lines: 721
     category: exempt
     reason: "TASK-095 added OAuth social login endpoints (+120 lines over TASK-016 base). TASK-096 will move page routes to routes/ui.py, reducing by ~26 lines."
     review_by: "v1.1"

--- a/tests/unit/test_auth_database.py
+++ b/tests/unit/test_auth_database.py
@@ -23,6 +23,7 @@ from dango.auth.database import (
     get_session_by_token,
     get_user_by_email,
     get_user_by_id,
+    get_user_by_oauth,
     invalidate_all_user_sessions,
     invalidate_session,
     list_user_sessions,
@@ -471,3 +472,33 @@ class TestSessionCRUD:
         assert fetched is not None
         assert fetched.ip_address == "10.0.0.1"
         assert fetched.user_agent == "TestAgent/1.0"
+
+
+@pytest.mark.unit
+class TestGetUserByOAuth:
+    """Tests for get_user_by_oauth()."""
+
+    def test_found(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user(oauth_provider="google", oauth_id="g-123")
+        create_user(db, user)
+        found = get_user_by_oauth(db, "google", "g-123")
+        assert found is not None
+        assert found.id == user.id
+
+    def test_not_found_wrong_provider(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user(oauth_provider="google", oauth_id="g-123")
+        create_user(db, user)
+        assert get_user_by_oauth(db, "github", "g-123") is None
+
+    def test_not_found_wrong_id(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        user = _make_user(oauth_provider="google", oauth_id="g-123")
+        create_user(db, user)
+        assert get_user_by_oauth(db, "google", "g-999") is None
+
+    def test_not_found_no_oauth_user(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        create_user(db, _make_user())
+        assert get_user_by_oauth(db, "google", "g-123") is None

--- a/tests/unit/test_auth_oauth_login.py
+++ b/tests/unit/test_auth_oauth_login.py
@@ -9,6 +9,7 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from dango.auth.oauth_login import (
@@ -217,6 +218,19 @@ class TestGoogleOAuthProvider:
         ):
             asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
 
+    def test_exchange_code_network_error(self) -> None:
+        """Network errors are wrapped in OAuthLoginError."""
+        provider = GoogleOAuthProvider(_make_config())
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="Failed to connect to Google"),
+        ):
+            asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
+
 
 @pytest.mark.unit
 class TestGitHubOAuthProvider:
@@ -335,3 +349,16 @@ class TestGitHubOAuthProvider:
             pytest.raises(OAuthLoginError, match="Failed to exchange GitHub"),
         ):
             asyncio.run(provider.exchange_code("bad", "https://app.example.com/callback"))
+
+    def test_exchange_code_network_error(self) -> None:
+        """Network errors are wrapped in OAuthLoginError."""
+        provider = GitHubOAuthProvider(_make_config())
+        mock_client = AsyncMock()
+        mock_client.post.side_effect = httpx.TimeoutException("read timed out")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="Failed to connect to GitHub"),
+        ):
+            asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))

--- a/tests/unit/test_auth_oauth_login.py
+++ b/tests/unit/test_auth_oauth_login.py
@@ -1,0 +1,337 @@
+"""tests/unit/test_auth_oauth_login.py
+
+Tests for the OAuth social login provider abstraction in dango/auth/oauth_login.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dango.auth.oauth_login import (
+    GitHubOAuthProvider,
+    GoogleOAuthProvider,
+    OAuthLoginError,
+    OAuthUserInfo,
+    generate_oauth_state,
+    get_configured_providers,
+    get_provider,
+)
+from dango.config.models import OAuthProviderConfig
+
+
+def _make_config(
+    client_id: str = "test-client-id",
+    client_secret: str = "test-client-secret",
+) -> OAuthProviderConfig:
+    return OAuthProviderConfig(client_id=client_id, client_secret=client_secret)
+
+
+def _mock_async_client(
+    token_status: int = 200,
+    token_data: dict[str, Any] | None = None,
+    user_status: int = 200,
+    user_data: dict[str, Any] | None = None,
+) -> AsyncMock:
+    """Build a mock httpx.AsyncClient for provider tests."""
+    mock_token = MagicMock()
+    mock_token.status_code = token_status
+    mock_token.json.return_value = token_data or {}
+
+    mock_user = MagicMock()
+    mock_user.status_code = user_status
+    mock_user.json.return_value = user_data or {}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_token
+    mock_client.get.return_value = mock_user
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+@pytest.mark.unit
+class TestOAuthUserInfo:
+    """Tests for the OAuthUserInfo dataclass."""
+
+    def test_creation(self) -> None:
+        info = OAuthUserInfo(
+            provider="google", provider_id="123", email="user@example.com", name="Test User"
+        )
+        assert info.provider == "google"
+        assert info.provider_id == "123"
+        assert info.email == "user@example.com"
+        assert info.name == "Test User"
+
+    def test_frozen(self) -> None:
+        info = OAuthUserInfo(provider="google", provider_id="1", email="a@b.com", name=None)
+        with pytest.raises(AttributeError):
+            info.email = "new@b.com"  # type: ignore[misc]
+
+    def test_name_optional(self) -> None:
+        info = OAuthUserInfo(provider="github", provider_id="1", email="a@b.com", name=None)
+        assert info.name is None
+
+
+@pytest.mark.unit
+class TestGenerateOAuthState:
+    """Tests for generate_oauth_state()."""
+
+    def test_uniqueness(self) -> None:
+        states = {generate_oauth_state() for _ in range(50)}
+        assert len(states) == 50
+
+    def test_url_safe(self) -> None:
+        state = generate_oauth_state()
+        assert all(c.isalnum() or c in "-_" for c in state)
+
+    def test_sufficient_length(self) -> None:
+        state = generate_oauth_state()
+        assert len(state) >= 32
+
+
+@pytest.mark.unit
+class TestGetProvider:
+    """Tests for get_provider() factory."""
+
+    def test_google(self) -> None:
+        provider = get_provider("google", _make_config())
+        assert isinstance(provider, GoogleOAuthProvider)
+        assert provider.name == "google"
+
+    def test_github(self) -> None:
+        provider = get_provider("github", _make_config())
+        assert isinstance(provider, GitHubOAuthProvider)
+        assert provider.name == "github"
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises(OAuthLoginError, match="Unknown OAuth provider"):
+            get_provider("facebook", _make_config())
+
+
+@pytest.mark.unit
+class TestGetConfiguredProviders:
+    """Tests for get_configured_providers()."""
+
+    def test_empty(self) -> None:
+        assert get_configured_providers({}) == []
+
+    def test_single_provider(self) -> None:
+        result = get_configured_providers({"google": _make_config()})
+        assert len(result) == 1
+        assert result[0].name == "google"
+
+    def test_multiple_providers(self) -> None:
+        configs = {
+            "google": _make_config(client_id="g-id"),
+            "github": _make_config(client_id="gh-id"),
+        }
+        result = get_configured_providers(configs)
+        assert len(result) == 2
+        assert {p.name for p in result} == {"google", "github"}
+
+    def test_unknown_provider_skipped(self) -> None:
+        configs = {"google": _make_config(), "facebook": _make_config()}
+        result = get_configured_providers(configs)
+        assert len(result) == 1
+        assert result[0].name == "google"
+
+
+@pytest.mark.unit
+class TestGoogleOAuthProvider:
+    """Tests for GoogleOAuthProvider."""
+
+    def test_class_attributes(self) -> None:
+        provider = GoogleOAuthProvider(_make_config())
+        assert provider.name == "google"
+        assert provider.display_name == "Google"
+        assert "<svg" in provider.icon_svg
+
+    def test_get_authorization_url(self) -> None:
+        provider = GoogleOAuthProvider(_make_config(client_id="my-client"))
+        url = provider.get_authorization_url(
+            redirect_uri="https://app.example.com/callback",
+            state="test-state-123",
+        )
+        assert "accounts.google.com" in url
+        assert "client_id=my-client" in url
+        assert "redirect_uri=https" in url
+        assert "state=test-state-123" in url
+        assert "scope=openid+email+profile" in url
+        assert "response_type=code" in url
+
+    def test_exchange_code_success(self) -> None:
+        provider = GoogleOAuthProvider(_make_config())
+        mock_client = _mock_async_client(
+            token_data={"access_token": "google-token"},
+            user_data={"id": "g-12345", "email": "user@gmail.com", "name": "Google User"},
+        )
+        with patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client):
+            info = asyncio.run(
+                provider.exchange_code("auth-code", "https://app.example.com/callback")
+            )
+        assert info.provider == "google"
+        assert info.provider_id == "g-12345"
+        assert info.email == "user@gmail.com"
+        assert info.name == "Google User"
+
+    def test_exchange_code_token_failure(self) -> None:
+        provider = GoogleOAuthProvider(_make_config())
+        mock_client = _mock_async_client(token_status=400)
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="Failed to exchange Google"),
+        ):
+            asyncio.run(provider.exchange_code("bad-code", "https://app.example.com/callback"))
+
+    def test_exchange_code_no_access_token(self) -> None:
+        provider = GoogleOAuthProvider(_make_config())
+        mock_client = _mock_async_client(token_data={"error": "invalid_grant"})
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="No access token"),
+        ):
+            asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
+
+    def test_exchange_code_no_email(self) -> None:
+        provider = GoogleOAuthProvider(_make_config())
+        mock_client = _mock_async_client(
+            token_data={"access_token": "token"},
+            user_data={"id": "123", "name": "No Email"},
+        )
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="No email"),
+        ):
+            asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
+
+    def test_exchange_code_user_info_failure(self) -> None:
+        provider = GoogleOAuthProvider(_make_config())
+        mock_client = _mock_async_client(token_data={"access_token": "token"}, user_status=403)
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="Failed to fetch Google user info"),
+        ):
+            asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
+
+
+@pytest.mark.unit
+class TestGitHubOAuthProvider:
+    """Tests for GitHubOAuthProvider."""
+
+    def test_class_attributes(self) -> None:
+        provider = GitHubOAuthProvider(_make_config())
+        assert provider.name == "github"
+        assert provider.display_name == "GitHub"
+        assert "<svg" in provider.icon_svg
+
+    def test_get_authorization_url(self) -> None:
+        provider = GitHubOAuthProvider(_make_config(client_id="gh-client"))
+        url = provider.get_authorization_url(
+            redirect_uri="https://app.example.com/callback", state="test-state"
+        )
+        assert "github.com/login/oauth/authorize" in url
+        assert "client_id=gh-client" in url
+        assert "state=test-state" in url
+        assert "scope=user" in url
+
+    def test_exchange_code_public_email(self) -> None:
+        """GitHub user with public email — no /user/emails fallback needed."""
+        provider = GitHubOAuthProvider(_make_config())
+        mock_client = _mock_async_client(
+            token_data={"access_token": "gh-token"},
+            user_data={"id": 42, "email": "dev@github.com", "name": "Dev User", "login": "dev"},
+        )
+        with patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client):
+            info = asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
+        assert info.provider == "github"
+        assert info.provider_id == "42"
+        assert info.email == "dev@github.com"
+        assert info.name == "Dev User"
+
+    def test_exchange_code_private_email_fallback(self) -> None:
+        """GitHub user with private email — fetches from /user/emails."""
+        provider = GitHubOAuthProvider(_make_config())
+
+        mock_token = MagicMock()
+        mock_token.status_code = 200
+        mock_token.json.return_value = {"access_token": "gh-token"}
+
+        mock_user = MagicMock()
+        mock_user.status_code = 200
+        mock_user.json.return_value = {
+            "id": 99,
+            "email": None,
+            "name": None,
+            "login": "privateuser",
+        }
+
+        mock_emails = MagicMock()
+        mock_emails.status_code = 200
+        mock_emails.json.return_value = [
+            {"email": "noreply@github.com", "primary": False, "verified": True},
+            {"email": "private@example.com", "primary": True, "verified": True},
+        ]
+
+        async def mock_get(url: str, **kwargs: Any) -> MagicMock:
+            if "user/emails" in url:
+                return mock_emails
+            return mock_user
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_token
+        mock_client.get = mock_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client):
+            info = asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
+        assert info.email == "private@example.com"
+        assert info.name == "privateuser"
+
+    def test_exchange_code_no_verified_email(self) -> None:
+        """GitHub user with no verified email raises OAuthLoginError."""
+        provider = GitHubOAuthProvider(_make_config())
+
+        mock_token = MagicMock()
+        mock_token.status_code = 200
+        mock_token.json.return_value = {"access_token": "token"}
+
+        mock_user = MagicMock()
+        mock_user.status_code = 200
+        mock_user.json.return_value = {"id": 1, "email": None, "login": "nomail"}
+
+        mock_emails = MagicMock()
+        mock_emails.status_code = 200
+        mock_emails.json.return_value = [
+            {"email": "unverified@example.com", "primary": True, "verified": False},
+        ]
+
+        async def mock_get(url: str, **kwargs: Any) -> MagicMock:
+            if "user/emails" in url:
+                return mock_emails
+            return mock_user
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_token
+        mock_client.get = mock_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="No verified email"),
+        ):
+            asyncio.run(provider.exchange_code("code", "https://app.example.com/callback"))
+
+    def test_exchange_code_token_failure(self) -> None:
+        provider = GitHubOAuthProvider(_make_config())
+        mock_client = _mock_async_client(token_status=401)
+        with (
+            patch("dango.auth.oauth_login.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(OAuthLoginError, match="Failed to exchange GitHub"),
+        ):
+            asyncio.run(provider.exchange_code("bad", "https://app.example.com/callback"))

--- a/tests/unit/test_web_auth_oauth.py
+++ b/tests/unit/test_web_auth_oauth.py
@@ -1,0 +1,498 @@
+"""tests/unit/test_web_auth_oauth.py
+
+Tests for OAuth social login endpoints in dango/web/routes/auth.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import unquote
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dango.auth import database as db
+from dango.auth.models import Role, User
+from dango.auth.oauth_login import OAuthLoginError, OAuthUserInfo
+from dango.auth.security import hash_password
+from dango.config.models import OAuthProviderConfig
+from dango.migrations.runner import MigrationRunner
+from dango.web.middleware.auth import COOKIE_NAME
+from dango.web.routes.auth import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database at the standard project path."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    db_path = dango_dir / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(
+    db_path: Path,
+    email: str = "oauth@example.com",
+    password: str = "securepassword123",
+    role: Role = Role.EDITOR,
+    **overrides: Any,
+) -> User:
+    """Create and persist a user, returning the model."""
+    defaults: dict[str, Any] = {
+        "email": email,
+        "password_hash": hash_password(password),
+        "role": role,
+    }
+    defaults.update(overrides)
+    user = User(**defaults)
+    db.create_user(db_path, user)
+    return user
+
+
+_GOOGLE_CONFIG = {"google": OAuthProviderConfig(client_id="g-id", client_secret="g-secret")}
+
+
+def _make_app(db_path: Path) -> FastAPI:
+    """Create a minimal FastAPI app with auth routes."""
+    app = FastAPI()
+    app.state.project_root = db_path.parent.parent
+    app.include_router(router)
+    return app
+
+
+def _make_client(app: FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _patch_oauth_config(configs: dict[str, OAuthProviderConfig]) -> Any:
+    """Patch _get_oauth_config to return given configs."""
+    return patch("dango.web.routes.auth._get_oauth_config", return_value=configs)
+
+
+def _mock_provider(user_info: OAuthUserInfo | None = None, error: str | None = None) -> Any:
+    """Create a mock provider.
+
+    Uses MagicMock for sync methods (get_authorization_url) and
+    AsyncMock for async methods (exchange_code).
+    """
+    mock_prov = MagicMock()
+    mock_prov.name = "google"
+    mock_prov.display_name = "Google"
+    mock_prov.icon_svg = "<svg></svg>"
+    mock_prov.get_authorization_url.return_value = "https://accounts.google.com/auth?test=1"
+
+    if error:
+        mock_prov.exchange_code = AsyncMock(side_effect=OAuthLoginError(error))
+    elif user_info:
+        mock_prov.exchange_code = AsyncMock(return_value=user_info)
+    else:
+        mock_prov.exchange_code = AsyncMock(return_value=None)
+    return mock_prov
+
+
+def _location(resp: Any) -> str:
+    """Get the decoded Location header from a redirect response."""
+    return unquote(resp.headers.get("location", ""))
+
+
+# ---------------------------------------------------------------------------
+# OAuth login redirect tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOAuthLoginRedirect:
+    """Tests for GET /api/auth/oauth/{provider}/login."""
+
+    def test_redirect_to_provider(self, tmp_path: Path) -> None:
+        """Successful redirect sets state cookie and 302s to provider."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        mock_prov = _mock_provider()
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            resp = client.get("/api/auth/oauth/google/login", follow_redirects=False)
+
+        assert resp.status_code == 302
+        assert "accounts.google.com" in resp.headers["location"]
+        assert "dango_oauth_state" in resp.cookies
+
+    def test_unconfigured_provider(self, tmp_path: Path) -> None:
+        """Unconfigured provider redirects to login with error."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config({}):
+            resp = client.get("/api/auth/oauth/google/login", follow_redirects=False)
+
+        assert resp.status_code == 302
+        assert "not configured" in _location(resp)
+
+
+# ---------------------------------------------------------------------------
+# OAuth callback tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOAuthCallback:
+    """Tests for GET /api/auth/oauth/{provider}/callback."""
+
+    def _callback_url(self, provider: str = "google", **params: str) -> str:
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        return f"/api/auth/oauth/{provider}/callback?{qs}"
+
+    def test_success_existing_oauth_user(self, tmp_path: Path) -> None:
+        """Existing OAuth user logs in and gets session cookie."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path, oauth_provider="google", oauth_id="g-123")
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        user_info = OAuthUserInfo(
+            provider="google", provider_id="g-123", email="oauth@example.com", name="Test"
+        )
+        mock_prov = _mock_provider(user_info=user_info)
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "state123")
+            resp = client.get(
+                self._callback_url(code="auth-code", state="state123"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/"
+        assert COOKIE_NAME in resp.cookies
+
+    def test_auto_link_email_match(self, tmp_path: Path) -> None:
+        """Email match with no existing OAuth link auto-links and logs in."""
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path, email="link@example.com")
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        user_info = OAuthUserInfo(
+            provider="google", provider_id="g-new", email="link@example.com", name="Link"
+        )
+        mock_prov = _mock_provider(user_info=user_info)
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "state1")
+            resp = client.get(
+                self._callback_url(code="code", state="state1"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert COOKIE_NAME in resp.cookies
+
+        # Verify the user was linked
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert updated.oauth_provider == "google"
+        assert updated.oauth_id == "g-new"
+
+    def test_reject_different_provider_linked(self, tmp_path: Path) -> None:
+        """Email linked to a different provider is rejected."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path, email="linked@example.com", oauth_provider="github", oauth_id="gh-1")
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        user_info = OAuthUserInfo(
+            provider="google", provider_id="g-1", email="linked@example.com", name="X"
+        )
+        mock_prov = _mock_provider(user_info=user_info)
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "s")
+            resp = client.get(
+                self._callback_url(code="c", state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "different login provider" in _location(resp)
+
+    def test_reject_unknown_user(self, tmp_path: Path) -> None:
+        """No account for the email redirects with error."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        user_info = OAuthUserInfo(
+            provider="google", provider_id="g-1", email="nobody@example.com", name="Nobody"
+        )
+        mock_prov = _mock_provider(user_info=user_info)
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "s")
+            resp = client.get(
+                self._callback_url(code="c", state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "No account found" in _location(resp)
+
+    def test_reject_inactive_user(self, tmp_path: Path) -> None:
+        """Inactive user is rejected."""
+        db_path = _make_db(tmp_path)
+        _make_user(
+            db_path,
+            email="inactive@example.com",
+            is_active=False,
+            oauth_provider="google",
+            oauth_id="g-1",
+        )
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        user_info = OAuthUserInfo(
+            provider="google", provider_id="g-1", email="inactive@example.com", name="Inactive"
+        )
+        mock_prov = _mock_provider(user_info=user_info)
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "s")
+            resp = client.get(
+                self._callback_url(code="c", state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "deactivated" in _location(resp)
+
+    def test_csrf_state_mismatch(self, tmp_path: Path) -> None:
+        """State mismatch redirects with CSRF error."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config(_GOOGLE_CONFIG):
+            client.cookies.set("dango_oauth_state", "correct-state")
+            resp = client.get(
+                self._callback_url(code="c", state="wrong-state"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        loc = _location(resp)
+        assert "CSRF" in loc or "state mismatch" in loc
+
+    def test_missing_state_cookie(self, tmp_path: Path) -> None:
+        """Missing state cookie redirects with CSRF error."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config(_GOOGLE_CONFIG):
+            resp = client.get(
+                self._callback_url(code="c", state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "error=" in resp.headers["location"]
+
+    def test_missing_code_param(self, tmp_path: Path) -> None:
+        """Missing code parameter redirects with error."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config(_GOOGLE_CONFIG):
+            resp = client.get(
+                self._callback_url(state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "missing code" in _location(resp)
+
+    def test_provider_error_param(self, tmp_path: Path) -> None:
+        """Provider error (user denied) redirects with message."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config(_GOOGLE_CONFIG):
+            resp = client.get(
+                self._callback_url(error="access_denied"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        loc = _location(resp)
+        assert "cancelled" in loc or "denied" in loc
+
+    def test_exchange_failure(self, tmp_path: Path) -> None:
+        """Token exchange failure redirects with error."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        mock_prov = _mock_provider(error="Token exchange failed")
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "s")
+            resp = client.get(
+                self._callback_url(code="bad-code", state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "error=" in resp.headers["location"]
+
+    def test_redirect_to_setup_if_must_change_password(self, tmp_path: Path) -> None:
+        """User with must_change_password is redirected to /setup."""
+        db_path = _make_db(tmp_path)
+        _make_user(
+            db_path,
+            email="setup@example.com",
+            oauth_provider="google",
+            oauth_id="g-setup",
+            must_change_password=True,
+        )
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        user_info = OAuthUserInfo(
+            provider="google", provider_id="g-setup", email="setup@example.com", name="Setup"
+        )
+        mock_prov = _mock_provider(user_info=user_info)
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "s")
+            resp = client.get(
+                self._callback_url(code="c", state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/setup"
+
+    def test_state_cookie_cleared_on_success(self, tmp_path: Path) -> None:
+        """State cookie is cleared after successful callback."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path, oauth_provider="google", oauth_id="g-1")
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        user_info = OAuthUserInfo(
+            provider="google", provider_id="g-1", email="oauth@example.com", name="T"
+        )
+        mock_prov = _mock_provider(user_info=user_info)
+
+        with (
+            _patch_oauth_config(_GOOGLE_CONFIG),
+            patch("dango.web.routes.auth.get_provider", return_value=mock_prov),
+        ):
+            client.cookies.set("dango_oauth_state", "s")
+            resp = client.get(
+                self._callback_url(code="c", state="s"),
+                follow_redirects=False,
+            )
+
+        # Cookie should be deleted (set to empty or max-age=0)
+        state_cookie = resp.cookies.get("dango_oauth_state")
+        assert state_cookie is None or state_cookie == ""
+
+    def test_unconfigured_provider_callback(self, tmp_path: Path) -> None:
+        """Callback to unconfigured provider redirects with error."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config({}):
+            client.cookies.set("dango_oauth_state", "s")
+            resp = client.get(
+                self._callback_url(code="c", state="s"),
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "not configured" in _location(resp)
+
+
+# ---------------------------------------------------------------------------
+# Login page OAuth integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoginPageOAuth:
+    """Tests for OAuth buttons on the login page."""
+
+    def test_login_page_no_providers(self, tmp_path: Path) -> None:
+        """Login page renders without OAuth section when no providers configured."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config({}):
+            resp = client.get("/login")
+
+        assert resp.status_code == 200
+        assert "or continue with" not in resp.text
+
+    def test_login_page_with_providers(self, tmp_path: Path) -> None:
+        """Login page shows OAuth buttons when providers are configured."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config(_GOOGLE_CONFIG):
+            resp = client.get("/login")
+
+        assert resp.status_code == 200
+        assert "Continue with Google" in resp.text
+        assert "/api/auth/oauth/google/login" in resp.text
+
+    def test_login_page_shows_error_from_params(self, tmp_path: Path) -> None:
+        """Login page displays error from URL query params."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+        client = _make_client(app)
+
+        with _patch_oauth_config({}):
+            resp = client.get("/login?error=Something+went+wrong")
+
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- Adds "Log in with Google" and "Log in with GitHub" buttons to the login page via an `OAuthLoginProvider` ABC with concrete `GoogleOAuthProvider` and `GitHubOAuthProvider` implementations
- CSRF protection via state cookie, auto-linking by email match, GitHub private email fallback (`/user/emails`), and full audit logging (LOGIN_SUCCESS/LOGIN_FAILURE)
- New `OAuthProviderConfig` in config models for `project.yml` configuration (`auth.oauth_providers.google.client_id`)
- 44 new tests (26 provider abstraction + 18 route endpoint), 966 total unit tests pass with 0 regressions

## Files changed

| File | Change |
|------|--------|
| `dango/auth/oauth_login.py` | New — provider abstraction (297 lines) |
| `dango/web/routes/auth.py` | +217 lines — OAuth endpoints + login page modifications |
| `dango/config/models.py` | +11 lines — `OAuthProviderConfig` model |
| `dango/auth/database.py` | +15 lines — `get_user_by_oauth()` |
| `dango/auth/__init__.py` | +17 lines — re-exports |
| `dango/web/templates/login.html` | +29 lines — OAuth buttons + error display |
| `tests/unit/test_auth_oauth_login.py` | New — 26 provider tests |
| `tests/unit/test_web_auth_oauth.py` | New — 18 route tests |
| `tests/unit/test_auth_database.py` | +4 tests for `get_user_by_oauth` |
| `docs/file-exemptions.yml` | Exemptions for auth.py (713), database.py (504), test_auth_database.py (504) |
| `.gitignore` | Added `.dango/` |

## Test plan

- [x] All 44 new tests pass (provider abstraction + route endpoints)
- [x] Full unit suite: 966 passed, 0 failures
- [x] ruff lint + format clean
- [x] mypy passes on all source files
- [x] All pre-commit hooks pass
- [ ] Manual: configure Google/GitHub OAuth app, verify login flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)