### PR TITLE
Add invite links for user onboarding (TASK-100)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ dango/                          # Python package source
 │   ├── main.py                 # Slim entry point (~88 lines) — registers commands
 │   ├── commands/               # Command modules (extracted from main.py by TASK-005)
 │   │   ├── __init__.py         # Package marker
-│   │   ├── auth.py             # auth group placeholder (Phase 2 user management)
+│   │   ├── auth.py             # auth group (12 subcommands, 538 lines)
 │   │   ├── oauth.py            # oauth group + 10 subcommands (815 lines)
 │   │   ├── config_cmd.py       # config group (validate/show)
 │   │   ├── dashboard.py        # dashboard group (provision)

--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -33,6 +33,7 @@ from dango.auth.database import (
     get_session_by_token,
     get_user_by_email,
     get_user_by_id,
+    get_user_by_invite_token_hash,
     get_user_by_oauth,
     list_user_api_keys,
     list_user_sessions,
@@ -83,6 +84,7 @@ from dango.auth.permissions import (
 from dango.auth.security import (
     check_password_strength,
     generate_api_key,
+    generate_invite_token,
     generate_recovery_codes,
     generate_session_token,
     generate_temp_password,
@@ -150,6 +152,7 @@ __all__ = [
     "create_user",
     "get_user_by_email",
     "get_user_by_id",
+    "get_user_by_invite_token_hash",
     "get_user_by_oauth",
     "list_users",
     "update_user",
@@ -222,6 +225,7 @@ __all__ = [
     # Security utilities
     "check_password_strength",
     "generate_api_key",
+    "generate_invite_token",
     "generate_recovery_codes",
     "generate_session_token",
     "generate_temp_password",

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -47,6 +47,8 @@ class AuditEvent(str, Enum):
     API_KEY_CREATED    = "api_key_created"
     API_KEY_REVOKED    = "api_key_revoked"
     RECOVERY_CODE_USED = "recovery_code_used"
+    INVITE_ACCEPTED    = "invite_accepted"
+    INVITE_RESENT      = "invite_resent"
     # fmt: on
 
 

--- a/dango/auth/database.py
+++ b/dango/auth/database.py
@@ -65,6 +65,8 @@ def _row_to_user(row: sqlite3.Row) -> User:
         metabase_password_enc=row["metabase_password_enc"],
         must_change_password=_bool_from_int(row["must_change_password"]),
         last_login=_datetime_from_str(row["last_login"]),
+        invite_token_hash=row["invite_token_hash"],
+        invite_expires_at=_datetime_from_str(row["invite_expires_at"]),
         created_at=_datetime_from_str(row["created_at"]),  # type: ignore[arg-type]
         updated_at=_datetime_from_str(row["updated_at"]),  # type: ignore[arg-type]
     )
@@ -125,8 +127,9 @@ def create_user(db_path: Path, user: User) -> User:
                 oauth_provider, oauth_id, failed_login_attempts, locked_until,
                 metabase_user_id, metabase_password_enc,
                 must_change_password, last_login,
+                invite_token_hash, invite_expires_at,
                 created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 user.id,
@@ -145,6 +148,8 @@ def create_user(db_path: Path, user: User) -> User:
                 user.metabase_password_enc,
                 int(user.must_change_password),
                 _dt_to_str(user.last_login),
+                user.invite_token_hash,
+                _dt_to_str(user.invite_expires_at),
                 user.created_at.isoformat(),
                 user.updated_at.isoformat(),
             ),
@@ -195,6 +200,26 @@ def get_user_by_oauth(db_path: Path, provider: str, oauth_id: str) -> User | Non
         row = conn.execute(
             "SELECT * FROM users WHERE oauth_provider = ? AND oauth_id = ?",
             (provider, oauth_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_user(row)
+    finally:
+        conn.close()
+
+
+def get_user_by_invite_token_hash(db_path: Path, token_hash: str) -> User | None:
+    """Look up an active user by invite token hash.
+
+    Does **not** check expiry — the caller should compare
+    ``invite_expires_at`` against the current time to produce
+    targeted error messages (invalid vs expired).
+    """
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM users WHERE invite_token_hash = ? AND is_active = 1",
+            (token_hash,),
         ).fetchone()
         if row is None:
             return None

--- a/dango/auth/models.py
+++ b/dango/auth/models.py
@@ -12,7 +12,7 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 
 class Role(str, Enum):
@@ -44,6 +44,8 @@ class User(BaseModel):
     metabase_password_enc: str | None = None
     must_change_password: bool = False
     last_login: datetime | None = None
+    invite_token_hash: str | None = None
+    invite_expires_at: datetime | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -97,6 +99,8 @@ class UserUpdate(BaseModel):
     metabase_password_enc: str | None = None
     must_change_password: bool | None = None
     last_login: datetime | None = None
+    invite_token_hash: str | None = None
+    invite_expires_at: datetime | None = None
 
     @field_validator("email", mode="before")
     @classmethod
@@ -122,8 +126,17 @@ class UserResponse(BaseModel):
     locked_until: datetime | None = None
     must_change_password: bool = False
     last_login: datetime | None = None
+    invite_expires_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def has_pending_invite(self) -> bool:
+        """True if the user has a non-expired invite."""
+        if self.invite_expires_at is None:
+            return False
+        return self.invite_expires_at > datetime.now(timezone.utc)
 
 
 class Session(BaseModel):

--- a/dango/auth/security.py
+++ b/dango/auth/security.py
@@ -297,6 +297,23 @@ def get_key_prefix(key: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Invite tokens (SHA-256, same pattern as API keys)
+# ---------------------------------------------------------------------------
+
+
+def generate_invite_token() -> tuple[str, str]:
+    """Generate an invite token and its SHA-256 hash.
+
+    Returns:
+        Tuple of ``(raw_token, token_hash)``.  The raw token is embedded
+        in the invite URL; only the hash is stored in the database.
+    """
+    raw_token = secrets.token_urlsafe(32)
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    return raw_token, token_hash
+
+
+# ---------------------------------------------------------------------------
 # Temporary passwords
 # ---------------------------------------------------------------------------
 

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -108,26 +108,56 @@ def auth_disable(ctx: click.Context) -> None:
 @auth.command("add-user")
 @click.argument("email")
 @click.option("--role", type=click.Choice(["admin", "editor", "viewer"]), default="viewer")
+@click.option(
+    "--password",
+    "use_password",
+    is_flag=True,
+    help="Generate a temporary password instead of an invite link.",
+)
+@click.option("--base-url", default="http://localhost:8800", help="Base URL for invite links.")
 @click.pass_context
-def auth_add_user(ctx: click.Context, email: str, role: str) -> None:
-    """Create a new user with a temporary password."""
-    from dango.auth.admin import format_credentials_panel
+def auth_add_user(
+    ctx: click.Context, email: str, role: str, use_password: bool, base_url: str
+) -> None:
+    """Create a new user with an invite link (or --password for a temp password)."""
     from dango.auth.database import create_user
     from dango.auth.models import Role, User
-    from dango.auth.security import generate_temp_password, hash_password
     from dango.exceptions import UserExistsError
 
     try:
         _, db_path = _get_db_path(ctx)
-        password = generate_temp_password()
-        user = User(
-            email=email,
-            password_hash=hash_password(password),
-            role=Role(role),
-            must_change_password=True,
-        )
-        create_user(db_path, user)
-        console.print(format_credentials_panel(user.email, password, title="User created"))
+
+        if use_password:
+            from dango.auth.admin import format_credentials_panel
+            from dango.auth.security import generate_temp_password, hash_password
+
+            password = generate_temp_password()
+            user = User(
+                email=email,
+                password_hash=hash_password(password),
+                role=Role(role),
+                must_change_password=True,
+            )
+            create_user(db_path, user)
+            console.print(format_credentials_panel(user.email, password, title="User created"))
+        else:
+            from datetime import timedelta
+
+            from dango.auth.security import generate_invite_token
+
+            raw_token, token_hash = generate_invite_token()
+            user = User(
+                email=email,
+                password_hash=None,
+                role=Role(role),
+                invite_token_hash=token_hash,
+                invite_expires_at=datetime.now(timezone.utc) + timedelta(hours=72),
+            )
+            create_user(db_path, user)
+            invite_url = f"{base_url.rstrip('/')}/invite/{raw_token}"
+            console.print(f"\n[green]User created:[/green] {user.email}")
+            console.print(f"[bold]Invite link:[/bold] {invite_url}")
+            console.print("[dim]Link expires in 72 hours. Share it securely.[/dim]\n")
     except click.Abort:
         raise
     except UserExistsError:
@@ -168,6 +198,14 @@ def auth_list_users(ctx: click.Context) -> None:
                 status = "[red]Inactive[/red]"
             elif user.locked_until is not None and user.locked_until > now:
                 status = "[yellow]Locked[/yellow]"
+            elif user.invite_expires_at is not None and user.invite_expires_at > now:
+                status = "[magenta]Invited[/magenta]"
+            elif (
+                user.invite_expires_at is not None
+                and user.invite_expires_at <= now
+                and user.last_login is None
+            ):
+                status = "[yellow]Invite Expired[/yellow]"
             else:
                 status = "[green]Active[/green]"
             last_login = user.last_login.strftime("%Y-%m-%d %H:%M") if user.last_login else "Never"

--- a/dango/migrations/auth/004_invite_tokens.py
+++ b/dango/migrations/auth/004_invite_tokens.py
@@ -1,0 +1,21 @@
+"""dango/migrations/auth/004_invite_tokens.py
+
+Add invite token columns to users table.
+
+Invite links (TASK-100) let admins onboard users without sharing temporary
+passwords.  The token hash is stored alongside an expiry timestamp so users
+can set their own password via a time-limited URL.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+VERSION = 4
+DESCRIPTION = "Add invite token columns"
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Add invite_token_hash and invite_expires_at columns to users."""
+    conn.execute("ALTER TABLE users ADD COLUMN invite_token_hash TEXT")
+    conn.execute("ALTER TABLE users ADD COLUMN invite_expires_at TEXT")

--- a/dango/web/middleware/auth.py
+++ b/dango/web/middleware/auth.py
@@ -60,6 +60,7 @@ _PUBLIC_EXACT: frozenset[str] = frozenset({
     "/api/auth/login",
     "/api/auth/2fa/verify",
     "/api/auth/oauth/callback",
+    "/api/auth/accept-invite",
     "/login",
     "/setup",
     "/api/health",
@@ -74,6 +75,7 @@ _PUBLIC_EXACT: frozenset[str] = frozenset({
 
 _PUBLIC_PREFIXES: tuple[str, ...] = (
     "/api/auth/oauth/",
+    "/invite/",
     "/static/",
 )
 

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -141,6 +141,7 @@ class CreateUserRequest(BaseModel):
 
     email: str
     role: str = "viewer"
+    generate_password: bool = False
 
     @field_validator("email", mode="before")
     @classmethod
@@ -150,6 +151,13 @@ class CreateUserRequest(BaseModel):
         if not v or "@" not in v:
             raise ValueError("Invalid email address")
         return v
+
+
+class AcceptInviteRequest(BaseModel):
+    """Invite acceptance payload."""
+
+    token: str
+    password: str
 
 
 class ChangeRoleRequest(BaseModel):

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -23,6 +23,7 @@ from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.database import (
     get_session_by_token,
     get_user_by_email,
+    get_user_by_invite_token_hash,
     get_user_by_oauth,
     list_user_api_keys,
     list_user_sessions,
@@ -53,6 +54,7 @@ from dango.config.models import AuthConfig, OAuthProviderConfig
 from dango.logging import get_logger
 from dango.web.middleware.auth import COOKIE_NAME, is_secure_request
 from dango.web.models import (
+    AcceptInviteRequest,
     ApiKeyCreateResponse,
     ApiKeyResponse,
     ChangePasswordRequest,
@@ -541,6 +543,63 @@ async def revoke_key(key_id: str, request: Request) -> JSONResponse:
     )
 
     return JSONResponse(content={"success": True})
+
+
+# ---------------------------------------------------------------------------
+# Invite acceptance
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/auth/accept-invite")
+async def accept_invite(request: Request) -> JSONResponse:
+    """Accept an invite link and set a password."""
+    db_path = _get_db_path(request)
+    try:
+        body = await request.json()
+        data = AcceptInviteRequest(**body)
+    except (ValueError, ValidationError):
+        return JSONResponse(status_code=400, content={"message": "Invalid request body"})
+
+    # Hash the token and look up the user
+    token_hash = hash_token(data.token)
+    user = get_user_by_invite_token_hash(db_path, token_hash)
+
+    invalid_msg = "This invite link is invalid or has expired"
+    if user is None:
+        return JSONResponse(status_code=400, content={"message": invalid_msg})
+
+    # Check expiry
+    if user.invite_expires_at is None or user.invite_expires_at <= datetime.now(timezone.utc):
+        return JSONResponse(status_code=400, content={"message": invalid_msg})
+
+    # Validate password strength
+    issues = check_password_strength(data.password)
+    if issues:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "Password is too weak", "issues": issues},
+        )
+
+    # Set password and clear invite fields
+    update_user(
+        db_path,
+        user.id,
+        UserUpdate(
+            password_hash=hash_password(data.password),
+            invite_token_hash=None,
+            invite_expires_at=None,
+            must_change_password=False,
+        ),
+    )
+
+    log_auth_event(
+        AuditEvent.INVITE_ACCEPTED,
+        user_id=user.id,
+        email=user.email,
+        ip=_get_client_ip(request),
+    )
+
+    return JSONResponse(content={"message": "Password set successfully"})
 
 
 # ---------------------------------------------------------------------------

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -159,10 +159,11 @@ async def invite_page(token: str, request: Request) -> HTMLResponse:
         token_hash = hash_token(token)
         user = get_user_by_invite_token_hash(db_path, token_hash)
 
+        invalid_msg = "This invite link is invalid or has expired."
         if user is None:
-            error = "This invite link is invalid or has expired."
+            error = invalid_msg
         elif user.invite_expires_at is None or user.invite_expires_at <= datetime.now(timezone.utc):
-            error = "This invite link has expired. Contact your administrator for a new invite."
+            error = invalid_msg
         else:
             email = user.email
     except Exception:

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -3,6 +3,7 @@
 UI page endpoints and API documentation.
 """
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, Request
@@ -138,5 +139,44 @@ async def setup_page(request: Request) -> HTMLResponse:
             "version": dango.__version__,
             "current_page": "setup",
             "subtitle": "Change Password",
+        },
+    )
+
+
+@router.get("/invite/{token}")
+async def invite_page(token: str, request: Request) -> HTMLResponse:
+    """Render the invite acceptance page."""
+    from dango.auth.admin import get_auth_db_path
+    from dango.auth.database import get_user_by_invite_token_hash
+    from dango.auth.security import hash_token
+
+    error: str | None = None
+    email: str | None = None
+
+    try:
+        project_root: Path = request.app.state.project_root
+        db_path = get_auth_db_path(project_root)
+        token_hash = hash_token(token)
+        user = get_user_by_invite_token_hash(db_path, token_hash)
+
+        if user is None:
+            error = "This invite link is invalid or has expired."
+        elif user.invite_expires_at is None or user.invite_expires_at <= datetime.now(timezone.utc):
+            error = "This invite link has expired. Contact your administrator for a new invite."
+        else:
+            email = user.email
+    except Exception:
+        error = "Unable to process invite. Please try again later."
+
+    return _render_template(
+        "invite.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "invite",
+            "subtitle": "Accept Invite",
+            "token": token,
+            "email": email,
+            "invite_error": error,
         },
     )

--- a/dango/web/routes/users.py
+++ b/dango/web/routes/users.py
@@ -30,7 +30,7 @@ from dango.auth.database import (
 )
 from dango.auth.models import Role, User, UserResponse, UserUpdate
 from dango.auth.permissions import require_permission
-from dango.auth.security import generate_temp_password, hash_password
+from dango.auth.security import generate_invite_token, generate_temp_password, hash_password
 from dango.exceptions import UserExistsError
 from dango.logging import get_logger
 from dango.web.models import ChangeRoleRequest, CreateUserRequest, DeleteUserConfirmation
@@ -129,7 +129,7 @@ async def admin_create_user(
     request: Request,
     user: User = Depends(require_permission("users.manage")),
 ) -> JSONResponse:
-    """Create a new user with a temporary password."""
+    """Create a new user via invite link or with a temporary password."""
     db_path = _get_db_path(request)
     try:
         body: dict[str, Any] = await request.json()
@@ -145,12 +145,47 @@ async def admin_create_user(
             content={"message": f"Invalid role '{data.role}'. Must be admin, editor, or viewer."},
         )
 
-    password = generate_temp_password()
+    if data.generate_password:
+        # Fallback: temp password flow
+        password = generate_temp_password()
+        new_user = User(
+            email=data.email,
+            password_hash=hash_password(password),
+            role=role,
+            must_change_password=True,
+        )
+        try:
+            create_user(db_path, new_user)
+        except UserExistsError:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "message": f"A user with email '{data.email.strip().lower()}' already exists"
+                },
+            )
+        log_auth_event(
+            AuditEvent.USER_CREATED,
+            user_id=new_user.id,
+            email=new_user.email,
+            ip=_get_client_ip(request),
+            details={"role": role.value, "created_by": user.email, "method": "temp_password"},
+        )
+        resp = UserResponse.model_validate(new_user)
+        return JSONResponse(
+            status_code=201,
+            content={"user": resp.model_dump(mode="json"), "temp_password": password},
+        )
+
+    # Default: invite link flow
+    from datetime import datetime, timedelta, timezone
+
+    raw_token, token_hash = generate_invite_token()
     new_user = User(
         email=data.email,
-        password_hash=hash_password(password),
+        password_hash=None,
         role=role,
-        must_change_password=True,
+        invite_token_hash=token_hash,
+        invite_expires_at=datetime.now(timezone.utc) + timedelta(hours=72),
     )
     try:
         create_user(db_path, new_user)
@@ -159,19 +194,61 @@ async def admin_create_user(
             status_code=409,
             content={"message": f"A user with email '{data.email.strip().lower()}' already exists"},
         )
-
     log_auth_event(
         AuditEvent.USER_CREATED,
         user_id=new_user.id,
         email=new_user.email,
         ip=_get_client_ip(request),
-        details={"role": role.value, "created_by": user.email},
+        details={"role": role.value, "created_by": user.email, "method": "invite"},
     )
     resp = UserResponse.model_validate(new_user)
     return JSONResponse(
         status_code=201,
-        content={"user": resp.model_dump(mode="json"), "temp_password": password},
+        content={"user": resp.model_dump(mode="json"), "invite_url": f"/invite/{raw_token}"},
     )
+
+
+@router.post("/api/admin/users/{user_id}/reinvite")
+async def admin_reinvite_user(
+    user_id: str,
+    request: Request,
+    user: User = Depends(require_permission("users.manage")),
+) -> JSONResponse:
+    """Generate a new invite link for a user who hasn't logged in yet."""
+    from datetime import datetime, timedelta, timezone
+
+    db_path = _get_db_path(request)
+    target = get_user_by_id(db_path, user_id)
+    if target is None:
+        return JSONResponse(status_code=404, content={"message": "User not found"})
+
+    if not target.is_active:
+        return JSONResponse(status_code=400, content={"message": "User is deactivated"})
+
+    # Only allow reinvite for users who haven't set a password yet
+    if target.password_hash is not None and target.invite_token_hash is None:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "User has already set a password. Use 'Reset Password' instead."},
+        )
+
+    raw_token, token_hash = generate_invite_token()
+    update_user(
+        db_path,
+        user_id,
+        UserUpdate(
+            invite_token_hash=token_hash,
+            invite_expires_at=datetime.now(timezone.utc) + timedelta(hours=72),
+        ),
+    )
+    log_auth_event(
+        AuditEvent.INVITE_RESENT,
+        user_id=user_id,
+        email=target.email,
+        ip=_get_client_ip(request),
+        details={"resent_by": user.email},
+    )
+    return JSONResponse(content={"invite_url": f"/invite/{raw_token}"})
 
 
 @router.put("/api/admin/users/{user_id}/role")

--- a/dango/web/templates/admin_users.html
+++ b/dango/web/templates/admin_users.html
@@ -65,6 +65,10 @@
                                                     class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Change Role</button>
                                             <button @click="resetPassword(u); open = false"
                                                     class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Reset Password</button>
+                                            <template x-if="canReinvite(u)">
+                                                <button @click="reinviteUser(u); open = false"
+                                                        class="block w-full text-left px-4 py-2 text-sm text-indigo-600 hover:bg-gray-100">Resend Invite</button>
+                                            </template>
                                             <template x-if="u.is_active">
                                                 <button @click="confirmAction('deactivate', u); open = false"
                                                         class="block w-full text-left px-4 py-2 text-sm text-yellow-600 hover:bg-gray-100">Deactivate</button>
@@ -130,21 +134,21 @@
             </div>
         </div>
 
-        <!-- Temp Password Modal -->
-        <div x-show="showTempPassword" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+        <!-- Invite Link / Temp Password Modal -->
+        <div x-show="showCredentialModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
             <div class="flex items-center justify-center min-h-screen px-4">
-                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showTempPassword = false"></div>
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showCredentialModal = false"></div>
                 <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
-                    <h3 class="text-lg font-medium text-gray-900 mb-2">Temporary Password</h3>
-                    <p class="text-sm text-gray-500 mb-4">Share this password securely. The user must change it on first login.</p>
+                    <h3 class="text-lg font-medium text-gray-900 mb-2" x-text="credentialTitle"></h3>
+                    <p class="text-sm text-gray-500 mb-4" x-text="credentialMessage"></p>
                     <div class="flex items-center space-x-2 mb-4">
-                        <input type="text" :value="tempPassword" readonly
+                        <input type="text" :value="credentialValue" readonly
                                class="flex-1 px-3 py-2 border border-gray-300 rounded-md bg-gray-50 font-mono text-sm">
-                        <button @click="navigator.clipboard.writeText(tempPassword)"
+                        <button @click="navigator.clipboard.writeText(credentialValue)"
                                 class="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Copy</button>
                     </div>
                     <div class="flex justify-end">
-                        <button @click="showTempPassword = false"
+                        <button @click="showCredentialModal = false"
                                 class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700">Done</button>
                     </div>
                 </div>
@@ -226,7 +230,7 @@ function adminUsers() {
     return {
         users: [], error: '', success: '',
         showAddModal: false, newEmail: '', newRole: 'viewer', addLoading: false,
-        showTempPassword: false, tempPassword: '',
+        showCredentialModal: false, credentialTitle: '', credentialMessage: '', credentialValue: '',
         showRoleModal: false, selectedRole: '',
         showConfirmModal: false, confirmTitle: '', confirmMessage: '', pendingAction: null,
         showDeleteModal: false, deleteConfirmEmail: '',
@@ -241,7 +245,14 @@ function adminUsers() {
             if (!u.is_active) return { text: 'Inactive', cls: 'text-red-600' };
             if (u.locked_until && new Date(u.locked_until) > new Date())
                 return { text: 'Locked', cls: 'text-yellow-600' };
+            if (u.has_pending_invite)
+                return { text: 'Invited', cls: 'text-indigo-600' };
+            if (u.invite_expires_at && !u.has_pending_invite && !u.last_login)
+                return { text: 'Invite Expired', cls: 'text-orange-600' };
             return { text: 'Active', cls: 'text-green-600' };
+        },
+        canReinvite(u) {
+            return u.is_active && !u.last_login && (u.has_pending_invite || (u.invite_expires_at && !u.has_pending_invite));
         },
 
         async loadUsers() {
@@ -263,8 +274,16 @@ function adminUsers() {
                 if (!res.ok) { this.error = data.message; this.addLoading = false; return; }
                 this.showAddModal = false;
                 this.newEmail = ''; this.newRole = 'viewer';
-                this.tempPassword = data.temp_password;
-                this.showTempPassword = true;
+                if (data.invite_url) {
+                    this.credentialTitle = 'Invite Link';
+                    this.credentialMessage = 'Share this link with the user. It expires in 72 hours.';
+                    this.credentialValue = window.location.origin + data.invite_url;
+                } else {
+                    this.credentialTitle = 'Temporary Password';
+                    this.credentialMessage = 'Share this password securely. The user must change it on first login.';
+                    this.credentialValue = data.temp_password;
+                }
+                this.showCredentialModal = true;
                 await this.loadUsers();
             } catch (e) { this.error = 'Failed to create user'; }
             this.addLoading = false;
@@ -300,9 +319,28 @@ function adminUsers() {
                 });
                 const data = await res.json();
                 if (!res.ok) { this.error = data.message; this.actionLoading = false; return; }
-                this.tempPassword = data.temp_password;
-                this.showTempPassword = true;
+                this.credentialTitle = 'Temporary Password';
+                this.credentialMessage = 'Share this password securely. The user must change it on first login.';
+                this.credentialValue = data.temp_password;
+                this.showCredentialModal = true;
             } catch (e) { this.error = 'Failed to reset password'; }
+            this.actionLoading = false;
+        },
+
+        async reinviteUser(u) {
+            this.actionLoading = true; this.error = '';
+            try {
+                const res = await fetch(`/api/admin/users/${u.id}/reinvite`, {
+                    method: 'POST', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.actionLoading = false; return; }
+                this.credentialTitle = 'Invite Link';
+                this.credentialMessage = 'Share this link with the user. It expires in 72 hours.';
+                this.credentialValue = window.location.origin + data.invite_url;
+                this.showCredentialModal = true;
+                await this.loadUsers();
+            } catch (e) { this.error = 'Failed to resend invite'; }
             this.actionLoading = false;
         },
 

--- a/dango/web/templates/admin_users.html
+++ b/dango/web/templates/admin_users.html
@@ -252,7 +252,7 @@ function adminUsers() {
             return { text: 'Active', cls: 'text-green-600' };
         },
         canReinvite(u) {
-            return u.is_active && !u.last_login && (u.has_pending_invite || (u.invite_expires_at && !u.has_pending_invite));
+            return u.is_active && !u.last_login && !!u.invite_expires_at;
         },
 
         async loadUsers() {

--- a/dango/web/templates/invite.html
+++ b/dango/web/templates/invite.html
@@ -1,0 +1,120 @@
+{% extends "base.html" %}
+
+{% block title %}Accept Invite - Dango{% endblock %}
+
+{% block header %}{% endblock %}
+{% block nav %}{% endblock %}
+{% block footer %}{% endblock %}
+
+{% block content %}
+<main class="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+    <div class="max-w-md w-full">
+        <div class="text-center mb-8">
+            <div class="text-5xl mb-3">🍡</div>
+            <h1 class="text-2xl font-bold text-gray-900">Welcome to Dango</h1>
+            <p class="text-sm text-gray-500 mt-1">Set your password to get started</p>
+        </div>
+
+        <div class="bg-white rounded-lg shadow-md p-8">
+            {% if invite_error %}
+            <!-- Invalid or expired invite -->
+            <div class="text-center">
+                <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded-md">
+                    <p class="text-sm text-red-700">{{ invite_error }}</p>
+                </div>
+                <a href="/login" class="text-sm text-dango-600 hover:text-dango-700">Go to login</a>
+            </div>
+            {% else %}
+            <!-- Valid invite — show password form -->
+            <div x-data="inviteForm()">
+                <div class="mb-4">
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                    <input type="email" value="{{ email }}" readonly
+                           class="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-50 text-gray-500">
+                </div>
+
+                <form @submit.prevent="submit()">
+                    <div class="mb-4">
+                        <label for="password" class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+                        <input type="password" id="password" x-model="password" required
+                               minlength="8" autocomplete="new-password"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 focus:border-transparent">
+                    </div>
+
+                    <div class="mb-6">
+                        <label for="confirmPassword" class="block text-sm font-medium text-gray-700 mb-1">Confirm Password</label>
+                        <input type="password" id="confirmPassword" x-model="confirmPassword" required
+                               minlength="8" autocomplete="new-password"
+                               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 focus:border-transparent">
+                    </div>
+
+                    <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+                        <p class="text-sm text-red-700" x-text="error"></p>
+                    </div>
+
+                    <div x-show="issues.length > 0" x-cloak class="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
+                        <p class="text-sm text-yellow-700 font-medium mb-1">Password requirements:</p>
+                        <ul class="list-disc list-inside text-sm text-yellow-700">
+                            <template x-for="issue in issues" :key="issue">
+                                <li x-text="issue"></li>
+                            </template>
+                        </ul>
+                    </div>
+
+                    <button type="submit" :disabled="loading"
+                            class="w-full py-2 px-4 bg-dango-600 text-white rounded-md hover:bg-dango-700 focus:outline-none focus:ring-2 focus:ring-dango-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                        <span x-show="!loading">Set Password</span>
+                        <span x-show="loading" x-cloak>Setting password...</span>
+                    </button>
+                </form>
+            </div>
+            {% endif %}
+        </div>
+
+        <p class="text-center text-xs text-gray-400 mt-6">Dango v{{ version }}</p>
+    </div>
+</main>
+{% endblock %}
+
+{% block scripts %}
+{% if not invite_error %}
+<script>
+function inviteForm() {
+    return {
+        password: '', confirmPassword: '',
+        error: '', issues: [], loading: false,
+        token: {{ token | tojson }},
+        async submit() {
+            this.error = '';
+            this.issues = [];
+            if (this.password !== this.confirmPassword) {
+                this.error = 'Passwords do not match';
+                return;
+            }
+            this.loading = true;
+            try {
+                const res = await fetch('/api/auth/accept-invite', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+                    body: JSON.stringify({token: this.token, password: this.password})
+                });
+                const data = await res.json();
+                if (res.ok) {
+                    window.location.href = '/login?message=password-set';
+                    return;
+                }
+                if (data.issues) {
+                    this.issues = data.issues;
+                } else {
+                    this.error = data.message || 'Failed to set password';
+                }
+            } catch (e) {
+                this.error = 'Unable to connect to server';
+            }
+            this.loading = false;
+        }
+    }
+}
+</script>
+{% endif %}
+{% endblock %}

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -25,15 +25,27 @@ exemptions:
 
   # --- Phase 2 auth additions ---
   - file: dango/web/routes/auth.py
-    lines: 721
+    lines: 788
     category: exempt
-    reason: "TASK-095 added OAuth social login endpoints (+120 lines over TASK-016 base). TASK-096 will move page routes to routes/ui.py, reducing by ~26 lines."
+    reason: "TASK-095 OAuth, TASK-096 2FA, TASK-100 accept-invite endpoint. Auth logic is tightly coupled."
     review_by: "v1.1"
 
   - file: dango/auth/database.py
-    lines: 504
+    lines: 529
     category: exempt
-    reason: "TASK-095 added get_user_by_oauth() (+14 lines). Marginally over limit."
+    reason: "TASK-100 added invite token lookup (+25 lines over TASK-095 base)."
+    review_by: "v1.1"
+
+  - file: dango/web/routes/users.py
+    lines: 525
+    category: exempt
+    reason: "TASK-100 added invite-based user creation and reinvite endpoint (+77 lines over base)."
+    review_by: "v1.1"
+
+  - file: dango/cli/commands/auth.py
+    lines: 538
+    category: exempt
+    reason: "TASK-100 added invite link flow to add-user and invite status to list-users (+38 lines)."
     review_by: "v1.1"
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
@@ -131,13 +143,6 @@ exemptions:
     review_by: "v1.1"
 
 # Removed: dango/platform/network.py — now 486 lines, within limit (TASK-088)
-
-  # --- Auth web routes (Metabase bridging hooks added by TASK-019) ---
-  - file: dango/web/routes/auth.py
-    lines: 530
-    category: refactor
-    reason: "Login/logout endpoints + API key CRUD + page routes. Grew past 500 with TASK-019 Metabase bridging hooks. Split into auth_api.py + auth_pages.py planned for TASK-095."
-    review_by: "TASK-095"
 
   # --- Test files (verbose by nature — each test class covers one public function) ---
   - file: tests/unit/test_oauth_validation.py

--- a/tests/unit/test_auth_audit.py
+++ b/tests/unit/test_auth_audit.py
@@ -27,8 +27,8 @@ class TestAuditEvent:
     """Validate AuditEvent taxonomy and type properties."""
 
     def test_member_count(self) -> None:
-        """AuditEvent has exactly 19 members."""
-        assert len(AuditEvent) == 19
+        """AuditEvent has exactly 21 members."""
+        assert len(AuditEvent) == 21
 
     def test_values_are_lowercase_snake_case(self) -> None:
         """All values use lowercase_snake_case (no uppercase, no hyphens)."""

--- a/tests/unit/test_web_auth_invite.py
+++ b/tests/unit/test_web_auth_invite.py
@@ -1,0 +1,464 @@
+"""tests/unit/test_web_auth_invite.py
+
+Tests for invite link functionality: generation, acceptance, reinvite,
+invite page rendering, and related model/database operations.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth import database as db
+from dango.auth.models import Role, User, UserResponse, UserUpdate
+from dango.auth.security import generate_invite_token, hash_password, hash_token, verify_password
+from dango.exceptions import DangoError
+from dango.migrations.runner import MigrationRunner
+from dango.web.routes.auth import router as auth_router
+from dango.web.routes.ui import router as ui_router
+from dango.web.routes.users import router as users_router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a fresh auth database at the standard project path."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    db_path = dango_dir / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+def _make_user(db_path: Path, email: str = "test@example.com", **kw: Any) -> User:
+    """Create and persist a user."""
+    defaults: dict[str, Any] = {"email": email, "role": Role.EDITOR}
+    defaults.update(kw)
+    user = User(**defaults)
+    db.create_user(db_path, user)
+    return user
+
+
+def _make_invited_user(
+    db_path: Path,
+    email: str = "invited@example.com",
+    hours_valid: int = 72,
+) -> tuple[User, str]:
+    """Create a user with a pending invite. Returns (user, raw_token)."""
+    raw_token, token_hash = generate_invite_token()
+    user = _make_user(
+        db_path,
+        email=email,
+        password_hash=None,
+        invite_token_hash=token_hash,
+        invite_expires_at=datetime.now(timezone.utc) + timedelta(hours=hours_valid),
+    )
+    return user, raw_token
+
+
+def _make_app(db_path: Path) -> FastAPI:
+    """Create a minimal FastAPI app with auth, users, and ui routes."""
+    from dango.exceptions import (
+        AuthenticationError,
+        AuthorizationError,
+        UserExistsError,
+        UserNotFoundError,
+    )
+
+    app = FastAPI()
+    app.state.project_root = db_path.parent.parent
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        UserNotFoundError: 404,
+        UserExistsError: 409,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse:
+        code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=code, content={"error_code": exc.error_code, "message": exc.user_message}
+        )
+
+    app.include_router(auth_router)
+    app.include_router(users_router)
+    app.include_router(ui_router)
+    return app
+
+
+_H = {"X-Requested-With": "XMLHttpRequest", "Content-Type": "application/json"}
+
+
+def _admin_client(tmp_path: Path) -> tuple[TestClient, Path, User]:
+    """Set up a test client with an admin user injected via middleware."""
+    db_path = _make_db(tmp_path)
+    admin = _make_user(
+        db_path, "admin@example.com", role=Role.ADMIN, password_hash=hash_password("adminpass123")
+    )
+    app = _make_app(db_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = admin
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    return TestClient(app, raise_server_exceptions=False), db_path, admin
+
+
+# ---------------------------------------------------------------------------
+# generate_invite_token()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGenerateInviteToken:
+    """Tests for the generate_invite_token() security function."""
+
+    def test_returns_url_safe_token_and_sha256_hash(self) -> None:
+        """Token is URL-safe, hash is 64-char hex, and they correspond."""
+        raw, hashed = generate_invite_token()
+        assert len(raw) >= 40
+        assert all(c.isalnum() or c in "-_" for c in raw)
+        assert len(hashed) == 64
+        assert hash_token(raw) == hashed
+
+    def test_unique_tokens(self) -> None:
+        """Each call produces a unique token."""
+        tokens = {generate_invite_token()[0] for _ in range(10)}
+        assert len(tokens) == 10
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auth/accept-invite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAcceptInvite:
+    """Tests for the accept-invite endpoint."""
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        """Valid token + strong password sets the password and clears invite."""
+        db_path = _make_db(tmp_path)
+        user, raw_token = _make_invited_user(db_path)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/auth/accept-invite",
+            json={"token": raw_token, "password": "MyNewSecurePass99"},
+            headers=_H,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "Password set successfully"
+
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert verify_password("MyNewSecurePass99", updated.password_hash)  # type: ignore[arg-type]
+        assert updated.invite_token_hash is None
+        assert updated.invite_expires_at is None
+
+    def test_expired_token(self, tmp_path: Path) -> None:
+        """Expired invite token returns 400."""
+        db_path = _make_db(tmp_path)
+        _, raw_token = _make_invited_user(db_path, hours_valid=-1)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/auth/accept-invite",
+            json={"token": raw_token, "password": "MyNewSecurePass99"},
+            headers=_H,
+        )
+        assert resp.status_code == 400
+        assert "invalid or has expired" in resp.json()["message"]
+
+    def test_invalid_token(self, tmp_path: Path) -> None:
+        """Unknown token returns 400 with same message as expired."""
+        db_path = _make_db(tmp_path)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/auth/accept-invite",
+            json={"token": "bogus-token", "password": "MyNewSecurePass99"},
+            headers=_H,
+        )
+        assert resp.status_code == 400
+        assert "invalid or has expired" in resp.json()["message"]
+
+    def test_already_used_token(self, tmp_path: Path) -> None:
+        """Token that was already accepted returns 400."""
+        db_path = _make_db(tmp_path)
+        _, raw_token = _make_invited_user(db_path)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        client.post(
+            "/api/auth/accept-invite",
+            json={"token": raw_token, "password": "MyNewSecurePass99"},
+            headers=_H,
+        )
+        resp = client.post(
+            "/api/auth/accept-invite",
+            json={"token": raw_token, "password": "AnotherPass123"},
+            headers=_H,
+        )
+        assert resp.status_code == 400
+
+    def test_weak_password(self, tmp_path: Path) -> None:
+        """Weak password returns 400 with issues."""
+        db_path = _make_db(tmp_path)
+        _, raw_token = _make_invited_user(db_path)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/auth/accept-invite", json={"token": raw_token, "password": "short"}, headers=_H
+        )
+        assert resp.status_code == 400
+        assert len(resp.json()["issues"]) > 0
+
+    def test_inactive_user_token_rejected(self, tmp_path: Path) -> None:
+        """Inactive user's invite token returns 400."""
+        db_path = _make_db(tmp_path)
+        raw_token, token_hash = generate_invite_token()
+        _make_user(
+            db_path,
+            "inactive@example.com",
+            is_active=False,
+            password_hash=None,
+            invite_token_hash=token_hash,
+            invite_expires_at=datetime.now(timezone.utc) + timedelta(hours=72),
+        )
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.post(
+            "/api/auth/accept-invite",
+            json={"token": raw_token, "password": "MyNewSecurePass99"},
+            headers=_H,
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_body(self, tmp_path: Path) -> None:
+        """Malformed request returns 400."""
+        db_path = _make_db(tmp_path)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.post("/api/auth/accept-invite", content=b"not json", headers=_H)
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/users (invite flow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCreateUserInvite:
+    """Tests for admin user creation with invite flow."""
+
+    def test_default_creates_invite(self, tmp_path: Path) -> None:
+        """Default user creation returns invite_url, not temp_password."""
+        client, db_path, _ = _admin_client(tmp_path)
+        resp = client.post(
+            "/api/admin/users", json={"email": "new@example.com", "role": "viewer"}, headers=_H
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "invite_url" in data
+        assert data["invite_url"].startswith("/invite/")
+        assert "temp_password" not in data
+
+        user = db.get_user_by_email(db_path, "new@example.com")
+        assert user is not None
+        assert user.password_hash is None
+        assert user.invite_token_hash is not None
+
+    def test_generate_password_flag(self, tmp_path: Path) -> None:
+        """generate_password=true uses temp password flow."""
+        client, db_path, _ = _admin_client(tmp_path)
+        resp = client.post(
+            "/api/admin/users",
+            json={"email": "new@example.com", "generate_password": True},
+            headers=_H,
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "temp_password" in data
+        assert "invite_url" not in data
+
+    def test_invited_user_has_pending_invite(self, tmp_path: Path) -> None:
+        """UserResponse has has_pending_invite=True for invited user."""
+        client, _, _ = _admin_client(tmp_path)
+        resp = client.post("/api/admin/users", json={"email": "new@example.com"}, headers=_H)
+        assert resp.json()["user"]["has_pending_invite"] is True
+
+    def test_duplicate_email_invite(self, tmp_path: Path) -> None:
+        """Creating invite for existing email returns 409."""
+        client, db_path, _ = _admin_client(tmp_path)
+        _make_user(db_path, email="existing@example.com")
+        resp = client.post("/api/admin/users", json={"email": "existing@example.com"}, headers=_H)
+        assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/users/{user_id}/reinvite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReinvite:
+    """Tests for the reinvite endpoint."""
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        """Reinviting generates a new token and invalidates the old one."""
+        client, db_path, _ = _admin_client(tmp_path)
+        user, _ = _make_invited_user(db_path)
+        old_hash = db.get_user_by_id(db_path, user.id)
+        assert old_hash is not None
+
+        resp = client.post(f"/api/admin/users/{user.id}/reinvite", headers=_H)
+        assert resp.status_code == 200
+        assert resp.json()["invite_url"].startswith("/invite/")
+
+        updated = db.get_user_by_id(db_path, user.id)
+        assert updated is not None
+        assert updated.invite_token_hash != old_hash.invite_token_hash
+
+    def test_expired_invite_can_be_resent(self, tmp_path: Path) -> None:
+        """Can reinvite a user whose invite expired."""
+        client, db_path, _ = _admin_client(tmp_path)
+        user, _ = _make_invited_user(db_path, hours_valid=-1)
+
+        resp = client.post(f"/api/admin/users/{user.id}/reinvite", headers=_H)
+        assert resp.status_code == 200
+
+    def test_user_not_found(self, tmp_path: Path) -> None:
+        """Returns 404 for non-existent user."""
+        client, _, _ = _admin_client(tmp_path)
+        resp = client.post("/api/admin/users/nonexistent/reinvite", headers=_H)
+        assert resp.status_code == 404
+
+    def test_user_with_password(self, tmp_path: Path) -> None:
+        """Cannot reinvite user who already set a password."""
+        client, db_path, _ = _admin_client(tmp_path)
+        user = _make_user(db_path, "active@example.com", password_hash=hash_password("pass123"))
+        resp = client.post(f"/api/admin/users/{user.id}/reinvite", headers=_H)
+        assert resp.status_code == 400
+        assert "already set a password" in resp.json()["message"]
+
+    def test_deactivated_user(self, tmp_path: Path) -> None:
+        """Cannot reinvite a deactivated user."""
+        client, db_path, _ = _admin_client(tmp_path)
+        user, _ = _make_invited_user(db_path, email="deactivated@example.com")
+        db.update_user(db_path, user.id, UserUpdate(is_active=False))
+        resp = client.post(f"/api/admin/users/{user.id}/reinvite", headers=_H)
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /invite/{token}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInvitePage:
+    """Tests for the invite page rendering."""
+
+    def test_valid_invite(self, tmp_path: Path) -> None:
+        """Valid invite renders form with email."""
+        db_path = _make_db(tmp_path)
+        user, raw_token = _make_invited_user(db_path)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.get(f"/invite/{raw_token}")
+        assert resp.status_code == 200
+        assert user.email in resp.text
+        assert "invalid or has expired" not in resp.text.lower()
+
+    def test_expired_invite(self, tmp_path: Path) -> None:
+        """Expired invite renders error."""
+        db_path = _make_db(tmp_path)
+        _, raw_token = _make_invited_user(db_path, hours_valid=-1)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.get(f"/invite/{raw_token}")
+        assert resp.status_code == 200
+        assert "expired" in resp.text.lower()
+
+    def test_invalid_token(self, tmp_path: Path) -> None:
+        """Invalid token renders error."""
+        db_path = _make_db(tmp_path)
+        client = TestClient(_make_app(db_path), raise_server_exceptions=False)
+
+        resp = client.get("/invite/bogus-token")
+        assert resp.status_code == 200
+        assert "invalid or has expired" in resp.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# UserResponse computed field + database lookup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInviteModelAndDB:
+    """Tests for invite-related model fields and DB lookup."""
+
+    def test_has_pending_invite_true(self) -> None:
+        """has_pending_invite is True for future expiry."""
+        user = User(
+            email="t@e.com", invite_expires_at=datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+        assert UserResponse.model_validate(user).has_pending_invite is True
+
+    def test_has_pending_invite_false_expired(self) -> None:
+        """has_pending_invite is False for past expiry."""
+        user = User(
+            email="t@e.com", invite_expires_at=datetime.now(timezone.utc) - timedelta(hours=1)
+        )
+        assert UserResponse.model_validate(user).has_pending_invite is False
+
+    def test_has_pending_invite_false_none(self) -> None:
+        """has_pending_invite is False when no invite exists."""
+        assert UserResponse.model_validate(User(email="t@e.com")).has_pending_invite is False
+
+    def test_db_lookup_by_token_hash(self, tmp_path: Path) -> None:
+        """get_user_by_invite_token_hash returns matching user."""
+        db_path = _make_db(tmp_path)
+        user, raw_token = _make_invited_user(db_path)
+        found = db.get_user_by_invite_token_hash(db_path, hash_token(raw_token))
+        assert found is not None
+        assert found.id == user.id
+
+    def test_db_lookup_not_found(self, tmp_path: Path) -> None:
+        """get_user_by_invite_token_hash returns None for unknown hash."""
+        db_path = _make_db(tmp_path)
+        assert db.get_user_by_invite_token_hash(db_path, "a" * 64) is None
+
+    def test_db_lookup_inactive_excluded(self, tmp_path: Path) -> None:
+        """Inactive users are excluded from invite token lookup."""
+        db_path = _make_db(tmp_path)
+        raw_token, token_hash = generate_invite_token()
+        _make_user(
+            db_path,
+            "inactive@e.com",
+            is_active=False,
+            password_hash=None,
+            invite_token_hash=token_hash,
+            invite_expires_at=datetime.now(timezone.utc) + timedelta(hours=72),
+        )
+        assert db.get_user_by_invite_token_hash(db_path, token_hash) is None

--- a/tests/unit/test_web_users.py
+++ b/tests/unit/test_web_users.py
@@ -164,7 +164,7 @@ class TestAdminCreateUser:
         assert "user2@example.com" in emails
 
     def test_create_user_success(self, tmp_path: Path) -> None:
-        """Creates user and returns temp_password."""
+        """Creates user with invite link by default."""
         client, db_path, _admin = _setup_admin_client(tmp_path)
 
         resp = client.post(
@@ -176,8 +176,8 @@ class TestAdminCreateUser:
         data = resp.json()
         assert data["user"]["email"] == "new@example.com"
         assert data["user"]["role"] == "editor"
-        assert "temp_password" in data
-        assert len(data["temp_password"]) > 0
+        assert "invite_url" in data
+        assert data["invite_url"].startswith("/invite/")
 
     def test_create_user_duplicate(self, tmp_path: Path) -> None:
         """Duplicate email returns 409."""


### PR DESCRIPTION
## Summary

- Replace temp-password sharing with invite links: admin creates user → gets `/invite/{token}` URL → shares it → user sets own password
- Preserve temp-password flow via `generate_password: true` flag for backward compatibility
- 72-hour invite expiry with admin reinvite capability
- CLI `dango auth add-user` defaults to invite URL output (`--password` for old behavior)
- Admin UI shows Invited/Invite Expired badges and Resend Invite action

## Changes

**New files (3):**
- `dango/migrations/auth/004_invite_tokens.py` — adds `invite_token_hash` and `invite_expires_at` columns
- `dango/web/templates/invite.html` — set-password page for invited users
- `tests/unit/test_web_auth_invite.py` — 27 tests covering token generation, acceptance, reinvite, page rendering, model/DB

**Modified (16):**
- `dango/auth/` — models (invite fields + `has_pending_invite` computed field), security (`generate_invite_token`), database (`get_user_by_invite_token_hash`, updated `_row_to_user`/`create_user`), audit (2 new events), exports
- `dango/web/routes/users.py` — invite-default create user + `POST /api/admin/users/{id}/reinvite`
- `dango/web/routes/auth.py` — `POST /api/auth/accept-invite` endpoint
- `dango/web/routes/ui.py` — `GET /invite/{token}` page route
- `dango/web/middleware/auth.py` — public route registration for invite paths
- `dango/web/models.py` — `AcceptInviteRequest`, `generate_password` field on `CreateUserRequest`
- `dango/web/templates/admin_users.html` — credential modal, status badges, reinvite action
- `dango/cli/commands/auth.py` — invite-default `add-user`, invite status in `list-users`
- `docs/file-exemptions.yml` — updated line counts, added new exemptions
- `tests/unit/test_auth_audit.py` — updated enum member count
- `tests/unit/test_web_users.py` — updated create-user test for invite default

## Test plan

- [x] 27 new tests in `test_web_auth_invite.py` (token gen, accept happy/expired/invalid/weak-pw/inactive, create-user invite/password, reinvite happy/expired/not-found/has-password/deactivated, invite page valid/expired/invalid, model computed fields, DB lookup)
- [x] Updated 2 existing tests (`test_auth_audit.py` member count, `test_web_users.py` create default)
- [x] Full suite: 1101 tests passing
- [x] ruff check + format clean
- [x] mypy clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)