### PR TITLE
Add TOTP two-factor authentication (TASK-096)

### DIFF
--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -108,6 +108,18 @@ from dango.auth.sessions import (
     validate_partial_session,
     validate_session,
 )
+from dango.auth.totp import (
+    consume_recovery_code,
+    disable_totp,
+    enable_totp,
+    generate_totp_secret,
+    get_provisioning_uri,
+    hash_and_store_codes,
+    regenerate_recovery_codes,
+    setup_totp,
+    verify_recovery_code,
+    verify_totp_code,
+)
 
 __all__ = [
     # Admin utilities
@@ -196,6 +208,17 @@ __all__ = [
     "generate_oauth_state",
     "get_configured_providers",
     "get_provider",
+    # TOTP 2FA
+    "consume_recovery_code",
+    "disable_totp",
+    "enable_totp",
+    "generate_totp_secret",
+    "get_provisioning_uri",
+    "hash_and_store_codes",
+    "regenerate_recovery_codes",
+    "setup_totp",
+    "verify_recovery_code",
+    "verify_totp_code",
     # Security utilities
     "check_password_strength",
     "generate_api_key",

--- a/dango/auth/totp.py
+++ b/dango/auth/totp.py
@@ -1,0 +1,220 @@
+"""dango/auth/totp.py
+
+TOTP two-factor authentication business logic.
+
+Provides secret generation, provisioning URI construction, code verification,
+recovery code management, and database persistence for TOTP 2FA.  Pure
+functions have no side effects; DB functions take ``db_path`` and operate
+on the auth SQLite database.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pyotp
+
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.database import get_user_by_id, update_user
+from dango.auth.models import UserUpdate
+from dango.auth.security import generate_recovery_codes, hash_recovery_code
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def generate_totp_secret() -> str:
+    """Generate a random base32 TOTP secret.
+
+    Returns:
+        A 32-character base32-encoded secret string.
+    """
+    return pyotp.random_base32()
+
+
+def get_provisioning_uri(secret: str, email: str, issuer: str = "Dango") -> str:
+    """Build an ``otpauth://`` provisioning URI for QR code display.
+
+    Args:
+        secret: Base32-encoded TOTP secret.
+        email: User email (used as the account name in authenticator apps).
+        issuer: Application name shown in the authenticator.
+
+    Returns:
+        Full ``otpauth://totp/...`` URI.
+    """
+    totp = pyotp.TOTP(secret)
+    return totp.provisioning_uri(name=email, issuer_name=issuer)
+
+
+def verify_totp_code(secret: str, code: str) -> bool:
+    """Verify a TOTP code against a secret with a +-30s drift window.
+
+    Returns ``False`` for empty/malformed input rather than raising.
+
+    Args:
+        secret: Base32-encoded TOTP secret.
+        code: 6-digit TOTP code to verify.
+
+    Returns:
+        ``True`` if the code is valid within ``valid_window=1``.
+    """
+    if not secret or not code:
+        return False
+    # Must be exactly 6 digits
+    stripped = code.strip()
+    if not stripped.isdigit() or len(stripped) != 6:
+        return False
+    totp = pyotp.TOTP(secret)
+    return totp.verify(stripped, valid_window=1)
+
+
+def verify_recovery_code(stored_hashes_json: str | None, code: str) -> tuple[bool, str | None]:
+    """Check a recovery code against stored hashes.
+
+    If the code matches, returns ``(True, updated_json)`` with the used
+    hash removed.  If not, returns ``(False, None)``.
+
+    Args:
+        stored_hashes_json: JSON array of SHA-256 hex hashes, or ``None``.
+        code: Raw recovery code (any case, with or without dashes).
+
+    Returns:
+        Tuple of ``(matched, updated_hashes_json_or_none)``.
+    """
+    if not stored_hashes_json or not code:
+        return False, None
+
+    try:
+        hashes: list[str] = json.loads(stored_hashes_json)
+    except (json.JSONDecodeError, TypeError):
+        return False, None
+
+    if not hashes:
+        return False, None
+
+    code_hash = hash_recovery_code(code)
+    for i, stored in enumerate(hashes):
+        if stored == code_hash:
+            remaining = hashes[:i] + hashes[i + 1 :]
+            return True, json.dumps(remaining)
+
+    return False, None
+
+
+def hash_and_store_codes(codes: list[str]) -> str:
+    """Hash recovery codes and return a JSON array of hex digests.
+
+    Args:
+        codes: Raw recovery code strings.
+
+    Returns:
+        JSON-encoded array of SHA-256 hex hashes.
+    """
+    hashes = [hash_recovery_code(c) for c in codes]
+    return json.dumps(hashes)
+
+
+# ---------------------------------------------------------------------------
+# Database operations
+# ---------------------------------------------------------------------------
+
+
+def setup_totp(db_path: Path, user_id: str, secret: str, codes: list[str]) -> None:
+    """Store a TOTP secret and hashed recovery codes (not yet enabled).
+
+    The secret is persisted immediately but ``totp_enabled`` stays
+    ``False`` until the user verifies a code via ``enable_totp()``.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        user_id: User ID to update.
+        secret: Base32-encoded TOTP secret.
+        codes: Raw recovery codes (will be hashed before storage).
+    """
+    hashed_json = hash_and_store_codes(codes)
+    update_user(
+        db_path,
+        user_id,
+        UserUpdate(
+            totp_secret=secret,
+            totp_enabled=False,
+            recovery_codes=hashed_json,
+        ),
+    )
+
+
+def enable_totp(db_path: Path, user_id: str) -> None:
+    """Flip ``totp_enabled`` to ``True`` and log the event.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        user_id: User ID to enable 2FA for.
+    """
+    update_user(db_path, user_id, UserUpdate(totp_enabled=True))
+    user = get_user_by_id(db_path, user_id)
+    email = user.email if user else None
+    log_auth_event(AuditEvent.TWO_FA_ENABLED, user_id=user_id, email=email)
+
+
+def disable_totp(db_path: Path, user_id: str) -> None:
+    """Clear all TOTP fields and log the event.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        user_id: User ID to disable 2FA for.
+    """
+    user = get_user_by_id(db_path, user_id)
+    email = user.email if user else None
+    update_user(
+        db_path,
+        user_id,
+        UserUpdate(
+            totp_secret=None,
+            totp_enabled=False,
+            recovery_codes=None,
+        ),
+    )
+    log_auth_event(AuditEvent.TWO_FA_DISABLED, user_id=user_id, email=email)
+
+
+def consume_recovery_code(
+    db_path: Path, user_id: str, stored_hashes_json: str | None, code: str
+) -> bool:
+    """Verify a recovery code and remove it from the database if valid.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        user_id: User ID.
+        stored_hashes_json: Current JSON array of hashed recovery codes.
+        code: Raw recovery code to check.
+
+    Returns:
+        ``True`` if the code was valid and consumed.
+    """
+    matched, updated_json = verify_recovery_code(stored_hashes_json, code)
+    if not matched:
+        return False
+    update_user(db_path, user_id, UserUpdate(recovery_codes=updated_json))
+    user = get_user_by_id(db_path, user_id)
+    email = user.email if user else None
+    log_auth_event(AuditEvent.RECOVERY_CODE_USED, user_id=user_id, email=email)
+    return True
+
+
+def regenerate_recovery_codes(db_path: Path, user_id: str) -> list[str]:
+    """Generate new recovery codes, replacing any existing ones.
+
+    Args:
+        db_path: Path to the auth SQLite database.
+        user_id: User ID.
+
+    Returns:
+        List of raw (unhashed) recovery codes to display to the user.
+    """
+    codes = generate_recovery_codes()
+    hashed_json = hash_and_store_codes(codes)
+    update_user(db_path, user_id, UserUpdate(recovery_codes=hashed_json))
+    return codes

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -203,16 +203,20 @@ class ConfigLoader:
 
     def save_project_context(self, project: ProjectContext) -> None:
         """Save project context to project.yml"""
-        # Check if project.yml exists and has platform settings
+        # Check if project.yml exists and has platform/auth settings
         existing_platform = {}
+        existing_auth = {}
         if self.project_file.exists():
             existing_data = self.load_yaml(self.project_file)
             existing_platform = existing_data.get("platform", {})
+            existing_auth = existing_data.get("auth", {})
 
-        data = {
+        data: dict[str, Any] = {
             "project": project.model_dump(mode="json", exclude_none=True),
-            "platform": existing_platform,  # Preserve existing platform settings
+            "platform": existing_platform,
         }
+        if existing_auth:
+            data["auth"] = existing_auth
         self.save_yaml(data, self.project_file)
 
     def save_sources_config(self, sources: SourcesConfig) -> None:
@@ -222,13 +226,18 @@ class ConfigLoader:
 
     def save_config(self, config: DangoConfig) -> None:
         """Save complete configuration"""
-        # Save project context and platform settings together in project.yml
-        data = {
+        from dango.config.models import AuthConfig
+
+        # Save project context, platform, and auth settings together in project.yml
+        data: dict[str, Any] = {
             "project": config.project.model_dump(mode="json", exclude_none=True),
-            "platform": config.platform.model_dump(
-                mode="json", exclude_none=False
-            ),  # Include all fields
+            "platform": config.platform.model_dump(mode="json", exclude_none=False),
         }
+        # Only write auth section if non-default to keep project.yml clean
+        auth_data = config.auth.model_dump(mode="json", exclude_none=False)
+        default_auth = AuthConfig().model_dump(mode="json", exclude_none=False)
+        if auth_data != default_auth:
+            data["auth"] = auth_data
         self.save_yaml(data, self.project_file)
 
         # Save sources separately

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -192,13 +192,14 @@ class ConfigLoader:
         project = self.load_project_context()
         sources = self.load_sources_config()
 
-        # Load platform settings from project.yml
+        # Load platform and auth settings from project.yml
         data = self.load_yaml(self.project_file)
-        from dango.config.models import PlatformSettings
+        from dango.config.models import AuthConfig, PlatformSettings
 
         platform = PlatformSettings(**data.get("platform", {}))
+        auth = AuthConfig(**data.get("auth", {}))
 
-        return DangoConfig(project=project, sources=sources, platform=platform)
+        return DangoConfig(project=project, sources=sources, platform=platform, auth=auth)
 
     def save_project_context(self, project: ProjectContext) -> None:
         """Save project context to project.yml"""

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -469,6 +469,7 @@ class AuthConfig(BaseModel):
     enabled: bool = Field(default=False, description="Enable authentication (required for cloud)")
     idle_timeout_minutes: int = Field(default=60, description="Session idle timeout in minutes")
     session_max_days: int = Field(default=30, description="Maximum session lifetime in days")
+    require_2fa: bool = Field(default=False, description="Require all users to set up 2FA")
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     lockout: AccountLockoutConfig = Field(default_factory=AccountLockoutConfig)
     oauth_providers: dict[str, OAuthProviderConfig] = Field(

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -217,6 +217,7 @@ async def unhandled_error_handler(request: Request, exc: Exception) -> Response:
 # Register routers — Dango API routes first, then proxy routes (catch-all last)
 # ---------------------------------------------------------------------------
 from dango.web.routes.auth import router as auth_router  # noqa: E402
+from dango.web.routes.auth_2fa import router as auth_2fa_router  # noqa: E402
 from dango.web.routes.config import router as config_router  # noqa: E402
 from dango.web.routes.dbt import router as dbt_router  # noqa: E402
 from dango.web.routes.health import router as health_router  # noqa: E402
@@ -232,6 +233,7 @@ from dango.web.routes.websocket import router as websocket_router  # noqa: E402
 # Dango API routers (order matters — more specific routes first)
 app.include_router(auth_router)
 app.include_router(users_router)
+app.include_router(auth_2fa_router)
 app.include_router(health_router)
 app.include_router(config_router)
 app.include_router(sources_router)

--- a/dango/web/middleware/auth.py
+++ b/dango/web/middleware/auth.py
@@ -58,6 +58,7 @@ _AUTH_TOGGLE_CACHE_TTL: float = 5.0  # seconds
 # fmt: off
 _PUBLIC_EXACT: frozenset[str] = frozenset({
     "/api/auth/login",
+    "/api/auth/2fa/verify",
     "/api/auth/oauth/callback",
     "/login",
     "/setup",

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -162,3 +162,40 @@ class DeleteUserConfirmation(BaseModel):
     """Delete user confirmation payload."""
 
     confirm_email: str
+
+
+# ---------------------------------------------------------------------------
+# 2FA DTOs (used by web/routes/auth_2fa.py)
+# ---------------------------------------------------------------------------
+
+
+class TwoFASetupRequest(BaseModel):
+    """Request to begin 2FA setup (verifies current password)."""
+
+    password: str
+
+
+class TwoFAVerifySetupRequest(BaseModel):
+    """Verify a TOTP code to complete 2FA setup."""
+
+    code: str
+
+
+class TwoFAVerifyRequest(BaseModel):
+    """Verify a TOTP or recovery code during login."""
+
+    code: str
+    is_recovery: bool = False
+
+
+class TwoFADisableRequest(BaseModel):
+    """Request to disable 2FA (verifies current password)."""
+
+    password: str
+
+
+class TwoFARegenerateRequest(BaseModel):
+    """Request to regenerate recovery codes (verifies password + TOTP)."""
+
+    password: str
+    code: str

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -34,7 +34,6 @@ from dango.auth.oauth_login import (
     OAuthLoginError,
     OAuthUserInfo,
     generate_oauth_state,
-    get_configured_providers,
     get_provider,
 )
 from dango.auth.security import (

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -15,10 +15,9 @@ from typing import Any
 from urllib.parse import quote
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import ValidationError
 
-import dango
 from dango.auth.admin import get_auth_db_path
 from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.database import (
@@ -62,7 +61,6 @@ from dango.web.models import (
     LoginRequest,
     SessionResponse,
 )
-from dango.web.routes.ui import _render_template
 
 router = APIRouter(tags=["auth"])
 logger = get_logger(__name__)
@@ -221,6 +219,25 @@ async def login(request: Request) -> JSONResponse:
 
     # Success
     reset_failed_logins(db_path, login_data.email)
+
+    # 2FA required — create partial session
+    if user.totp_enabled:
+        raw_token, _session = create_session(
+            db_path,
+            user.id,
+            ip_address=ip,
+            user_agent=_get_user_agent(request),
+            is_partial=True,
+        )
+        response = JSONResponse(content={"requires_2fa": True})
+        _set_session_cookie(response, raw_token, request)
+        return response
+
+    # Check if admin requires 2FA but user hasn't set it up
+    requires_2fa_setup = False
+    if auth_config is not None and auth_config.require_2fa and not user.totp_enabled:
+        requires_2fa_setup = True
+
     raw_token, _session = create_session(
         db_path,
         user.id,
@@ -236,6 +253,7 @@ async def login(request: Request) -> JSONResponse:
         content={
             "user": user_response.model_dump(mode="json"),
             "must_change_password": user.must_change_password,
+            "requires_2fa_setup": requires_2fa_setup,
         }
     )
     _set_session_cookie(response, raw_token, request)
@@ -710,42 +728,3 @@ async def _resolve_oauth_user(
         secure=is_secure_request(request.scope),
     )
     return response
-
-
-# ---------------------------------------------------------------------------
-# Page routes
-# ---------------------------------------------------------------------------
-
-
-@router.get("/login")
-async def login_page(request: Request) -> HTMLResponse:
-    """Render the login page."""
-    oauth_configs = _get_oauth_config(request)
-    providers = get_configured_providers(oauth_configs)
-    oauth_providers = [
-        {"name": p.name, "display_name": p.display_name, "icon_svg": p.icon_svg} for p in providers
-    ]
-    return _render_template(
-        "login.html",
-        {
-            "request": request,
-            "version": dango.__version__,
-            "current_page": "login",
-            "subtitle": "Login",
-            "oauth_providers": oauth_providers,
-        },
-    )
-
-
-@router.get("/setup")
-async def setup_page(request: Request) -> HTMLResponse:
-    """Render the change-password page (first-login setup)."""
-    return _render_template(
-        "change_password.html",
-        {
-            "request": request,
-            "version": dango.__version__,
-            "current_page": "setup",
-            "subtitle": "Change Password",
-        },
-    )

--- a/dango/web/routes/auth_2fa.py
+++ b/dango/web/routes/auth_2fa.py
@@ -19,9 +19,9 @@ from pydantic import ValidationError
 
 from dango.auth.admin import get_auth_db_path
 from dango.auth.audit import AuditEvent, log_auth_event
-from dango.auth.database import get_user_by_id, update_user
+from dango.auth.database import get_session_by_token, get_user_by_id, update_user
 from dango.auth.models import User, UserResponse, UserUpdate
-from dango.auth.security import verify_password
+from dango.auth.security import generate_recovery_codes, hash_token, verify_password
 from dango.auth.sessions import create_session, invalidate_session, validate_partial_session
 from dango.auth.totp import (
     consume_recovery_code,
@@ -124,10 +124,16 @@ async def setup_2fa(request: Request) -> JSONResponse:
     if user.password_hash is None or not verify_password(data.password, user.password_hash):
         return JSONResponse(status_code=400, content={"message": "Invalid password"})
 
+    # Reject if 2FA is already active — user must disable first
+    current_user = get_user_by_id(db_path, user.id)
+    if current_user is not None and current_user.totp_enabled:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "2FA is already enabled. Disable it first to re-setup."},
+        )
+
     # Generate secret and recovery codes
     secret = generate_totp_secret()
-    from dango.auth.security import generate_recovery_codes
-
     codes = generate_recovery_codes()
 
     # Store (totp_enabled stays False until verify-setup)
@@ -219,14 +225,13 @@ async def verify_2fa(request: Request) -> JSONResponse:
         verified = verify_totp_code(current_user.totp_secret, data.code)
 
     if not verified:
+        # TODO: Add failed-attempt tracking on partial sessions to prevent
+        # brute-force TOTP guessing within the 5-minute window. Requires
+        # a migration to add failed_2fa_attempts column to sessions table.
         return JSONResponse(status_code=400, content={"message": "Invalid verification code"})
 
     # Invalidate the partial session
-    from dango.auth.security import hash_token
-
     token_hash = hash_token(cookie_token)
-    from dango.auth.database import get_session_by_token
-
     partial_session = get_session_by_token(db_path, token_hash)
     if partial_session:
         invalidate_session(db_path, partial_session.id)

--- a/dango/web/routes/auth_2fa.py
+++ b/dango/web/routes/auth_2fa.py
@@ -1,0 +1,319 @@
+"""dango/web/routes/auth_2fa.py
+
+API endpoints for TOTP two-factor authentication.
+
+Provides setup, verification, disable, and recovery code regeneration
+endpoints.  The ``/api/auth/2fa/verify`` endpoint is public (uses a
+partial session cookie) while all others require a full authenticated
+session.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+
+from dango.auth.admin import get_auth_db_path
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.database import get_user_by_id, update_user
+from dango.auth.models import User, UserResponse, UserUpdate
+from dango.auth.security import verify_password
+from dango.auth.sessions import create_session, invalidate_session, validate_partial_session
+from dango.auth.totp import (
+    consume_recovery_code,
+    disable_totp,
+    enable_totp,
+    generate_totp_secret,
+    get_provisioning_uri,
+    regenerate_recovery_codes,
+    setup_totp,
+    verify_totp_code,
+)
+from dango.config.models import AuthConfig
+from dango.logging import get_logger
+from dango.web.middleware.auth import COOKIE_NAME, is_secure_request
+from dango.web.models import (
+    TwoFADisableRequest,
+    TwoFARegenerateRequest,
+    TwoFASetupRequest,
+    TwoFAVerifyRequest,
+    TwoFAVerifySetupRequest,
+)
+
+router = APIRouter(tags=["auth-2fa"])
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (same pattern as auth.py — small, redefined here to
+# avoid cross-importing private functions between route modules)
+# ---------------------------------------------------------------------------
+
+
+def _get_db_path(request: Request) -> Path:
+    """Resolve the auth database path from application state."""
+    project_root: Path = request.app.state.project_root
+    return get_auth_db_path(project_root)
+
+
+def _get_current_user(request: Request) -> User | None:
+    """Return the authenticated user from request state, or None."""
+    return getattr(request.state, "user", None)
+
+
+def _get_client_ip(request: Request) -> str | None:
+    """Extract client IP address from the request."""
+    if request.client is not None:
+        return request.client.host
+    return None
+
+
+def _get_user_agent(request: Request) -> str | None:
+    """Extract User-Agent header from the request."""
+    return request.headers.get("user-agent")
+
+
+def _set_session_cookie(response: JSONResponse, token: str, request: Request) -> None:
+    """Set the session cookie on a response with appropriate security flags."""
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=token,
+        path="/",
+        httponly=True,
+        samesite="lax",
+        secure=is_secure_request(request.scope),
+    )
+
+
+def _get_auth_config(request: Request) -> AuthConfig | None:
+    """Load AuthConfig from project config. Returns None on failure."""
+    try:
+        from dango.config.helpers import load_config
+
+        project_root: Path = request.app.state.project_root
+        config = load_config(project_root)
+        return config.auth
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/auth/2fa/setup")
+async def setup_2fa(request: Request) -> JSONResponse:
+    """Begin 2FA setup: verify password, generate secret and recovery codes."""
+    user = _get_current_user(request)
+    if user is None:
+        return JSONResponse(status_code=401, content={"message": "Not authenticated"})
+
+    db_path = _get_db_path(request)
+    try:
+        body = await request.json()
+        data = TwoFASetupRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    # Verify password before allowing setup
+    if user.password_hash is None or not verify_password(data.password, user.password_hash):
+        return JSONResponse(status_code=400, content={"message": "Invalid password"})
+
+    # Generate secret and recovery codes
+    secret = generate_totp_secret()
+    from dango.auth.security import generate_recovery_codes
+
+    codes = generate_recovery_codes()
+
+    # Store (totp_enabled stays False until verify-setup)
+    setup_totp(db_path, user.id, secret, codes)
+
+    uri = get_provisioning_uri(secret, user.email)
+    return JSONResponse(
+        content={
+            "provisioning_uri": uri,
+            "secret": secret,
+            "recovery_codes": codes,
+        }
+    )
+
+
+@router.post("/api/auth/2fa/verify-setup")
+async def verify_setup_2fa(request: Request) -> JSONResponse:
+    """Complete 2FA setup by verifying a TOTP code."""
+    user = _get_current_user(request)
+    if user is None:
+        return JSONResponse(status_code=401, content={"message": "Not authenticated"})
+
+    db_path = _get_db_path(request)
+    try:
+        body = await request.json()
+        data = TwoFAVerifySetupRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    # Re-read user to get the pending totp_secret
+    current_user = get_user_by_id(db_path, user.id)
+    if current_user is None:
+        return JSONResponse(status_code=401, content={"message": "User not found"})
+
+    if current_user.totp_enabled:
+        return JSONResponse(status_code=400, content={"message": "2FA is already enabled"})
+
+    if not current_user.totp_secret:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "No pending 2FA setup. Call /api/auth/2fa/setup first."},
+        )
+
+    # Verify the code against the pending secret
+    if not verify_totp_code(current_user.totp_secret, data.code):
+        return JSONResponse(status_code=400, content={"message": "Invalid verification code"})
+
+    enable_totp(db_path, user.id)
+    return JSONResponse(content={"success": True})
+
+
+@router.post("/api/auth/2fa/verify")
+async def verify_2fa(request: Request) -> JSONResponse:
+    """Verify a TOTP or recovery code to upgrade a partial session to full.
+
+    This endpoint is public (bypasses auth middleware). It reads the
+    partial session cookie directly and validates it.
+    """
+    db_path = _get_db_path(request)
+    try:
+        body = await request.json()
+        data = TwoFAVerifyRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    # Extract partial session from cookie
+    cookie_token = request.cookies.get(COOKIE_NAME)
+    if not cookie_token:
+        return JSONResponse(status_code=401, content={"message": "Invalid or expired session"})
+
+    user = validate_partial_session(db_path, cookie_token)
+    if user is None:
+        return JSONResponse(status_code=401, content={"message": "Invalid or expired session"})
+
+    # Re-read user for current TOTP state
+    current_user = get_user_by_id(db_path, user.id)
+    if current_user is None or not current_user.totp_enabled or not current_user.totp_secret:
+        return JSONResponse(
+            status_code=400, content={"message": "2FA is not enabled for this account"}
+        )
+
+    # Verify code (TOTP or recovery)
+    verified = False
+    if data.is_recovery:
+        verified = consume_recovery_code(
+            db_path, current_user.id, current_user.recovery_codes, data.code
+        )
+    else:
+        verified = verify_totp_code(current_user.totp_secret, data.code)
+
+    if not verified:
+        return JSONResponse(status_code=400, content={"message": "Invalid verification code"})
+
+    # Invalidate the partial session
+    from dango.auth.security import hash_token
+
+    token_hash = hash_token(cookie_token)
+    from dango.auth.database import get_session_by_token
+
+    partial_session = get_session_by_token(db_path, token_hash)
+    if partial_session:
+        invalidate_session(db_path, partial_session.id)
+
+    # Create full session
+    auth_config = _get_auth_config(request)
+    session_max_days = auth_config.session_max_days if auth_config else 30
+
+    raw_token, _session = create_session(
+        db_path,
+        current_user.id,
+        ip_address=_get_client_ip(request),
+        user_agent=_get_user_agent(request),
+        session_max_days=session_max_days,
+    )
+
+    update_user(db_path, current_user.id, UserUpdate(last_login=datetime.now(timezone.utc)))
+    log_auth_event(
+        AuditEvent.LOGIN_SUCCESS,
+        user_id=current_user.id,
+        email=current_user.email,
+        ip=_get_client_ip(request),
+    )
+
+    user_response = UserResponse.model_validate(current_user)
+    response = JSONResponse(
+        content={
+            "user": user_response.model_dump(mode="json"),
+            "must_change_password": current_user.must_change_password,
+        }
+    )
+    _set_session_cookie(response, raw_token, request)
+    return response
+
+
+@router.post("/api/auth/2fa/disable")
+async def disable_2fa(request: Request) -> JSONResponse:
+    """Disable 2FA for the current user (requires password verification)."""
+    user = _get_current_user(request)
+    if user is None:
+        return JSONResponse(status_code=401, content={"message": "Not authenticated"})
+
+    db_path = _get_db_path(request)
+    try:
+        body = await request.json()
+        data = TwoFADisableRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    # Verify password
+    if user.password_hash is None or not verify_password(data.password, user.password_hash):
+        return JSONResponse(status_code=400, content={"message": "Invalid password"})
+
+    # Check that 2FA is actually enabled
+    current_user = get_user_by_id(db_path, user.id)
+    if current_user is None or not current_user.totp_enabled:
+        return JSONResponse(status_code=400, content={"message": "2FA is not enabled"})
+
+    disable_totp(db_path, user.id)
+    return JSONResponse(content={"success": True})
+
+
+@router.post("/api/auth/2fa/regenerate-recovery")
+async def regenerate_recovery(request: Request) -> JSONResponse:
+    """Regenerate recovery codes (requires password + TOTP verification)."""
+    user = _get_current_user(request)
+    if user is None:
+        return JSONResponse(status_code=401, content={"message": "Not authenticated"})
+
+    db_path = _get_db_path(request)
+    try:
+        body = await request.json()
+        data = TwoFARegenerateRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    # Verify password
+    if user.password_hash is None or not verify_password(data.password, user.password_hash):
+        return JSONResponse(status_code=400, content={"message": "Invalid password"})
+
+    # Verify TOTP code
+    current_user = get_user_by_id(db_path, user.id)
+    if current_user is None or not current_user.totp_enabled or not current_user.totp_secret:
+        return JSONResponse(status_code=400, content={"message": "2FA is not enabled"})
+
+    if not verify_totp_code(current_user.totp_secret, data.code):
+        return JSONResponse(status_code=400, content={"message": "Invalid TOTP code"})
+
+    codes = regenerate_recovery_codes(db_path, user.id)
+    return JSONResponse(content={"recovery_codes": codes})

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -98,3 +98,31 @@ async def custom_redoc_html() -> HTMLResponse:
     from fastapi.openapi.docs import get_redoc_html
 
     return get_redoc_html(openapi_url="/openapi.json", title="Dango API - Documentation")
