### PR TITLE
TASK-023 + TASK-025: Droplet provisioning and firewall management

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -23,6 +23,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
+| `commands/remote.py` (~220 lines) | `remote` group → `firewall` subgroup (`list`, `allow-ip`, `allow-all`) | `remote`, `firewall` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
@@ -72,6 +73,9 @@ dango (top-level group)
 │   ├── provision
 ├── migrate (group)             ← commands/migrate.py
 │   ├── status, run
+├── remote (group)              ← commands/remote.py
+│   └── firewall (subgroup)
+│       ├── list, allow-ip, allow-all
 └── metabase (group)            ← commands/metabase_cmd.py
     ├── save, load, refresh
 ```

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -1,0 +1,232 @@
+"""dango/cli/commands/remote.py
+
+Remote server management commands for Dango cloud deployments.
+
+Command hierarchy::
+
+    dango remote (group)
+    └── firewall (subgroup)
+        ├── list       — Show current firewall rules
+        ├── allow-ip   — Restrict ports 80/443 to a specific IP
+        └── allow-all  — Revert ports 80/443 to public access
+
+All commands require an active cloud deployment (``droplet_id`` and
+``firewall_id`` set in ``.dango/cloud.yml``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+from dango.cli import console
+
+# ---------------------------------------------------------------------------
+# Top-level group
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+@click.pass_context
+def remote(ctx: click.Context) -> None:
+    """Manage the remote Dango cloud server.
+
+    Commands:
+      dango remote firewall list        Show current firewall rules
+      dango remote firewall allow-ip    Restrict web to a specific IP
+      dango remote firewall allow-all   Revert web access to public
+    """
+    ctx.ensure_object(dict)
+
+
+# ---------------------------------------------------------------------------
+# firewall subgroup
+# ---------------------------------------------------------------------------
+
+
+@remote.group("firewall")
+@click.pass_context
+def firewall(ctx: click.Context) -> None:
+    """Manage the cloud server firewall.
+
+    Commands:
+      list       Show current inbound/outbound rules
+      allow-ip   Restrict ports 80/443 to a specific IP or CIDR
+      allow-all  Revert ports 80/443 to public (allow all traffic)
+    """
+    ctx.ensure_object(dict)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_cloud_config_or_fail(ctx: click.Context) -> tuple[Any, str]:
+    """Load CloudConfig and return (config, firewall_id), or exit with an error.
+
+    Returns:
+        Tuple of (CloudConfig, firewall_id string).
+
+    Raises:
+        SystemExit: If no deployment or no firewall is configured.
+    """
+    from dango.cli.utils import require_project_context
+    from dango.config.loader import ConfigLoader
+
+    project_root: Path = require_project_context(ctx)
+    loader = ConfigLoader(project_root)
+    cloud_cfg = loader.load_cloud_config()
+
+    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+        console.print(
+            "[red]Error:[/red] No cloud deployment found. "
+            "Run [bold]dango deploy[/bold] to provision a server first."
+        )
+        raise SystemExit(1)
+
+    if cloud_cfg.firewall_id is None:
+        console.print(
+            "[red]Error:[/red] No firewall configured for this deployment. "
+            "Re-provision or manually set [bold]firewall_id[/bold] in "
+            "[bold].dango/cloud.yml[/bold]."
+        )
+        raise SystemExit(1)
+
+    return cloud_cfg, cloud_cfg.firewall_id
+
+
+def _make_client() -> Any:
+    """Create and return a DigitalOceanClient instance."""
+    from dango.platform.cloud.digitalocean import DigitalOceanClient
+
+    return DigitalOceanClient()
+
+
+# ---------------------------------------------------------------------------
+# firewall list
+# ---------------------------------------------------------------------------
+
+
+@firewall.command("list")
+@click.pass_context
+def firewall_list(ctx: click.Context) -> None:
+    """Show current inbound and outbound firewall rules.
+
+    Displays all firewall rules in a table, separated by direction.
+    Requires an active deployment with a configured firewall.
+
+    Example:
+      dango remote firewall list
+    """
+    from rich.table import Table
+
+    from dango.platform.cloud.firewall import format_firewall_rules, get_firewall_rules
+
+    _cloud_cfg, firewall_id = _load_cloud_config_or_fail(ctx)
+    client = _make_client()
+
+    try:
+        fw = get_firewall_rules(client, firewall_id)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Failed to retrieve firewall rules: {exc}")
+        raise SystemExit(1) from exc
+
+    rows = format_firewall_rules(fw)
+
+    if not rows:
+        console.print("[yellow]No firewall rules configured.[/yellow]")
+        return
+
+    table = Table(
+        title=f"Firewall: {fw.get('name', firewall_id)}",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Direction", style="dim", width=10)
+    table.add_column("Protocol", width=10)
+    table.add_column("Ports", width=12)
+    table.add_column("Sources / Destinations")
+
+    for row in rows:
+        direction = row["direction"]
+        style = "green" if direction == "inbound" else "blue"
+        table.add_row(
+            f"[{style}]{direction}[/{style}]",
+            row["protocol"],
+            row["ports"],
+            row["sources_or_destinations"],
+        )
+
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# firewall allow-ip
+# ---------------------------------------------------------------------------
+
+
+@firewall.command("allow-ip")
+@click.argument("ip_address")
+@click.pass_context
+def firewall_allow_ip(ctx: click.Context, ip_address: str) -> None:
+    """Restrict ports 80 and 443 to IP_ADDRESS.
+
+    IP_ADDRESS can be a bare IPv4 address (e.g. 203.0.113.42) or a CIDR
+    range (e.g. 203.0.113.0/24).  Bare IPs are treated as /32 (single host).
+
+    SSH (port 22) is always left open to allow continued server access.
+
+    Examples:
+      dango remote firewall allow-ip 203.0.113.42
+      dango remote firewall allow-ip 203.0.113.0/24
+    """
+    from dango.platform.cloud.firewall import add_allowed_ip
+
+    _cloud_cfg, firewall_id = _load_cloud_config_or_fail(ctx)
+    client = _make_client()
+
+    try:
+        fw = add_allowed_ip(client, firewall_id, ip_address)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(
+        f"[green]Firewall updated.[/green] "
+        f"Ports 80/443 now restricted to [bold]{ip_address}[/bold]."
+    )
+    console.print(f"  Firewall: {fw.get('name', firewall_id)}")
+
+
+# ---------------------------------------------------------------------------
+# firewall allow-all
+# ---------------------------------------------------------------------------
+
+
+@firewall.command("allow-all")
+@click.pass_context
+def firewall_allow_all(ctx: click.Context) -> None:
+    """Revert ports 80 and 443 to allow all public traffic.
+
+    Removes any IP restrictions on HTTP/HTTPS access.  SSH (port 22) is
+    always left open to allow continued server access.
+
+    Example:
+      dango remote firewall allow-all
+    """
+    from dango.platform.cloud.firewall import allow_all_web
+
+    _cloud_cfg, firewall_id = _load_cloud_config_or_fail(ctx)
+    client = _make_client()
+
+    try:
+        fw = allow_all_web(client, firewall_id)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print("[green]Firewall updated.[/green] Ports 80/443 are now open to all traffic.")
+    console.print(f"  Firewall: {fw.get('name', firewall_id)}")

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -19,6 +19,7 @@ from dango.cli.commands.model import model
 from dango.cli.commands.oauth import oauth
 from dango.cli.commands.platform import start, status, stop
 from dango.cli.commands.project import info, init, rename
+from dango.cli.commands.remote import remote
 from dango.cli.commands.source import source, sync
 from dango.cli.commands.transform import docs, generate, run
 from dango.cli.commands.web import web
@@ -79,6 +80,7 @@ cli.add_command(model)
 cli.add_command(dashboard)
 cli.add_command(metabase)
 cli.add_command(migrate)
+cli.add_command(remote)
 
 
 def main() -> None:

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -9,7 +9,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports, `__all__` | Re-exports all public symbols |
-| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `ShopifySourceConfig` |
+| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `ShopifySourceConfig`, `CloudConfig` (incl. `firewall_id`) |
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
 | `credentials.py` | Credential loading for dlt sources | `CredentialManager`, `init_dlt_directory` |

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -515,6 +515,9 @@ class CloudConfig(BaseModel):
     droplet_ip: str | None = Field(
         default=None, description="Droplet public IP address (set after provisioning)"
     )
+    firewall_id: str | None = Field(
+        default=None, description="DigitalOcean firewall ID (set after provisioning)"
+    )
     region: str = Field(default="nyc1", description="DigitalOcean region")
     size: str = Field(default="s-2vcpu-4gb", description="Droplet size slug")
     domain: str | None = Field(default=None, description="Custom domain name")

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -382,25 +382,19 @@ class CloudAPIError(CloudError):
         status_code: int | None = None,
         response_body: str | None = None,
         error_code: str | None = None,
-        context: dict[str, Any] | None = None,
         user_message: str | None = None,
     ) -> None:
         self.status_code = status_code
         self.response_body = response_body
-        extra: dict[str, Any] = {}
+        ctx: dict[str, Any] = {}
         if status_code is not None:
-            extra["status_code"] = status_code
+            ctx["status_code"] = status_code
         if response_body is not None:
-            extra["response_body"] = response_body
-        if extra:
-            merged = dict(extra)
-            if context:
-                merged.update(context)
-            context = merged
+            ctx["response_body"] = response_body
         super().__init__(
             message,
             error_code=error_code,
-            context=context,
+            context=ctx if ctx else None,
             user_message=user_message,
         )
 

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -27,8 +27,10 @@ platform/
 │   └── watcher_runner.py    # Background watcher process entry point
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
-│   ├── __init__.py      # Exports CommandResult, DigitalOceanClient, SpacesClient, SSHManager
+│   ├── __init__.py      # Exports CommandResult, DigitalOceanClient, SpacesClient, SSHManager, provisioning, firewall symbols
 │   ├── digitalocean.py  # DO REST API v2 client (Droplets, SSH Keys, Firewalls)
+│   ├── provisioning.py  # Size tiers, regions, provision_droplet() orchestration (TASK-023)
+│   ├── firewall.py      # Firewall lifecycle, IP allowlisting (TASK-025)
 │   ├── spaces.py        # DO Spaces client (S3-compatible via boto3)
 │   └── ssh.py           # SSH key management, TOFU known-hosts, exec/SFTP (TASK-024)
 │
@@ -50,6 +52,8 @@ platform/
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |
 | `local/watcher_runner.py` | Background watcher process | `main` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |
+| `cloud/provisioning.py` | Droplet size tiers, regions, provisioning orchestration | `DropletSizeTier`, `RegionInfo`, `SIZE_TIERS`, `DEFAULT_TIER`, `provision_droplet`, `wait_for_droplet_ready`, `wait_for_ssh`, `suggest_nearest_region`, `save_provisioning_metadata` |
+| `cloud/firewall.py` | Firewall lifecycle and IP allowlisting | `create_default_firewall`, `add_allowed_ip`, `restrict_web_to_ips`, `allow_all_web`, `validate_ip_or_cidr`, `save_firewall_metadata` |
 | `cloud/spaces.py` | DigitalOcean Spaces (S3-compatible) client | `SpacesClient` |
 | `cloud/ssh.py` | SSH key management, TOFU known-hosts, command exec, SFTP | `SSHManager`, `CommandResult` |
 
@@ -74,6 +78,12 @@ from dango.platform.cloud import DigitalOceanClient, SpacesClient
 # SSH management (TASK-024)
 from dango.platform.cloud import SSHManager, CommandResult
 from dango.platform.cloud.ssh import SSHManager, CommandResult  # also valid
+
+# Provisioning (TASK-023)
+from dango.platform.cloud import provision_droplet, suggest_nearest_region, SIZE_TIERS
+
+# Firewall management (TASK-025)
+from dango.platform.cloud import create_default_firewall, add_allowed_ip, restrict_web_to_ips
 ```
 
 ### Also valid (backwards-compatible shims):
@@ -103,7 +113,8 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | Add a startup step for both local + cloud | `common/startup.py` | `pytest tests/unit/test_platform_startup.py` |
 | Add a local-only startup step | `local/` and `cli/commands/platform.py` | `dango start` manually |
 | Add cloud infrastructure | `cloud/` | `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py` |
-| Provision a Droplet | `cloud/digitalocean.py` → `DigitalOceanClient` | `pytest tests/unit/test_digitalocean_client.py` |
+| Provision a Droplet | `cloud/provisioning.py` → `provision_droplet()` | `pytest tests/unit/test_provisioning.py` |
+| Manage firewall rules | `cloud/firewall.py` → `add_allowed_ip()` / `restrict_web_to_ips()` | `pytest tests/unit/test_firewall.py` |
 | Backup to Spaces | `cloud/spaces.py` → `SpacesClient` | `pytest tests/unit/test_spaces_client.py` |
 | Manage SSH keys / remote exec | `cloud/ssh.py` → `SSHManager` | `pytest tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py` |
 | Modify watcher logic | `local/watcher.py` | `pytest tests/unit/test_watcher_lifecycle.py` |

--- a/dango/platform/cloud/__init__.py
+++ b/dango/platform/cloud/__init__.py
@@ -6,7 +6,68 @@ Populated by TASK-022+ (cloud provisioning, Caddy, remote sync).
 """
 
 from .digitalocean import DigitalOceanClient
+from .firewall import (
+    add_allowed_ip,
+    allow_all_web,
+    create_default_firewall,
+    delete_firewall,
+    format_firewall_rules,
+    get_firewall_rules,
+    restrict_web_to_ips,
+    save_firewall_metadata,
+    validate_ip_or_cidr,
+)
+from .provisioning import (
+    BUDGET_TIER,
+    DEFAULT_TIER,
+    PERFORMANCE_TIER,
+    SIZE_TIERS,
+    STANDARD_TIER,
+    DropletSizeTier,
+    RegionInfo,
+    get_region_info,
+    get_size_tier,
+    list_regions,
+    provision_droplet,
+    save_provisioning_metadata,
+    suggest_nearest_region,
+    validate_custom_size,
+    wait_for_droplet_ready,
+    wait_for_ssh,
+)
 from .spaces import SpacesClient
 from .ssh import CommandResult, SSHManager
 
-__all__ = ["CommandResult", "DigitalOceanClient", "SpacesClient", "SSHManager"]
+__all__ = [
+    "CommandResult",
+    "DigitalOceanClient",
+    "SpacesClient",
+    "SSHManager",
+    # Provisioning
+    "DropletSizeTier",
+    "RegionInfo",
+    "SIZE_TIERS",
+    "DEFAULT_TIER",
+    "BUDGET_TIER",
+    "STANDARD_TIER",
+    "PERFORMANCE_TIER",
+    "get_size_tier",
+    "validate_custom_size",
+    "get_region_info",
+    "list_regions",
+    "suggest_nearest_region",
+    "provision_droplet",
+    "save_provisioning_metadata",
+    "wait_for_droplet_ready",
+    "wait_for_ssh",
+    # Firewall
+    "validate_ip_or_cidr",
+    "create_default_firewall",
+    "delete_firewall",
+    "get_firewall_rules",
+    "add_allowed_ip",
+    "restrict_web_to_ips",
+    "allow_all_web",
+    "format_firewall_rules",
+    "save_firewall_metadata",
+]

--- a/dango/platform/cloud/digitalocean.py
+++ b/dango/platform/cloud/digitalocean.py
@@ -110,7 +110,6 @@ class DigitalOceanClient:
         if response.status_code == 401:
             raise CloudAuthError(
                 "DigitalOcean API authentication failed. Check your token.",
-                context={"status_code": response.status_code},
             )
         raise CloudAPIError(
             f"DigitalOcean API error: HTTP {response.status_code}",
@@ -402,6 +401,56 @@ class DigitalOceanClient:
         """
         payload = {"droplet_ids": droplet_ids}
         self._request_with_retry("POST", f"/firewalls/{firewall_id}/droplets", json=payload)
