### PR TITLE
Add user management web UI and account settings (TASK-098)

### DIFF
--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -226,10 +226,12 @@ from dango.web.routes.sources import router as sources_router  # noqa: E402
 from dango.web.routes.sync import router as sync_router  # noqa: E402
 from dango.web.routes.ui import router as ui_router  # noqa: E402
 from dango.web.routes.upload import router as upload_router  # noqa: E402
+from dango.web.routes.users import router as users_router  # noqa: E402
 from dango.web.routes.websocket import router as websocket_router  # noqa: E402
 
 # Dango API routers (order matters — more specific routes first)
 app.include_router(auth_router)
+app.include_router(users_router)
 app.include_router(health_router)
 app.include_router(config_router)
 app.include_router(sources_router)

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -129,3 +129,27 @@ class ApiKeyCreateResponse(ApiKeyResponse):
     """API key creation response — includes the full key shown once."""
 
     key: str
+
+
+# ---------------------------------------------------------------------------
+# Admin user management DTOs (used by web/routes/users.py)
+# ---------------------------------------------------------------------------
+
+
+class CreateUserRequest(BaseModel):
+    """Admin user creation payload."""
+
+    email: str
+    role: str = "viewer"
+
+
+class ChangeRoleRequest(BaseModel):
+    """Admin role change payload."""
+
+    role: str
+
+
+class DeleteUserConfirmation(BaseModel):
+    """Delete user confirmation payload."""
+
+    confirm_email: str

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -6,7 +6,7 @@ Pydantic request/response DTOs for the web API.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class TableInfo(BaseModel):
@@ -141,6 +141,15 @@ class CreateUserRequest(BaseModel):
 
     email: str
     role: str = "viewer"
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        """Normalize and minimally validate the email address."""
+        v = v.strip().lower()
+        if not v or "@" not in v:
+            raise ValueError("Invalid email address")
+        return v
 
 
 class ChangeRoleRequest(BaseModel):