+
+
+@router.get("/login")
+async def login_page(request: Request) -> HTMLResponse:
+    """Render the login page."""
+    return _render_template(
+        "login.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "login",
+            "subtitle": "Login",
+        },
+    )
+
+
+@router.get("/setup")
+async def setup_page(request: Request) -> HTMLResponse:
+    """Render the change-password page (first-login setup)."""
+    return _render_template(
+        "change_password.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "setup",
+            "subtitle": "Change Password",
+        },
+    )

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -103,6 +103,19 @@ async def custom_redoc_html() -> HTMLResponse:
 @router.get("/login")
 async def login_page(request: Request) -> HTMLResponse:
     """Render the login page."""
+    oauth_providers: list[dict[str, str]] = []
+    try:
+        from dango.auth.oauth_login import get_configured_providers
+        from dango.web.routes.auth import _get_oauth_config
+
+        oauth_configs = _get_oauth_config(request)
+        providers = get_configured_providers(oauth_configs)
+        oauth_providers = [
+            {"name": p.name, "display_name": p.display_name, "icon_svg": p.icon_svg}
+            for p in providers
+        ]
+    except Exception:
+        pass
     return _render_template(
         "login.html",
         {
@@ -110,6 +123,7 @@ async def login_page(request: Request) -> HTMLResponse:
             "version": dango.__version__,
             "current_page": "login",
             "subtitle": "Login",
+            "oauth_providers": oauth_providers,
         },
     )
 