+
+    def get_firewall(self, firewall_id: str) -> dict[str, Any]:
+        """Retrieve a single Firewall by ID.
+
+        Args:
+            firewall_id: UUID of the Firewall to retrieve.
+
+        Returns:
+            The ``firewall`` object from the DO API response.
+        """
+        response = self._request_with_retry("GET", f"/firewalls/{firewall_id}")
+        data: dict[str, Any] = response.json()
+        return cast(dict[str, Any], data["firewall"])
+
+    def update_firewall(
+        self,
+        firewall_id: str,
+        name: str,
+        inbound_rules: list[dict[str, Any]],
+        outbound_rules: list[dict[str, Any]],
+        droplet_ids: list[int] | None = None,
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Replace a Firewall's configuration (full replacement, not partial update).
+
+        Args:
+            firewall_id: UUID of the Firewall to update.
+            name: Firewall name.
+            inbound_rules: New inbound rule list (replaces existing).
+            outbound_rules: New outbound rule list (replaces existing).
+            droplet_ids: Droplet IDs to associate. Pass empty list to remove all;
+                pass ``None`` to leave associations unchanged (omits field).
+            tags: Tag names to associate (optional).
+
+        Returns:
+            The updated ``firewall`` object from the DO API response.
+        """
+        payload: dict[str, Any] = {
+            "name": name,
+            "inbound_rules": inbound_rules,
+            "outbound_rules": outbound_rules,
+        }
+        if droplet_ids is not None:
+            payload["droplet_ids"] = droplet_ids
+        if tags is not None:
+            payload["tags"] = tags
+
+        response = self._request_with_retry("PUT", f"/firewalls/{firewall_id}", json=payload)
+        data: dict[str, Any] = response.json()
+        return cast(dict[str, Any], data["firewall"])
 
     def delete_firewall(self, firewall_id: str) -> None:
         """Delete a Firewall by ID.

--- a/dango/platform/cloud/firewall.py
+++ b/dango/platform/cloud/firewall.py
@@ -1,0 +1,414 @@
+"""dango/platform/cloud/firewall.py
+
+Firewall lifecycle and IP allowlisting for Dango cloud deployments.
+
+Manages DigitalOcean Cloud Firewalls: creation with default rules, IP-based
+access restriction on ports 80/443, and reversion to public access.
+
+Default inbound rules
+---------------------
+- SSH (22): open to all (0.0.0.0/0 and ::/0)
+- HTTP (80): open to all
+- HTTPS (443): open to all
+
+Default outbound rules
+----------------------
+All TCP, UDP, and ICMP to all destinations.
+
+IP allowlisting
+---------------
+``add_allowed_ip()`` uses a read-modify-write pattern:
+
+- If the firewall currently allows ``0.0.0.0/0`` on 80/443, it switches to
+  allowlist mode with just the new IP.
+- If already in allowlist mode, it appends the new IP (deduplicating via set).
+
+``restrict_web_to_ips()`` replaces the 80/443 rules entirely while preserving
+SSH open-to-all and existing outbound rules.
+
+Error codes
+-----------
+- DANGO-D020: Invalid IP address or CIDR notation
+- DANGO-D021: Empty IP list for allowlisting
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from pathlib import Path
+from typing import Any
+
+from dango.exceptions import CloudError
+
+__all__ = [
+    "DEFAULT_INBOUND_RULES",
+    "DEFAULT_OUTBOUND_RULES",
+    "validate_ip_or_cidr",
+    "create_default_firewall",
+    "delete_firewall",
+    "get_firewall_rules",
+    "add_allowed_ip",
+    "restrict_web_to_ips",
+    "allow_all_web",
+    "format_firewall_rules",
+    "save_firewall_metadata",
+]
+
+# ---------------------------------------------------------------------------
+# Default rule constants
+# ---------------------------------------------------------------------------
+
+_PUBLIC_SOURCES: dict[str, Any] = {"addresses": ["0.0.0.0/0", "::/0"]}
+_ALL_DESTINATIONS: dict[str, Any] = {"addresses": ["0.0.0.0/0", "::/0"]}
+
+DEFAULT_INBOUND_RULES: list[dict[str, Any]] = [
+    {"protocol": "tcp", "ports": "22", "sources": _PUBLIC_SOURCES},
+    {"protocol": "tcp", "ports": "80", "sources": _PUBLIC_SOURCES},
+    {"protocol": "tcp", "ports": "443", "sources": _PUBLIC_SOURCES},
+]
+
+DEFAULT_OUTBOUND_RULES: list[dict[str, Any]] = [
+    {"protocol": "tcp", "ports": "all", "destinations": _ALL_DESTINATIONS},
+    {"protocol": "udp", "ports": "all", "destinations": _ALL_DESTINATIONS},
+    {"protocol": "icmp", "destinations": _ALL_DESTINATIONS},
+]
+
+_WEB_PORTS = {"80", "443"}
+_SSH_PORT = "22"
+
+
+# ---------------------------------------------------------------------------
+# IP / CIDR validation
+# ---------------------------------------------------------------------------
+
+
+def validate_ip_or_cidr(value: str) -> str:
+    """Validate and normalise *value* as an IPv4 address or CIDR range.
+
+    - Bare IPv4 addresses are normalised to ``/32`` (e.g. ``"1.2.3.4"``
+      → ``"1.2.3.4/32"``).
+    - CIDR ranges with host bits set are normalised to the network address
+      (``strict=False``), e.g. ``"10.0.0.5/24"`` → ``"10.0.0.0/24"``.
+    - IPv6 addresses are rejected (IPv4-only for v1).
+
+    Args:
+        value: IP address or CIDR string to validate.
+
+    Returns:
+        Normalised CIDR string.
+
+    Raises:
+        CloudError: DANGO-D020 if *value* is invalid or IPv6.
+    """
+    if not value or not value.strip():
+        raise CloudError(
+            "IP address or CIDR cannot be empty.",
+            error_code="DANGO-D020",
+        )
+
+    stripped = value.strip()
+
+    # Reject IPv6
+    if ":" in stripped:
+        raise CloudError(
+            f"IPv6 addresses are not supported for allowlisting (got '{stripped}'). "
+            "Use an IPv4 address or CIDR range.",
+            error_code="DANGO-D020",
+        )
+
+    try:
+        if "/" in stripped:
+            network = ipaddress.IPv4Network(stripped, strict=False)
+            return str(network)
+        else:
+            # Bare IP — validate then append /32
+            ipaddress.IPv4Address(stripped)
+            return f"{stripped}/32"
+    except ValueError as exc:
+        raise CloudError(
+            f"Invalid IP address or CIDR notation: '{stripped}'. {exc}",
+            error_code="DANGO-D020",
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Firewall lifecycle
+# ---------------------------------------------------------------------------
+
+
+def create_default_firewall(
+    client: Any,
+    droplet_id: int,
+) -> dict[str, Any]:
+    """Create a Dango firewall with default rules and apply it to *droplet_id*.
+
+    The firewall name is ``dango-fw-{droplet_id}``.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        droplet_id: Droplet ID to associate with the new firewall.
+
+    Returns:
+        The firewall dict returned by the DO API.
+    """
+    name = f"dango-fw-{droplet_id}"
+    return client.create_firewall(  # type: ignore[no-any-return]
+        name=name,
+        inbound_rules=DEFAULT_INBOUND_RULES,
+        outbound_rules=DEFAULT_OUTBOUND_RULES,
+        droplet_ids=[droplet_id],
+    )
+
+
+def delete_firewall(client: Any, firewall_id: str) -> None:
+    """Delete a firewall by ID.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        firewall_id: UUID of the firewall to delete.
+    """
+    client.delete_firewall(firewall_id)
+
+
+def get_firewall_rules(client: Any, firewall_id: str) -> dict[str, Any]:
+    """Return the full firewall dict for *firewall_id*.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        firewall_id: UUID of the firewall to retrieve.
+
+    Returns:
+        The firewall dict from the DO API.
+    """
+    return client.get_firewall(firewall_id)  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# IP allowlisting helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_public_sources(sources: dict[str, Any]) -> bool:
+    """Return True if *sources* includes the open-to-all ``0.0.0.0/0`` address."""
+    addresses: list[str] = sources.get("addresses", [])
+    return "0.0.0.0/0" in addresses
+
+
+def _build_web_inbound_rule(port: str, cidr_list: list[str]) -> dict[str, Any]:
+    """Build a single inbound rule for *port* restricted to *cidr_list*."""
+    return {
+        "protocol": "tcp",
+        "ports": port,
+        "sources": {"addresses": cidr_list},
+    }
+
+
+def add_allowed_ip(client: Any, firewall_id: str, ip_cidr: str) -> dict[str, Any]:
+    """Add *ip_cidr* to the 80/443 allowlist, switching from public mode if needed.
+
+    Behaviour:
+    - If the firewall currently allows ``0.0.0.0/0`` on both 80 and 443 (public
+      mode), switches to allowlist mode with *ip_cidr* as the sole source.
+    - If already in allowlist mode, appends *ip_cidr* (deduplicates via set).
+    - SSH (port 22) is always left unchanged.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        firewall_id: UUID of the firewall to modify.
+        ip_cidr: IPv4 address or CIDR to allow (will be validated/normalised).
+
+    Returns:
+        The updated firewall dict.
+    """
+    normalised = validate_ip_or_cidr(ip_cidr)
+    fw = client.get_firewall(firewall_id)
+
+    existing_inbound: list[dict[str, Any]] = fw.get("inbound_rules", [])
+    existing_outbound: list[dict[str, Any]] = fw.get("outbound_rules", [])
+    droplet_ids: list[int] = fw.get("droplet_ids", [])
+    tags: list[str] = fw.get("tags", [])
+    name: str = fw.get("name", f"dango-fw-{firewall_id}")
+
+    # Separate SSH rule from web rules
+    ssh_rules = [r for r in existing_inbound if r.get("ports") == _SSH_PORT]
+    web_rules = {r["ports"]: r for r in existing_inbound if r.get("ports") in _WEB_PORTS}
+
+    # Determine if currently in public mode (any web rule has 0.0.0.0/0)
+    public_mode = any(_is_public_sources(rule.get("sources", {})) for rule in web_rules.values())
+
+    if public_mode:
+        new_cidrs = [normalised]
+    else:
+        # Collect all existing IPs across 80/443 rules, then add new one
+        existing_cidrs: set[str] = set()
+        for rule in web_rules.values():
+            existing_cidrs.update(rule.get("sources", {}).get("addresses", []))
+        existing_cidrs.add(normalised)
+        new_cidrs = sorted(existing_cidrs)
+
+    new_web_rules = [_build_web_inbound_rule(port, new_cidrs) for port in sorted(_WEB_PORTS)]
+    new_inbound = ssh_rules + new_web_rules
+
+    return client.update_firewall(  # type: ignore[no-any-return]
+        firewall_id=firewall_id,
+        name=name,
+        inbound_rules=new_inbound,
+        outbound_rules=existing_outbound,
+        droplet_ids=droplet_ids,
+        tags=tags or None,
+    )
+
+
+def restrict_web_to_ips(
+    client: Any,
+    firewall_id: str,
+    ip_cidrs: list[str],
+) -> dict[str, Any]:
+    """Replace 80/443 inbound rules with the given IP list.
+
+    SSH (port 22) is left open to all.  Existing outbound rules and droplet
+    associations are preserved.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        firewall_id: UUID of the firewall to modify.
+        ip_cidrs: Non-empty list of IPv4 addresses or CIDRs to allow.
+
+    Returns:
+        The updated firewall dict.
+
+    Raises:
+        CloudError: DANGO-D021 if *ip_cidrs* is empty.
+    """
+    if not ip_cidrs:
+        raise CloudError(
+            "ip_cidrs must not be empty when restricting web access.",
+            error_code="DANGO-D021",
+        )
+
+    normalised = [validate_ip_or_cidr(ip) for ip in ip_cidrs]
+
+    fw = client.get_firewall(firewall_id)
+    existing_inbound: list[dict[str, Any]] = fw.get("inbound_rules", [])
+    existing_outbound: list[dict[str, Any]] = fw.get("outbound_rules", [])
+    droplet_ids: list[int] = fw.get("droplet_ids", [])
+    tags: list[str] = fw.get("tags", [])
+    name: str = fw.get("name", f"dango-fw-{firewall_id}")
+
+    ssh_rules = [r for r in existing_inbound if r.get("ports") == _SSH_PORT]
+    new_web_rules = [_build_web_inbound_rule(port, normalised) for port in sorted(_WEB_PORTS)]
+    new_inbound = ssh_rules + new_web_rules
+
+    return client.update_firewall(  # type: ignore[no-any-return]
+        firewall_id=firewall_id,
+        name=name,
+        inbound_rules=new_inbound,
+        outbound_rules=existing_outbound,
+        droplet_ids=droplet_ids,
+        tags=tags or None,
+    )
+
+
+def allow_all_web(client: Any, firewall_id: str) -> dict[str, Any]:
+    """Revert 80/443 inbound rules to allow all traffic.
+
+    SSH (port 22) and outbound rules are left unchanged.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        firewall_id: UUID of the firewall to modify.
+
+    Returns:
+        The updated firewall dict.
+    """
+    fw = client.get_firewall(firewall_id)
+    existing_inbound: list[dict[str, Any]] = fw.get("inbound_rules", [])
+    existing_outbound: list[dict[str, Any]] = fw.get("outbound_rules", [])
+    droplet_ids: list[int] = fw.get("droplet_ids", [])
+    tags: list[str] = fw.get("tags", [])
+    name: str = fw.get("name", f"dango-fw-{firewall_id}")
+
+    ssh_rules = [r for r in existing_inbound if r.get("ports") == _SSH_PORT]
+    new_web_rules = [
+        {"protocol": "tcp", "ports": port, "sources": _PUBLIC_SOURCES}
+        for port in sorted(_WEB_PORTS)
+    ]
+    new_inbound = ssh_rules + new_web_rules
+
+    return client.update_firewall(  # type: ignore[no-any-return]
+        firewall_id=firewall_id,
+        name=name,
+        inbound_rules=new_inbound,
+        outbound_rules=existing_outbound,
+        droplet_ids=droplet_ids,
+        tags=tags or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Display helper
+# ---------------------------------------------------------------------------
+
+
+def format_firewall_rules(firewall: dict[str, Any]) -> list[dict[str, str]]:
+    """Format firewall inbound and outbound rules for Rich table display.
+
+    Args:
+        firewall: Firewall dict from the DO API.
+
+    Returns:
+        List of dicts with keys ``direction``, ``protocol``, ``ports``,
+        ``sources_or_destinations``.
+    """
+    rows: list[dict[str, str]] = []
+
+    for rule in firewall.get("inbound_rules", []):
+        sources = rule.get("sources", {})
+        addresses = sources.get("addresses", [])
+        rows.append(
+            {
+                "direction": "inbound",
+                "protocol": rule.get("protocol", ""),
+                "ports": rule.get("ports", "all"),
+                "sources_or_destinations": ", ".join(addresses) if addresses else "all",
+            }
+        )
+
+    for rule in firewall.get("outbound_rules", []):
+        destinations = rule.get("destinations", {})
+        addresses = destinations.get("addresses", [])
+        rows.append(
+            {
+                "direction": "outbound",
+                "protocol": rule.get("protocol", ""),
+                "ports": rule.get("ports", "all"),
+                "sources_or_destinations": ", ".join(addresses) if addresses else "all",
+            }
+        )
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Config persistence
+# ---------------------------------------------------------------------------
+
+
+def save_firewall_metadata(project_root: Path, firewall_id: str) -> None:
+    """Persist the firewall ID to ``.dango/cloud.yml``.
+
+    Loads the existing ``CloudConfig`` (or creates a new one), sets
+    ``firewall_id``, and saves.
+
+    Args:
+        project_root: Project root directory (contains ``.dango/``).
+        firewall_id: DO firewall UUID to persist.
+    """
+    from dango.config.loader import ConfigLoader
+    from dango.config.models import CloudConfig
+
+    loader = ConfigLoader(project_root)
+    existing = loader.load_cloud_config() or CloudConfig()
+
+    updated = existing.model_copy(update={"firewall_id": firewall_id})
+    loader.save_cloud_config(updated)

--- a/dango/platform/cloud/firewall.py
+++ b/dango/platform/cloud/firewall.py
@@ -229,9 +229,10 @@ def add_allowed_ip(client: Any, firewall_id: str, ip_cidr: str) -> dict[str, Any
     tags: list[str] = fw.get("tags", [])
     name: str = fw.get("name", f"dango-fw-{firewall_id}")
 
-    # Separate SSH rule from web rules
+    # Separate SSH rule from web rules; preserve any other custom inbound rules
     ssh_rules = [r for r in existing_inbound if r.get("ports") == _SSH_PORT]
     web_rules = {r["ports"]: r for r in existing_inbound if r.get("ports") in _WEB_PORTS}
+    other_rules = [r for r in existing_inbound if r.get("ports") not in (_SSH_PORT, *_WEB_PORTS)]
 
     # Determine if currently in public mode (any web rule has 0.0.0.0/0)
     public_mode = any(_is_public_sources(rule.get("sources", {})) for rule in web_rules.values())
@@ -247,7 +248,7 @@ def add_allowed_ip(client: Any, firewall_id: str, ip_cidr: str) -> dict[str, Any
         new_cidrs = sorted(existing_cidrs)
 
     new_web_rules = [_build_web_inbound_rule(port, new_cidrs) for port in sorted(_WEB_PORTS)]
-    new_inbound = ssh_rules + new_web_rules
+    new_inbound = ssh_rules + other_rules + new_web_rules
 
     return client.update_firewall(  # type: ignore[no-any-return]
         firewall_id=firewall_id,
@@ -296,8 +297,9 @@ def restrict_web_to_ips(
     name: str = fw.get("name", f"dango-fw-{firewall_id}")
 
     ssh_rules = [r for r in existing_inbound if r.get("ports") == _SSH_PORT]
+    other_rules = [r for r in existing_inbound if r.get("ports") not in (_SSH_PORT, *_WEB_PORTS)]
     new_web_rules = [_build_web_inbound_rule(port, normalised) for port in sorted(_WEB_PORTS)]
-    new_inbound = ssh_rules + new_web_rules
+    new_inbound = ssh_rules + other_rules + new_web_rules
 
     return client.update_firewall(  # type: ignore[no-any-return]
         firewall_id=firewall_id,
@@ -329,11 +331,12 @@ def allow_all_web(client: Any, firewall_id: str) -> dict[str, Any]:
     name: str = fw.get("name", f"dango-fw-{firewall_id}")
 
     ssh_rules = [r for r in existing_inbound if r.get("ports") == _SSH_PORT]
+    other_rules = [r for r in existing_inbound if r.get("ports") not in (_SSH_PORT, *_WEB_PORTS)]
     new_web_rules = [
-        {"protocol": "tcp", "ports": port, "sources": _PUBLIC_SOURCES}
+        _build_web_inbound_rule(port, list(_PUBLIC_SOURCES["addresses"]))
         for port in sorted(_WEB_PORTS)
     ]
-    new_inbound = ssh_rules + new_web_rules
+    new_inbound = ssh_rules + other_rules + new_web_rules
 
     return client.update_firewall(  # type: ignore[no-any-return]
         firewall_id=firewall_id,

--- a/dango/platform/cloud/firewall.py
+++ b/dango/platform/cloud/firewall.py
@@ -256,7 +256,7 @@ def add_allowed_ip(client: Any, firewall_id: str, ip_cidr: str) -> dict[str, Any
         inbound_rules=new_inbound,
         outbound_rules=existing_outbound,
         droplet_ids=droplet_ids,
-        tags=tags or None,
+        tags=tags,
     )
 
 
@@ -307,7 +307,7 @@ def restrict_web_to_ips(
         inbound_rules=new_inbound,
         outbound_rules=existing_outbound,
         droplet_ids=droplet_ids,
-        tags=tags or None,
+        tags=tags,
     )
 
 
@@ -344,7 +344,7 @@ def allow_all_web(client: Any, firewall_id: str) -> dict[str, Any]:
         inbound_rules=new_inbound,
         outbound_rules=existing_outbound,
         droplet_ids=droplet_ids,
-        tags=tags or None,
+        tags=tags,
     )
 
 

--- a/dango/platform/cloud/provisioning.py
+++ b/dango/platform/cloud/provisioning.py
@@ -1,0 +1,430 @@
+"""dango/platform/cloud/provisioning.py
+
+Droplet provisioning orchestration for Dango cloud deployments.
+
+Provides size tier selection, region recommendations, and the full
+``provision_droplet()`` workflow: create → poll until active → SSH check →
+cleanup on failure.
+
+Size tiers
+----------
+Three pre-defined tiers cover most use cases:
+
+- Budget (s-1vcpu-2gb, $12/mo) — Metabase may be slow
+- Standard (s-2vcpu-4gb, $24/mo) — recommended default
+- Performance (s-4vcpu-8gb, $48/mo) — for heavier workloads
+
+Region selection
+----------------
+``suggest_nearest_region()`` uses the local UTC offset (from ``time.timezone``)
+to recommend the geographically closest DO region without making any network
+calls.
+
+Error codes
+-----------
+- DANGO-D010: Droplet entered errored or archived state
+- DANGO-D011: Droplet did not become active within timeout
+- DANGO-D012: SSH not available after maximum attempts
+- DANGO-D013: Droplet is active but has no public IPv4 address
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dango.exceptions import CloudError
+
+__all__ = [
+    "DropletSizeTier",
+    "RegionInfo",
+    "SIZE_TIERS",
+    "DEFAULT_TIER",
+    "BUDGET_TIER",
+    "STANDARD_TIER",
+    "PERFORMANCE_TIER",
+    "get_size_tier",
+    "validate_custom_size",
+    "get_region_info",
+    "list_regions",
+    "suggest_nearest_region",
+    "provision_droplet",
+    "save_provisioning_metadata",
+    "wait_for_droplet_ready",
+    "wait_for_ssh",
+]
+
+_DANGO_IMAGE = "ubuntu-22-04-x64"
+_DANGO_TAG = "dango"
+
+# ---------------------------------------------------------------------------
+# Size tiers
+# ---------------------------------------------------------------------------
+
+_ERRORED_STATES = {"errored", "archive"}
+
+
+@dataclass(frozen=True)
+class DropletSizeTier:
+    """Describes a pre-defined Droplet size option.
+
+    Attributes:
+        name: Human-readable tier name (e.g. ``"Standard"``).
+        slug: DO size slug passed to the API (e.g. ``"s-2vcpu-4gb"``).
+        vcpus: Number of virtual CPUs.
+        ram_gb: RAM in gigabytes.
+        disk_gb: SSD disk in gigabytes.
+        price_monthly: Monthly cost in USD.
+        warning: Optional caution note shown to the user (e.g. performance caveats).
+    """
+
+    name: str
+    slug: str
+    vcpus: int
+    ram_gb: int
+    disk_gb: int
+    price_monthly: int
+    warning: str | None = None
+
+
+BUDGET_TIER = DropletSizeTier(
+    name="Budget",
+    slug="s-1vcpu-2gb",
+    vcpus=1,
+    ram_gb=2,
+    disk_gb=50,
+    price_monthly=12,
+    warning="Metabase may be slow on this tier.",
+)
+
+STANDARD_TIER = DropletSizeTier(
+    name="Standard",
+    slug="s-2vcpu-4gb",
+    vcpus=2,
+    ram_gb=4,
+    disk_gb=80,
+    price_monthly=24,
+)
+
+PERFORMANCE_TIER = DropletSizeTier(
+    name="Performance",
+    slug="s-4vcpu-8gb",
+    vcpus=4,
+    ram_gb=8,
+    disk_gb=160,
+    price_monthly=48,
+)
+
+SIZE_TIERS: list[DropletSizeTier] = [BUDGET_TIER, STANDARD_TIER, PERFORMANCE_TIER]
+DEFAULT_TIER: DropletSizeTier = STANDARD_TIER
+
+_TIER_BY_SLUG: dict[str, DropletSizeTier] = {t.slug: t for t in SIZE_TIERS}
+
+
+def get_size_tier(slug: str) -> DropletSizeTier | None:
+    """Return the ``DropletSizeTier`` for the given slug, or ``None`` if not found."""
+    return _TIER_BY_SLUG.get(slug)
+
+
+def validate_custom_size(slug: str) -> bool:
+    """Return ``True`` if *slug* looks like a valid DO size slug.
+
+    Accepts any non-empty string that starts with ``"s-"`` or ``"g-"`` or
+    ``"so"``-prefix (General Purpose, CPU-Optimized, etc.).  This is a
+    lightweight heuristic — the DO API is the authoritative validator.
+    """
+    return bool(slug) and slug.startswith(("s-", "g-", "so", "c-", "m-"))
+
+
+# ---------------------------------------------------------------------------
+# Region data
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RegionInfo:
+    """Metadata for a DigitalOcean region.
+
+    Attributes:
+        slug: DO region slug (e.g. ``"nyc1"``).
+        name: Full region name (e.g. ``"New York 1"``).
+        city: City name.
+        country: ISO country name or abbreviation.
+        utc_offset: UTC offset in hours (e.g. ``-5`` for EST).
+        gdpr: ``True`` if this region is in the EU and subject to GDPR.
+    """
+
+    slug: str
+    name: str
+    city: str
+    country: str
+    utc_offset: float
+    gdpr: bool = False
+
+
+_REGIONS: list[RegionInfo] = [
+    RegionInfo("nyc1", "New York 1", "New York", "US", -5.0),
+    RegionInfo("nyc3", "New York 3", "New York", "US", -5.0),
+    RegionInfo("sfo3", "San Francisco 3", "San Francisco", "US", -8.0),
+    RegionInfo("ams3", "Amsterdam 3", "Amsterdam", "NL", 1.0, gdpr=True),
+    RegionInfo("sgp1", "Singapore 1", "Singapore", "SG", 8.0),
+    RegionInfo("lon1", "London 1", "London", "GB", 0.0),
+    RegionInfo("fra1", "Frankfurt 1", "Frankfurt", "DE", 1.0, gdpr=True),
+    RegionInfo("tor1", "Toronto 1", "Toronto", "CA", -5.0),
+    RegionInfo("blr1", "Bangalore 1", "Bangalore", "IN", 5.5),
+    RegionInfo("syd1", "Sydney 1", "Sydney", "AU", 10.0),
+]
+
+_REGION_BY_SLUG: dict[str, RegionInfo] = {r.slug: r for r in _REGIONS}
+
+
+def get_region_info(slug: str) -> RegionInfo | None:
+    """Return the ``RegionInfo`` for the given slug, or ``None`` if not found."""
+    return _REGION_BY_SLUG.get(slug)
+
+
+def list_regions() -> list[RegionInfo]:
+    """Return all known regions."""
+    return list(_REGIONS)
+
+
+def suggest_nearest_region() -> RegionInfo:
+    """Suggest the geographically closest DO region based on local UTC offset.
+
+    Uses ``time.timezone`` / ``time.altzone`` to determine the local UTC offset
+    without making any network requests.  Picks the region whose ``utc_offset``
+    has the smallest absolute difference from the local offset.
+
+    Returns:
+        The closest ``RegionInfo`` — defaults to ``nyc1`` on any error.
+    """
+    try:
+        # time.timezone is seconds *west* of UTC (sign is opposite of UTC offset)
+        if time.daylight:
+            local_offset_seconds = -time.altzone
+        else:
+            local_offset_seconds = -time.timezone
+        local_offset_hours = local_offset_seconds / 3600.0
+    except Exception:
+        return _REGION_BY_SLUG["nyc1"]
+
+    best = min(_REGIONS, key=lambda r: abs(r.utc_offset - local_offset_hours))
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Provisioning helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_public_ipv4(droplet: dict[str, Any]) -> str | None:
+    """Extract the public IPv4 address from a droplet dict.
+
+    Returns:
+        IP address string if found, else ``None``.
+    """
+    networks = droplet.get("networks", {})
+    v4_list = networks.get("v4", [])
+    for network in v4_list:
+        if network.get("type") == "public":
+            return str(network.get("ip_address", "")) or None
+    return None
+
+
+def wait_for_droplet_ready(
+    client: Any,
+    droplet_id: int,
+    *,
+    poll_interval: float = 5.0,
+    timeout: float = 120.0,
+) -> dict[str, Any]:
+    """Poll the DO API until the droplet reaches ``active`` status.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        droplet_id: ID of the droplet to poll.
+        poll_interval: Seconds between polls. Default: 5.
+        timeout: Maximum total seconds to wait. Default: 120.
+
+    Returns:
+        The active droplet dict.
+
+    Raises:
+        CloudError: DANGO-D010 if droplet enters an errored/archived state.
+        CloudError: DANGO-D011 if the timeout elapses before the droplet is active.
+    """
+    deadline = time.monotonic() + timeout
+
+    while True:
+        droplet = client.get_droplet(droplet_id)
+        status = droplet.get("status", "")
+
+        if status == "active":
+            return droplet  # type: ignore[no-any-return]
+
+        if status in _ERRORED_STATES:
+            raise CloudError(
+                f"Droplet {droplet_id} entered state '{status}' during provisioning.",
+                error_code="DANGO-D010",
+            )
+
+        if time.monotonic() >= deadline:
+            raise CloudError(
+                f"Droplet {droplet_id} did not become active within {timeout:.0f}s "
+                f"(current status: '{status}').",
+                error_code="DANGO-D011",
+            )
+
+        time.sleep(poll_interval)
+
+
+def wait_for_ssh(
+    ip_address: str,
+    *,
+    port: int = 22,
+    max_attempts: int = 12,
+    attempt_interval: float = 5.0,
+) -> None:
+    """Wait for SSH to become reachable on *ip_address*.
+
+    Opens a TCP socket connection on *port* to check reachability.  Does not
+    perform any SSH handshake or authentication.
+
+    Args:
+        ip_address: Target IP address.
+        port: SSH port. Default: 22.
+        max_attempts: Maximum connection attempts. Default: 12.
+        attempt_interval: Seconds between attempts. Default: 5.
+
+    Raises:
+        CloudError: DANGO-D012 if the port does not become reachable.
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with socket.create_connection((ip_address, port), timeout=5.0):
+                return  # success
+        except OSError as exc:
+            if attempt == max_attempts:
+                raise CloudError(
+                    f"SSH port {port} on {ip_address} did not become reachable "
+                    f"after {max_attempts} attempts ({max_attempts * attempt_interval:.0f}s).",
+                    error_code="DANGO-D012",
+                ) from exc
+            time.sleep(attempt_interval)
+
+
+def provision_droplet(
+    client: Any,
+    name: str,
+    region: str,
+    size: str,
+    ssh_key_ids: list[int],
+    *,
+    user_data: str | None = None,
+    extra_tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Provision a new Droplet and wait for it to be fully reachable.
+
+    Workflow:
+    1. Create the droplet (always adds the ``"dango"`` tag, pins Ubuntu 22.04).
+    2. Poll until ``status == "active"`` (up to 120s).
+    3. Extract the public IPv4 address.
+    4. Verify SSH reachability (up to 12 × 5s attempts).
+
+    If any step fails after the droplet is created, a best-effort cleanup
+    (``delete_droplet``) is attempted before re-raising the original error.
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        name: Hostname for the new droplet.
+        region: DO region slug (e.g. ``"nyc1"``).
+        size: Droplet size slug (e.g. ``"s-2vcpu-4gb"``).
+        ssh_key_ids: List of SSH key IDs to install.
+        user_data: Cloud-init script (optional).
+        extra_tags: Additional tags beyond ``"dango"`` (optional).
+
+    Returns:
+        The active droplet dict (as returned by the DO API).
+
+    Raises:
+        CloudError: DANGO-D010/D011/D012/D013 on provisioning failure.
+        CloudAPIError / CloudAuthError: On DO API errors.
+    """
+    tags = [_DANGO_TAG] + (extra_tags or [])
+
+    droplet = client.create_droplet(
+        name=name,
+        region=region,
+        size=size,
+        image=_DANGO_IMAGE,
+        ssh_key_ids=ssh_key_ids,
+        tags=tags,
+        user_data=user_data,
+    )
+    droplet_id: int = droplet["id"]
+
+    try:
+        active_droplet = wait_for_droplet_ready(client, droplet_id)
+
+        ip_address = _extract_public_ipv4(active_droplet)
+        if ip_address is None:
+            raise CloudError(
+                f"Droplet {droplet_id} is active but has no public IPv4 address.",
+                error_code="DANGO-D013",
+            )
+
+        wait_for_ssh(ip_address)
+
+    except Exception:
+        # Best-effort cleanup — swallow delete errors, re-raise original
+        try:
+            client.delete_droplet(droplet_id)
+        except Exception:
+            pass
+        raise
+
+    return active_droplet  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Config persistence
+# ---------------------------------------------------------------------------
+
+
+def save_provisioning_metadata(
+    project_root: Path,
+    droplet_id: int,
+    droplet_ip: str,
+    region: str,
+    size: str,
+) -> None:
+    """Persist droplet provisioning metadata to ``.dango/cloud.yml``.
+
+    Loads the existing ``CloudConfig`` (or creates a new one) and updates
+    ``droplet_id``, ``droplet_ip``, ``region``, and ``size``, then saves.
+
+    Args:
+        project_root: Project root directory (contains ``.dango/``).
+        droplet_id: Numeric DO droplet ID.
+        droplet_ip: Public IPv4 address of the droplet.
+        region: DO region slug used during provisioning.
+        size: Droplet size slug used during provisioning.
+    """
+    from dango.config.loader import ConfigLoader
+    from dango.config.models import CloudConfig
+
+    loader = ConfigLoader(project_root)
+    existing = loader.load_cloud_config() or CloudConfig()
+
+    updated = existing.model_copy(
+        update={
+            "droplet_id": droplet_id,
+            "droplet_ip": droplet_ip,
+            "region": region,
+            "size": size,
+        }
+    )
+    loader.save_cloud_config(updated)

--- a/dango/platform/cloud/provisioning.py
+++ b/dango/platform/cloud/provisioning.py
@@ -202,8 +202,9 @@ def suggest_nearest_region() -> RegionInfo:
         The closest ``RegionInfo`` — defaults to ``nyc1`` on any error.
     """
     try:
-        # time.timezone is seconds *west* of UTC (sign is opposite of UTC offset)
-        if time.daylight:
+        # time.timezone is seconds *west* of UTC (sign is opposite of UTC offset).
+        # Use tm_isdst > 0 to check if DST is *currently active* (not just observed).
+        if time.localtime().tm_isdst > 0:
             local_offset_seconds = -time.altzone
         else:
             local_offset_seconds = -time.timezone
@@ -230,7 +231,8 @@ def _extract_public_ipv4(droplet: dict[str, Any]) -> str | None:
     v4_list = networks.get("v4", [])
     for network in v4_list:
         if network.get("type") == "public":
-            return str(network.get("ip_address", "")) or None
+            ip = network.get("ip_address")
+            return str(ip) if ip else None
     return None
 
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -169,6 +169,12 @@ exemptions:
     reason: "TASK-023: 8 test classes covering size tiers, region info, nearest-region suggestion, wait_for_droplet_ready, wait_for_ssh, extract_public_ipv4, provision_droplet (6 scenarios incl. cleanup), and save_provisioning_metadata. Each scenario requires isolated mock setup."
     review_by: "v1.1"
 
+  - file: tests/unit/test_firewall.py
+    lines: 554
+    category: exempt
+    reason: "TASK-025: 9 test classes covering validate_ip_or_cidr, create_default_firewall, restrict_web_to_ips, allow_all_web, add_allowed_ip (incl. other-rules preservation), format_firewall_rules, delete_firewall, get_firewall_rules, and save_firewall_metadata. Each requires isolated mock setup; deepcopy fixture helpers add necessary boilerplate."
+    review_by: "v1.1"
+
   - file: dango/config/models.py
     lines: 530
     category: exempt

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -158,9 +158,15 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_digitalocean_client.py
-    lines: 562
+    lines: 620
     category: exempt
-    reason: "TASK-022: 33 tests covering DigitalOceanClient init, retry/backoff logic (9 cases), Droplet/SSH Key/Firewall CRUD, and error handling. Retry tests require per-test mock setup for call sequencing — each is self-contained for readability."
+    reason: "TASK-022+023+025: 36 tests covering DigitalOceanClient init, retry/backoff logic (9 cases), Droplet/SSH Key/Firewall CRUD (incl. get_firewall, update_firewall), and error handling. Retry tests require per-test mock setup for call sequencing — each is self-contained for readability."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_provisioning.py
+    lines: 539
+    category: exempt
+    reason: "TASK-023: 8 test classes covering size tiers, region info, nearest-region suggestion, wait_for_droplet_ready, wait_for_ssh, extract_public_ipv4, provision_droplet (6 scenarios incl. cleanup), and save_provisioning_metadata. Each scenario requires isolated mock setup."
     review_by: "v1.1"
 
   - file: dango/config/models.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,9 @@ module = [
     "tests.unit.test_spaces_client",
     "tests.unit.test_ssh_manager",
     "tests.unit.test_ssh_sftp",
+    "tests.unit.test_provisioning",
+    "tests.unit.test_firewall",
+    "tests.unit.test_remote_cli",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_cloud_config.py
+++ b/tests/unit/test_cloud_config.py
@@ -19,15 +19,27 @@ class TestCloudConfig:
         assert config.ssh_key_path == ".dango/cloud_key"
         assert config.droplet_id is None
         assert config.droplet_ip is None
+        assert config.firewall_id is None
         assert config.domain is None
         assert config.spaces is None
         assert config.dbt_overrides is None
+
+    def test_firewall_id_default_none(self):
+        """firewall_id defaults to None."""
+        config = CloudConfig()
+        assert config.firewall_id is None
+
+    def test_firewall_id_set(self):
+        """firewall_id can be set as a string UUID."""
+        config = CloudConfig(firewall_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        assert config.firewall_id == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
     def test_all_fields(self):
         """CloudConfig accepts all optional fields."""
         config = CloudConfig(
             droplet_id=12345,
             droplet_ip="1.2.3.4",
+            firewall_id="fw-uuid-001",
             region="sfo3",
             size="s-4vcpu-8gb",
             domain="example.com",
@@ -37,6 +49,7 @@ class TestCloudConfig:
         )
         assert config.droplet_id == 12345
         assert config.droplet_ip == "1.2.3.4"
+        assert config.firewall_id == "fw-uuid-001"
         assert config.region == "sfo3"
         assert config.size == "s-4vcpu-8gb"
         assert config.domain == "example.com"
@@ -50,6 +63,7 @@ class TestCloudConfig:
         data = config.model_dump(mode="json", exclude_none=True)
         assert "droplet_id" not in data
         assert "droplet_ip" not in data
+        assert "firewall_id" not in data
         assert "domain" not in data
         assert "spaces" not in data
         assert "dbt_overrides" not in data

--- a/tests/unit/test_digitalocean_client.py
+++ b/tests/unit/test_digitalocean_client.py
@@ -521,6 +521,65 @@ class TestFirewallOperations:
         with self._patch(resp):
             self.client.delete_firewall("fw-123")  # should not raise
 
+    def test_get_firewall(self):
+        """get_firewall returns the firewall dict for the given ID."""
+        firewall = {"id": "fw-abc", "name": "dango-fw-42"}
+        resp = _mock_response(200, {"firewall": firewall})
+
+        with self._patch(resp):
+            result = self.client.get_firewall("fw-abc")
+
+        assert result == firewall
+
+    def test_update_firewall(self):
+        """update_firewall sends PUT with all fields and returns the firewall dict."""
+        firewall = {"id": "fw-abc", "name": "dango-fw-42"}
+        resp = _mock_response(200, {"firewall": firewall})
+        mock_http = _make_client_mock(resp)
+
+        inbound = [{"protocol": "tcp", "ports": "22", "sources": {"addresses": ["0.0.0.0/0"]}}]
+        outbound = [
+            {"protocol": "tcp", "ports": "all", "destinations": {"addresses": ["0.0.0.0/0"]}}
+        ]
+
+        with patch("dango.platform.cloud.digitalocean.httpx.Client", return_value=mock_http):
+            result = self.client.update_firewall(
+                firewall_id="fw-abc",
+                name="dango-fw-42",
+                inbound_rules=inbound,
+                outbound_rules=outbound,
+                droplet_ids=[42],
+            )
+
+        assert result == firewall
+        # Verify PUT method was used
+        method = mock_http.request.call_args[0][0]
+        assert method == "PUT"
+        payload = mock_http.request.call_args[1].get("json") or {}
+        assert payload["name"] == "dango-fw-42"
+        assert payload["inbound_rules"] == inbound
+        assert payload["outbound_rules"] == outbound
+        assert payload["droplet_ids"] == [42]
+
+    def test_update_firewall_with_empty_droplet_ids(self):
+        """update_firewall passes empty droplet_ids list (not omitted)."""
+        firewall = {"id": "fw-abc"}
+        resp = _mock_response(200, {"firewall": firewall})
+        mock_http = _make_client_mock(resp)
+
+        with patch("dango.platform.cloud.digitalocean.httpx.Client", return_value=mock_http):
+            self.client.update_firewall(
+                firewall_id="fw-abc",
+                name="dango-fw-42",
+                inbound_rules=[],
+                outbound_rules=[],
+                droplet_ids=[],  # empty list — should be included, not omitted
+            )
+
+        payload = mock_http.request.call_args[1].get("json") or {}
+        assert "droplet_ids" in payload
+        assert payload["droplet_ids"] == []
+
 
 # ---------------------------------------------------------------------------
 # 6. Error handling

--- a/tests/unit/test_firewall.py
+++ b/tests/unit/test_firewall.py
@@ -1,0 +1,460 @@
+"""tests/unit/test_firewall.py
+
+Unit tests for dango/platform/cloud/firewall.py.
+
+All DO API client calls are mocked — no real network traffic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from dango.exceptions import CloudError
+from dango.platform.cloud.firewall import (
+    DEFAULT_OUTBOUND_RULES,
+    add_allowed_ip,
+    allow_all_web,
+    create_default_firewall,
+    format_firewall_rules,
+    restrict_web_to_ips,
+    save_firewall_metadata,
+    validate_ip_or_cidr,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PUBLIC_SOURCES = {"addresses": ["0.0.0.0/0", "::/0"]}
+_SSH_RULE = {"protocol": "tcp", "ports": "22", "sources": _PUBLIC_SOURCES}
+_HTTP_RULE_PUBLIC = {"protocol": "tcp", "ports": "80", "sources": _PUBLIC_SOURCES}
+_HTTPS_RULE_PUBLIC = {"protocol": "tcp", "ports": "443", "sources": _PUBLIC_SOURCES}
+
+
+def _make_public_firewall(
+    fw_id: str = "fw-abc",
+    droplet_ids: list[int] | None = None,
+    tags: list[str] | None = None,
+) -> dict:
+    """Return a firewall dict with all-public inbound rules."""
+    return {
+        "id": fw_id,
+        "name": f"dango-fw-{fw_id}",
+        "inbound_rules": [_SSH_RULE, _HTTP_RULE_PUBLIC, _HTTPS_RULE_PUBLIC],
+        "outbound_rules": DEFAULT_OUTBOUND_RULES,
+        "droplet_ids": droplet_ids or [42],
+        "tags": tags or [],
+    }
+
+
+def _make_allowlist_firewall(
+    cidrs: list[str],
+    fw_id: str = "fw-abc",
+    droplet_ids: list[int] | None = None,
+) -> dict:
+    """Return a firewall dict with allowlist inbound rules for ports 80 and 443."""
+    sources = {"addresses": cidrs}
+    return {
+        "id": fw_id,
+        "name": f"dango-fw-{fw_id}",
+        "inbound_rules": [
+            _SSH_RULE,
+            {"protocol": "tcp", "ports": "80", "sources": sources},
+            {"protocol": "tcp", "ports": "443", "sources": sources},
+        ],
+        "outbound_rules": DEFAULT_OUTBOUND_RULES,
+        "droplet_ids": droplet_ids or [42],
+        "tags": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. validate_ip_or_cidr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateIpOrCidr:
+    def test_bare_ipv4_appends_slash32(self):
+        """Bare IPv4 address is normalised to /32."""
+        assert validate_ip_or_cidr("203.0.113.42") == "203.0.113.42/32"
+
+    def test_valid_cidr(self):
+        """Valid CIDR is accepted and returned as-is (after normalisation)."""
+        assert validate_ip_or_cidr("203.0.113.0/24") == "203.0.113.0/24"
+
+    def test_cidr_with_host_bits_normalised(self):
+        """CIDR with host bits set is normalised to network address."""
+        assert validate_ip_or_cidr("10.0.0.5/24") == "10.0.0.0/24"
+
+    def test_whitespace_stripped(self):
+        """Leading/trailing whitespace is stripped."""
+        assert validate_ip_or_cidr("  1.2.3.4  ") == "1.2.3.4/32"
+
+    def test_invalid_ip_raises(self):
+        """Invalid IP raises CloudError D020."""
+        with pytest.raises(CloudError) as exc_info:
+            validate_ip_or_cidr("999.999.999.999")
+        assert exc_info.value.error_code == "DANGO-D020"
+
+    def test_empty_string_raises(self):
+        """Empty string raises CloudError D020."""
+        with pytest.raises(CloudError) as exc_info:
+            validate_ip_or_cidr("")
+        assert exc_info.value.error_code == "DANGO-D020"
+
+    def test_ipv6_rejected(self):
+        """IPv6 addresses are rejected with CloudError D020."""
+        with pytest.raises(CloudError) as exc_info:
+            validate_ip_or_cidr("2001:db8::1")
+        assert exc_info.value.error_code == "DANGO-D020"
+
+    def test_slash32_cidr_is_valid(self):
+        """An explicit /32 CIDR is valid."""
+        assert validate_ip_or_cidr("1.2.3.4/32") == "1.2.3.4/32"
+
+
+# ---------------------------------------------------------------------------
+# 2. create_default_firewall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCreateDefaultFirewall:
+    def test_creates_with_correct_name(self):
+        """Firewall name is dango-fw-{droplet_id}."""
+        client = MagicMock()
+        client.create_firewall.return_value = {"id": "fw-1", "name": "dango-fw-42"}
+
+        create_default_firewall(client, droplet_id=42)
+
+        client.create_firewall.assert_called_once()
+        kwargs = client.create_firewall.call_args[1]
+        assert kwargs["name"] == "dango-fw-42"
+
+    def test_applied_to_droplet(self):
+        """Firewall is associated with the given droplet_id."""
+        client = MagicMock()
+        client.create_firewall.return_value = {"id": "fw-1"}
+
+        create_default_firewall(client, droplet_id=99)
+
+        kwargs = client.create_firewall.call_args[1]
+        assert kwargs["droplet_ids"] == [99]
+
+    def test_includes_ssh_http_https_inbound(self):
+        """Default firewall allows SSH, HTTP, and HTTPS inbound."""
+        client = MagicMock()
+        client.create_firewall.return_value = {"id": "fw-1"}
+
+        create_default_firewall(client, droplet_id=1)
+
+        kwargs = client.create_firewall.call_args[1]
+        ports = {r["ports"] for r in kwargs["inbound_rules"]}
+        assert "22" in ports
+        assert "80" in ports
+        assert "443" in ports
+
+    def test_inbound_rules_open_to_all(self):
+        """All default inbound rules include 0.0.0.0/0 in sources."""
+        client = MagicMock()
+        client.create_firewall.return_value = {"id": "fw-1"}
+
+        create_default_firewall(client, droplet_id=1)
+
+        kwargs = client.create_firewall.call_args[1]
+        for rule in kwargs["inbound_rules"]:
+            addresses = rule["sources"]["addresses"]
+            assert "0.0.0.0/0" in addresses
+
+    def test_returns_firewall_dict(self):
+        """create_default_firewall returns the client's response."""
+        client = MagicMock()
+        fw = {"id": "fw-abc", "name": "dango-fw-42"}
+        client.create_firewall.return_value = fw
+
+        result = create_default_firewall(client, droplet_id=42)
+        assert result == fw
+
+
+# ---------------------------------------------------------------------------
+# 3. restrict_web_to_ips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRestrictWebToIps:
+    def test_restricts_80_and_443(self):
+        """80 and 443 rules are replaced with the given IP list."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall()
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        restrict_web_to_ips(client, "fw-abc", ["203.0.113.1"])
+
+        kwargs = client.update_firewall.call_args[1]
+        inbound = kwargs["inbound_rules"]
+        web_rules = [r for r in inbound if r["ports"] in ("80", "443")]
+        for rule in web_rules:
+            assert rule["sources"]["addresses"] == ["203.0.113.1/32"]
+
+    def test_ssh_stays_open(self):
+        """SSH rule is preserved open-to-all."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall()
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        restrict_web_to_ips(client, "fw-abc", ["1.2.3.4"])
+
+        kwargs = client.update_firewall.call_args[1]
+        ssh_rules = [r for r in kwargs["inbound_rules"] if r["ports"] == "22"]
+        assert len(ssh_rules) == 1
+        assert "0.0.0.0/0" in ssh_rules[0]["sources"]["addresses"]
+
+    def test_empty_ip_list_raises(self):
+        """Empty ip_cidrs list raises CloudError D021."""
+        client = MagicMock()
+        with pytest.raises(CloudError) as exc_info:
+            restrict_web_to_ips(client, "fw-abc", [])
+        assert exc_info.value.error_code == "DANGO-D021"
+
+    def test_preserves_outbound_rules(self):
+        """Existing outbound rules are preserved unchanged."""
+        client = MagicMock()
+        fw = _make_public_firewall()
+        client.get_firewall.return_value = fw
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        restrict_web_to_ips(client, "fw-abc", ["1.2.3.4"])
+
+        kwargs = client.update_firewall.call_args[1]
+        assert kwargs["outbound_rules"] == DEFAULT_OUTBOUND_RULES
+
+    def test_preserves_droplet_associations(self):
+        """Droplet IDs are passed through to update_firewall."""
+        client = MagicMock()
+        fw = _make_public_firewall(droplet_ids=[10, 20])
+        client.get_firewall.return_value = fw
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        restrict_web_to_ips(client, "fw-abc", ["1.2.3.4"])
+
+        kwargs = client.update_firewall.call_args[1]
+        assert kwargs["droplet_ids"] == [10, 20]
+
+    def test_multiple_ips(self):
+        """Multiple IPs are all included in the rule sources."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall()
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        restrict_web_to_ips(client, "fw-abc", ["1.1.1.1", "2.2.2.2"])
+
+        kwargs = client.update_firewall.call_args[1]
+        web_rules = [r for r in kwargs["inbound_rules"] if r["ports"] in ("80", "443")]
+        for rule in web_rules:
+            addrs = rule["sources"]["addresses"]
+            assert "1.1.1.1/32" in addrs
+            assert "2.2.2.2/32" in addrs
+
+
+# ---------------------------------------------------------------------------
+# 4. allow_all_web
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAllowAllWeb:
+    def test_reverts_inbound_to_public(self):
+        """80/443 rules are changed back to 0.0.0.0/0."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_allowlist_firewall(["1.2.3.4/32"])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        allow_all_web(client, "fw-abc")
+
+        kwargs = client.update_firewall.call_args[1]
+        web_rules = [r for r in kwargs["inbound_rules"] if r["ports"] in ("80", "443")]
+        for rule in web_rules:
+            assert "0.0.0.0/0" in rule["sources"]["addresses"]
+
+    def test_ssh_remains_open(self):
+        """SSH rule is left unchanged."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_allowlist_firewall(["1.2.3.4/32"])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        allow_all_web(client, "fw-abc")
+
+        kwargs = client.update_firewall.call_args[1]
+        ssh_rules = [r for r in kwargs["inbound_rules"] if r["ports"] == "22"]
+        assert len(ssh_rules) == 1
+
+    def test_preserves_outbound_rules(self):
+        """Outbound rules are not changed."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_allowlist_firewall(["1.2.3.4/32"])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        allow_all_web(client, "fw-abc")
+
+        kwargs = client.update_firewall.call_args[1]
+        assert kwargs["outbound_rules"] == DEFAULT_OUTBOUND_RULES
+
+
+# ---------------------------------------------------------------------------
+# 5. add_allowed_ip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAddAllowedIp:
+    def test_public_to_allowlist_mode(self):
+        """Switches from public to allowlist with only the new IP."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall()
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        add_allowed_ip(client, "fw-abc", "203.0.113.1")
+
+        kwargs = client.update_firewall.call_args[1]
+        web_rules = [r for r in kwargs["inbound_rules"] if r["ports"] in ("80", "443")]
+        for rule in web_rules:
+            addrs = rule["sources"]["addresses"]
+            assert "203.0.113.1/32" in addrs
+            assert "0.0.0.0/0" not in addrs
+
+    def test_append_to_existing_allowlist(self):
+        """New IP appended when already in allowlist mode."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_allowlist_firewall(["1.1.1.1/32"])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        add_allowed_ip(client, "fw-abc", "2.2.2.2")
+
+        kwargs = client.update_firewall.call_args[1]
+        web_rules = [r for r in kwargs["inbound_rules"] if r["ports"] in ("80", "443")]
+        for rule in web_rules:
+            addrs = rule["sources"]["addresses"]
+            assert "1.1.1.1/32" in addrs
+            assert "2.2.2.2/32" in addrs
+
+    def test_deduplication(self):
+        """Duplicate IPs are deduplicated."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_allowlist_firewall(["1.1.1.1/32"])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        add_allowed_ip(client, "fw-abc", "1.1.1.1")
+
+        kwargs = client.update_firewall.call_args[1]
+        web_rules = [r for r in kwargs["inbound_rules"] if r["ports"] in ("80", "443")]
+        for rule in web_rules:
+            addrs = rule["sources"]["addresses"]
+            assert addrs.count("1.1.1.1/32") == 1
+
+    def test_invalid_ip_raises_before_api_call(self):
+        """CloudError D020 raised without making an API call for bad IP."""
+        client = MagicMock()
+        with pytest.raises(CloudError) as exc_info:
+            add_allowed_ip(client, "fw-abc", "not-an-ip")
+        assert exc_info.value.error_code == "DANGO-D020"
+        client.get_firewall.assert_not_called()
+
+    def test_cidr_accepted(self):
+        """CIDR notation is accepted and normalised."""
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall()
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        add_allowed_ip(client, "fw-abc", "10.0.0.0/24")
+
+        kwargs = client.update_firewall.call_args[1]
+        web_rules = [r for r in kwargs["inbound_rules"] if r["ports"] in ("80", "443")]
+        for rule in web_rules:
+            assert "10.0.0.0/24" in rule["sources"]["addresses"]
+
+
+# ---------------------------------------------------------------------------
+# 6. format_firewall_rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFormatFirewallRules:
+    def test_inbound_and_outbound_rows(self):
+        """Returns rows for both inbound and outbound rules."""
+        fw = _make_public_firewall()
+        rows = format_firewall_rules(fw)
+        directions = {r["direction"] for r in rows}
+        assert "inbound" in directions
+        assert "outbound" in directions
+
+    def test_inbound_row_fields(self):
+        """Inbound rows have the correct field keys."""
+        fw = _make_public_firewall()
+        rows = format_firewall_rules(fw)
+        inbound_rows = [r for r in rows if r["direction"] == "inbound"]
+        assert len(inbound_rows) > 0
+        for row in inbound_rows:
+            assert "direction" in row
+            assert "protocol" in row
+            assert "ports" in row
+            assert "sources_or_destinations" in row
+
+    def test_empty_rules(self):
+        """Empty firewall returns empty list."""
+        fw: dict = {"inbound_rules": [], "outbound_rules": []}
+        assert format_firewall_rules(fw) == []
+
+    def test_sources_joined(self):
+        """Multiple source addresses are comma-joined."""
+        fw = _make_public_firewall()
+        rows = format_firewall_rules(fw)
+        inbound_rows = [r for r in rows if r["direction"] == "inbound"]
+        ssh_row = next(r for r in inbound_rows if r["ports"] == "22")
+        assert "0.0.0.0/0" in ssh_row["sources_or_destinations"]
+        assert "::/0" in ssh_row["sources_or_destinations"]
+
+
+# ---------------------------------------------------------------------------
+# 7. save_firewall_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSaveFirewallMetadata:
+    def test_saves_firewall_id(self, tmp_path: Path):
+        """Persists firewall_id to cloud.yml."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+
+        save_firewall_metadata(tmp_path, "fw-uuid-123")
+
+        from dango.config.loader import ConfigLoader
+
+        loader = ConfigLoader(tmp_path)
+        saved = loader.load_cloud_config()
+        assert saved is not None
+        assert saved.firewall_id == "fw-uuid-123"
+
+    def test_updates_existing_config(self, tmp_path: Path):
+        """Updates firewall_id while preserving other CloudConfig fields."""
+        from dango.config.loader import ConfigLoader
+        from dango.config.models import CloudConfig
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        loader = ConfigLoader(tmp_path)
+        loader.save_cloud_config(CloudConfig(droplet_id=42, droplet_ip="1.2.3.4", region="nyc1"))
+
+        save_firewall_metadata(tmp_path, "fw-new-id")
+
+        saved = loader.load_cloud_config()
+        assert saved is not None
+        assert saved.firewall_id == "fw-new-id"
+        assert saved.droplet_id == 42  # preserved
+        assert saved.droplet_ip == "1.2.3.4"  # preserved

--- a/tests/unit/test_firewall.py
+++ b/tests/unit/test_firewall.py
@@ -7,6 +7,7 @@ All DO API client calls are mocked — no real network traffic.
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -30,23 +31,42 @@ from dango.platform.cloud.firewall import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Rule constants are references only — never passed directly into firewall dicts.
+# Helper functions deep-copy them so each test gets independent mutable state.
 _PUBLIC_SOURCES = {"addresses": ["0.0.0.0/0", "::/0"]}
-_SSH_RULE = {"protocol": "tcp", "ports": "22", "sources": _PUBLIC_SOURCES}
-_HTTP_RULE_PUBLIC = {"protocol": "tcp", "ports": "80", "sources": _PUBLIC_SOURCES}
-_HTTPS_RULE_PUBLIC = {"protocol": "tcp", "ports": "443", "sources": _PUBLIC_SOURCES}
+
+
+def _ssh_rule() -> dict:
+    return {"protocol": "tcp", "ports": "22", "sources": copy.deepcopy(_PUBLIC_SOURCES)}
+
+
+def _http_rule_public() -> dict:
+    return {"protocol": "tcp", "ports": "80", "sources": copy.deepcopy(_PUBLIC_SOURCES)}
+
+
+def _https_rule_public() -> dict:
+    return {"protocol": "tcp", "ports": "443", "sources": copy.deepcopy(_PUBLIC_SOURCES)}
 
 
 def _make_public_firewall(
     fw_id: str = "fw-abc",
     droplet_ids: list[int] | None = None,
     tags: list[str] | None = None,
+    extra_inbound: list[dict] | None = None,
 ) -> dict:
-    """Return a firewall dict with all-public inbound rules."""
+    """Return a firewall dict with all-public inbound rules.
+
+    Each call returns a fully independent dict (no shared references).
+    Pass ``extra_inbound`` to include custom rules beyond SSH/HTTP/HTTPS.
+    """
+    inbound = [_ssh_rule(), _http_rule_public(), _https_rule_public()]
+    if extra_inbound:
+        inbound.extend(extra_inbound)
     return {
         "id": fw_id,
         "name": f"dango-fw-{fw_id}",
-        "inbound_rules": [_SSH_RULE, _HTTP_RULE_PUBLIC, _HTTPS_RULE_PUBLIC],
-        "outbound_rules": DEFAULT_OUTBOUND_RULES,
+        "inbound_rules": inbound,
+        "outbound_rules": copy.deepcopy(DEFAULT_OUTBOUND_RULES),
         "droplet_ids": droplet_ids or [42],
         "tags": tags or [],
     }
@@ -58,16 +78,16 @@ def _make_allowlist_firewall(
     droplet_ids: list[int] | None = None,
 ) -> dict:
     """Return a firewall dict with allowlist inbound rules for ports 80 and 443."""
-    sources = {"addresses": cidrs}
+    sources = {"addresses": list(cidrs)}
     return {
         "id": fw_id,
         "name": f"dango-fw-{fw_id}",
         "inbound_rules": [
-            _SSH_RULE,
-            {"protocol": "tcp", "ports": "80", "sources": sources},
-            {"protocol": "tcp", "ports": "443", "sources": sources},
+            _ssh_rule(),
+            {"protocol": "tcp", "ports": "80", "sources": copy.deepcopy(sources)},
+            {"protocol": "tcp", "ports": "443", "sources": copy.deepcopy(sources)},
         ],
-        "outbound_rules": DEFAULT_OUTBOUND_RULES,
+        "outbound_rules": copy.deepcopy(DEFAULT_OUTBOUND_RULES),
         "droplet_ids": droplet_ids or [42],
         "tags": [],
     }
@@ -262,6 +282,19 @@ class TestRestrictWebToIps:
             assert "1.1.1.1/32" in addrs
             assert "2.2.2.2/32" in addrs
 
+    def test_preserves_other_inbound_rules(self):
+        """Custom inbound rules (non-SSH, non-web) are not dropped."""
+        custom_rule = {"protocol": "tcp", "ports": "8080", "sources": {"addresses": ["10.0.0.0/8"]}}
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall(extra_inbound=[custom_rule])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        restrict_web_to_ips(client, "fw-abc", ["1.2.3.4"])
+
+        kwargs = client.update_firewall.call_args[1]
+        ports_in_output = [r["ports"] for r in kwargs["inbound_rules"]]
+        assert "8080" in ports_in_output
+
 
 # ---------------------------------------------------------------------------
 # 4. allow_all_web
@@ -305,6 +338,19 @@ class TestAllowAllWeb:
 
         kwargs = client.update_firewall.call_args[1]
         assert kwargs["outbound_rules"] == DEFAULT_OUTBOUND_RULES
+
+    def test_preserves_other_inbound_rules(self):
+        """Custom inbound rules (non-SSH, non-web) are not dropped."""
+        custom_rule = {"protocol": "tcp", "ports": "8080", "sources": {"addresses": ["10.0.0.0/8"]}}
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall(extra_inbound=[custom_rule])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        allow_all_web(client, "fw-abc")
+
+        kwargs = client.update_firewall.call_args[1]
+        ports_in_output = [r["ports"] for r in kwargs["inbound_rules"]]
+        assert "8080" in ports_in_output
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +424,19 @@ class TestAddAllowedIp:
         web_rules = [r for r in kwargs["inbound_rules"] if r["ports"] in ("80", "443")]
         for rule in web_rules:
             assert "10.0.0.0/24" in rule["sources"]["addresses"]
+
+    def test_preserves_other_inbound_rules(self):
+        """Custom inbound rules (non-SSH, non-web) are not dropped."""
+        custom_rule = {"protocol": "tcp", "ports": "8080", "sources": {"addresses": ["10.0.0.0/8"]}}
+        client = MagicMock()
+        client.get_firewall.return_value = _make_public_firewall(extra_inbound=[custom_rule])
+        client.update_firewall.return_value = {"id": "fw-abc"}
+
+        add_allowed_ip(client, "fw-abc", "1.2.3.4")
+
+        kwargs = client.update_firewall.call_args[1]
+        ports_in_output = [r["ports"] for r in kwargs["inbound_rules"]]
+        assert "8080" in ports_in_output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_firewall.py
+++ b/tests/unit/test_firewall.py
@@ -18,7 +18,9 @@ from dango.platform.cloud.firewall import (
     add_allowed_ip,
     allow_all_web,
     create_default_firewall,
+    delete_firewall,
     format_firewall_rules,
+    get_firewall_rules,
     restrict_web_to_ips,
     save_firewall_metadata,
     validate_ip_or_cidr,
@@ -421,7 +423,40 @@ class TestFormatFirewallRules:
 
 
 # ---------------------------------------------------------------------------
-# 7. save_firewall_metadata
+# 7. delete_firewall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeleteFirewall:
+    def test_delegates_to_client(self):
+        """delete_firewall calls client.delete_firewall with the firewall ID."""
+        client = MagicMock()
+        delete_firewall(client, "fw-abc")
+        client.delete_firewall.assert_called_once_with("fw-abc")
+
+
+# ---------------------------------------------------------------------------
+# 8. get_firewall_rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetFirewallRules:
+    def test_returns_firewall_dict(self):
+        """get_firewall_rules returns the dict from client.get_firewall."""
+        client = MagicMock()
+        fw = {"id": "fw-abc", "name": "dango-fw-42"}
+        client.get_firewall.return_value = fw
+
+        result = get_firewall_rules(client, "fw-abc")
+
+        assert result == fw
+        client.get_firewall.assert_called_once_with("fw-abc")
+
+
+# ---------------------------------------------------------------------------
+# 9. save_firewall_metadata
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -1,0 +1,533 @@
+"""tests/unit/test_provisioning.py
+
+Unit tests for dango/platform/cloud/provisioning.py.
+
+All external calls (DO API, socket, time.sleep) are mocked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import CloudError
+from dango.platform.cloud.provisioning import (
+    BUDGET_TIER,
+    DEFAULT_TIER,
+    PERFORMANCE_TIER,
+    SIZE_TIERS,
+    STANDARD_TIER,
+    _extract_public_ipv4,
+    get_region_info,
+    get_size_tier,
+    list_regions,
+    provision_droplet,
+    save_provisioning_metadata,
+    suggest_nearest_region,
+    validate_custom_size,
+    wait_for_droplet_ready,
+    wait_for_ssh,
+)
+
+# ---------------------------------------------------------------------------
+# 1. DropletSizeTier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDropletSizeTier:
+    def test_budget_tier_values(self):
+        """Budget tier has correct slug, vCPUs, RAM, and price."""
+        assert BUDGET_TIER.slug == "s-1vcpu-2gb"
+        assert BUDGET_TIER.vcpus == 1
+        assert BUDGET_TIER.ram_gb == 2
+        assert BUDGET_TIER.disk_gb == 50
+        assert BUDGET_TIER.price_monthly == 12
+        assert BUDGET_TIER.warning is not None
+
+    def test_standard_tier_is_default(self):
+        """DEFAULT_TIER and STANDARD_TIER are the same object."""
+        assert DEFAULT_TIER is STANDARD_TIER
+
+    def test_standard_tier_values(self):
+        """Standard tier has correct values and no warning."""
+        assert STANDARD_TIER.slug == "s-2vcpu-4gb"
+        assert STANDARD_TIER.vcpus == 2
+        assert STANDARD_TIER.ram_gb == 4
+        assert STANDARD_TIER.disk_gb == 80
+        assert STANDARD_TIER.price_monthly == 24
+        assert STANDARD_TIER.warning is None
+
+    def test_performance_tier_values(self):
+        """Performance tier has correct values."""
+        assert PERFORMANCE_TIER.slug == "s-4vcpu-8gb"
+        assert PERFORMANCE_TIER.vcpus == 4
+        assert PERFORMANCE_TIER.ram_gb == 8
+        assert PERFORMANCE_TIER.disk_gb == 160
+        assert PERFORMANCE_TIER.price_monthly == 48
+
+    def test_size_tiers_list_has_three_entries(self):
+        """SIZE_TIERS contains exactly three tiers."""
+        assert len(SIZE_TIERS) == 3
+        slugs = [t.slug for t in SIZE_TIERS]
+        assert "s-1vcpu-2gb" in slugs
+        assert "s-2vcpu-4gb" in slugs
+        assert "s-4vcpu-8gb" in slugs
+
+    def test_get_size_tier_known_slug(self):
+        """get_size_tier returns the correct tier for a known slug."""
+        tier = get_size_tier("s-2vcpu-4gb")
+        assert tier is STANDARD_TIER
+
+    def test_get_size_tier_unknown_slug_returns_none(self):
+        """get_size_tier returns None for an unknown slug."""
+        assert get_size_tier("s-99vcpu-999gb") is None
+
+    def test_validate_custom_size_valid_slugs(self):
+        """validate_custom_size accepts known DO slug prefixes."""
+        assert validate_custom_size("s-1vcpu-1gb") is True
+        assert validate_custom_size("g-2vcpu-8gb") is True
+        assert validate_custom_size("so1_5-2vcpu-16gb") is True
+        assert validate_custom_size("c-4") is True
+        assert validate_custom_size("m-2vcpu-16gb") is True
+
+    def test_validate_custom_size_invalid(self):
+        """validate_custom_size rejects empty strings and bad prefixes."""
+        assert validate_custom_size("") is False
+        assert validate_custom_size("invalid-slug") is False
+        assert validate_custom_size("2vcpu") is False
+
+    def test_tier_is_frozen(self):
+        """DropletSizeTier instances are immutable (frozen dataclass)."""
+        with pytest.raises((AttributeError, TypeError)):
+            STANDARD_TIER.vcpus = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. RegionInfo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRegionInfo:
+    def test_region_count(self):
+        """list_regions returns exactly 10 regions."""
+        assert len(list_regions()) == 10
+
+    def test_gdpr_regions(self):
+        """ams3 and fra1 are flagged as GDPR regions."""
+        ams3 = get_region_info("ams3")
+        fra1 = get_region_info("fra1")
+        assert ams3 is not None and ams3.gdpr is True
+        assert fra1 is not None and fra1.gdpr is True
+
+    def test_non_gdpr_regions(self):
+        """nyc1 and sgp1 are not GDPR regions."""
+        nyc1 = get_region_info("nyc1")
+        sgp1 = get_region_info("sgp1")
+        assert nyc1 is not None and nyc1.gdpr is False
+        assert sgp1 is not None and sgp1.gdpr is False
+
+    def test_get_region_info_known_slug(self):
+        """get_region_info returns a RegionInfo for a known slug."""
+        region = get_region_info("sfo3")
+        assert region is not None
+        assert region.slug == "sfo3"
+        assert region.city == "San Francisco"
+
+    def test_get_region_info_unknown_returns_none(self):
+        """get_region_info returns None for an unknown slug."""
+        assert get_region_info("xyz99") is None
+
+    def test_list_regions_returns_all(self):
+        """list_regions includes nyc1, ams3, syd1 (spot check)."""
+        slugs = {r.slug for r in list_regions()}
+        assert "nyc1" in slugs
+        assert "ams3" in slugs
+        assert "syd1" in slugs
+
+    def test_region_is_frozen(self):
+        """RegionInfo instances are immutable (frozen dataclass)."""
+        nyc1 = get_region_info("nyc1")
+        assert nyc1 is not None
+        with pytest.raises((AttributeError, TypeError)):
+            nyc1.city = "Boston"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 3. suggest_nearest_region
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSuggestNearestRegion:
+    def test_us_east_timezone_suggests_nyc(self):
+        """UTC-5 (US East) maps to nyc1 or nyc3 (utc_offset = -5)."""
+        # timezone is seconds WEST of UTC, so EST = +18000
+        with patch("dango.platform.cloud.provisioning.time.daylight", 0):
+            with patch("dango.platform.cloud.provisioning.time.timezone", 18000):
+                result = suggest_nearest_region()
+        assert result.utc_offset == -5.0
+
+    def test_us_west_timezone_suggests_sfo(self):
+        """UTC-8 (US West) maps to sfo3 (utc_offset = -8)."""
+        with patch("dango.platform.cloud.provisioning.time.daylight", 0):
+            with patch("dango.platform.cloud.provisioning.time.timezone", 28800):
+                result = suggest_nearest_region()
+        assert result.slug == "sfo3"
+
+    def test_singapore_timezone_suggests_sgp(self):
+        """UTC+8 maps to sgp1 (utc_offset = +8)."""
+        with patch("dango.platform.cloud.provisioning.time.daylight", 0):
+            with patch("dango.platform.cloud.provisioning.time.timezone", -28800):
+                result = suggest_nearest_region()
+        assert result.slug == "sgp1"
+
+    def test_exception_falls_back_to_nyc1(self):
+        """Any exception during offset calculation falls back to nyc1."""
+        with patch(
+            "dango.platform.cloud.provisioning.time.daylight",
+            new_callable=lambda: property(lambda self: (_ for _ in ()).throw(RuntimeError())),
+        ):
+            pass  # Can't easily mock property — test via patching the function itself
+
+        # Patch time.timezone to raise instead
+        with patch("dango.platform.cloud.provisioning.time") as mock_time:
+            mock_time.daylight = 0
+            mock_time.timezone = "bad"  # Will cause division error
+            result = suggest_nearest_region()
+        assert result.slug == "nyc1"
+
+    def test_daylight_saving_uses_altzone(self):
+        """When daylight is set, altzone is used for local offset."""
+        # UTC+1 (Amsterdam summer time = CEST, altzone = -3600)
+        with patch("dango.platform.cloud.provisioning.time.daylight", 1):
+            with patch("dango.platform.cloud.provisioning.time.altzone", -3600):
+                result = suggest_nearest_region()
+        # ams3 and fra1 both at +1
+        assert result.utc_offset == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 4. wait_for_droplet_ready
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestWaitForDropletReady:
+    def test_already_active(self):
+        """Droplet that is already active returns immediately."""
+        client = MagicMock()
+        active = {"id": 1, "status": "active"}
+        client.get_droplet.return_value = active
+
+        with patch("dango.platform.cloud.provisioning.time.sleep") as mock_sleep:
+            result = wait_for_droplet_ready(client, 1, poll_interval=5.0, timeout=30.0)
+
+        assert result == active
+        mock_sleep.assert_not_called()
+
+    def test_polls_until_active(self):
+        """Droplet transitions from 'new' → 'new' → 'active'."""
+        client = MagicMock()
+        client.get_droplet.side_effect = [
+            {"id": 1, "status": "new"},
+            {"id": 1, "status": "new"},
+            {"id": 1, "status": "active"},
+        ]
+
+        with patch("dango.platform.cloud.provisioning.time.sleep") as mock_sleep:
+            with patch("dango.platform.cloud.provisioning.time.monotonic") as mock_mono:
+                mock_mono.side_effect = [0.0, 0.0, 5.0, 10.0, 15.0, 20.0]
+                result = wait_for_droplet_ready(client, 1, poll_interval=5.0, timeout=120.0)
+
+        assert result["status"] == "active"
+        assert mock_sleep.call_count == 2
+
+    def test_errored_state_raises(self):
+        """Droplet entering 'errored' state raises CloudError D010."""
+        client = MagicMock()
+        client.get_droplet.return_value = {"id": 1, "status": "errored"}
+
+        with pytest.raises(CloudError) as exc_info:
+            wait_for_droplet_ready(client, 1, poll_interval=1.0, timeout=30.0)
+
+        assert exc_info.value.error_code == "DANGO-D010"
+
+    def test_archive_state_raises(self):
+        """Droplet entering 'archive' state raises CloudError D010."""
+        client = MagicMock()
+        client.get_droplet.return_value = {"id": 1, "status": "archive"}
+
+        with pytest.raises(CloudError) as exc_info:
+            wait_for_droplet_ready(client, 1, poll_interval=1.0, timeout=30.0)
+
+        assert exc_info.value.error_code == "DANGO-D010"
+
+    def test_timeout_raises(self):
+        """CloudError D011 raised when timeout elapses."""
+        client = MagicMock()
+        client.get_droplet.return_value = {"id": 1, "status": "new"}
+
+        with patch("dango.platform.cloud.provisioning.time.sleep"):
+            with patch("dango.platform.cloud.provisioning.time.monotonic") as mock_mono:
+                # deadline = start + timeout; first check passes, second exceeds deadline
+                mock_mono.side_effect = [0.0, 0.0, 200.0]
+                with pytest.raises(CloudError) as exc_info:
+                    wait_for_droplet_ready(client, 1, poll_interval=5.0, timeout=120.0)
+
+        assert exc_info.value.error_code == "DANGO-D011"
+
+
+# ---------------------------------------------------------------------------
+# 5. wait_for_ssh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestWaitForSSH:
+    def test_immediate_success(self):
+        """Returns immediately if SSH is reachable on first attempt."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        with patch("dango.platform.cloud.provisioning.socket.create_connection") as mock_create:
+            mock_create.return_value = mock_conn
+            with patch("dango.platform.cloud.provisioning.time.sleep") as mock_sleep:
+                wait_for_ssh("1.2.3.4", max_attempts=3, attempt_interval=1.0)
+
+        mock_sleep.assert_not_called()
+        mock_create.assert_called_once_with(("1.2.3.4", 22), timeout=5.0)
+
+    def test_retries_then_succeeds(self):
+        """Retries on OSError, succeeds on second attempt."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        with patch("dango.platform.cloud.provisioning.socket.create_connection") as mock_create:
+            mock_create.side_effect = [OSError("refused"), mock_conn]
+            with patch("dango.platform.cloud.provisioning.time.sleep") as mock_sleep:
+                wait_for_ssh("1.2.3.4", max_attempts=3, attempt_interval=2.0)
+
+        mock_sleep.assert_called_once_with(2.0)
+
+    def test_all_attempts_fail_raises(self):
+        """CloudError D012 raised when all attempts fail."""
+        with patch("dango.platform.cloud.provisioning.socket.create_connection") as mock_create:
+            mock_create.side_effect = OSError("refused")
+            with patch("dango.platform.cloud.provisioning.time.sleep"):
+                with pytest.raises(CloudError) as exc_info:
+                    wait_for_ssh("1.2.3.4", max_attempts=3, attempt_interval=1.0)
+
+        assert exc_info.value.error_code == "DANGO-D012"
+
+
+# ---------------------------------------------------------------------------
+# 6. _extract_public_ipv4
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractPublicIpv4:
+    def test_extracts_public_ip(self):
+        """Extracts the public IPv4 from network data."""
+        droplet: dict = {
+            "networks": {
+                "v4": [
+                    {"type": "private", "ip_address": "10.0.0.1"},
+                    {"type": "public", "ip_address": "1.2.3.4"},
+                ]
+            }
+        }
+        assert _extract_public_ipv4(droplet) == "1.2.3.4"
+
+    def test_returns_none_when_no_public(self):
+        """Returns None when only private networks exist."""
+        droplet: dict = {"networks": {"v4": [{"type": "private", "ip_address": "10.0.0.1"}]}}
+        assert _extract_public_ipv4(droplet) is None
+
+    def test_returns_none_when_no_networks(self):
+        """Returns None when networks key is missing."""
+        assert _extract_public_ipv4({}) is None
+
+
+# ---------------------------------------------------------------------------
+# 7. provision_droplet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProvisionDroplet:
+    def _active_droplet(self, droplet_id: int = 42, ip: str = "1.2.3.4") -> dict:
+        return {
+            "id": droplet_id,
+            "status": "active",
+            "networks": {"v4": [{"type": "public", "ip_address": ip}]},
+        }
+
+    def test_full_success_flow(self):
+        """provision_droplet returns the active droplet on success."""
+        client = MagicMock()
+        new_droplet = {"id": 42, "status": "new"}
+        active = self._active_droplet()
+        client.create_droplet.return_value = new_droplet
+
+        with patch("dango.platform.cloud.provisioning.wait_for_droplet_ready") as mock_poll:
+            mock_poll.return_value = active
+            with patch("dango.platform.cloud.provisioning.wait_for_ssh") as mock_ssh:
+                result = provision_droplet(
+                    client, "test-node", "nyc1", "s-2vcpu-4gb", ssh_key_ids=[100]
+                )
+
+        assert result["id"] == 42
+        mock_ssh.assert_called_once_with("1.2.3.4")
+
+    def test_always_adds_dango_tag(self):
+        """provision_droplet always includes the 'dango' tag."""
+        client = MagicMock()
+        client.create_droplet.return_value = {"id": 1, "status": "new"}
+        active = self._active_droplet(1)
+
+        with patch("dango.platform.cloud.provisioning.wait_for_droplet_ready") as mock_poll:
+            mock_poll.return_value = active
+            with patch("dango.platform.cloud.provisioning.wait_for_ssh"):
+                provision_droplet(client, "n", "nyc1", "s-2vcpu-4gb", ssh_key_ids=[])
+
+        call_kwargs = client.create_droplet.call_args[1]
+        assert "dango" in call_kwargs["tags"]
+
+    def test_extra_tags_appended(self):
+        """extra_tags are appended alongside the 'dango' tag."""
+        client = MagicMock()
+        client.create_droplet.return_value = {"id": 1, "status": "new"}
+        active = self._active_droplet(1)
+
+        with patch("dango.platform.cloud.provisioning.wait_for_droplet_ready") as mock_poll:
+            mock_poll.return_value = active
+            with patch("dango.platform.cloud.provisioning.wait_for_ssh"):
+                provision_droplet(
+                    client, "n", "nyc1", "s-2vcpu-4gb", ssh_key_ids=[], extra_tags=["prod", "web"]
+                )
+
+        tags = client.create_droplet.call_args[1]["tags"]
+        assert "dango" in tags
+        assert "prod" in tags
+        assert "web" in tags
+
+    def test_cleanup_on_poll_failure(self):
+        """Droplet is deleted when polling fails."""
+        client = MagicMock()
+        client.create_droplet.return_value = {"id": 42, "status": "new"}
+
+        with patch("dango.platform.cloud.provisioning.wait_for_droplet_ready") as mock_poll:
+            mock_poll.side_effect = CloudError("timeout", error_code="DANGO-D011")
+            with pytest.raises(CloudError):
+                provision_droplet(client, "n", "nyc1", "s-2vcpu-4gb", ssh_key_ids=[])
+
+        client.delete_droplet.assert_called_once_with(42)
+
+    def test_cleanup_on_ssh_failure(self):
+        """Droplet is deleted when SSH check fails."""
+        client = MagicMock()
+        client.create_droplet.return_value = {"id": 42, "status": "new"}
+        active = self._active_droplet()
+
+        with patch("dango.platform.cloud.provisioning.wait_for_droplet_ready") as mock_poll:
+            mock_poll.return_value = active
+            with patch("dango.platform.cloud.provisioning.wait_for_ssh") as mock_ssh:
+                mock_ssh.side_effect = CloudError("no ssh", error_code="DANGO-D012")
+                with pytest.raises(CloudError) as exc_info:
+                    provision_droplet(client, "n", "nyc1", "s-2vcpu-4gb", ssh_key_ids=[])
+
+        client.delete_droplet.assert_called_once_with(42)
+        assert exc_info.value.error_code == "DANGO-D012"
+
+    def test_cleanup_on_no_ip(self):
+        """Droplet is deleted when no public IPv4 is found."""
+        client = MagicMock()
+        client.create_droplet.return_value = {"id": 42, "status": "new"}
+        active_no_ip = {"id": 42, "status": "active", "networks": {"v4": []}}
+
+        with patch("dango.platform.cloud.provisioning.wait_for_droplet_ready") as mock_poll:
+            mock_poll.return_value = active_no_ip
+            with pytest.raises(CloudError) as exc_info:
+                provision_droplet(client, "n", "nyc1", "s-2vcpu-4gb", ssh_key_ids=[])
+
+        client.delete_droplet.assert_called_once_with(42)
+        assert exc_info.value.error_code == "DANGO-D013"
+
+    def test_cleanup_failure_swallowed(self):
+        """Cleanup errors are swallowed and original error is re-raised."""
+        client = MagicMock()
+        client.create_droplet.return_value = {"id": 42, "status": "new"}
+        client.delete_droplet.side_effect = Exception("delete failed")
+
+        with patch("dango.platform.cloud.provisioning.wait_for_droplet_ready") as mock_poll:
+            mock_poll.side_effect = CloudError("timeout", error_code="DANGO-D011")
+            with pytest.raises(CloudError) as exc_info:
+                provision_droplet(client, "n", "nyc1", "s-2vcpu-4gb", ssh_key_ids=[])
+
+        # Original error propagated, not the delete error
+        assert exc_info.value.error_code == "DANGO-D011"
+
+
+# ---------------------------------------------------------------------------
+# 8. save_provisioning_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSaveProvisioningMetadata:
+    def test_creates_new_config(self, tmp_path: Path):
+        """Creates cloud.yml with provisioning metadata when none exists."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+
+        save_provisioning_metadata(
+            tmp_path,
+            droplet_id=123,
+            droplet_ip="5.6.7.8",
+            region="sfo3",
+            size="s-2vcpu-4gb",
+        )
+
+        from dango.config.loader import ConfigLoader
+
+        loader = ConfigLoader(tmp_path)
+        saved = loader.load_cloud_config()
+        assert saved is not None
+        assert saved.droplet_id == 123
+        assert saved.droplet_ip == "5.6.7.8"
+        assert saved.region == "sfo3"
+        assert saved.size == "s-2vcpu-4gb"
+
+    def test_updates_existing_config(self, tmp_path: Path):
+        """Updates existing cloud.yml, preserving other fields."""
+        from dango.config.loader import ConfigLoader
+        from dango.config.models import CloudConfig
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        loader = ConfigLoader(tmp_path)
+        loader.save_cloud_config(
+            CloudConfig(region="nyc1", size="s-2vcpu-4gb", domain="example.com")
+        )
+
+        save_provisioning_metadata(
+            tmp_path,
+            droplet_id=999,
+            droplet_ip="9.9.9.9",
+            region="nyc1",
+            size="s-4vcpu-8gb",
+        )
+
+        saved = loader.load_cloud_config()
+        assert saved is not None
+        assert saved.droplet_id == 999
+        assert saved.droplet_ip == "9.9.9.9"
+        assert saved.size == "s-4vcpu-8gb"
+        assert saved.domain == "example.com"  # preserved

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -166,46 +166,43 @@ class TestSuggestNearestRegion:
     def test_us_east_timezone_suggests_nyc(self):
         """UTC-5 (US East) maps to nyc1 or nyc3 (utc_offset = -5)."""
         # timezone is seconds WEST of UTC, so EST = +18000
-        with patch("dango.platform.cloud.provisioning.time.daylight", 0):
-            with patch("dango.platform.cloud.provisioning.time.timezone", 18000):
-                result = suggest_nearest_region()
+        with patch("dango.platform.cloud.provisioning.time") as mock_time:
+            mock_time.localtime.return_value.tm_isdst = 0
+            mock_time.timezone = 18000
+            result = suggest_nearest_region()
         assert result.utc_offset == -5.0
 
     def test_us_west_timezone_suggests_sfo(self):
         """UTC-8 (US West) maps to sfo3 (utc_offset = -8)."""
-        with patch("dango.platform.cloud.provisioning.time.daylight", 0):
-            with patch("dango.platform.cloud.provisioning.time.timezone", 28800):
-                result = suggest_nearest_region()
+        with patch("dango.platform.cloud.provisioning.time") as mock_time:
+            mock_time.localtime.return_value.tm_isdst = 0
+            mock_time.timezone = 28800
+            result = suggest_nearest_region()
         assert result.slug == "sfo3"
 
     def test_singapore_timezone_suggests_sgp(self):
         """UTC+8 maps to sgp1 (utc_offset = +8)."""
-        with patch("dango.platform.cloud.provisioning.time.daylight", 0):
-            with patch("dango.platform.cloud.provisioning.time.timezone", -28800):
-                result = suggest_nearest_region()
+        with patch("dango.platform.cloud.provisioning.time") as mock_time:
+            mock_time.localtime.return_value.tm_isdst = 0
+            mock_time.timezone = -28800
+            result = suggest_nearest_region()
         assert result.slug == "sgp1"
 
     def test_exception_falls_back_to_nyc1(self):
         """Any exception during offset calculation falls back to nyc1."""
-        with patch(
-            "dango.platform.cloud.provisioning.time.daylight",
-            new_callable=lambda: property(lambda self: (_ for _ in ()).throw(RuntimeError())),
-        ):
-            pass  # Can't easily mock property — test via patching the function itself
-
-        # Patch time.timezone to raise instead
         with patch("dango.platform.cloud.provisioning.time") as mock_time:
-            mock_time.daylight = 0
-            mock_time.timezone = "bad"  # Will cause division error
+            mock_time.localtime.return_value.tm_isdst = 0
+            mock_time.timezone = "bad"  # TypeError on / 3600.0 → caught by except Exception
             result = suggest_nearest_region()
         assert result.slug == "nyc1"
 
     def test_daylight_saving_uses_altzone(self):
-        """When daylight is set, altzone is used for local offset."""
+        """When DST is currently active, altzone is used for local offset."""
         # UTC+1 (Amsterdam summer time = CEST, altzone = -3600)
-        with patch("dango.platform.cloud.provisioning.time.daylight", 1):
-            with patch("dango.platform.cloud.provisioning.time.altzone", -3600):
-                result = suggest_nearest_region()
+        with patch("dango.platform.cloud.provisioning.time") as mock_time:
+            mock_time.localtime.return_value.tm_isdst = 1
+            mock_time.altzone = -3600
+            result = suggest_nearest_region()
         # ams3 and fra1 both at +1
         assert result.utc_offset == 1.0
 
@@ -353,6 +350,11 @@ class TestExtractPublicIpv4:
     def test_returns_none_when_no_networks(self):
         """Returns None when networks key is missing."""
         assert _extract_public_ipv4({}) is None
+
+    def test_returns_none_when_ip_address_is_none(self):
+        """Returns None when ip_address field is None (not just absent)."""
+        droplet: dict = {"networks": {"v4": [{"type": "public", "ip_address": None}]}}
+        assert _extract_public_ipv4(droplet) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_provisioning.py
+++ b/tests/unit/test_provisioning.py
@@ -192,16 +192,19 @@ class TestSuggestNearestRegion:
         """Any exception during offset calculation falls back to nyc1."""
         with patch("dango.platform.cloud.provisioning.time") as mock_time:
             mock_time.localtime.return_value.tm_isdst = 0
-            mock_time.timezone = "bad"  # TypeError on / 3600.0 → caught by except Exception
+            # -"bad" raises TypeError (unary minus on str) → caught by except Exception
+            mock_time.timezone = "bad"
             result = suggest_nearest_region()
         assert result.slug == "nyc1"
 
     def test_daylight_saving_uses_altzone(self):
         """When DST is currently active, altzone is used for local offset."""
-        # UTC+1 (Amsterdam summer time = CEST, altzone = -3600)
+        # UTC+1 (Amsterdam summer time = CEST, altzone = -3600).
+        # timezone set to sfo3 equivalent so a wrong branch gives utc_offset=-8, not +1.
         with patch("dango.platform.cloud.provisioning.time") as mock_time:
             mock_time.localtime.return_value.tm_isdst = 1
-            mock_time.altzone = -3600
+            mock_time.altzone = -3600  # DST branch: UTC+1 → ams3/fra1
+            mock_time.timezone = 28800  # non-DST branch: UTC-8 → sfo3 (wrong result)
             result = suggest_nearest_region()
         # ams3 and fra1 both at +1
         assert result.utc_offset == 1.0

--- a/tests/unit/test_remote_cli.py
+++ b/tests/unit/test_remote_cli.py
@@ -20,7 +20,7 @@ import pytest
 from click.testing import CliRunner
 
 from dango.cli.commands.remote import remote
-from dango.exceptions import CloudAPIError, CloudError
+from dango.exceptions import CloudAPIError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -53,10 +53,19 @@ def _make_cloud_config(firewall_id: str | None = "fw-abc") -> MagicMock:
     return cfg
 
 
-def _make_loader(cloud_cfg: MagicMock | None = None) -> MagicMock:
-    """Return a mock ConfigLoader instance."""
+_UNSET = object()  # Sentinel to distinguish "no arg" from explicit None
+
+
+def _make_loader(cloud_cfg: MagicMock | None = _UNSET) -> MagicMock:  # type: ignore[assignment]
+    """Return a mock ConfigLoader instance.
+
+    Pass ``cloud_cfg=None`` to simulate no cloud deployment (load_cloud_config
+    returns None).  Omit the argument to use a default valid CloudConfig.
+    """
     loader = MagicMock()
-    loader.load_cloud_config.return_value = cloud_cfg or _make_cloud_config()
+    loader.load_cloud_config.return_value = (
+        _make_cloud_config() if cloud_cfg is _UNSET else cloud_cfg
+    )
     return loader
 
 
@@ -109,8 +118,8 @@ class TestFirewallListCommand:
             with patch(_PATCH_LOADER, return_value=mock_loader_instance):
                 result = _run(["firewall", "list"], tmp_path, catch_exceptions=True)
 
-        # Either exits non-zero, or the output contains an error message
-        assert result.exit_code != 0 or "No cloud deployment" in result.output
+        assert result.exit_code != 0
+        assert "No cloud deployment" in result.output
 
     def test_no_firewall_configured_exits_with_error(self, tmp_path: Path):
         """Exits when firewall_id is not set in cloud config."""
@@ -120,7 +129,8 @@ class TestFirewallListCommand:
             with patch(_PATCH_LOADER, return_value=mock_loader_instance):
                 result = _run(["firewall", "list"], tmp_path, catch_exceptions=True)
 
-        assert result.exit_code != 0 or "No firewall" in result.output
+        assert result.exit_code != 0
+        assert "No firewall" in result.output
 
     def test_api_error_exits_with_message(self, tmp_path: Path):
         """API error from get_firewall is shown as a user-facing error."""
@@ -137,7 +147,8 @@ class TestFirewallListCommand:
 
                     result = _run(["firewall", "list"], tmp_path, catch_exceptions=True)
 
-        assert result.exit_code != 0 or "Error" in result.output
+        assert result.exit_code != 0
+        assert "Error" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -191,18 +202,17 @@ class TestFirewallAllowIpCommand:
         assert result.exit_code == 0
 
     def test_invalid_ip_exits_with_error(self, tmp_path: Path):
-        """allow-ip with an invalid IP prints an error and exits non-zero."""
+        """allow-ip with an invalid IP prints an error and exits non-zero.
+
+        validate_ip_or_cidr raises before any API call is made, so no client
+        mock is needed — the real validation path is exercised here.
+        """
         mock_loader_instance = _make_loader()
 
         with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
             with patch(_PATCH_LOADER, return_value=mock_loader_instance):
                 with patch(_PATCH_CLIENT) as mock_client_cls:
-                    mock_client = MagicMock()
-                    # validate_ip_or_cidr is called before get_firewall, raises immediately
-                    mock_client.get_firewall.side_effect = CloudError(
-                        "Invalid IP", error_code="DANGO-D020"
-                    )
-                    mock_client_cls.return_value = mock_client
+                    mock_client_cls.return_value = MagicMock()
 
                     result = _run(
                         ["firewall", "allow-ip", "not-an-ip"],
@@ -210,7 +220,8 @@ class TestFirewallAllowIpCommand:
                         catch_exceptions=True,
                     )
 
-        assert result.exit_code != 0 or "Error" in result.output
+        assert result.exit_code != 0
+        assert "Error" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -261,4 +272,5 @@ class TestFirewallAllowAllCommand:
                         catch_exceptions=True,
                     )
 
-        assert result.exit_code != 0 or "Error" in result.output
+        assert result.exit_code != 0
+        assert "Error" in result.output

--- a/tests/unit/test_remote_cli.py
+++ b/tests/unit/test_remote_cli.py
@@ -1,0 +1,264 @@
+"""tests/unit/test_remote_cli.py
+
+Unit tests for dango/cli/commands/remote.py.
+
+Uses Click's CliRunner with mocked DigitalOceanClient and ConfigLoader
+to avoid any real network or filesystem access.
+
+Patching note: ``remote.py`` uses lazy imports inside function bodies, so
+patches must target the canonical module paths (e.g.
+``dango.config.loader.ConfigLoader``), not the remote module itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.remote import remote
+from dango.exceptions import CloudAPIError, CloudError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PUBLIC_SOURCES = {"addresses": ["0.0.0.0/0", "::/0"]}
+_SSH_RULE = {"protocol": "tcp", "ports": "22", "sources": _PUBLIC_SOURCES}
+_HTTP_RULE = {"protocol": "tcp", "ports": "80", "sources": _PUBLIC_SOURCES}
+_HTTPS_RULE = {"protocol": "tcp", "ports": "443", "sources": _PUBLIC_SOURCES}
+_OUTBOUND_RULE = {"protocol": "tcp", "ports": "all", "destinations": _PUBLIC_SOURCES}
+
+
+def _make_firewall_dict(name: str = "dango-fw-42") -> dict[str, Any]:
+    return {
+        "id": "fw-abc",
+        "name": name,
+        "inbound_rules": [_SSH_RULE, _HTTP_RULE, _HTTPS_RULE],
+        "outbound_rules": [_OUTBOUND_RULE],
+        "droplet_ids": [42],
+        "tags": [],
+    }
+
+
+def _make_cloud_config(firewall_id: str | None = "fw-abc") -> MagicMock:
+    """Return a mock CloudConfig object."""
+    cfg = MagicMock()
+    cfg.droplet_id = 42
+    cfg.droplet_ip = "1.2.3.4"
+    cfg.firewall_id = firewall_id
+    return cfg
+
+
+def _make_loader(cloud_cfg: MagicMock | None = None) -> MagicMock:
+    """Return a mock ConfigLoader instance."""
+    loader = MagicMock()
+    loader.load_cloud_config.return_value = cloud_cfg or _make_cloud_config()
+    return loader
+
+
+# Patch paths — lazy imports resolved at call time, patch at definition site
+_PATCH_LOADER = "dango.config.loader.ConfigLoader"
+_PATCH_CLIENT = "dango.platform.cloud.digitalocean.DigitalOceanClient"
+_PATCH_REQUIRE_CTX = "dango.cli.utils.require_project_context"
+
+
+def _run(args: list[str], tmp_path: Path, *, catch_exceptions: bool = False) -> Any:
+    """Invoke ``remote`` CLI group with the given args."""
+    runner = CliRunner()
+    return runner.invoke(
+        remote,
+        args,
+        obj={"project_root": tmp_path},
+        catch_exceptions=catch_exceptions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. firewall list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFirewallListCommand:
+    def test_shows_firewall_rules_table(self, tmp_path: Path):
+        """firewall list displays a Rich table of rules."""
+        fw = _make_firewall_dict()
+        mock_loader_instance = _make_loader()
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                with patch(_PATCH_CLIENT) as mock_client_cls:
+                    mock_client = MagicMock()
+                    mock_client.get_firewall.return_value = fw
+                    mock_client_cls.return_value = mock_client
+
+                    result = _run(["firewall", "list"], tmp_path, catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert "dango-fw-42" in result.output
+
+    def test_no_deployment_exits_with_error(self, tmp_path: Path):
+        """Exits when no cloud deployment is configured."""
+        mock_loader_instance = _make_loader(cloud_cfg=None)
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                result = _run(["firewall", "list"], tmp_path, catch_exceptions=True)
+
+        # Either exits non-zero, or the output contains an error message
+        assert result.exit_code != 0 or "No cloud deployment" in result.output
+
+    def test_no_firewall_configured_exits_with_error(self, tmp_path: Path):
+        """Exits when firewall_id is not set in cloud config."""
+        mock_loader_instance = _make_loader(cloud_cfg=_make_cloud_config(firewall_id=None))
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                result = _run(["firewall", "list"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0 or "No firewall" in result.output
+
+    def test_api_error_exits_with_message(self, tmp_path: Path):
+        """API error from get_firewall is shown as a user-facing error."""
+        mock_loader_instance = _make_loader()
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                with patch(_PATCH_CLIENT) as mock_client_cls:
+                    mock_client = MagicMock()
+                    mock_client.get_firewall.side_effect = CloudAPIError(
+                        "Not found", status_code=404
+                    )
+                    mock_client_cls.return_value = mock_client
+
+                    result = _run(["firewall", "list"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0 or "Error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 2. firewall allow-ip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFirewallAllowIpCommand:
+    def test_valid_ip_succeeds(self, tmp_path: Path):
+        """allow-ip with a valid IP prints a success message."""
+        fw = _make_firewall_dict()
+        mock_loader_instance = _make_loader()
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                with patch(_PATCH_CLIENT) as mock_client_cls:
+                    mock_client = MagicMock()
+                    mock_client.get_firewall.return_value = fw
+                    mock_client.update_firewall.return_value = fw
+                    mock_client_cls.return_value = mock_client
+
+                    result = _run(
+                        ["firewall", "allow-ip", "203.0.113.42"],
+                        tmp_path,
+                        catch_exceptions=False,
+                    )
+
+        assert result.exit_code == 0
+        assert "203.0.113.42" in result.output
+
+    def test_valid_cidr_succeeds(self, tmp_path: Path):
+        """allow-ip with a CIDR range succeeds."""
+        fw = _make_firewall_dict()
+        mock_loader_instance = _make_loader()
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                with patch(_PATCH_CLIENT) as mock_client_cls:
+                    mock_client = MagicMock()
+                    mock_client.get_firewall.return_value = fw
+                    mock_client.update_firewall.return_value = fw
+                    mock_client_cls.return_value = mock_client
+
+                    result = _run(
+                        ["firewall", "allow-ip", "203.0.113.0/24"],
+                        tmp_path,
+                        catch_exceptions=False,
+                    )
+
+        assert result.exit_code == 0
+
+    def test_invalid_ip_exits_with_error(self, tmp_path: Path):
+        """allow-ip with an invalid IP prints an error and exits non-zero."""
+        mock_loader_instance = _make_loader()
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                with patch(_PATCH_CLIENT) as mock_client_cls:
+                    mock_client = MagicMock()
+                    # validate_ip_or_cidr is called before get_firewall, raises immediately
+                    mock_client.get_firewall.side_effect = CloudError(
+                        "Invalid IP", error_code="DANGO-D020"
+                    )
+                    mock_client_cls.return_value = mock_client
+
+                    result = _run(
+                        ["firewall", "allow-ip", "not-an-ip"],
+                        tmp_path,
+                        catch_exceptions=True,
+                    )
+
+        assert result.exit_code != 0 or "Error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 3. firewall allow-all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFirewallAllowAllCommand:
+    def test_reverts_to_public_access(self, tmp_path: Path):
+        """allow-all prints a success message on success."""
+        fw = _make_firewall_dict()
+        mock_loader_instance = _make_loader()
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                with patch(_PATCH_CLIENT) as mock_client_cls:
+                    mock_client = MagicMock()
+                    mock_client.get_firewall.return_value = fw
+                    mock_client.update_firewall.return_value = fw
+                    mock_client_cls.return_value = mock_client
+
+                    result = _run(
+                        ["firewall", "allow-all"],
+                        tmp_path,
+                        catch_exceptions=False,
+                    )
+
+        assert result.exit_code == 0
+        assert "open to all" in result.output
+
+    def test_api_error_shows_message(self, tmp_path: Path):
+        """API error during allow-all is shown as a user-facing error."""
+        mock_loader_instance = _make_loader()
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                with patch(_PATCH_CLIENT) as mock_client_cls:
+                    mock_client = MagicMock()
+                    mock_client.get_firewall.side_effect = CloudAPIError(
+                        "Server error", status_code=500
+                    )
+                    mock_client_cls.return_value = mock_client
+
+                    result = _run(
+                        ["firewall", "allow-all"],
+                        tmp_path,
+                        catch_exceptions=True,
+                    )
+
+        assert result.exit_code != 0 or "Error" in result.output

--- a/tests/unit/test_remote_cli.py
+++ b/tests/unit/test_remote_cli.py
@@ -56,7 +56,7 @@ def _make_cloud_config(firewall_id: str | None = "fw-abc") -> MagicMock:
 _UNSET = object()  # Sentinel to distinguish "no arg" from explicit None
 
 
-def _make_loader(cloud_cfg: MagicMock | None = _UNSET) -> MagicMock:  # type: ignore[assignment]
+def _make_loader(cloud_cfg: MagicMock | None = _UNSET) -> MagicMock:  # type: ignore[assignment]  # _UNSET sentinel doesn't match annotated types
     """Return a mock ConfigLoader instance.
 
     Pass ``cloud_cfg=None`` to simulate no cloud deployment (load_cloud_config
@@ -181,7 +181,7 @@ class TestFirewallAllowIpCommand:
         assert "203.0.113.42" in result.output
 
     def test_valid_cidr_succeeds(self, tmp_path: Path):
-        """allow-ip with a CIDR range succeeds."""
+        """allow-ip with a CIDR range succeeds and echoes the normalised CIDR."""
         fw = _make_firewall_dict()
         mock_loader_instance = _make_loader()
 
@@ -200,6 +200,7 @@ class TestFirewallAllowIpCommand:
                     )
 
         assert result.exit_code == 0
+        assert "203.0.113.0" in result.output
 
     def test_invalid_ip_exits_with_error(self, tmp_path: Path):
         """allow-ip with an invalid IP prints an error and exits non-zero.
@@ -222,6 +223,38 @@ class TestFirewallAllowIpCommand:
 
         assert result.exit_code != 0
         assert "Error" in result.output
+        # Validation raises before any API call is made
+        mock_client_cls.return_value.get_firewall.assert_not_called()
+
+    def test_no_deployment_exits_with_error(self, tmp_path: Path):
+        """Exits when no cloud deployment is configured."""
+        mock_loader_instance = _make_loader(cloud_cfg=None)
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                result = _run(
+                    ["firewall", "allow-ip", "203.0.113.42"],
+                    tmp_path,
+                    catch_exceptions=True,
+                )
+
+        assert result.exit_code != 0
+        assert "No cloud deployment" in result.output
+
+    def test_no_firewall_configured_exits_with_error(self, tmp_path: Path):
+        """Exits when firewall_id is not set in cloud config."""
+        mock_loader_instance = _make_loader(cloud_cfg=_make_cloud_config(firewall_id=None))
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                result = _run(
+                    ["firewall", "allow-ip", "203.0.113.42"],
+                    tmp_path,
+                    catch_exceptions=True,
+                )
+
+        assert result.exit_code != 0
+        assert "No firewall" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -274,3 +307,25 @@ class TestFirewallAllowAllCommand:
 
         assert result.exit_code != 0
         assert "Error" in result.output
+
+    def test_no_deployment_exits_with_error(self, tmp_path: Path):
+        """Exits when no cloud deployment is configured."""
+        mock_loader_instance = _make_loader(cloud_cfg=None)
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                result = _run(["firewall", "allow-all"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "No cloud deployment" in result.output
+
+    def test_no_firewall_configured_exits_with_error(self, tmp_path: Path):
+        """Exits when firewall_id is not set in cloud config."""
+        mock_loader_instance = _make_loader(cloud_cfg=_make_cloud_config(firewall_id=None))
+
+        with patch(_PATCH_REQUIRE_CTX, return_value=tmp_path):
+            with patch(_PATCH_LOADER, return_value=mock_loader_instance):
+                result = _run(["firewall", "allow-all"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "No firewall" in result.output


### PR DESCRIPTION
## Summary

- **TASK-023**: Add `provisioning.py` — DropletSizeTier/RegionInfo dataclasses, 3 size tiers, 10 DO regions (GDPR-flagged), `provision_droplet()` orchestration (create→poll→SSH check with cleanup on failure), `suggest_nearest_region()` via UTC offset
- **TASK-025**: Add `firewall.py` — default rules, `validate_ip_or_cidr()`, `add_allowed_ip()` (public→allowlist switch + dedup), `allow_all_web()` / `restrict_web_to_ips()`, `format_firewall_rules()`; CLI `dango remote firewall {list,allow-ip,allow-all}`
- **Shared prerequisites**: Remove generic `context` kwarg from `CloudAPIError`, add `firewall_id` to `CloudConfig`, add `get_firewall()` + `update_firewall()` to `DigitalOceanClient`

## Test plan

- [ ] `pytest tests/unit/test_provisioning.py -v` — 42 tests (size tiers, regions, wait loops, provision orchestration, metadata persistence)
- [ ] `pytest tests/unit/test_firewall.py -v` — 33 tests (IP validation, lifecycle, allowlisting, display)
- [ ] `pytest tests/unit/test_remote_cli.py -v` — 9 CLI tests (list, allow-ip, allow-all; error paths)
- [ ] `pytest tests/unit/test_digitalocean_client.py tests/unit/test_cloud_config.py -v` — updated tests pass
- [ ] `pytest -m unit` — full suite (1299 tests, no regressions)
- [ ] `dango remote firewall --help` — CLI group responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)