--- a/dango/web/routes/users.py
+++ b/dango/web/routes/users.py
@@ -263,6 +263,12 @@ async def admin_deactivate_user(
     if target is None:
         return JSONResponse(status_code=404, content={"message": "User not found"})
 
+    if user_id == user.id:
+        return JSONResponse(
+            status_code=409,
+            content={"message": "Cannot deactivate your own account"},
+        )
+
     if target.role == Role.ADMIN and _count_active_admins(db_path) <= 1:
         return JSONResponse(
             status_code=409,
@@ -367,6 +373,13 @@ async def admin_unlock_user(
         return JSONResponse(status_code=404, content={"message": "User not found"})
 
     update_user(db_path, user_id, UserUpdate(failed_login_attempts=0, locked_until=None))
+    log_auth_event(
+        AuditEvent.ACCOUNT_LOCKED,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"action": "unlock", "unlocked_by": user.email},
+    )
     return JSONResponse(content={"success": True})
 
 
@@ -383,6 +396,13 @@ async def admin_revoke_sessions(
         return JSONResponse(status_code=404, content={"message": "User not found"})
 
     revoked_count = invalidate_all_user_sessions(db_path, user_id)
+    log_auth_event(
+        AuditEvent.SESSION_EXPIRED,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"action": "admin_revoke_all", "revoked_by": user.email, "count": revoked_count},
+    )
     return JSONResponse(content={"success": True, "revoked_count": revoked_count})
 
 
@@ -415,7 +435,7 @@ async def account_page(request: Request) -> HTMLResponse:
     if current_user is None:
         return HTMLResponse(status_code=302, headers={"Location": "/login"})
 
-    user_json = UserResponse.model_validate(current_user).model_dump_json()
+    user_json = UserResponse.model_validate(current_user).model_dump(mode="json")
     return _render_template(
         "account.html",
         {

--- a/dango/web/routes/users.py
+++ b/dango/web/routes/users.py
@@ -1,0 +1,428 @@
+"""dango/web/routes/users.py
+
+Admin user management API and settings page routes.
+
+Provides CRUD operations for user accounts (list, create, change role,
+reset password, deactivate, reactivate, delete, unlock, revoke sessions)
+and serves the admin user management and account settings pages.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import ValidationError
+
+import dango
+from dango.auth.admin import get_auth_db_path
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.database import (
+    create_user,
+    deactivate_user,
+    delete_user,
+    get_user_by_id,
+    invalidate_all_user_sessions,
+    list_users,
+    update_user,
+)
+from dango.auth.models import Role, User, UserResponse, UserUpdate
+from dango.auth.permissions import require_permission
+from dango.auth.security import generate_temp_password, hash_password
+from dango.exceptions import UserExistsError
+from dango.logging import get_logger
+from dango.web.models import ChangeRoleRequest, CreateUserRequest, DeleteUserConfirmation
+from dango.web.routes.ui import _render_template
+
+router = APIRouter(tags=["users"])
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_db_path(request: Request) -> Path:
+    """Resolve the auth database path from the application state."""
+    project_root: Path = request.app.state.project_root
+    return get_auth_db_path(project_root)
+
+
+def _get_current_user(request: Request) -> User | None:
+    """Return the authenticated user from request state, or None."""
+    return getattr(request.state, "user", None)
+
+
+def _get_client_ip(request: Request) -> str | None:
+    """Extract client IP address from the request."""
+    if request.client is not None:
+        return request.client.host
+    return None
+
+
+def _count_active_admins(db_path: Path) -> int:
+    """Count active admin users."""
+    return sum(1 for u in list_users(db_path, active_only=True) if u.role == Role.ADMIN)
+
+
+def _metabase_sync_role(db_path: Path, user_id: str, request: Request) -> None:
+    """Sync role change to Metabase (best-effort)."""
+    try:
+        from dango.auth.metabase_sync import _load_metabase_credentials, sync_user_role
+
+        project_root: Path = request.app.state.project_root
+        creds = _load_metabase_credentials(project_root)
+        if creds and creds.get("metabase_url"):
+            sync_user_role(db_path, user_id, project_root, creds["metabase_url"])
+    except Exception:
+        logger.warning("metabase_role_sync_failed", user_id=user_id, exc_info=True)
+
+
+def _metabase_deactivate(db_path: Path, user_id: str, request: Request) -> None:
+    """Deactivate user in Metabase (best-effort)."""
+    try:
+        from dango.auth.metabase_sync import _load_metabase_credentials, deactivate_metabase_user
+
+        project_root: Path = request.app.state.project_root
+        creds = _load_metabase_credentials(project_root)
+        if creds and creds.get("metabase_url"):
+            deactivate_metabase_user(db_path, user_id, project_root, creds["metabase_url"])
+    except Exception:
+        logger.warning("metabase_deactivation_failed", user_id=user_id, exc_info=True)
+
+
+def _metabase_delete(db_path: Path, user_id: str, request: Request) -> None:
+    """Delete user from Metabase (best-effort)."""
+    try:
+        from dango.auth.metabase_sync import _load_metabase_credentials, delete_metabase_user
+
+        project_root: Path = request.app.state.project_root
+        creds = _load_metabase_credentials(project_root)
+        if creds and creds.get("metabase_url"):
+            delete_metabase_user(db_path, user_id, project_root, creds["metabase_url"])
+    except Exception:
+        logger.warning("metabase_deletion_failed", user_id=user_id, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Admin API endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/admin/users")
+async def admin_list_users(
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """List all users."""
+    db_path = _get_db_path(request)
+    users = list_users(db_path)
+    result = [UserResponse.model_validate(u).model_dump(mode="json") for u in users]
+    return JSONResponse(content=result)
+
+
+@router.post("/api/admin/users")
+async def admin_create_user(
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Create a new user with a temporary password."""
+    db_path = _get_db_path(request)
+    try:
+        body: dict[str, Any] = await request.json()
+        data = CreateUserRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    try:
+        role = Role(data.role)
+    except ValueError:
+        return JSONResponse(
+            status_code=400,
+            content={"message": f"Invalid role '{data.role}'. Must be admin, editor, or viewer."},
+        )
+
+    password = generate_temp_password()
+    new_user = User(
+        email=data.email,
+        password_hash=hash_password(password),
+        role=role,
+        must_change_password=True,
+    )
+    try:
+        create_user(db_path, new_user)
+    except UserExistsError:
+        return JSONResponse(
+            status_code=409,
+            content={"message": f"A user with email '{data.email.strip().lower()}' already exists"},
+        )
+
+    log_auth_event(
+        AuditEvent.USER_CREATED,
+        user_id=new_user.id,
+        email=new_user.email,
+        ip=_get_client_ip(request),
+        details={"role": role.value, "created_by": user.email},
+    )
+    resp = UserResponse.model_validate(new_user)
+    return JSONResponse(
+        status_code=201,
+        content={"user": resp.model_dump(mode="json"), "temp_password": password},
+    )
+
+
+@router.put("/api/admin/users/{user_id}/role")
+async def admin_change_role(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Change a user's role."""
+    db_path = _get_db_path(request)
+    try:
+        body: dict[str, Any] = await request.json()
+        data = ChangeRoleRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    try:
+        new_role = Role(data.role)
+    except ValueError:
+        return JSONResponse(
+            status_code=400,
+            content={"message": f"Invalid role '{data.role}'. Must be admin, editor, or viewer."},
+        )
+
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    if target.role == Role.ADMIN and new_role != Role.ADMIN:
+        if _count_active_admins(db_path) <= 1:
+            return JSONResponse(
+                status_code=409,
+                content={"message": "Cannot demote the only active admin"},
+            )
+
+    old_role = target.role
+    updated = update_user(db_path, user_id, UserUpdate(role=new_role))
+    _metabase_sync_role(db_path, user_id, request)
+    log_auth_event(
+        AuditEvent.ROLE_CHANGED,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"old_role": old_role.value, "new_role": new_role.value, "changed_by": user.email},
+    )
+    resp = UserResponse.model_validate(updated)
+    return JSONResponse(content=resp.model_dump(mode="json"))
+
+
+@router.post("/api/admin/users/{user_id}/reset-password")
+async def admin_reset_password(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Reset a user's password to a temporary one."""
+    db_path = _get_db_path(request)
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    password = generate_temp_password()
+    updated = update_user(
+        db_path,
+        user_id,
+        UserUpdate(password_hash=hash_password(password), must_change_password=True),
+    )
+    invalidate_all_user_sessions(db_path, user_id)
+    log_auth_event(
+        AuditEvent.PASSWORD_RESET,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"reset_by": user.email},
+    )
+    resp = UserResponse.model_validate(updated)
+    return JSONResponse(content={"user": resp.model_dump(mode="json"), "temp_password": password})
+
+
+@router.post("/api/admin/users/{user_id}/deactivate")
+async def admin_deactivate_user(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Deactivate a user account."""
+    db_path = _get_db_path(request)
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    if target.role == Role.ADMIN and _count_active_admins(db_path) <= 1:
+        return JSONResponse(
+            status_code=409,
+            content={"message": "Cannot deactivate the only active admin"},
+        )
+
+    deactivate_user(db_path, user_id)
+    invalidate_all_user_sessions(db_path, user_id)
+    _metabase_deactivate(db_path, user_id, request)
+    log_auth_event(
+        AuditEvent.USER_DEACTIVATED,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"deactivated_by": user.email},
+    )
+    return JSONResponse(content={"success": True})
+
+
+@router.post("/api/admin/users/{user_id}/reactivate")
+async def admin_reactivate_user(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Reactivate a deactivated user account."""
+    db_path = _get_db_path(request)
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    updated = update_user(db_path, user_id, UserUpdate(is_active=True))
+    log_auth_event(
+        AuditEvent.USER_REACTIVATED,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"reactivated_by": user.email},
+    )
+    resp = UserResponse.model_validate(updated)
+    return JSONResponse(content=resp.model_dump(mode="json"))
+
+
+@router.delete("/api/admin/users/{user_id}")
+async def admin_delete_user(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Permanently delete a user (requires email confirmation)."""
+    db_path = _get_db_path(request)
+    try:
+        body: dict[str, Any] = await request.json()
+        data = DeleteUserConfirmation(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    if data.confirm_email.strip().lower() != target.email:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "Confirmation email does not match user email"},
+        )
+
+    if user_id == user.id:
+        return JSONResponse(
+            status_code=409,
+            content={"message": "Cannot delete your own account"},
+        )
+
+    if target.role == Role.ADMIN and _count_active_admins(db_path) <= 1:
+        return JSONResponse(
+            status_code=409,
+            content={"message": "Cannot delete the only active admin"},
+        )
+
+    _metabase_delete(db_path, user_id, request)
+    delete_user(db_path, user_id)
+    log_auth_event(
+        AuditEvent.USER_DELETED,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"deleted_by": user.email},
+    )
+    return JSONResponse(content={"success": True})
+
+
+@router.post("/api/admin/users/{user_id}/unlock")
+async def admin_unlock_user(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Unlock a locked-out user account."""
+    db_path = _get_db_path(request)
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    update_user(db_path, user_id, UserUpdate(failed_login_attempts=0, locked_until=None))
+    return JSONResponse(content={"success": True})
+
+
+@router.post("/api/admin/users/{user_id}/revoke-sessions")
+async def admin_revoke_sessions(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Revoke all active sessions for a user."""
+    db_path = _get_db_path(request)
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    revoked_count = invalidate_all_user_sessions(db_path, user_id)
+    return JSONResponse(content={"success": True, "revoked_count": revoked_count})
+
+
+# ---------------------------------------------------------------------------
+# Page routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings/users")
+async def admin_users_page(
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> HTMLResponse:
+    """Render the admin user management page."""
+    return _render_template(
+        "admin_users.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "settings",
+            "subtitle": "User Management",
+        },
+    )
+
+
+@router.get("/settings/account")
+async def account_page(request: Request) -> HTMLResponse:
+    """Render the user account settings page."""
+    current_user = _get_current_user(request)
+    if current_user is None:
+        return HTMLResponse(status_code=302, headers={"Location": "/login"})
+
+    user_json = UserResponse.model_validate(current_user).model_dump_json()
+    return _render_template(
+        "account.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "settings",
+            "subtitle": "Account Settings",
+            "user_json": user_json,
+        },
+    )

--- a/dango/web/templates/account.html
+++ b/dango/web/templates/account.html
@@ -211,7 +211,7 @@
 function accountPage() {
     const headers = {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'};
     return {
-        user: {{ user_json | safe }},
+        user: {{ user_json | tojson }},
         currentPassword: '', newPassword: '', confirmPassword: '',
         pwError: '', pwSuccess: false, pwLoading: false,
         sessions: [], sessionError: '', sessionLoading: false,

--- a/dango/web/templates/account.html
+++ b/dango/web/templates/account.html
@@ -1,0 +1,308 @@
+{% extends "base.html" %}
+
+{% block title %}Account Settings - Dango{% endblock %}
+
+{% block content %}
+<main class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div x-data="accountPage()" x-init="init()">
+        <h2 class="text-xl font-bold text-gray-900 mb-6">Account Settings</h2>
+
+        <!-- Profile Section -->
+        <div class="bg-white shadow rounded-lg p-6 mb-6">
+            <h3 class="text-lg font-medium text-gray-900 mb-4">Profile</h3>
+            <div class="space-y-3">
+                <div class="flex items-center justify-between">
+                    <span class="text-sm text-gray-500">Email</span>
+                    <span class="text-sm font-medium text-gray-900" x-text="user.email"></span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <span class="text-sm text-gray-500">Role</span>
+                    <span class="px-2 py-0.5 text-xs font-semibold rounded-full"
+                          :class="user.role === 'admin' ? 'bg-red-100 text-red-800' : user.role === 'editor' ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-800'"
+                          x-text="user.role"></span>
+                </div>
+                <div class="flex items-center justify-between">
+                    <span class="text-sm text-gray-500">Member since</span>
+                    <span class="text-sm text-gray-900" x-text="new Date(user.created_at).toLocaleDateString()"></span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Change Password Section -->
+        <div class="bg-white shadow rounded-lg p-6 mb-6">
+            <h3 class="text-lg font-medium text-gray-900 mb-4">Change Password</h3>
+            <form @submit.prevent="changePassword()" class="max-w-sm">
+                <div class="mb-3">
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Current Password</label>
+                    <input type="password" x-model="currentPassword" required autocomplete="current-password"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm">
+                </div>
+                <div class="mb-3">
+                    <label class="block text-sm font-medium text-gray-700 mb-1">New Password</label>
+                    <input type="password" x-model="newPassword" required autocomplete="new-password"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm">
+                    <p class="text-xs text-gray-400 mt-1">At least 8 characters</p>
+                </div>
+                <div class="mb-4">
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Confirm New Password</label>
+                    <input type="password" x-model="confirmPassword" required autocomplete="new-password"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm">
+                </div>
+                <div x-show="pwError" x-cloak class="mb-3 p-2 bg-red-50 border border-red-200 rounded-md">
+                    <p class="text-sm text-red-700" x-text="pwError"></p>
+                </div>
+                <div x-show="pwSuccess" x-cloak class="mb-3 p-2 bg-green-50 border border-green-200 rounded-md">
+                    <p class="text-sm text-green-700">Password changed. Redirecting to login...</p>
+                </div>
+                <button type="submit" :disabled="pwLoading"
+                        class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50 transition-colors">
+                    <span x-show="!pwLoading">Change Password</span>
+                    <span x-show="pwLoading" x-cloak>Updating...</span>
+                </button>
+            </form>
+        </div>
+
+        <!-- Active Sessions Section -->
+        <div class="bg-white shadow rounded-lg p-6 mb-6">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-lg font-medium text-gray-900">Active Sessions</h3>
+                <button @click="revokeAllOtherSessions()" :disabled="sessionLoading"
+                        class="text-sm text-red-600 hover:text-red-800 disabled:opacity-50">Revoke All Others</button>
+            </div>
+            <div x-show="sessionError" x-cloak class="mb-3 p-2 bg-red-50 border border-red-200 rounded-md">
+                <p class="text-sm text-red-700" x-text="sessionError"></p>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead><tr>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">IP</th>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase hidden sm:table-cell">User Agent</th>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Last Active</th>
+                        <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
+                    </tr></thead>
+                    <tbody class="divide-y divide-gray-200">
+                        <template x-for="s in sessions" :key="s.id">
+                            <tr>
+                                <td class="px-3 py-2 text-gray-900" x-text="s.ip_address || 'Unknown'"></td>
+                                <td class="px-3 py-2 text-gray-500 truncate max-w-xs hidden sm:table-cell"
+                                    x-text="s.user_agent ? s.user_agent.substring(0, 60) : 'Unknown'"></td>
+                                <td class="px-3 py-2 text-gray-500">
+                                    <span x-text="new Date(s.last_activity).toLocaleString()"></span>
+                                    <template x-if="s.is_current">
+                                        <span class="ml-1 px-1.5 py-0.5 text-xs bg-green-100 text-green-800 rounded">Current</span>
+                                    </template>
+                                </td>
+                                <td class="px-3 py-2 text-right">
+                                    <template x-if="!s.is_current">
+                                        <button @click="revokeSession(s.id)" class="text-red-600 hover:text-red-800 text-xs">Revoke</button>
+                                    </template>
+                                </td>
+                            </tr>
+                        </template>
+                        <template x-if="sessions.length === 0">
+                            <tr><td colspan="4" class="px-3 py-4 text-center text-gray-500">No active sessions.</td></tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- API Keys Section -->
+        <div class="bg-white shadow rounded-lg p-6 mb-6">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-lg font-medium text-gray-900">API Keys</h3>
+                <button @click="showKeyModal = true"
+                        class="px-3 py-1.5 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Create Key</button>
+            </div>
+            <div x-show="keyError" x-cloak class="mb-3 p-2 bg-red-50 border border-red-200 rounded-md">
+                <p class="text-sm text-red-700" x-text="keyError"></p>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead><tr>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Prefix</th>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase hidden sm:table-cell">Created</th>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase hidden sm:table-cell">Last Used</th>
+                        <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
+                    </tr></thead>
+                    <tbody class="divide-y divide-gray-200">
+                        <template x-for="k in apiKeys" :key="k.id">
+                            <tr>
+                                <td class="px-3 py-2 text-gray-900" x-text="k.name"></td>
+                                <td class="px-3 py-2 text-gray-500 font-mono text-xs" x-text="k.key_prefix + '...'"></td>
+                                <td class="px-3 py-2 text-gray-500 hidden sm:table-cell"
+                                    x-text="new Date(k.created_at).toLocaleDateString()"></td>
+                                <td class="px-3 py-2 text-gray-500 hidden sm:table-cell"
+                                    x-text="k.last_used_at ? new Date(k.last_used_at).toLocaleDateString() : 'Never'"></td>
+                                <td class="px-3 py-2 text-right">
+                                    <button @click="revokeKey(k.id)" class="text-red-600 hover:text-red-800 text-xs">Revoke</button>
+                                </td>
+                            </tr>
+                        </template>
+                        <template x-if="apiKeys.length === 0">
+                            <tr><td colspan="5" class="px-3 py-4 text-center text-gray-500">No API keys.</td></tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Two-Factor Authentication Section -->
+        <div class="bg-white shadow rounded-lg p-6">
+            <h3 class="text-lg font-medium text-gray-900 mb-4">Two-Factor Authentication</h3>
+            <div class="flex items-center space-x-3">
+                <span class="px-2 py-0.5 text-xs font-semibold rounded-full"
+                      :class="user.totp_enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'"
+                      x-text="user.totp_enabled ? 'Enabled' : 'Disabled'"></span>
+                <span class="text-sm text-gray-500">2FA setup is not yet available.</span>
+            </div>
+        </div>
+
+        <!-- Create API Key Modal -->
+        <div x-show="showKeyModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showKeyModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">Create API Key</h3>
+                    <form @submit.prevent="createKey()">
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Key Name</label>
+                            <input type="text" x-model="newKeyName" required placeholder="e.g. CLI access"
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm">
+                        </div>
+                        <div class="flex justify-end space-x-3">
+                            <button type="button" @click="showKeyModal = false"
+                                    class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            <button type="submit" :disabled="keyLoading"
+                                    class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">Create</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Show New API Key Modal -->
+        <div x-show="showNewKey" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showNewKey = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-2">API Key Created</h3>
+                    <p class="text-sm text-gray-500 mb-4">Copy this key now. It will not be shown again.</p>
+                    <div class="flex items-center space-x-2 mb-4">
+                        <input type="text" :value="newKeyValue" readonly
+                               class="flex-1 px-3 py-2 border border-gray-300 rounded-md bg-gray-50 font-mono text-xs">
+                        <button @click="navigator.clipboard.writeText(newKeyValue)"
+                                class="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Copy</button>
+                    </div>
+                    <div class="flex justify-end">
+                        <button @click="showNewKey = false"
+                                class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700">Done</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function accountPage() {
+    const headers = {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'};
+    return {
+        user: {{ user_json | safe }},
+        currentPassword: '', newPassword: '', confirmPassword: '',
+        pwError: '', pwSuccess: false, pwLoading: false,
+        sessions: [], sessionError: '', sessionLoading: false,
+        apiKeys: [], keyError: '', keyLoading: false,
+        showKeyModal: false, newKeyName: '',
+        showNewKey: false, newKeyValue: '',
+
+        async init() {
+            await Promise.all([this.loadSessions(), this.loadKeys()]);
+        },
+
+        async changePassword() {
+            this.pwError = ''; this.pwSuccess = false;
+            if (this.newPassword !== this.confirmPassword) {
+                this.pwError = 'Passwords do not match'; return;
+            }
+            this.pwLoading = true;
+            try {
+                const res = await fetch('/api/auth/change-password', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ current_password: this.currentPassword, new_password: this.newPassword })
+                });
+                if (res.ok) {
+                    this.pwSuccess = true;
+                    setTimeout(() => { window.location.href = '/login'; }, 2000);
+                    return;
+                }
+                const data = await res.json();
+                this.pwError = data.issues ? data.issues.join('. ') : (data.message || 'Failed');
+            } catch (e) { this.pwError = 'Unable to connect'; }
+            this.pwLoading = false;
+        },
+
+        async loadSessions() {
+            try {
+                const res = await fetch('/api/auth/sessions', { headers });
+                if (res.ok) this.sessions = await res.json();
+            } catch (e) { this.sessionError = 'Failed to load sessions'; }
+        },
+        async revokeSession(id) {
+            this.sessionError = '';
+            try {
+                const res = await fetch(`/api/auth/sessions/${id}`, { method: 'DELETE', headers });
+                if (!res.ok) { const d = await res.json(); this.sessionError = d.message; return; }
+                await this.loadSessions();
+            } catch (e) { this.sessionError = 'Failed to revoke session'; }
+        },
+        async revokeAllOtherSessions() {
+            this.sessionLoading = true; this.sessionError = '';
+            try {
+                const others = this.sessions.filter(s => !s.is_current);
+                for (const s of others) {
+                    await fetch(`/api/auth/sessions/${s.id}`, { method: 'DELETE', headers });
+                }
+                await this.loadSessions();
+            } catch (e) { this.sessionError = 'Failed to revoke sessions'; }
+            this.sessionLoading = false;
+        },
+
+        async loadKeys() {
+            try {
+                const res = await fetch('/api/auth/api-keys', { headers });
+                if (res.ok) this.apiKeys = await res.json();
+            } catch (e) { this.keyError = 'Failed to load API keys'; }
+        },
+        async createKey() {
+            this.keyLoading = true; this.keyError = '';
+            try {
+                const res = await fetch('/api/auth/api-keys', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ name: this.newKeyName })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.keyError = data.message; this.keyLoading = false; return; }
+                this.showKeyModal = false;
+                this.newKeyName = '';
+                this.newKeyValue = data.key;
+                this.showNewKey = true;
+                await this.loadKeys();
+            } catch (e) { this.keyError = 'Failed to create key'; }
+            this.keyLoading = false;
+        },
+        async revokeKey(id) {
+            this.keyError = '';
+            try {
+                const res = await fetch(`/api/auth/api-keys/${id}`, { method: 'DELETE', headers });
+                if (!res.ok) { const d = await res.json(); this.keyError = d.message; return; }
+                await this.loadKeys();
+            } catch (e) { this.keyError = 'Failed to revoke key'; }
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/dango/web/templates/admin_users.html
+++ b/dango/web/templates/admin_users.html
@@ -1,0 +1,364 @@
+{% extends "base.html" %}
+
+{% block title %}User Management - Dango{% endblock %}
+
+{% block content %}
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div x-data="adminUsers()" x-init="loadUsers()">
+        <!-- Header -->
+        <div class="flex items-center justify-between mb-6">
+            <h2 class="text-xl font-bold text-gray-900">User Management</h2>
+            <button @click="showAddModal = true"
+                    class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors">
+                Add User
+            </button>
+        </div>
+
+        <!-- Error banner -->
+        <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+            <p class="text-sm text-red-700" x-text="error"></p>
+        </div>
+
+        <!-- Success banner -->
+        <div x-show="success" x-cloak class="mb-4 p-3 bg-green-50 border border-green-200 rounded-md">
+            <p class="text-sm text-green-700" x-text="success"></p>
+        </div>
+
+        <!-- Users table -->
+        <div class="bg-white shadow rounded-lg overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Last Login</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Created</th>
+                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    <template x-for="u in users" :key="u.id">
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900" x-text="u.email"></td>
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
+                                      :class="roleBadge(u.role)" x-text="u.role"></span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm"
+                                :class="getStatus(u).cls" x-text="getStatus(u).text"></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
+                                x-text="u.last_login ? new Date(u.last_login).toLocaleDateString() : 'Never'"></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell"
+                                x-text="new Date(u.created_at).toLocaleDateString()"></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
+                                <div x-data="{ open: false }" class="relative inline-block text-left">
+                                    <button @click="open = !open" class="text-gray-400 hover:text-gray-600">
+                                        <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                                            <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
+                                        </svg>
+                                    </button>
+                                    <div x-show="open" @click.away="open = false" x-cloak
+                                         class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-10">
+                                        <div class="py-1">
+                                            <button @click="openRoleModal(u); open = false"
+                                                    class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Change Role</button>
+                                            <button @click="resetPassword(u); open = false"
+                                                    class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Reset Password</button>
+                                            <template x-if="u.is_active">
+                                                <button @click="confirmAction('deactivate', u); open = false"
+                                                        class="block w-full text-left px-4 py-2 text-sm text-yellow-600 hover:bg-gray-100">Deactivate</button>
+                                            </template>
+                                            <template x-if="!u.is_active">
+                                                <button @click="confirmAction('reactivate', u); open = false"
+                                                        class="block w-full text-left px-4 py-2 text-sm text-green-600 hover:bg-gray-100">Reactivate</button>
+                                            </template>
+                                            <template x-if="u.locked_until && new Date(u.locked_until) > new Date()">
+                                                <button @click="confirmAction('unlock', u); open = false"
+                                                        class="block w-full text-left px-4 py-2 text-sm text-blue-600 hover:bg-gray-100">Unlock</button>
+                                            </template>
+                                            <button @click="confirmAction('revoke-sessions', u); open = false"
+                                                    class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Revoke Sessions</button>
+                                            <hr class="my-1">
+                                            <button @click="openDeleteModal(u); open = false"
+                                                    class="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-gray-100">Delete</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                    </template>
+                    <template x-if="users.length === 0">
+                        <tr><td colspan="6" class="px-6 py-8 text-center text-sm text-gray-500">No users found.</td></tr>
+                    </template>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Add User Modal -->
+        <div x-show="showAddModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showAddModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">Add User</h3>
+                    <form @submit.prevent="createUser()">
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                            <input type="email" x-model="newEmail" required
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
+                        </div>
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Role</label>
+                            <select x-model="newRole"
+                                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
+                                <option value="viewer">Viewer</option>
+                                <option value="editor">Editor</option>
+                                <option value="admin">Admin</option>
+                            </select>
+                        </div>
+                        <div class="flex justify-end space-x-3">
+                            <button type="button" @click="showAddModal = false"
+                                    class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            <button type="submit" :disabled="addLoading"
+                                    class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">
+                                <span x-show="!addLoading">Create</span>
+                                <span x-show="addLoading" x-cloak>Creating...</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Temp Password Modal -->
+        <div x-show="showTempPassword" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showTempPassword = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-2">Temporary Password</h3>
+                    <p class="text-sm text-gray-500 mb-4">Share this password securely. The user must change it on first login.</p>
+                    <div class="flex items-center space-x-2 mb-4">
+                        <input type="text" :value="tempPassword" readonly
+                               class="flex-1 px-3 py-2 border border-gray-300 rounded-md bg-gray-50 font-mono text-sm">
+                        <button @click="navigator.clipboard.writeText(tempPassword)"
+                                class="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Copy</button>
+                    </div>
+                    <div class="flex justify-end">
+                        <button @click="showTempPassword = false"
+                                class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700">Done</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Change Role Modal -->
+        <div x-show="showRoleModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showRoleModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">Change Role</h3>
+                    <p class="text-sm text-gray-500 mb-3">
+                        Change role for <span class="font-medium" x-text="targetUser?.email"></span>
+                    </p>
+                    <select x-model="selectedRole"
+                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 mb-4">
+                        <option value="viewer">Viewer</option>
+                        <option value="editor">Editor</option>
+                        <option value="admin">Admin</option>
+                    </select>
+                    <div class="flex justify-end space-x-3">
+                        <button @click="showRoleModal = false"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="changeRole()" :disabled="actionLoading"
+                                class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">Save</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Confirm Action Modal -->
+        <div x-show="showConfirmModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showConfirmModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-2" x-text="confirmTitle"></h3>
+                    <p class="text-sm text-gray-500 mb-4" x-text="confirmMessage"></p>
+                    <div class="flex justify-end space-x-3">
+                        <button @click="showConfirmModal = false"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="executeConfirmedAction()" :disabled="actionLoading"
+                                class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">Confirm</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Delete Confirmation Modal -->
+        <div x-show="showDeleteModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showDeleteModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-red-600 mb-2">Delete User</h3>
+                    <p class="text-sm text-gray-500 mb-4">
+                        This action is permanent and cannot be undone. Type the user's email
+                        (<span class="font-mono font-medium" x-text="targetUser?.email"></span>)
+                        to confirm.
+                    </p>
+                    <input type="text" x-model="deleteConfirmEmail" placeholder="Type email to confirm"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 mb-4">
+                    <div class="flex justify-end space-x-3">
+                        <button @click="showDeleteModal = false; deleteConfirmEmail = ''"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="deleteUser()" :disabled="actionLoading || deleteConfirmEmail !== targetUser?.email"
+                                class="px-4 py-2 text-sm text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed">Delete</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function adminUsers() {
+    const headers = {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'};
+    return {
+        users: [], error: '', success: '',
+        showAddModal: false, newEmail: '', newRole: 'viewer', addLoading: false,
+        showTempPassword: false, tempPassword: '',
+        showRoleModal: false, selectedRole: '',
+        showConfirmModal: false, confirmTitle: '', confirmMessage: '', pendingAction: null,
+        showDeleteModal: false, deleteConfirmEmail: '',
+        targetUser: null, actionLoading: false,
+
+        roleBadge(role) {
+            if (role === 'admin') return 'bg-red-100 text-red-800';
+            if (role === 'editor') return 'bg-blue-100 text-blue-800';
+            return 'bg-gray-100 text-gray-800';
+        },
+        getStatus(u) {
+            if (!u.is_active) return { text: 'Inactive', cls: 'text-red-600' };
+            if (u.locked_until && new Date(u.locked_until) > new Date())
+                return { text: 'Locked', cls: 'text-yellow-600' };
+            return { text: 'Active', cls: 'text-green-600' };
+        },
+
+        async loadUsers() {
+            try {
+                const res = await fetch('/api/admin/users', { headers });
+                if (!res.ok) throw new Error('Failed to load users');
+                this.users = await res.json();
+            } catch (e) { this.error = e.message; }
+        },
+
+        async createUser() {
+            this.addLoading = true; this.error = '';
+            try {
+                const res = await fetch('/api/admin/users', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ email: this.newEmail, role: this.newRole })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.addLoading = false; return; }
+                this.showAddModal = false;
+                this.newEmail = ''; this.newRole = 'viewer';
+                this.tempPassword = data.temp_password;
+                this.showTempPassword = true;
+                await this.loadUsers();
+            } catch (e) { this.error = 'Failed to create user'; }
+            this.addLoading = false;
+        },
+
+        openRoleModal(u) {
+            this.targetUser = u;
+            this.selectedRole = u.role;
+            this.showRoleModal = true;
+        },
+        async changeRole() {
+            this.actionLoading = true; this.error = '';
+            try {
+                const res = await fetch(`/api/admin/users/${this.targetUser.id}/role`, {
+                    method: 'PUT', headers,
+                    body: JSON.stringify({ role: this.selectedRole })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.actionLoading = false; return; }
+                this.showRoleModal = false;
+                this.success = 'Role updated successfully.';
+                setTimeout(() => this.success = '', 3000);
+                await this.loadUsers();
+            } catch (e) { this.error = 'Failed to change role'; }
+            this.actionLoading = false;
+        },
+
+        async resetPassword(u) {
+            this.actionLoading = true; this.error = '';
+            try {
+                const res = await fetch(`/api/admin/users/${u.id}/reset-password`, {
+                    method: 'POST', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.actionLoading = false; return; }
+                this.tempPassword = data.temp_password;
+                this.showTempPassword = true;
+            } catch (e) { this.error = 'Failed to reset password'; }
+            this.actionLoading = false;
+        },
+
+        confirmAction(action, u) {
+            this.targetUser = u;
+            this.pendingAction = action;
+            const labels = {
+                'deactivate': ['Deactivate User', `Deactivate ${u.email}? They will be unable to log in.`],
+                'reactivate': ['Reactivate User', `Reactivate ${u.email}?`],
+                'unlock': ['Unlock User', `Unlock ${u.email}? This clears the lockout and failed login attempts.`],
+                'revoke-sessions': ['Revoke Sessions', `Revoke all active sessions for ${u.email}?`]
+            };
+            const [title, msg] = labels[action] || ['Confirm', 'Are you sure?'];
+            this.confirmTitle = title;
+            this.confirmMessage = msg;
+            this.showConfirmModal = true;
+        },
+        async executeConfirmedAction() {
+            this.actionLoading = true; this.error = '';
+            try {
+                const res = await fetch(`/api/admin/users/${this.targetUser.id}/${this.pendingAction}`, {
+                    method: 'POST', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.actionLoading = false; return; }
+                this.showConfirmModal = false;
+                this.success = `Action completed successfully.`;
+                setTimeout(() => this.success = '', 3000);
+                await this.loadUsers();
+            } catch (e) { this.error = 'Action failed'; }
+            this.actionLoading = false;
+        },
+
+        openDeleteModal(u) {
+            this.targetUser = u;
+            this.deleteConfirmEmail = '';
+            this.showDeleteModal = true;
+        },
+        async deleteUser() {
+            this.actionLoading = true; this.error = '';
+            try {
+                const res = await fetch(`/api/admin/users/${this.targetUser.id}`, {
+                    method: 'DELETE', headers,
+                    body: JSON.stringify({ confirm_email: this.deleteConfirmEmail })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.actionLoading = false; return; }
+                this.showDeleteModal = false;
+                this.deleteConfirmEmail = '';
+                this.success = 'User deleted.';
+                setTimeout(() => this.success = '', 3000);
+                await this.loadUsers();
+            } catch (e) { this.error = 'Failed to delete user'; }
+            this.actionLoading = false;
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -96,7 +96,10 @@
                         </button>
                         <div x-show="open" @click.away="open = false" x-cloak
                              class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50">
-                            <a href="/setup" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Change Password</a>
+                            <a href="/settings/account" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Account Settings</a>
+                            {% if request.state.user.role.value == 'admin' %}
+                            <a href="/settings/users" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">User Management</a>
+                            {% endif %}
                             <hr class="my-1">
                             <button @click="fetch('/api/auth/logout', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}}).then(() => window.location.href = '/login').catch(() => window.location.href = '/login')" class="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-gray-100">Logout</button>
                         </div>

--- a/tests/unit/test_web_users.py
+++ b/tests/unit/test_web_users.py
@@ -300,8 +300,8 @@ class TestAdminDeactivateUser:
         assert updated is not None
         assert updated.is_active is False
 
-    def test_deactivate_last_admin(self, tmp_path: Path) -> None:
-        """Cannot deactivate the only admin."""
+    def test_deactivate_self(self, tmp_path: Path) -> None:
+        """Cannot deactivate own account."""
         client, _db_path, admin = _setup_admin_client(tmp_path)
 
         resp = client.post(
@@ -309,6 +309,7 @@ class TestAdminDeactivateUser:
             headers=_auth_headers(),
         )
         assert resp.status_code == 409
+        assert "own account" in resp.json()["message"].lower()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_web_users.py
+++ b/tests/unit/test_web_users.py
@@ -1,0 +1,498 @@
+"""tests/unit/test_web_users.py
+
+Tests for admin user management endpoints in dango/web/routes/users.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth import database as db
+from dango.auth.models import Role, User, UserUpdate
+from dango.auth.security import hash_password
+from dango.exceptions import DangoError
+from dango.migrations.runner import MigrationRunner
+from dango.web.routes.users import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database at the standard project path."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    db_path = dango_dir / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(
+    db_path: Path,
+    email: str = "test@example.com",
+    password: str = "securepassword123",
+    role: Role = Role.EDITOR,
+    **overrides: Any,
+) -> User:
+    """Create and persist a user, returning the model."""
+    defaults: dict[str, Any] = {
+        "email": email,
+        "password_hash": hash_password(password),
+        "role": role,
+    }
+    defaults.update(overrides)
+    user = User(**defaults)
+    db.create_user(db_path, user)
+    return user
+
+
+def _make_app(db_path: Path) -> FastAPI:
+    """Create a minimal FastAPI app with users routes + error handlers."""
+    from dango.exceptions import (
+        AuthenticationError,
+        AuthorizationError,
+        UserExistsError,
+        UserNotFoundError,
+    )
+
+    app = FastAPI()
+    app.state.project_root = db_path.parent.parent
+
+    # Register the DangoError handler so require_permission works correctly
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        UserNotFoundError: 404,
+        UserExistsError: 409,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _make_client(app: FastAPI) -> TestClient:
+    """Create a test client."""
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _auth_headers() -> dict[str, str]:
+    """Standard headers for authenticated requests."""
+    return {"X-Requested-With": "XMLHttpRequest", "Content-Type": "application/json"}
+
+
+def _setup_admin_client(
+    tmp_path: Path,
+    **user_overrides: Any,
+) -> tuple[TestClient, Path, User]:
+    """Set up a test client with an admin user injected via middleware."""
+    db_path = _make_db(tmp_path)
+    defaults: dict[str, Any] = {"email": "admin@example.com", "role": Role.ADMIN}
+    defaults.update(user_overrides)
+    admin = _make_user(db_path, **defaults)
+    app = _make_app(db_path)
+    client = _make_client(app)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = admin
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    return client, db_path, admin
+
+
+def _setup_viewer_client(
+    tmp_path: Path,
+) -> tuple[TestClient, Path, User]:
+    """Set up a test client with a viewer user (non-admin)."""
+    db_path = _make_db(tmp_path)
+    viewer = _make_user(db_path, email="viewer@example.com", role=Role.VIEWER)
+    app = _make_app(db_path)
+    client = _make_client(app)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = viewer
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    return client, db_path, viewer
+
+
+# ---------------------------------------------------------------------------
+# Admin user management tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdminCreateUser:
+    """Tests for GET/POST /api/admin/users."""
+
+    def test_list_users(self, tmp_path: Path) -> None:
+        """Returns all users as JSON array."""
+        client, db_path, admin = _setup_admin_client(tmp_path)
+        _make_user(db_path, email="user2@example.com", role=Role.VIEWER)
+        resp = client.get("/api/admin/users", headers=_auth_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        emails = {u["email"] for u in data}
+        assert "admin@example.com" in emails
+        assert "user2@example.com" in emails
+
+    def test_create_user_success(self, tmp_path: Path) -> None:
+        """Creates user and returns temp_password."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+
+        resp = client.post(
+            "/api/admin/users",
+            json={"email": "new@example.com", "role": "editor"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["user"]["email"] == "new@example.com"
+        assert data["user"]["role"] == "editor"
+        assert "temp_password" in data
+        assert len(data["temp_password"]) > 0
+
+    def test_create_user_duplicate(self, tmp_path: Path) -> None:
+        """Duplicate email returns 409."""
+        client, db_path, admin = _setup_admin_client(tmp_path)
+
+        resp = client.post(
+            "/api/admin/users",
+            json={"email": "admin@example.com"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 409
+
+    def test_create_user_invalid_role(self, tmp_path: Path) -> None:
+        """Invalid role returns 400."""
+        client, _db_path, _admin = _setup_admin_client(tmp_path)
+
+        resp = client.post(
+            "/api/admin/users",
+            json={"email": "x@example.com", "role": "superadmin"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 400
+        assert "Invalid role" in resp.json()["message"]
+
+    def test_create_user_invalid_body(self, tmp_path: Path) -> None:
+        """Malformed body returns 400."""
+        client, _db_path, _admin = _setup_admin_client(tmp_path)
+
+        resp = client.post("/api/admin/users", content=b"not json", headers=_auth_headers())
+        assert resp.status_code == 400
+
+
+@pytest.mark.unit
+class TestAdminChangeRole:
+    """Tests for PUT /api/admin/users/{user_id}/role."""
+
+    def test_change_role(self, tmp_path: Path) -> None:
+        """Successfully changes user role."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="user@example.com", role=Role.VIEWER)
+
+        resp = client.put(
+            f"/api/admin/users/{user.id}/role",
+            json={"role": "editor"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["role"] == "editor"
+
+    def test_change_role_last_admin(self, tmp_path: Path) -> None:
+        """Cannot demote the only admin."""
+        client, _db_path, admin = _setup_admin_client(tmp_path)
+
+        resp = client.put(
+            f"/api/admin/users/{admin.id}/role",
+            json={"role": "viewer"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 409
+        assert "only active admin" in resp.json()["message"].lower()
+
+    def test_change_role_not_found(self, tmp_path: Path) -> None:
+        """Non-existent user returns 404."""
+        client, _db_path, _admin = _setup_admin_client(tmp_path)
+
+        resp = client.put(
+            "/api/admin/users/nonexistent-id/role",
+            json={"role": "editor"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.unit
+class TestAdminResetPassword:
+    """Tests for POST /api/admin/users/{user_id}/reset-password."""
+
+    def test_reset_password(self, tmp_path: Path) -> None:
+        """Reset returns a new temp password and invalidates sessions."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="user@example.com")
+
+        resp = client.post(
+            f"/api/admin/users/{user.id}/reset-password",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "temp_password" in data
+        assert data["user"]["must_change_password"] is True
+
+    def test_reset_password_not_found(self, tmp_path: Path) -> None:
+        """Non-existent user returns 404."""
+        client, _db_path, _admin = _setup_admin_client(tmp_path)
+
+        resp = client.post(
+            "/api/admin/users/nonexistent-id/reset-password",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.unit
+class TestAdminDeactivateUser:
+    """Tests for POST /api/admin/users/{user_id}/deactivate."""
+
+    def test_deactivate_user(self, tmp_path: Path) -> None:
+        """Deactivates a user."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="user@example.com")
+
+        resp = client.post(
+            f"/api/admin/users/{user.id}/deactivate",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert updated.is_active is False
+
+    def test_deactivate_last_admin(self, tmp_path: Path) -> None:
+        """Cannot deactivate the only admin."""
+        client, _db_path, admin = _setup_admin_client(tmp_path)
+
+        resp = client.post(
+            f"/api/admin/users/{admin.id}/deactivate",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 409
+
+
+@pytest.mark.unit
+class TestAdminReactivateUser:
+    """Tests for POST /api/admin/users/{user_id}/reactivate."""
+
+    def test_reactivate_user(self, tmp_path: Path) -> None:
+        """Reactivates an inactive user."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="user@example.com", is_active=False)
+
+        resp = client.post(
+            f"/api/admin/users/{user.id}/reactivate",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["is_active"] is True
+
+
+@pytest.mark.unit
+class TestAdminDeleteUser:
+    """Tests for DELETE /api/admin/users/{user_id}."""
+
+    def test_delete_user_success(self, tmp_path: Path) -> None:
+        """Deletes a user with correct email confirmation."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="doomed@example.com")
+
+        resp = client.request(
+            "DELETE",
+            f"/api/admin/users/{user.id}",
+            json={"confirm_email": "doomed@example.com"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        assert db.get_user_by_id(db_path, user.id) is None
+
+    def test_delete_user_wrong_email(self, tmp_path: Path) -> None:
+        """Wrong confirmation email returns 400."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="user@example.com")
+
+        resp = client.request(
+            "DELETE",
+            f"/api/admin/users/{user.id}",
+            json={"confirm_email": "wrong@example.com"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 400
+
+    def test_delete_user_self(self, tmp_path: Path) -> None:
+        """Cannot delete own account."""
+        client, _db_path, admin = _setup_admin_client(tmp_path)
+
+        resp = client.request(
+            "DELETE",
+            f"/api/admin/users/{admin.id}",
+            json={"confirm_email": "admin@example.com"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 409
+        assert "own account" in resp.json()["message"].lower()
+
+    def test_delete_not_found(self, tmp_path: Path) -> None:
+        """Non-existent user returns 404."""
+        client, _db_path, _admin = _setup_admin_client(tmp_path)
+        resp = client.request(
+            "DELETE",
+            "/api/admin/users/nonexistent-id",
+            json={"confirm_email": "x@example.com"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.unit
+class TestAdminUnlockUser:
+    """Tests for POST /api/admin/users/{user_id}/unlock."""
+
+    def test_unlock_user(self, tmp_path: Path) -> None:
+        """Unlocks a locked user."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="locked@example.com")
+        locked_until = datetime.now(timezone.utc) + timedelta(minutes=15)
+        db.update_user(
+            db_path,
+            user.id,
+            UserUpdate(failed_login_attempts=5, locked_until=locked_until),
+        )
+
+        resp = client.post(
+            f"/api/admin/users/{user.id}/unlock",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert updated.failed_login_attempts == 0
+        assert updated.locked_until is None
+
+
+@pytest.mark.unit
+class TestAdminRevokeSessions:
+    """Tests for POST /api/admin/users/{user_id}/revoke-sessions."""
+
+    def test_revoke_sessions(self, tmp_path: Path) -> None:
+        """Revokes all sessions for a user."""
+        client, db_path, _admin = _setup_admin_client(tmp_path)
+        user = _make_user(db_path, email="user@example.com")
+
+        resp = client.post(
+            f"/api/admin/users/{user.id}/revoke-sessions",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert "revoked_count" in data
+
+
+@pytest.mark.unit
+class TestNonAdminForbidden:
+    """Test that non-admin users get 403 on all admin endpoints."""
+
+    def test_viewer_forbidden_list(self, tmp_path: Path) -> None:
+        """Viewer cannot list users."""
+        client, _db_path, _viewer = _setup_viewer_client(tmp_path)
+        resp = client.get("/api/admin/users", headers=_auth_headers())
+        assert resp.status_code == 403
+
+    def test_viewer_forbidden_create(self, tmp_path: Path) -> None:
+        """Viewer cannot create users."""
+        client, _db_path, _viewer = _setup_viewer_client(tmp_path)
+        resp = client.post(
+            "/api/admin/users",
+            json={"email": "new@example.com"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Settings page tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSettingsPages:
+    """Tests for page routes."""
+
+    def test_admin_page_renders(self, tmp_path: Path) -> None:
+        """Admin can access /settings/users."""
+        client, _db_path, _admin = _setup_admin_client(tmp_path)
+        resp = client.get("/settings/users")
+        assert resp.status_code == 200
+        assert "User Management" in resp.text
+
+    def test_admin_page_forbidden_for_viewer(self, tmp_path: Path) -> None:
+        """Viewer gets 403 on /settings/users."""
+        client, _db_path, _viewer = _setup_viewer_client(tmp_path)
+        resp = client.get("/settings/users")
+        assert resp.status_code == 403
+
+    def test_account_page_renders(self, tmp_path: Path) -> None:
+        """Authenticated user can access /settings/account."""
+        client, _db_path, admin = _setup_admin_client(tmp_path)
+        resp = client.get("/settings/account")
+        assert resp.status_code == 200
+        assert "Account Settings" in resp.text
+
+    def test_account_page_unauthenticated(self, tmp_path: Path) -> None:
+        """Unauthenticated user gets redirected to /login."""
+        db_path = _make_db(tmp_path)
+        app = _make_app(db_path)
+
+        @app.middleware("http")
+        async def set_user(request: Any, call_next: Any) -> Any:
+            request.state.user = None
+            request.state.auth_method = None
+            return await call_next(request)
+
+        client = _make_client(app)
+        resp = client.get("/settings/account", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login"


### PR DESCRIPTION
## Summary
- Admin user management page (`/settings/users`) with 9 API endpoints: list, create, change role, reset password, deactivate, reactivate, delete (with email confirmation), unlock, and revoke sessions
- User self-service account page (`/settings/account`) reusing existing auth endpoints for password change, active sessions, API keys, and 2FA status (graceful degradation)
- Nav dropdown updated with "Account Settings" and admin-only "User Management" links

## Files
| File | Lines | Type |
|------|-------|------|
| `dango/web/routes/users.py` | 428 | New |
| `dango/web/templates/admin_users.html` | 364 | New |
| `dango/web/templates/account.html` | 308 | New |
| `tests/unit/test_web_users.py` | 498 | New |
| `dango/web/models.py` | 155 (+24) | Modified |
| `dango/web/app.py` | 286 (+2) | Modified |
| `dango/web/templates/base.html` | 137 (+3) | Modified |

## Test plan
- [x] 25/25 new tests pass (`pytest tests/unit/test_web_users.py -v`)
- [x] 29/29 existing auth tests pass (regression: `pytest tests/unit/test_web_auth.py tests/unit/test_web_auth_keys.py -v`)
- [x] 943/943 full unit suite passes (`pytest -m unit`)
- [x] ruff lint + format pass on all modified/new files
- [x] mypy passes on all modified/new files
- [x] All files within 500-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)