--- a/dango/web/templates/login.html
+++ b/dango/web/templates/login.html
@@ -12,11 +12,12 @@
         <div class="text-center mb-8">
             <div class="text-5xl mb-3">🍡</div>
             <h1 class="text-2xl font-bold text-gray-900">Dango</h1>
-            <p class="text-sm text-gray-500 mt-1">Sign in to your account</p>
+            <p class="text-sm text-gray-500 mt-1" x-text="step === 'totp' ? 'Two-factor authentication' : 'Sign in to your account'"></p>
         </div>
 
         <div class="bg-white rounded-lg shadow-md p-8">
-            <form @submit.prevent="submit()">
+            <!-- Step 1: Credentials -->
+            <form x-show="step === 'credentials'" @submit.prevent="submit()">
                 <div class="mb-4">
                     <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email</label>
                     <input type="email" id="email" x-model="email" required autocomplete="email"
@@ -47,7 +48,7 @@
             </form>
 
             {% if oauth_providers %}
-            <div class="mt-6">
+            <div x-show="step === 'credentials'" class="mt-6">
                 <div class="relative">
                     <div class="absolute inset-0 flex items-center">
                         <div class="w-full border-t border-gray-300"></div>
@@ -68,6 +69,45 @@
                 </div>
             </div>
             {% endif %}
+
+            <!-- Step 2: TOTP verification -->
+            <div x-show="step === 'totp'" x-cloak>
+                <form @submit.prevent="submitTotp()">
+                    <div x-show="!useRecovery" class="mb-4">
+                        <label for="totpCode" class="block text-sm font-medium text-gray-700 mb-1">Authentication code</label>
+                        <input type="text" id="totpCode" x-model="totpCode" inputmode="numeric"
+                               autocomplete="one-time-code" maxlength="6" pattern="[0-9]{6}"
+                               placeholder="000000"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 focus:border-transparent text-center text-lg tracking-widest">
+                        <p class="text-xs text-gray-500 mt-1">Enter the 6-digit code from your authenticator app</p>
+                    </div>
+
+                    <div x-show="useRecovery" class="mb-4">
+                        <label for="recoveryCode" class="block text-sm font-medium text-gray-700 mb-1">Recovery code</label>
+                        <input type="text" id="recoveryCode" x-model="recoveryCode"
+                               placeholder="XXXX-XXXX" autocomplete="off"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 focus:border-transparent text-center text-lg tracking-widest">
+                        <p class="text-xs text-gray-500 mt-1">Enter one of your recovery codes</p>
+                    </div>
+
+                    <div x-show="totpError" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+                        <p class="text-sm text-red-700" x-text="totpError"></p>
+                    </div>
+
+                    <button type="submit" :disabled="loading"
+                            class="w-full py-2 px-4 bg-dango-600 text-white rounded-md hover:bg-dango-700 focus:outline-none focus:ring-2 focus:ring-dango-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                        <span x-show="!loading">Verify</span>
+                        <span x-show="loading" x-cloak>Verifying...</span>
+                    </button>
+                </form>
+
+                <div class="mt-3 text-center">
+                    <button @click="useRecovery = !useRecovery; totpError = ''"
+                            class="text-sm text-dango-600 hover:text-dango-700">
+                        <span x-text="useRecovery ? 'Use authenticator app instead' : 'Use a recovery code instead'"></span>
+                    </button>
+                </div>
+            </div>
         </div>
 
         <p class="text-center text-xs text-gray-400 mt-6">Dango v{{ version }}</p>
@@ -82,6 +122,8 @@ function loginForm() {
         email: '', password: '',
         error: new URLSearchParams(window.location.search).get('error') || '',
         loading: false, locked: false, lockoutRemaining: 0, _timer: null,
+        step: 'credentials',
+        totpCode: '', recoveryCode: '', useRecovery: false, totpError: '',
         async submit() {
             this.loading = true;
             this.error = '';
@@ -94,8 +136,15 @@ function loginForm() {
                 });
                 const data = await res.json();
                 if (res.ok) {
+                    if (data.requires_2fa) {
+                        this.step = 'totp';
+                        this.loading = false;
+                        return;
+                    }
                     if (data.must_change_password) {
                         window.location.href = '/setup';
+                    } else if (data.requires_2fa_setup) {
+                        window.location.href = '/';
                     } else {
                         window.location.href = '/';
                     }
@@ -110,6 +159,31 @@ function loginForm() {
                 }
             } catch (e) {
                 this.error = 'Unable to connect to server';
+            }
+            this.loading = false;
+        },
+        async submitTotp() {
+            this.loading = true;
+            this.totpError = '';
+            const code = this.useRecovery ? this.recoveryCode : this.totpCode;
+            try {
+                const res = await fetch('/api/auth/2fa/verify', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+                    body: JSON.stringify({code: code, is_recovery: this.useRecovery})
+                });
+                const data = await res.json();
+                if (res.ok) {
+                    if (data.must_change_password) {
+                        window.location.href = '/setup';
+                    } else {
+                        window.location.href = '/';
+                    }
+                    return;
+                }
+                this.totpError = data.message || 'Invalid verification code';
+            } catch (e) {
+                this.totpError = 'Unable to connect to server';
             }
             this.loading = false;
         },

--- a/dango/web/templates/login.html
+++ b/dango/web/templates/login.html
@@ -101,10 +101,15 @@
                     </button>
                 </form>
 
-                <div class="mt-3 text-center">
+                <div class="mt-3 text-center space-y-1">
                     <button @click="useRecovery = !useRecovery; totpError = ''"
                             class="text-sm text-dango-600 hover:text-dango-700">
                         <span x-text="useRecovery ? 'Use authenticator app instead' : 'Use a recovery code instead'"></span>
+                    </button>
+                    <br>
+                    <button @click="step = 'credentials'; totpCode = ''; recoveryCode = ''; totpError = ''"
+                            class="text-sm text-gray-500 hover:text-gray-700">
+                        Back to login
                     </button>
                 </div>
             </div>

--- a/dango/web/templates/login.html
+++ b/dango/web/templates/login.html
@@ -143,8 +143,6 @@ function loginForm() {
                     }
                     if (data.must_change_password) {
                         window.location.href = '/setup';
-                    } else if (data.requires_2fa_setup) {
-                        window.location.href = '/';
                     } else {
                         window.location.href = '/';
                     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "keyring>=24.0.0",    # Secure credential storage in OS keychain
     "cryptography>=41.0.0",  # Token encryption
     "pwdlib[bcrypt]>=0.3.0,<1.0",  # Password hashing (bcrypt)
+    "pyotp>=2.9,<3.0",   # TOTP two-factor authentication
     "toml>=0.10.2",       # TOML file parsing for .dlt/secrets.toml
 
     # Google API dependencies (for bundled Google Sheets source)

--- a/tests/unit/test_auth_totp.py
+++ b/tests/unit/test_auth_totp.py
@@ -1,0 +1,353 @@
+"""tests/unit/test_auth_totp.py
+
+Unit tests for dango/auth/totp.py — TOTP 2FA business logic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pyotp
+import pytest
+
+from dango.auth import database as db
+from dango.auth.models import Role, User
+from dango.auth.security import hash_password, hash_recovery_code
+from dango.auth.totp import (
+    consume_recovery_code,
+    disable_totp,
+    enable_totp,
+    generate_totp_secret,
+    get_provisioning_uri,
+    hash_and_store_codes,
+    regenerate_recovery_codes,
+    setup_totp,
+    verify_recovery_code,
+    verify_totp_code,
+)
+from dango.migrations.runner import MigrationRunner
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    db_path = dango_dir / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(db_path: Path, **overrides: Any) -> User:
+    """Create and persist a test user."""
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": hash_password("securepassword123"),
+        "role": Role.EDITOR,
+    }
+    defaults.update(overrides)
+    user = User(**defaults)
+    db.create_user(db_path, user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGenerateTotpSecret:
+    """Tests for generate_totp_secret()."""
+
+    def test_returns_base32_string(self) -> None:
+        secret = generate_totp_secret()
+        assert secret
+        assert len(secret) == 32
+        # Valid base32 characters
+        valid = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=")
+        assert set(secret).issubset(valid)
+
+    def test_unique_secrets(self) -> None:
+        secrets = {generate_totp_secret() for _ in range(10)}
+        assert len(secrets) == 10
+
+
+@pytest.mark.unit
+class TestGetProvisioningUri:
+    """Tests for get_provisioning_uri()."""
+
+    def test_format(self) -> None:
+        secret = generate_totp_secret()
+        uri = get_provisioning_uri(secret, "user@example.com")
+        assert uri.startswith("otpauth://totp/")
+        assert "user%40example.com" in uri or "user@example.com" in uri
+        assert "Dango" in uri
+
+    def test_custom_issuer(self) -> None:
+        secret = generate_totp_secret()
+        uri = get_provisioning_uri(secret, "user@example.com", issuer="CustomApp")
+        assert "CustomApp" in uri
+
+    def test_contains_secret(self) -> None:
+        secret = generate_totp_secret()
+        uri = get_provisioning_uri(secret, "user@example.com")
+        assert f"secret={secret}" in uri
+
+
+@pytest.mark.unit
+class TestVerifyTotpCode:
+    """Tests for verify_totp_code()."""
+
+    def test_valid_code(self) -> None:
+        secret = generate_totp_secret()
+        totp = pyotp.TOTP(secret)
+        code = totp.now()
+        assert verify_totp_code(secret, code) is True
+
+    def test_invalid_code(self) -> None:
+        secret = generate_totp_secret()
+        assert verify_totp_code(secret, "000000") is False
+
+    def test_empty_code(self) -> None:
+        secret = generate_totp_secret()
+        assert verify_totp_code(secret, "") is False
+
+    def test_empty_secret(self) -> None:
+        assert verify_totp_code("", "123456") is False
+
+    def test_non_digit_code(self) -> None:
+        secret = generate_totp_secret()
+        assert verify_totp_code(secret, "abcdef") is False
+
+    def test_wrong_length_code(self) -> None:
+        secret = generate_totp_secret()
+        assert verify_totp_code(secret, "12345") is False
+        assert verify_totp_code(secret, "1234567") is False
+
+    def test_code_with_spaces_stripped(self) -> None:
+        secret = generate_totp_secret()
+        totp = pyotp.TOTP(secret)
+        code = totp.now()
+        # Leading/trailing spaces should be stripped
+        assert verify_totp_code(secret, f" {code} ") is True
+
+
+@pytest.mark.unit
+class TestVerifyRecoveryCode:
+    """Tests for verify_recovery_code()."""
+
+    def test_match_found(self) -> None:
+        codes = ["ABCD-EFGH", "JKLM-NPQR"]
+        hashes = [hash_recovery_code(c) for c in codes]
+        stored_json = json.dumps(hashes)
+
+        matched, updated = verify_recovery_code(stored_json, "ABCD-EFGH")
+        assert matched is True
+        assert updated is not None
+        remaining = json.loads(updated)
+        assert len(remaining) == 1
+        assert remaining[0] == hashes[1]
+
+    def test_no_match(self) -> None:
+        hashes = [hash_recovery_code("ABCD-EFGH")]
+        stored_json = json.dumps(hashes)
+
+        matched, updated = verify_recovery_code(stored_json, "XXXX-YYYY")
+        assert matched is False
+        assert updated is None
+
+    def test_case_insensitive(self) -> None:
+        hashes = [hash_recovery_code("ABCD-EFGH")]
+        stored_json = json.dumps(hashes)
+
+        matched, _ = verify_recovery_code(stored_json, "abcd-efgh")
+        assert matched is True
+
+    def test_without_dashes(self) -> None:
+        hashes = [hash_recovery_code("ABCD-EFGH")]
+        stored_json = json.dumps(hashes)
+
+        matched, _ = verify_recovery_code(stored_json, "ABCDEFGH")
+        assert matched is True
+
+    def test_none_input(self) -> None:
+        matched, updated = verify_recovery_code(None, "ABCD-EFGH")
+        assert matched is False
+        assert updated is None
+
+    def test_empty_list(self) -> None:
+        matched, updated = verify_recovery_code("[]", "ABCD-EFGH")
+        assert matched is False
+        assert updated is None
+
+    def test_empty_code(self) -> None:
+        hashes = [hash_recovery_code("ABCD-EFGH")]
+        matched, updated = verify_recovery_code(json.dumps(hashes), "")
+        assert matched is False
+        assert updated is None
+
+    def test_invalid_json(self) -> None:
+        matched, updated = verify_recovery_code("not json", "ABCD-EFGH")
+        assert matched is False
+        assert updated is None
+
+
+@pytest.mark.unit
+class TestHashAndStoreCodes:
+    """Tests for hash_and_store_codes()."""
+
+    def test_correct_count(self) -> None:
+        codes = ["AAAA-BBBB", "CCCC-DDDD", "EEEE-FFFF"]
+        result = hash_and_store_codes(codes)
+        hashes = json.loads(result)
+        assert len(hashes) == 3
+
+    def test_valid_hashes(self) -> None:
+        codes = ["AAAA-BBBB"]
+        result = hash_and_store_codes(codes)
+        hashes = json.loads(result)
+        # SHA-256 hex is 64 chars
+        assert len(hashes[0]) == 64
+
+    def test_round_trip_with_verify(self) -> None:
+        codes = ["ABCD-EFGH", "JKLM-NPQR"]
+        stored = hash_and_store_codes(codes)
+        matched, _ = verify_recovery_code(stored, "ABCD-EFGH")
+        assert matched is True
+
+
+# ---------------------------------------------------------------------------
+# Database operation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetupTotp:
+    """Tests for setup_totp()."""
+
+    def test_stores_secret_and_codes(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        secret = generate_totp_secret()
+        codes = ["AAAA-BBBB", "CCCC-DDDD"]
+
+        setup_totp(db_path, user.id, secret, codes)
+
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert updated.totp_secret == secret
+        assert updated.totp_enabled is False
+        assert updated.recovery_codes is not None
+        stored_hashes = json.loads(updated.recovery_codes)
+        assert len(stored_hashes) == 2
+
+
+@pytest.mark.unit
+class TestEnableTotp:
+    """Tests for enable_totp()."""
+
+    def test_flips_enabled(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        secret = generate_totp_secret()
+        setup_totp(db_path, user.id, secret, ["AAAA-BBBB"])
+
+        enable_totp(db_path, user.id)
+
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert updated.totp_enabled is True
+
+
+@pytest.mark.unit
+class TestDisableTotp:
+    """Tests for disable_totp()."""
+
+    def test_clears_fields(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        secret = generate_totp_secret()
+        setup_totp(db_path, user.id, secret, ["AAAA-BBBB"])
+        enable_totp(db_path, user.id)
+
+        disable_totp(db_path, user.id)
+
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert updated.totp_secret is None
+        assert updated.totp_enabled is False
+        assert updated.recovery_codes is None
+
+
+@pytest.mark.unit
+class TestConsumeRecoveryCode:
+    """Tests for consume_recovery_code()."""
+
+    def test_consumes_valid_code(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        codes = ["AAAA-BBBB", "CCCC-DDDD"]
+        setup_totp(db_path, user.id, generate_totp_secret(), codes)
+
+        # Re-read to get stored hashes
+        u = db.get_user_by_id(db_path, user.id)
+        assert u is not None
+        result = consume_recovery_code(db_path, user.id, u.recovery_codes, "AAAA-BBBB")
+        assert result is True
+
+        # Only one code should remain
+        u2 = db.get_user_by_id(db_path, user.id)
+        assert u2 is not None
+        remaining = json.loads(u2.recovery_codes)  # type: ignore[arg-type]
+        assert len(remaining) == 1
+
+    def test_rejects_invalid_code(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        codes = ["AAAA-BBBB"]
+        setup_totp(db_path, user.id, generate_totp_secret(), codes)
+
+        u = db.get_user_by_id(db_path, user.id)
+        assert u is not None
+        result = consume_recovery_code(db_path, user.id, u.recovery_codes, "XXXX-YYYY")
+        assert result is False
+
+
+@pytest.mark.unit
+class TestRegenerateRecoveryCodes:
+    """Tests for regenerate_recovery_codes()."""
+
+    def test_returns_new_codes(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        setup_totp(db_path, user.id, generate_totp_secret(), ["AAAA-BBBB"])
+
+        new_codes = regenerate_recovery_codes(db_path, user.id)
+        assert len(new_codes) == 8  # Default count
+        # All formatted as XXXX-XXXX
+        for code in new_codes:
+            assert len(code) == 9
+            assert code[4] == "-"
+
+    def test_replaces_old_codes(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        user = _make_user(db_path)
+        setup_totp(db_path, user.id, generate_totp_secret(), ["AAAA-BBBB"])
+
+        regenerate_recovery_codes(db_path, user.id)
+        u = db.get_user_by_id(db_path, user.id)
+        assert u is not None
+        hashes = json.loads(u.recovery_codes)  # type: ignore[arg-type]
+        assert len(hashes) == 8
+
+        # Old code should no longer work
+        matched, _ = verify_recovery_code(u.recovery_codes, "AAAA-BBBB")
+        assert matched is False

--- a/tests/unit/test_web_auth_2fa.py
+++ b/tests/unit/test_web_auth_2fa.py
@@ -6,6 +6,7 @@ Tests for 2FA endpoints in dango/web/routes/auth_2fa.py and the
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -113,6 +114,13 @@ class TestTwoFASetup:
         resp = tc.post("/api/auth/2fa/setup", json={"password": "wrong"}, headers=_hdrs())
         assert resp.status_code == 400
         assert "Invalid password" in resp.json()["message"]
+
+    def test_already_enabled_rejects(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        _enable_2fa(db_path, user.id)
+        resp = tc.post("/api/auth/2fa/setup", json={"password": _TEST_PASSWORD}, headers=_hdrs())
+        assert resp.status_code == 400
+        assert "already enabled" in resp.json()["message"]
 
     def test_unauthenticated(self, tmp_path: Path) -> None:
         db_path = _make_db(tmp_path)
@@ -229,6 +237,26 @@ class TestTwoFAVerify:
             "/api/auth/2fa/verify",
             json={"code": "123456"},
             cookies={COOKIE_NAME: "bogus"},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 401
+
+    def test_expired_partial_session(self, tmp_path: Path) -> None:
+        """A partial session past its 5-min window should be rejected."""
+        import sqlite3
+
+        tc, db_path, user, secret, cookie = self._partial_login(tmp_path)
+        # Expire the partial session by backdating expires_at
+        past = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+        conn = sqlite3.connect(db_path)
+        conn.execute("UPDATE sessions SET expires_at = ? WHERE is_partial = 1", (past,))
+        conn.commit()
+        conn.close()
+        code = pyotp.TOTP(secret).now()
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": code, "is_recovery": False},
+            cookies={COOKIE_NAME: cookie},
             headers=_hdrs(),
         )
         assert resp.status_code == 401

--- a/tests/unit/test_web_auth_2fa.py
+++ b/tests/unit/test_web_auth_2fa.py
@@ -1,0 +1,346 @@
+"""tests/unit/test_web_auth_2fa.py
+
+Tests for 2FA endpoints in dango/web/routes/auth_2fa.py and the
+2FA login flow integration with dango/web/routes/auth.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pyotp
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dango.auth import database as db
+from dango.auth.models import Role, User, UserUpdate
+from dango.auth.security import hash_password
+from dango.auth.totp import (
+    enable_totp,
+    generate_totp_secret,
+    hash_and_store_codes,
+    setup_totp,
+)
+from dango.migrations.runner import MigrationRunner
+from dango.web.middleware.auth import COOKIE_NAME
+from dango.web.routes.auth import router as auth_router
+from dango.web.routes.auth_2fa import router as auth_2fa_router
+
+_TEST_PASSWORD = "securepassword123"
+_MIGRATIONS = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+
+
+def _make_db(tmp_path: Path) -> Path:
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    db_path = dango_dir / "auth.db"
+    MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=_MIGRATIONS).apply_pending()
+    return db_path
+
+
+def _make_user(db_path: Path, **overrides: Any) -> User:
+    defaults: dict[str, Any] = {
+        "email": "test@example.com",
+        "password_hash": hash_password(_TEST_PASSWORD),
+        "role": Role.EDITOR,
+    }
+    defaults.update(overrides)
+    user = User(**defaults)
+    db.create_user(db_path, user)
+    return user
+
+
+def _make_app(db_path: Path) -> FastAPI:
+    app = FastAPI()
+    app.state.project_root = db_path.parent.parent
+    app.include_router(auth_router)
+    app.include_router(auth_2fa_router)
+    return app
+
+
+def _client(app: FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _hdrs() -> dict[str, str]:
+    return {"X-Requested-With": "XMLHttpRequest"}
+
+
+def _authed(tmp_path: Path, **kw: Any) -> tuple[TestClient, Path, User]:
+    """Client with a logged-in user via middleware mock."""
+    db_path = _make_db(tmp_path)
+    user = _make_user(db_path, **kw)
+    app = _make_app(db_path)
+    tc = _client(app)
+
+    @app.middleware("http")
+    async def _set(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    return tc, db_path, user
+
+
+def _enable_2fa(db_path: Path, user_id: str) -> str:
+    """Enable 2FA for a user, returning the secret."""
+    secret = generate_totp_secret()
+    setup_totp(db_path, user_id, secret, ["AAAA-BBBB"])
+    enable_totp(db_path, user_id)
+    return secret
+
+
+@pytest.mark.unit
+class TestTwoFASetup:
+    """POST /api/auth/2fa/setup."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        resp = tc.post("/api/auth/2fa/setup", json={"password": _TEST_PASSWORD}, headers=_hdrs())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["provisioning_uri"].startswith("otpauth://totp/")
+        assert len(data["recovery_codes"]) == 8
+        u = db.get_user_by_id(db_path, user.id)
+        assert u is not None
+        assert u.totp_secret == data["secret"]
+        assert u.totp_enabled is False
+
+    def test_wrong_password(self, tmp_path: Path) -> None:
+        tc, _, _ = _authed(tmp_path)
+        resp = tc.post("/api/auth/2fa/setup", json={"password": "wrong"}, headers=_hdrs())
+        assert resp.status_code == 400
+        assert "Invalid password" in resp.json()["message"]
+
+    def test_unauthenticated(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)
+        tc = _client(_make_app(db_path))
+        resp = tc.post("/api/auth/2fa/setup", json={"password": _TEST_PASSWORD}, headers=_hdrs())
+        assert resp.status_code == 401
+
+
+@pytest.mark.unit
+class TestTwoFAVerifySetup:
+    """POST /api/auth/2fa/verify-setup."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        resp = tc.post("/api/auth/2fa/setup", json={"password": _TEST_PASSWORD}, headers=_hdrs())
+        secret = resp.json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        resp = tc.post("/api/auth/2fa/verify-setup", json={"code": code}, headers=_hdrs())
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        u = db.get_user_by_id(db_path, user.id)
+        assert u is not None and u.totp_enabled is True
+
+    def test_invalid_code(self, tmp_path: Path) -> None:
+        tc, _, _ = _authed(tmp_path)
+        tc.post("/api/auth/2fa/setup", json={"password": _TEST_PASSWORD}, headers=_hdrs())
+        resp = tc.post("/api/auth/2fa/verify-setup", json={"code": "000000"}, headers=_hdrs())
+        assert resp.status_code == 400
+
+    def test_no_pending(self, tmp_path: Path) -> None:
+        tc, _, _ = _authed(tmp_path)
+        resp = tc.post("/api/auth/2fa/verify-setup", json={"code": "123456"}, headers=_hdrs())
+        assert resp.status_code == 400
+        assert "No pending" in resp.json()["message"]
+
+    def test_already_enabled(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        _enable_2fa(db_path, user.id)
+        resp = tc.post("/api/auth/2fa/verify-setup", json={"code": "123456"}, headers=_hdrs())
+        assert resp.status_code == 400
+        assert "already enabled" in resp.json()["message"]
+
+
+@pytest.mark.unit
+class TestTwoFAVerify:
+    """POST /api/auth/2fa/verify (partial session → full session)."""
+
+    def _partial_login(self, tmp_path: Path) -> tuple[TestClient, Path, User, str, str]:
+        """Create user with 2FA, login to get partial session cookie."""
+        db_path = _make_db(tmp_path)
+        secret = generate_totp_secret()
+        user = _make_user(db_path, totp_secret=secret, totp_enabled=True)
+        hashed = hash_and_store_codes(["AAAA-BBBB", "CCCC-DDDD"])
+        db.update_user(db_path, user.id, UserUpdate(recovery_codes=hashed))
+        app = _make_app(db_path)
+        tc = _client(app)
+        resp = tc.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": _TEST_PASSWORD},
+        )
+        assert resp.status_code == 200 and resp.json()["requires_2fa"] is True
+        cookie = resp.cookies.get(COOKIE_NAME)
+        assert cookie is not None
+        return tc, db_path, user, secret, cookie
+
+    def test_totp_success(self, tmp_path: Path) -> None:
+        tc, _, user, secret, cookie = self._partial_login(tmp_path)
+        code = pyotp.TOTP(secret).now()
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": code, "is_recovery": False},
+            cookies={COOKIE_NAME: cookie},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user"]["email"] == "test@example.com"
+        assert resp.cookies.get(COOKIE_NAME) is not None
+
+    def test_recovery_code(self, tmp_path: Path) -> None:
+        tc, _, _, _, cookie = self._partial_login(tmp_path)
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": "AAAA-BBBB", "is_recovery": True},
+            cookies={COOKIE_NAME: cookie},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 200
+        assert "user" in resp.json()
+
+    def test_invalid_code(self, tmp_path: Path) -> None:
+        tc, _, _, _, cookie = self._partial_login(tmp_path)
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": "000000", "is_recovery": False},
+            cookies={COOKIE_NAME: cookie},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 400
+
+    def test_no_cookie(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)
+        tc = _client(_make_app(db_path))
+        resp = tc.post("/api/auth/2fa/verify", json={"code": "123456"}, headers=_hdrs())
+        assert resp.status_code == 401
+
+    def test_invalid_session(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)
+        tc = _client(_make_app(db_path))
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": "123456"},
+            cookies={COOKIE_NAME: "bogus"},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.unit
+class TestTwoFADisable:
+    """POST /api/auth/2fa/disable."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        _enable_2fa(db_path, user.id)
+        resp = tc.post("/api/auth/2fa/disable", json={"password": _TEST_PASSWORD}, headers=_hdrs())
+        assert resp.status_code == 200
+        u = db.get_user_by_id(db_path, user.id)
+        assert u is not None and u.totp_enabled is False and u.totp_secret is None
+
+    def test_wrong_password(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        _enable_2fa(db_path, user.id)
+        resp = tc.post("/api/auth/2fa/disable", json={"password": "wrong"}, headers=_hdrs())
+        assert resp.status_code == 400
+
+    def test_not_enabled(self, tmp_path: Path) -> None:
+        tc, _, _ = _authed(tmp_path)
+        resp = tc.post("/api/auth/2fa/disable", json={"password": _TEST_PASSWORD}, headers=_hdrs())
+        assert resp.status_code == 400
+        assert "not enabled" in resp.json()["message"]
+
+
+@pytest.mark.unit
+class TestTwoFARegenerate:
+    """POST /api/auth/2fa/regenerate-recovery."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        secret = _enable_2fa(db_path, user.id)
+        code = pyotp.TOTP(secret).now()
+        resp = tc.post(
+            "/api/auth/2fa/regenerate-recovery",
+            json={"password": _TEST_PASSWORD, "code": code},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["recovery_codes"]) == 8
+
+    def test_wrong_password(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        secret = _enable_2fa(db_path, user.id)
+        resp = tc.post(
+            "/api/auth/2fa/regenerate-recovery",
+            json={"password": "wrong", "code": pyotp.TOTP(secret).now()},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 400
+
+    def test_wrong_totp(self, tmp_path: Path) -> None:
+        tc, db_path, user = _authed(tmp_path)
+        _enable_2fa(db_path, user.id)
+        resp = tc.post(
+            "/api/auth/2fa/regenerate-recovery",
+            json={"password": _TEST_PASSWORD, "code": "000000"},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.unit
+class TestLoginWith2FA:
+    """Login endpoint 2FA integration."""
+
+    def test_totp_enabled_returns_requires_2fa(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        _make_user(db_path, totp_secret=generate_totp_secret(), totp_enabled=True)
+        tc = _client(_make_app(db_path))
+        resp = tc.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": _TEST_PASSWORD},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["requires_2fa"] is True
+        assert COOKIE_NAME in resp.cookies
+        assert "user" not in data
+
+    def test_normal_login_no_2fa(self, tmp_path: Path) -> None:
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)
+        tc = _client(_make_app(db_path))
+        resp = tc.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": _TEST_PASSWORD},
+        )
+        data = resp.json()
+        assert "user" in data
+        assert data["requires_2fa_setup"] is False
+
+    def test_require_2fa_flag(self, tmp_path: Path) -> None:
+        """require_2fa=True config → requires_2fa_setup in response."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)
+        # Config lives in .dango/project.yml (write BEFORE creating client)
+        dango_dir = db_path.parent  # tmp_path / ".dango"
+        (dango_dir / "project.yml").write_text(
+            "project:\n  name: test\n  created_by: tester\n  purpose: testing\n"
+            "auth:\n  require_2fa: true\n"
+        )
+        tc = _client(_make_app(db_path))
+        resp = tc.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": _TEST_PASSWORD},
+        )
+        data = resp.json()
+        assert data["requires_2fa_setup"] is True
+        assert "user" in data

--- a/tests/unit/test_web_auth_keys.py
+++ b/tests/unit/test_web_auth_keys.py
@@ -20,6 +20,7 @@ from dango.auth.sessions import create_api_key, create_session
 from dango.migrations.runner import MigrationRunner
 from dango.web.middleware.auth import COOKIE_NAME
 from dango.web.routes.auth import router
+from dango.web.routes.ui import router as ui_router
 
 # ---------------------------------------------------------------------------
 # Test infrastructure (duplicated from test_web_auth.py for independence)
@@ -62,6 +63,7 @@ def _make_app(db_path: Path) -> FastAPI:
     # project_root is the parent of .dango/ which contains auth.db
     app.state.project_root = db_path.parent.parent
     app.include_router(router)
+    app.include_router(ui_router)
     return app
 
 

--- a/tests/unit/test_web_auth_oauth.py
+++ b/tests/unit/test_web_auth_oauth.py
@@ -22,6 +22,7 @@ from dango.config.models import OAuthProviderConfig
 from dango.migrations.runner import MigrationRunner
 from dango.web.middleware.auth import COOKIE_NAME
 from dango.web.routes.auth import router
+from dango.web.routes.ui import router as ui_router
 
 # ---------------------------------------------------------------------------
 # Test infrastructure
@@ -66,6 +67,7 @@ def _make_app(db_path: Path) -> FastAPI:
     app = FastAPI()
     app.state.project_root = db_path.parent.parent
     app.include_router(router)
+    app.include_router(ui_router)
     return app
 
 


### PR DESCRIPTION
## Summary

- Add optional TOTP 2FA with recovery codes to Dango's auth system
- New `dango/auth/totp.py` module with pyotp-based TOTP verification, recovery code management, and provisioning URI generation
- New `dango/web/routes/auth_2fa.py` with 5 API endpoints: setup, verify-setup, verify (partial→full session), disable, regenerate-recovery
- Login flow creates a partial session (5-min timeout) when user has 2FA enabled, requiring TOTP/recovery code verification before upgrading to full session
- Alpine.js multi-step login template (credentials → TOTP code entry)
- `require_2fa` config flag for admin-enforced 2FA setup (soft enforcement via login response flag)
- Moved `/login` and `/setup` page routes from `auth.py` to `ui.py` to free headroom
- Fixed `ConfigLoader.load_config()` to also load `auth` section from project.yml

## Test plan

- [x] 30 unit tests for `dango/auth/totp.py` (secret generation, code verification, recovery codes, enable/disable/consume)
- [x] 21 endpoint tests for 2FA API routes (setup flow, partial→full session upgrade, recovery codes, disable, regenerate)
- [x] Existing page route tests updated (`test_web_auth_keys.py` now includes `ui_router`)
- [x] Full suite: 977/977 tests pass
- [x] ruff check + format clean, mypy clean
- [x] All files under 500-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)