### PR TITLE
TASK-026: Server setup + dango serve command

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -25,6 +25,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
 | `commands/remote.py` (~220 lines) | `remote` group → `firewall` subgroup (`list`, `allow-ip`, `allow-all`) | `remote`, `firewall` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
+| `commands/serve.py` (~110 lines) | `serve` production foreground server | `serve()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
 | `init.py` (965 lines) | Project initialization wizard | `ProjectInitializer` |
@@ -50,6 +51,7 @@ Click-based command-line interface for all Dango operations — project init, so
 dango (top-level group)
 ├── init, rename, info          ← commands/project.py
 ├── start, stop, status         ← commands/platform.py
+├── serve                       ← commands/serve.py
 ├── sync                        ← commands/source.py
 ├── run, docs, generate         ← commands/transform.py
 ├── validate                    ← commands/data.py

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -12,6 +12,7 @@ Reuses all startup helpers from ``dango.platform.common.startup``.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import click
 
@@ -52,9 +53,14 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
     except (click.Abort, SystemExit):
         raise SystemExit(1) from None
 
-    # Load config
-    config_loader = ConfigLoader(project_root)
-    config = config_loader.load_config()
+    # Load config (M6: catch config errors cleanly)
+    try:
+        config_loader = ConfigLoader(project_root)
+        config = config_loader.load_config()
+    except Exception as exc:
+        print(f"Failed to load project config: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
     project_name = config.project.name
     organization = getattr(config.project, "organization", None)
     effective_port = port if port is not None else config.platform.port
@@ -102,18 +108,38 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
     except Exception:
         pass
 
-    # 7. Start uvicorn in foreground
+    # H4: Check port availability before starting uvicorn
+    _check_port(effective_port)
+
+    # H3: Wrap uvicorn in try/finally for Docker cleanup
     import uvicorn
 
     print(f"Starting Dango on {host}:{effective_port}")
-    uvicorn.run("dango.web.app:app", host=host, port=effective_port, log_level="info")
+    try:
+        uvicorn.run("dango.web.app:app", host=host, port=effective_port, log_level="info")
+    finally:
+        _stop_docker_quiet(project_root)
 
 
-def _stop_docker_quiet(project_root: object) -> None:
+def _check_port(port: int) -> None:
+    """Exit with a clean error if *port* is already in use."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(("0.0.0.0", port))
+        except OSError:
+            print(f"Port {port} is already in use", file=sys.stderr)
+            raise SystemExit(1) from None
+
+
+# M5: typed as Path, not object
+def _stop_docker_quiet(project_root: Path) -> None:
     """Best-effort Docker service cleanup."""
     try:
         from dango.platform import DockerManager
 
-        DockerManager(project_root).stop_services()  # type: ignore[arg-type]
+        DockerManager(project_root).stop_services()
     except Exception:
         pass

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -1,0 +1,119 @@
+"""dango/cli/commands/serve.py
+
+Production foreground server command for cloud deployments.
+
+``dango serve`` runs the Dango web platform in the foreground (under
+systemd on the server).  Unlike ``dango start`` it does not daemonise,
+open a browser, or start the file watcher.
+
+Reuses all startup helpers from ``dango.platform.common.startup``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+
+@click.command()
+@click.option("--host", default="0.0.0.0", help="Bind address (default: 0.0.0.0)")
+@click.option("--port", default=None, type=int, help="Port (default: config value or 8800)")
+@click.pass_context
+def serve(ctx: click.Context, host: str, port: int | None) -> None:
+    """Run Dango in production server mode (foreground).
+
+    Intended for use under systemd on a cloud server.  Runs all startup
+    steps (migrations, Docker services, Metabase setup) then starts
+    uvicorn in the foreground.
+
+    Unlike ``dango start``, this command:
+
+    \b
+      - Binds to 0.0.0.0 (all interfaces)
+      - Runs uvicorn in the foreground (no PID file)
+      - Does not open a browser or start the file watcher
+      - Minimal console output (no Rich formatting)
+    """
+    from dango.config import ConfigLoader
+    from dango.platform.common.startup import (
+        ensure_dbt_schemas,
+        ensure_duckdb_driver,
+        import_dashboards,
+        run_pending_migrations,
+        setup_metabase_if_needed,
+        start_docker_services,
+    )
+
+    from ..utils import require_project_context
+
+    try:
+        project_root = require_project_context(ctx)
+    except (click.Abort, SystemExit):
+        raise SystemExit(1) from None
+
+    # Load config
+    config_loader = ConfigLoader(project_root)
+    config = config_loader.load_config()
+    project_name = config.project.name
+    organization = getattr(config.project, "organization", None)
+    effective_port = port if port is not None else config.platform.port
+
+    # 1. Migrations
+    try:
+        run_pending_migrations(project_root)
+    except Exception as exc:
+        print(f"Migration failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    # 2. dbt schemas
+    try:
+        ensure_dbt_schemas(project_root)
+    except Exception as exc:
+        print(f"Schema setup failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    # 3. DuckDB driver
+    try:
+        ensure_duckdb_driver(project_root)
+    except Exception as exc:
+        print(f"DuckDB driver download failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    # 4. Docker services
+    try:
+        start_docker_services(project_root)
+    except Exception as exc:
+        print(f"Docker services failed: {exc}", file=sys.stderr)
+        _stop_docker_quiet(project_root)
+        raise SystemExit(1) from exc
+
+    # 5. Metabase setup
+    try:
+        setup_metabase_if_needed(project_root, project_name, organization)
+    except Exception as exc:
+        print(f"Metabase setup failed: {exc}", file=sys.stderr)
+        _stop_docker_quiet(project_root)
+        raise SystemExit(1) from exc
+
+    # 6. Dashboard import (non-critical)
+    try:
+        import_dashboards(project_root)
+    except Exception:
+        pass
+
+    # 7. Start uvicorn in foreground
+    import uvicorn
+
+    print(f"Starting Dango on {host}:{effective_port}")
+    uvicorn.run("dango.web.app:app", host=host, port=effective_port, log_level="info")
+
+
+def _stop_docker_quiet(project_root: object) -> None:
+    """Best-effort Docker service cleanup."""
+    try:
+        from dango.platform import DockerManager
+
+        DockerManager(project_root).stop_services()  # type: ignore[arg-type]
+    except Exception:
+        pass

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -20,6 +20,7 @@ from dango.cli.commands.oauth import oauth
 from dango.cli.commands.platform import start, status, stop
 from dango.cli.commands.project import info, init, rename
 from dango.cli.commands.remote import remote
+from dango.cli.commands.serve import serve
 from dango.cli.commands.source import source, sync
 from dango.cli.commands.transform import docs, generate, run
 from dango.cli.commands.web import web
@@ -69,6 +70,7 @@ cli.add_command(docs)
 cli.add_command(generate)
 cli.add_command(validate)
 cli.add_command(web)
+cli.add_command(serve)
 
 # --- Register command groups ---
 cli.add_command(source)

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -58,6 +58,7 @@ __all__ = [
     "CloudAPIError",
     "CloudAuthError",
     "CloudSSHError",
+    "CloudProvisioningError",
     "is_debug_mode",
 ]
 
@@ -409,3 +410,9 @@ class CloudSSHError(CloudError):
     """SSH connection or command execution failed."""
 
     _default_error_code = "DANGO-D004"
+
+
+class CloudProvisioningError(CloudError):
+    """Server setup or provisioning step failed."""
+
+    _default_error_code = "DANGO-D005"

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -32,7 +32,9 @@ platform/
 │   ├── provisioning.py  # Size tiers, regions, provision_droplet() orchestration (TASK-023)
 │   ├── firewall.py      # Firewall lifecycle, IP allowlisting (TASK-025)
 │   ├── spaces.py        # DO Spaces client (S3-compatible via boto3)
-│   └── ssh.py           # SSH key management, TOFU known-hosts, exec/SFTP (TASK-024)
+│   ├── ssh.py           # SSH key management, TOFU known-hosts, exec/SFTP (TASK-024)
+│   ├── server_setup.py  # SSH-based server setup orchestration (TASK-026)
+│   └── _server_templates.py  # Config file templates for server_setup.py
 │
 │   # Backwards-compatible shims (re-export from local/)
 ├── network.py           # → platform.local.network
@@ -56,6 +58,8 @@ platform/
 | `cloud/firewall.py` | Firewall lifecycle and IP allowlisting | `create_default_firewall`, `add_allowed_ip`, `restrict_web_to_ips`, `allow_all_web`, `validate_ip_or_cidr`, `save_firewall_metadata` |
 | `cloud/spaces.py` | DigitalOcean Spaces (S3-compatible) client | `SpacesClient` |
 | `cloud/ssh.py` | SSH key management, TOFU known-hosts, command exec, SFTP | `SSHManager`, `CommandResult` |
+| `cloud/server_setup.py` | SSH-based server setup orchestration (16 idempotent steps) | `setup_server`, `SetupResult` |
+| `cloud/_server_templates.py` | Config file templates (systemd, Caddy, fail2ban, etc.) | `SYSTEMD_UNIT`, `CADDYFILE`, etc. |
 
 ## Import Patterns
 
@@ -117,6 +121,7 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | Manage firewall rules | `cloud/firewall.py` → `add_allowed_ip()` / `restrict_web_to_ips()` | `pytest tests/unit/test_firewall.py` |
 | Backup to Spaces | `cloud/spaces.py` → `SpacesClient` | `pytest tests/unit/test_spaces_client.py` |
 | Manage SSH keys / remote exec | `cloud/ssh.py` → `SSHManager` | `pytest tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py` |
+| Setup server after provisioning | `cloud/server_setup.py` → `setup_server()` | `pytest tests/unit/test_server_setup.py` |
 | Modify watcher logic | `local/watcher.py` | `pytest tests/unit/test_watcher_lifecycle.py` |
 | Change Docker service startup | `docker.py` | `dango start` manually |
 | Load/save cloud.yml | `from dango.config import ConfigLoader` → `load_cloud_config()` / `save_cloud_config()` | `pytest tests/unit/test_cloud_config_loader.py` |
@@ -145,4 +150,5 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 
 **Used by:**
 - `dango.cli.commands.platform` — start/stop/status commands
+- `dango.cli.commands.serve` — production foreground server
 - `dango.web.routes.health` — get_watcher_status

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -132,14 +132,14 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 
 **Imports from:**
 - `dango.config` — ConfigLoader, CloudConfig (load cloud.yml)
-- `dango.exceptions` — CloudError, CloudAPIError, CloudAuthError (cloud/)
+- `dango.exceptions` — CloudError, CloudAPIError, CloudAuthError, CloudProvisioningError (cloud/)
 - `dango.migrations` — apply_all_pending (startup.py)
 - `dango.utils.database` — ensure_dbt_schemas (startup.py)
 - `dango.utils.process` — is_process_running, kill_process (watcher_lifecycle.py)
 - `dango.visualization` — setup_metabase, import_dashboards (startup.py)
 - `httpx` — HTTP transport for DigitalOcean API (cloud/digitalocean.py)
-- `boto3` (optional, `[cloud]` extra) — Spaces S3 client (cloud/spaces.py)
-- `paramiko` (optional, `[cloud]` extra) — SSH transport (cloud/ssh.py)
+- `boto3` — Spaces S3 client (cloud/spaces.py)
+- `paramiko` — SSH transport (cloud/ssh.py)
 - `cryptography` — Ed25519 key generation (cloud/ssh.py; core dependency)
 - `watchdog` — Observer, FileSystemEventHandler (watcher.py)
 

--- a/dango/platform/cloud/__init__.py
+++ b/dango/platform/cloud/__init__.py
@@ -35,6 +35,7 @@ from .provisioning import (
     wait_for_droplet_ready,
     wait_for_ssh,
 )
+from .server_setup import SetupResult, setup_server
 from .spaces import SpacesClient
 from .ssh import CommandResult, SSHManager
 
@@ -70,4 +71,7 @@ __all__ = [
     "allow_all_web",
     "format_firewall_rules",
     "save_firewall_metadata",
+    # Server setup
+    "setup_server",
+    "SetupResult",
 ]

--- a/dango/platform/cloud/_server_templates.py
+++ b/dango/platform/cloud/_server_templates.py
@@ -1,0 +1,82 @@
+"""dango/platform/cloud/_server_templates.py
+
+Config file templates for server setup (server_setup.py).
+
+These are plain string constants written to the remote host during setup.
+Extracted from server_setup.py to keep that module under 500 lines.
+"""
+
+from __future__ import annotations
+
+SYSTEMD_UNIT = """\
+[Unit]
+Description=Dango Web Platform
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=dango
+Group=dango
+WorkingDirectory=/srv/dango/project
+Environment=DLT_DATA_DIR=/srv/dango/project/.dlt
+ExecStart=/srv/dango/venv/bin/dango serve
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+CADDYFILE = """\
+:80 {
+\treverse_proxy localhost:8800
+}
+"""
+
+DOCKER_DAEMON_JSON = """\
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+"""
+
+JOURNALD_CONF = """\
+[Journal]
+SystemMaxUse=500M
+"""
+
+LOGROTATE_CONF = """\
+/srv/dango/project/.dango/logs/activity.log {
+    size 10M
+    rotate 3
+    compress
+    copytruncate
+    missingok
+    notifempty
+}
+"""
+
+FAIL2BAN_JAIL = """\
+[sshd]
+enabled = true
+port = ssh
+filter = sshd
+maxretry = 5
+bantime = 3600
+"""
+
+UNATTENDED_UPGRADES_CONF = """\
+Unattended-Upgrade::Allowed-Origins {
+    "${distro_id}:${distro_codename}";
+    "${distro_id}:${distro_codename}-security";
+    "${distro_id}ESMApps:${distro_codename}-apps-security";
+    "${distro_id}ESM:${distro_codename}-infra-security";
+};
+Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+"""

--- a/dango/platform/cloud/_server_templates.py
+++ b/dango/platform/cloud/_server_templates.py
@@ -65,6 +65,7 @@ FAIL2BAN_JAIL = """\
 enabled = true
 port = ssh
 filter = sshd
+backend = systemd
 maxretry = 5
 bantime = 3600
 """

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -1,0 +1,484 @@
+"""dango/platform/cloud/server_setup.py
+
+SSH-based server setup orchestration for Dango cloud deployments.
+
+Runs idempotent setup steps on a freshly provisioned Ubuntu 22.04 droplet
+via an already-connected ``SSHManager``.  Each step checks whether the
+target state already exists before acting, making the entire sequence safe
+to re-run.
+
+Steps
+-----
+1. Install system packages (apt)
+2. Create ``dango`` user
+3. Install Docker (get.docker.com)
+4. Add ``dango`` to ``docker`` group
+5. Install Caddy (official apt repo)
+6. Create directory structure under ``/srv/dango/``
+7. Create Python venv and install ``getdango``
+8. Disable SSH password authentication
+9. Copy SSH authorized_keys to ``dango`` user
+10. Configure Docker daemon logging
+11. Configure journald limits
+12. Configure logrotate for activity log
+13. Create ``dango-web`` systemd unit (enabled, NOT started)
+14. Write minimal HTTP Caddyfile
+15. Configure fail2ban for SSH
+16. Enable unattended-upgrades
+
+Config file templates are in ``_server_templates.py``.
+
+All steps raise ``CloudProvisioningError`` on failure.  The ``on_progress``
+callback, if provided, is called with ``(step_name, status)`` where status
+is ``"running"``, ``"done"``, or ``"skipped"``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from dango.exceptions import CloudProvisioningError
+from dango.platform.cloud._server_templates import (
+    CADDYFILE,
+    DOCKER_DAEMON_JSON,
+    FAIL2BAN_JAIL,
+    JOURNALD_CONF,
+    LOGROTATE_CONF,
+    SYSTEMD_UNIT,
+    UNATTENDED_UPGRADES_CONF,
+)
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.ssh import SSHManager
+
+
+# ---------------------------------------------------------------------------
+# Public data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SetupResult:
+    """Result of a full server setup run."""
+
+    steps_completed: list[str] = field(default_factory=list)
+    steps_skipped: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_checked(
+    ssh: SSHManager,
+    command: str,
+    *,
+    step: str,
+    timeout: int = 120,
+) -> str:
+    """Run *command* via SSH, raising ``CloudProvisioningError`` on failure.
+
+    Returns:
+        The stdout of the command.
+    """
+    result = ssh.exec_command(command, timeout=timeout)
+    if not result.success:
+        raise CloudProvisioningError(
+            f"Server setup step '{step}' failed (exit {result.exit_code}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout
+
+
+def _write_remote_config(
+    ssh: SSHManager,
+    path: str,
+    content: str,
+    *,
+    step: str,
+    mode: int = 0o644,
+) -> None:
+    """Write a config file to *path* on the remote host.
+
+    Creates parent directories automatically.
+    """
+    parent = "/".join(path.split("/")[:-1])
+    if parent:
+        _run_checked(ssh, f"mkdir -p {parent}", step=step)
+    ssh.write_remote_file(path, content, mode=mode)
+
+
+def _notify(
+    callback: Callable[[str, str], None] | None,
+    step: str,
+    status: str,
+) -> None:
+    """Call the progress callback if provided."""
+    if callback is not None:
+        callback(step, status)
+
+
+# ---------------------------------------------------------------------------
+# Individual setup steps
+# ---------------------------------------------------------------------------
+
+
+def _setup_apt_packages(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 1: Install system packages via apt."""
+    step = "apt_packages"
+    _notify(on_progress, step, "running")
+    _run_checked(
+        ssh,
+        "DEBIAN_FRONTEND=noninteractive apt-get update -qq"
+        " && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq"
+        " python3-pip python3-venv fail2ban unattended-upgrades"
+        " logrotate curl",
+        step=step,
+        timeout=300,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_dango_user(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 2: Create the dango system user."""
+    step = "create_user"
+    _notify(on_progress, step, "running")
+    check = ssh.exec_command("id -u dango")
+    if check.success:
+        result.steps_skipped.append(step)
+        _notify(on_progress, step, "skipped")
+        return
+    _run_checked(ssh, "useradd -m -s /bin/bash dango", step=step)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_docker(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 3: Install Docker via get.docker.com."""
+    step = "install_docker"
+    _notify(on_progress, step, "running")
+    check = ssh.exec_command("docker --version")
+    if check.success:
+        result.steps_skipped.append(step)
+        _notify(on_progress, step, "skipped")
+        return
+    _run_checked(
+        ssh,
+        "curl -fsSL https://get.docker.com | sh",
+        step=step,
+        timeout=300,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_docker_group(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 4: Add dango user to docker group."""
+    step = "docker_group"
+    _notify(on_progress, step, "running")
+    _run_checked(ssh, "usermod -aG docker dango", step=step)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_caddy(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 5: Install Caddy via official apt repository."""
+    step = "install_caddy"
+    _notify(on_progress, step, "running")
+    check = ssh.exec_command("caddy version")
+    if check.success:
+        result.steps_skipped.append(step)
+        _notify(on_progress, step, "skipped")
+        return
+    _run_checked(
+        ssh,
+        "apt-get install -y -qq debian-keyring debian-archive-keyring apt-transport-https"
+        " && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key'"
+        " | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg"
+        " && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt'"
+        " | tee /etc/apt/sources.list.d/caddy-stable.list"
+        " && apt-get update -qq"
+        " && apt-get install -y -qq caddy",
+        step=step,
+        timeout=300,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_directories(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 6: Create /srv/dango directory structure."""
+    step = "directories"
+    _notify(on_progress, step, "running")
+    _run_checked(
+        ssh,
+        "mkdir -p /srv/dango/project/.dango"
+        " /srv/dango/project/data"
+        " /srv/dango/project/.dlt"
+        " /srv/dango/project/dbt"
+        " /srv/dango/backups/deploy"
+        " && chown -R dango:dango /srv/dango",
+        step=step,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_venv(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 7: Create Python venv and install getdango."""
+    step = "python_venv"
+    _notify(on_progress, step, "running")
+    _run_checked(
+        ssh,
+        "python3 -m venv /srv/dango/venv"
+        " && /srv/dango/venv/bin/pip install --upgrade pip -q"
+        " && /srv/dango/venv/bin/pip install getdango -q",
+        step=step,
+        timeout=300,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_ssh_hardening(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 8: Disable SSH password authentication."""
+    step = "ssh_hardening"
+    _notify(on_progress, step, "running")
+    _run_checked(
+        ssh,
+        "sed -i 's/^#\\?PasswordAuthentication.*/PasswordAuthentication no/'"
+        " /etc/ssh/sshd_config"
+        " && sed -i 's/^#\\?ChallengeResponseAuthentication.*"
+        "/ChallengeResponseAuthentication no/'"
+        " /etc/ssh/sshd_config"
+        " && systemctl reload sshd",
+        step=step,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_ssh_key_copy(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 9: Copy root's authorized_keys to dango user."""
+    step = "ssh_key_copy"
+    _notify(on_progress, step, "running")
+    _run_checked(
+        ssh,
+        "mkdir -p /home/dango/.ssh"
+        " && cp /root/.ssh/authorized_keys /home/dango/.ssh/authorized_keys"
+        " && chown -R dango:dango /home/dango/.ssh"
+        " && chmod 700 /home/dango/.ssh"
+        " && chmod 600 /home/dango/.ssh/authorized_keys",
+        step=step,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_docker_daemon(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 10: Configure Docker daemon log rotation."""
+    step = "docker_daemon"
+    _notify(on_progress, step, "running")
+    _write_remote_config(ssh, "/etc/docker/daemon.json", DOCKER_DAEMON_JSON, step=step)
+    _run_checked(ssh, "systemctl restart docker", step=step, timeout=60)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_journald(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 11: Configure journald storage limits."""
+    step = "journald"
+    _notify(on_progress, step, "running")
+    _write_remote_config(ssh, "/etc/systemd/journald.conf.d/dango.conf", JOURNALD_CONF, step=step)
+    _run_checked(ssh, "systemctl restart systemd-journald", step=step)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_logrotate(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 12: Configure logrotate for activity log."""
+    step = "logrotate"
+    _notify(on_progress, step, "running")
+    _write_remote_config(ssh, "/etc/logrotate.d/dango", LOGROTATE_CONF, step=step)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_systemd_unit(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 13: Create and enable dango-web systemd service (NOT started)."""
+    step = "systemd_unit"
+    _notify(on_progress, step, "running")
+    _write_remote_config(ssh, "/etc/systemd/system/dango-web.service", SYSTEMD_UNIT, step=step)
+    _run_checked(ssh, "systemctl daemon-reload && systemctl enable dango-web", step=step)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_caddyfile(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 14: Write minimal HTTP Caddyfile."""
+    step = "caddyfile"
+    _notify(on_progress, step, "running")
+    _write_remote_config(ssh, "/etc/caddy/Caddyfile", CADDYFILE, step=step)
+    _run_checked(ssh, "systemctl reload caddy", step=step)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_fail2ban(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 15: Configure fail2ban SSH jail."""
+    step = "fail2ban"
+    _notify(on_progress, step, "running")
+    _write_remote_config(ssh, "/etc/fail2ban/jail.local", FAIL2BAN_JAIL, step=step)
+    _run_checked(ssh, "systemctl restart fail2ban", step=step)
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+def _setup_unattended_upgrades(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 16: Enable unattended security upgrades."""
+    step = "unattended_upgrades"
+    _notify(on_progress, step, "running")
+    _write_remote_config(
+        ssh, "/etc/apt/apt.conf.d/50unattended-upgrades", UNATTENDED_UPGRADES_CONF, step=step
+    )
+    _run_checked(
+        ssh,
+        "systemctl enable unattended-upgrades && systemctl start unattended-upgrades",
+        step=step,
+    )
+    result.steps_completed.append(step)
+    _notify(on_progress, step, "done")
+
+
+# ---------------------------------------------------------------------------
+# Public orchestrator
+# ---------------------------------------------------------------------------
+
+# Ordered list of (step_function, step_name) for the setup sequence.
+_SETUP_STEPS: list[
+    tuple[
+        Callable[
+            [SSHManager, SetupResult, Callable[[str, str], None] | None],
+            None,
+        ],
+        str,
+    ]
+] = [
+    (_setup_apt_packages, "apt_packages"),
+    (_setup_dango_user, "create_user"),
+    (_setup_docker, "install_docker"),
+    (_setup_docker_group, "docker_group"),
+    (_setup_caddy, "install_caddy"),
+    (_setup_directories, "directories"),
+    (_setup_venv, "python_venv"),
+    (_setup_ssh_hardening, "ssh_hardening"),
+    (_setup_ssh_key_copy, "ssh_key_copy"),
+    (_setup_docker_daemon, "docker_daemon"),
+    (_setup_journald, "journald"),
+    (_setup_logrotate, "logrotate"),
+    (_setup_systemd_unit, "systemd_unit"),
+    (_setup_caddyfile, "caddyfile"),
+    (_setup_fail2ban, "fail2ban"),
+    (_setup_unattended_upgrades, "unattended_upgrades"),
+]
+
+
+def setup_server(
+    ssh: SSHManager,
+    *,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> SetupResult:
+    """Run all server setup steps on a connected droplet.
+
+    The SSH connection must already be established as **root**.  Each step
+    is idempotent — safe to re-run on a partially or fully configured server.
+
+    The systemd service is **enabled but not started**; the deploy wizard
+    (TASK-029) starts it after file sync.
+
+    Args:
+        ssh: A connected ``SSHManager`` (as root).
+        on_progress: Optional callback ``(step_name, status)`` where status
+            is ``"running"``, ``"done"``, or ``"skipped"``.
+
+    Returns:
+        ``SetupResult`` with completed, skipped, and warning lists.
+
+    Raises:
+        CloudProvisioningError: If any step fails.
+    """
+    result = SetupResult()
+
+    for step_fn, _step_name in _SETUP_STEPS:
+        step_fn(ssh, result, on_progress)
+
+    return result

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -2,31 +2,10 @@
 
 SSH-based server setup orchestration for Dango cloud deployments.
 
-Runs idempotent setup steps on a freshly provisioned Ubuntu 22.04 droplet
-via an already-connected ``SSHManager``.  Each step checks whether the
-target state already exists before acting, making the entire sequence safe
-to re-run.
-
-Steps
------
-1. Install system packages (apt)
-2. Create ``dango`` user
-3. Install Docker (get.docker.com)
-4. Add ``dango`` to ``docker`` group
-5. Install Caddy (official apt repo)
-6. Create directory structure under ``/srv/dango/``
-7. Create Python venv and install ``getdango``
-8. Disable SSH password authentication
-9. Copy SSH authorized_keys to ``dango`` user
-10. Configure Docker daemon logging
-11. Configure journald limits
-12. Configure logrotate for activity log
-13. Create ``dango-web`` systemd unit (enabled, NOT started)
-14. Write minimal HTTP Caddyfile
-15. Configure fail2ban for SSH
-16. Enable unattended-upgrades
-
-Config file templates are in ``_server_templates.py``.
+Runs 16 idempotent setup steps on a freshly provisioned Ubuntu 22.04
+droplet via an already-connected ``SSHManager``.  Each step checks whether
+the target state already exists before acting, making the entire sequence
+safe to re-run.  Config file templates are in ``_server_templates.py``.
 
 All steps raise ``CloudProvisioningError`` on failure.  The ``on_progress``
 callback, if provided, is called with ``(step_name, status)`` where status
@@ -101,15 +80,24 @@ def _write_remote_config(
     *,
     step: str,
     mode: int = 0o644,
-) -> None:
+) -> bool:
     """Write a config file to *path* on the remote host.
 
-    Creates parent directories automatically.
+    Creates parent directories automatically.  If the file already exists
+    with identical content, the write is skipped.
+
+    Returns:
+        ``True`` if the file was written, ``False`` if skipped (unchanged).
     """
+    # Check if the file already has the expected content.
+    check = ssh.exec_command(f"cat {path} 2>/dev/null")
+    if check.success and check.stdout == content:
+        return False
     parent = "/".join(path.split("/")[:-1])
     if parent:
         _run_checked(ssh, f"mkdir -p {parent}", step=step)
     ssh.write_remote_file(path, content, mode=mode)
+    return True
 
 
 def _notify(
@@ -120,6 +108,21 @@ def _notify(
     """Call the progress callback if provided."""
     if callback is not None:
         callback(step, status)
+
+
+def _mark(
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+    step: str,
+    changed: bool,
+) -> None:
+    """Record step as completed or skipped based on *changed*."""
+    if changed:
+        result.steps_completed.append(step)
+        _notify(on_progress, step, "done")
+    else:
+        result.steps_skipped.append(step)
+        _notify(on_progress, step, "skipped")
 
 
 # ---------------------------------------------------------------------------
@@ -219,7 +222,7 @@ def _setup_caddy(
         ssh,
         "apt-get install -y -qq debian-keyring debian-archive-keyring apt-transport-https"
         " && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key'"
-        " | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg"
+        " | gpg --batch --yes --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg"
         " && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt'"
         " | tee /etc/apt/sources.list.d/caddy-stable.list"
         " && apt-get update -qq"
@@ -241,7 +244,7 @@ def _setup_directories(
     _notify(on_progress, step, "running")
     _run_checked(
         ssh,
-        "mkdir -p /srv/dango/project/.dango"
+        "mkdir -p /srv/dango/project/.dango/logs"
         " /srv/dango/project/data"
         " /srv/dango/project/.dlt"
         " /srv/dango/project/dbt"
@@ -261,6 +264,11 @@ def _setup_venv(
     """Step 7: Create Python venv and install getdango."""
     step = "python_venv"
     _notify(on_progress, step, "running")
+    check = ssh.exec_command("test -x /srv/dango/venv/bin/dango")
+    if check.success:
+        result.steps_skipped.append(step)
+        _notify(on_progress, step, "skipped")
+        return
     _run_checked(
         ssh,
         "python3 -m venv /srv/dango/venv"
@@ -287,6 +295,9 @@ def _setup_ssh_hardening(
         " /etc/ssh/sshd_config"
         " && sed -i 's/^#\\?ChallengeResponseAuthentication.*"
         "/ChallengeResponseAuthentication no/'"
+        " /etc/ssh/sshd_config"
+        " && sed -i 's/^#\\?KbdInteractiveAuthentication.*"
+        "/KbdInteractiveAuthentication no/'"
         " /etc/ssh/sshd_config"
         " && systemctl reload sshd",
         step=step,
@@ -324,10 +335,10 @@ def _setup_docker_daemon(
     """Step 10: Configure Docker daemon log rotation."""
     step = "docker_daemon"
     _notify(on_progress, step, "running")
-    _write_remote_config(ssh, "/etc/docker/daemon.json", DOCKER_DAEMON_JSON, step=step)
-    _run_checked(ssh, "systemctl restart docker", step=step, timeout=60)
-    result.steps_completed.append(step)
-    _notify(on_progress, step, "done")
+    changed = _write_remote_config(ssh, "/etc/docker/daemon.json", DOCKER_DAEMON_JSON, step=step)
+    if changed:
+        _run_checked(ssh, "systemctl restart docker", step=step, timeout=60)
+    _mark(result, on_progress, step, changed)
 
 
 def _setup_journald(
@@ -338,10 +349,12 @@ def _setup_journald(
     """Step 11: Configure journald storage limits."""
     step = "journald"
     _notify(on_progress, step, "running")
-    _write_remote_config(ssh, "/etc/systemd/journald.conf.d/dango.conf", JOURNALD_CONF, step=step)
-    _run_checked(ssh, "systemctl restart systemd-journald", step=step)
-    result.steps_completed.append(step)
-    _notify(on_progress, step, "done")
+    changed = _write_remote_config(
+        ssh, "/etc/systemd/journald.conf.d/dango.conf", JOURNALD_CONF, step=step
+    )
+    if changed:
+        _run_checked(ssh, "systemctl restart systemd-journald", step=step)
+    _mark(result, on_progress, step, changed)
 
 
 def _setup_logrotate(
@@ -352,9 +365,8 @@ def _setup_logrotate(
     """Step 12: Configure logrotate for activity log."""
     step = "logrotate"
     _notify(on_progress, step, "running")
-    _write_remote_config(ssh, "/etc/logrotate.d/dango", LOGROTATE_CONF, step=step)
-    result.steps_completed.append(step)
-    _notify(on_progress, step, "done")
+    changed = _write_remote_config(ssh, "/etc/logrotate.d/dango", LOGROTATE_CONF, step=step)
+    _mark(result, on_progress, step, changed)
 
 
 def _setup_systemd_unit(
@@ -365,10 +377,12 @@ def _setup_systemd_unit(
     """Step 13: Create and enable dango-web systemd service (NOT started)."""
     step = "systemd_unit"
     _notify(on_progress, step, "running")
-    _write_remote_config(ssh, "/etc/systemd/system/dango-web.service", SYSTEMD_UNIT, step=step)
+    changed = _write_remote_config(
+        ssh, "/etc/systemd/system/dango-web.service", SYSTEMD_UNIT, step=step
+    )
+    # Always daemon-reload + enable (idempotent)
     _run_checked(ssh, "systemctl daemon-reload && systemctl enable dango-web", step=step)
-    result.steps_completed.append(step)
-    _notify(on_progress, step, "done")
+    _mark(result, on_progress, step, changed)
 
 
 def _setup_caddyfile(
@@ -379,10 +393,10 @@ def _setup_caddyfile(
     """Step 14: Write minimal HTTP Caddyfile."""
     step = "caddyfile"
     _notify(on_progress, step, "running")
-    _write_remote_config(ssh, "/etc/caddy/Caddyfile", CADDYFILE, step=step)
-    _run_checked(ssh, "systemctl reload caddy", step=step)
-    result.steps_completed.append(step)
-    _notify(on_progress, step, "done")
+    changed = _write_remote_config(ssh, "/etc/caddy/Caddyfile", CADDYFILE, step=step)
+    if changed:
+        _run_checked(ssh, "systemctl reload-or-restart caddy", step=step)
+    _mark(result, on_progress, step, changed)
 
 
 def _setup_fail2ban(
@@ -393,10 +407,10 @@ def _setup_fail2ban(
     """Step 15: Configure fail2ban SSH jail."""
     step = "fail2ban"
     _notify(on_progress, step, "running")
-    _write_remote_config(ssh, "/etc/fail2ban/jail.local", FAIL2BAN_JAIL, step=step)
-    _run_checked(ssh, "systemctl restart fail2ban", step=step)
-    result.steps_completed.append(step)
-    _notify(on_progress, step, "done")
+    changed = _write_remote_config(ssh, "/etc/fail2ban/jail.local", FAIL2BAN_JAIL, step=step)
+    if changed:
+        _run_checked(ssh, "systemctl restart fail2ban", step=step)
+    _mark(result, on_progress, step, changed)
 
 
 def _setup_unattended_upgrades(
@@ -407,48 +421,45 @@ def _setup_unattended_upgrades(
     """Step 16: Enable unattended security upgrades."""
     step = "unattended_upgrades"
     _notify(on_progress, step, "running")
-    _write_remote_config(
-        ssh, "/etc/apt/apt.conf.d/50unattended-upgrades", UNATTENDED_UPGRADES_CONF, step=step
+    changed = _write_remote_config(
+        ssh, "/etc/apt/apt.conf.d/51unattended-upgrades-dango", UNATTENDED_UPGRADES_CONF, step=step
     )
+    # Always enable+start (idempotent)
     _run_checked(
         ssh,
         "systemctl enable unattended-upgrades && systemctl start unattended-upgrades",
         step=step,
     )
-    result.steps_completed.append(step)
-    _notify(on_progress, step, "done")
+    _mark(result, on_progress, step, changed)
 
 
 # ---------------------------------------------------------------------------
 # Public orchestrator
 # ---------------------------------------------------------------------------
 
-# Ordered list of (step_function, step_name) for the setup sequence.
+# Ordered list of step functions for the setup sequence.
 _SETUP_STEPS: list[
-    tuple[
-        Callable[
-            [SSHManager, SetupResult, Callable[[str, str], None] | None],
-            None,
-        ],
-        str,
+    Callable[
+        [SSHManager, SetupResult, Callable[[str, str], None] | None],
+        None,
     ]
 ] = [
-    (_setup_apt_packages, "apt_packages"),
-    (_setup_dango_user, "create_user"),
-    (_setup_docker, "install_docker"),
-    (_setup_docker_group, "docker_group"),
-    (_setup_caddy, "install_caddy"),
-    (_setup_directories, "directories"),
-    (_setup_venv, "python_venv"),
-    (_setup_ssh_hardening, "ssh_hardening"),
-    (_setup_ssh_key_copy, "ssh_key_copy"),
-    (_setup_docker_daemon, "docker_daemon"),
-    (_setup_journald, "journald"),
-    (_setup_logrotate, "logrotate"),
-    (_setup_systemd_unit, "systemd_unit"),
-    (_setup_caddyfile, "caddyfile"),
-    (_setup_fail2ban, "fail2ban"),
-    (_setup_unattended_upgrades, "unattended_upgrades"),
+    _setup_apt_packages,
+    _setup_dango_user,
+    _setup_docker,
+    _setup_docker_group,
+    _setup_caddy,
+    _setup_directories,
+    _setup_venv,
+    _setup_ssh_hardening,
+    _setup_ssh_key_copy,
+    _setup_docker_daemon,
+    _setup_journald,
+    _setup_logrotate,
+    _setup_systemd_unit,
+    _setup_caddyfile,
+    _setup_fail2ban,
+    _setup_unattended_upgrades,
 ]
 
 
@@ -478,7 +489,7 @@ def setup_server(
     """
     result = SetupResult()
 
-    for step_fn, _step_name in _SETUP_STEPS:
+    for step_fn in _SETUP_STEPS:
         step_fn(ssh, result, on_progress)
 
     return result

--- a/dango/platform/cloud/spaces.py
+++ b/dango/platform/cloud/spaces.py
@@ -2,9 +2,9 @@
 
 DigitalOcean Spaces client for Dango cloud backups.
 
-DO Spaces is S3-compatible; this client uses ``boto3`` (optional dependency,
-``pip install getdango[cloud]``) to interact with it.  boto3 is lazy-imported
-so the core package can be installed without the cloud extras.
+DO Spaces is S3-compatible; this client uses ``boto3`` (core dependency,
+``pip install getdango``) to interact with it.  boto3 is lazy-imported
+to keep CLI startup fast.
 
 Authentication
 --------------
@@ -22,7 +22,7 @@ from typing import IO, Any
 from dango.exceptions import CloudAuthError, CloudError
 
 # boto3 / botocore are imported lazily inside _get_client().
-# This keeps the core package importable without the [cloud] extra.
+# Lazy-imported to keep CLI startup fast.
 
 
 class SpacesClient:
@@ -92,7 +92,7 @@ class SpacesClient:
             import boto3  # type: ignore[import]
         except ImportError:
             raise CloudError(
-                "boto3 is required for Spaces operations. Install with: pip install getdango[cloud]"
+                "boto3 is required for Spaces operations. Reinstall with: pip install getdango"
             ) from None
 
         endpoint = f"https://{self.region}.digitaloceanspaces.com"

--- a/dango/platform/cloud/ssh.py
+++ b/dango/platform/cloud/ssh.py
@@ -6,8 +6,8 @@ Provides Ed25519 key generation, SSH connections via paramiko, command
 execution, SFTP file transfer, and Trust-On-First-Use (TOFU) known hosts
 management.
 
-paramiko is an optional dependency (``pip install getdango[cloud]``) and is
-lazy-imported so the core package can be installed without the cloud extras.
+paramiko is a core dependency (``pip install getdango``) and is lazy-imported
+to keep CLI startup fast.
 
 Authentication
 --------------
@@ -59,7 +59,7 @@ def _ensure_paramiko() -> Any:
         return _paramiko
     except ImportError:
         raise CloudError(
-            "paramiko is required for SSH operations. Install with: pip install getdango[cloud]"
+            "paramiko is required for SSH operations. Reinstall with: pip install getdango"
         ) from None
 
 

--- a/dango/templates/CLAUDE.md
+++ b/dango/templates/CLAUDE.md
@@ -41,6 +41,10 @@ Jinja2 templates and Dockerfiles used by CLI project scaffolding and dbt model g
 - **Integration:** `dango init` in a temp directory, verify generated files
 - **Manual:** Inspect generated `docker-compose.yml` and dbt models after `dango init` + `dango sync`
 
+## Notes
+
+- **Cloud server config templates** (systemd unit, Caddyfile, fail2ban, etc.) are NOT in this directory. They are embedded as string constants in `platform/cloud/_server_templates.py` because they are not Jinja2 templates — they are plain config files written verbatim to the remote host.
+
 ## Don't Modify
 
 | File | Reason |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,7 @@ module = [
     "tests.unit.test_firewall",
     "tests.unit.test_remote_cli",
     "tests.unit.test_server_setup",
+    "tests.unit.test_serve_command",
 ]
 ignore_errors = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ dependencies = [
     "google-api-python-client>=2.100.0",  # Google Sheets API
     "google-auth-oauthlib>=1.0.0",        # OAuth for Google services
     "google-auth>=2.22.0",                # Google authentication
+
+    # Cloud deployment
+    "boto3>=1.34.0",      # DigitalOcean Spaces (S3-compatible)
+    "paramiko>=3.0.0",    # SSH key management and remote execution
 ]
 
 [project.optional-dependencies]
@@ -80,11 +84,6 @@ dev = [
     "pre-commit>=3.6.0",
     "pip-audit>=2.7.0",
 ]
-cloud = [
-    "boto3>=1.34.0",
-    "paramiko>=3.0.0",
-]
-
 # Note: dlt distributes sources via `dlt init <source>`, not pip extras.
 # dlt's pip extras are for DESTINATIONS (duckdb, bigquery, etc.) and infrastructure.
 # Source code is bundled in dango/ingestion/dlt_sources/ with all necessary dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ module = [
     "tests.unit.test_provisioning",
     "tests.unit.test_firewall",
     "tests.unit.test_remote_cli",
+    "tests.unit.test_server_setup",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_serve_command.py
+++ b/tests/unit/test_serve_command.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -20,6 +21,7 @@ from dango.cli.commands.serve import serve
 _UTILS = "dango.cli.utils"
 _CONFIG = "dango.config"
 _STARTUP = "dango.platform.common.startup"
+_SERVE = "dango.cli.commands.serve"
 
 
 def _make_config_mock(port: int = 8800) -> MagicMock:
@@ -41,6 +43,7 @@ def _make_config_mock(port: int = 8800) -> MagicMock:
 @pytest.mark.unit
 class TestServeHappyPath:
     @patch("uvicorn.run")
+    @patch(f"{_SERVE}._check_port")
     @patch(f"{_STARTUP}.import_dashboards")
     @patch(f"{_STARTUP}.setup_metabase_if_needed")
     @patch(f"{_STARTUP}.start_docker_services")
@@ -59,6 +62,7 @@ class TestServeHappyPath:
         mock_docker,
         mock_metabase,
         mock_dashboards,
+        mock_check_port,
         mock_uvicorn_run,
         tmp_path,
     ):
@@ -76,11 +80,13 @@ class TestServeHappyPath:
         mock_docker.assert_called_once_with(tmp_path)
         mock_metabase.assert_called_once_with(tmp_path, "test-project", None)
         mock_dashboards.assert_called_once_with(tmp_path)
+        mock_check_port.assert_called_once_with(8800)
         mock_uvicorn_run.assert_called_once_with(
             "dango.web.app:app", host="0.0.0.0", port=8800, log_level="info"
         )
 
     @patch("uvicorn.run")
+    @patch(f"{_SERVE}._check_port")
     @patch(f"{_STARTUP}.import_dashboards")
     @patch(f"{_STARTUP}.setup_metabase_if_needed")
     @patch(f"{_STARTUP}.start_docker_services")
@@ -99,6 +105,7 @@ class TestServeHappyPath:
         mock_docker,
         mock_metabase,
         mock_dashboards,
+        mock_check_port,
         mock_uvicorn_run,
         tmp_path,
     ):
@@ -110,11 +117,13 @@ class TestServeHappyPath:
         result = runner.invoke(serve, ["--port", "9000"], obj={})
 
         assert result.exit_code == 0, result.output
+        mock_check_port.assert_called_once_with(9000)
         mock_uvicorn_run.assert_called_once_with(
             "dango.web.app:app", host="0.0.0.0", port=9000, log_level="info"
         )
 
     @patch("uvicorn.run")
+    @patch(f"{_SERVE}._check_port")
     @patch(f"{_STARTUP}.import_dashboards")
     @patch(f"{_STARTUP}.setup_metabase_if_needed")
     @patch(f"{_STARTUP}.start_docker_services")
@@ -133,6 +142,7 @@ class TestServeHappyPath:
         mock_docker,
         mock_metabase,
         mock_dashboards,
+        mock_check_port,
         mock_uvicorn_run,
         tmp_path,
     ):
@@ -156,6 +166,27 @@ class TestServeHappyPath:
 
 @pytest.mark.unit
 class TestServeFailures:
+    @patch(f"{_UTILS}.require_project_context", side_effect=click.Abort())
+    def test_project_context_abort_exits(self, mock_ctx):
+        """require_project_context abort causes SystemExit(1) (L4)."""
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 1
+
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_config_load_failure_exits(self, mock_ctx, mock_loader_cls, tmp_path):
+        """Config load failure causes clean exit (M6)."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.side_effect = RuntimeError("bad config")
+
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 1
+        assert "Failed to load project config" in result.output
+
     @patch(f"{_STARTUP}.run_pending_migrations", side_effect=RuntimeError("migration err"))
     @patch(f"{_CONFIG}.ConfigLoader")
     @patch(f"{_UTILS}.require_project_context")
@@ -169,6 +200,41 @@ class TestServeFailures:
 
         assert result.exit_code == 1
         assert "Migration failed" in result.output
+
+    @patch(f"{_STARTUP}.ensure_dbt_schemas", side_effect=RuntimeError("schema err"))
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_schema_failure_exits(
+        self, mock_ctx, mock_loader_cls, mock_migrate, mock_schemas, tmp_path
+    ):
+        """Schema setup failure causes SystemExit(1) (L4)."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 1
+        assert "Schema setup failed" in result.output
+
+    @patch(f"{_STARTUP}.ensure_duckdb_driver", side_effect=RuntimeError("driver err"))
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_duckdb_driver_failure_exits(
+        self, mock_ctx, mock_loader_cls, mock_migrate, mock_schemas, mock_driver, tmp_path
+    ):
+        """DuckDB driver failure causes SystemExit(1) (L4)."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 1
+        assert "DuckDB driver download failed" in result.output
 
     @patch(f"{_STARTUP}.start_docker_services", side_effect=RuntimeError("docker err"))
     @patch(f"{_STARTUP}.ensure_duckdb_driver")
@@ -190,7 +256,7 @@ class TestServeFailures:
         mock_ctx.return_value = tmp_path
         mock_loader_cls.return_value = _make_config_mock()
 
-        with patch("dango.cli.commands.serve._stop_docker_quiet") as mock_stop:
+        with patch(f"{_SERVE}._stop_docker_quiet") as mock_stop:
             runner = CliRunner()
             result = runner.invoke(serve, [], obj={})
 
@@ -220,7 +286,7 @@ class TestServeFailures:
         mock_ctx.return_value = tmp_path
         mock_loader_cls.return_value = _make_config_mock()
 
-        with patch("dango.cli.commands.serve._stop_docker_quiet") as mock_stop:
+        with patch(f"{_SERVE}._stop_docker_quiet") as mock_stop:
             runner = CliRunner()
             result = runner.invoke(serve, [], obj={})
 
@@ -229,6 +295,7 @@ class TestServeFailures:
             mock_stop.assert_called_once()
 
     @patch("uvicorn.run")
+    @patch(f"{_SERVE}._check_port")
     @patch(f"{_STARTUP}.import_dashboards", side_effect=RuntimeError("dashboard err"))
     @patch(f"{_STARTUP}.setup_metabase_if_needed")
     @patch(f"{_STARTUP}.start_docker_services")
@@ -247,6 +314,7 @@ class TestServeFailures:
         mock_docker,
         mock_metabase,
         mock_dashboards,
+        mock_check_port,
         mock_uvicorn_run,
         tmp_path,
     ):
@@ -259,3 +327,69 @@ class TestServeFailures:
 
         assert result.exit_code == 0, result.output
         mock_uvicorn_run.assert_called_once()
+
+    @patch(f"{_SERVE}._check_port", side_effect=SystemExit(1))
+    @patch(f"{_STARTUP}.import_dashboards")
+    @patch(f"{_STARTUP}.setup_metabase_if_needed")
+    @patch(f"{_STARTUP}.start_docker_services")
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_port_in_use_exits(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        mock_metabase,
+        mock_dashboards,
+        mock_check_port,
+        tmp_path,
+    ):
+        """Port in use causes clean exit (H4)."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 1
+
+    @patch("uvicorn.run", side_effect=RuntimeError("bind failed"))
+    @patch(f"{_SERVE}._check_port")
+    @patch(f"{_STARTUP}.import_dashboards")
+    @patch(f"{_STARTUP}.setup_metabase_if_needed")
+    @patch(f"{_STARTUP}.start_docker_services")
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_uvicorn_failure_stops_docker(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        mock_metabase,
+        mock_dashboards,
+        mock_check_port,
+        mock_uvicorn_run,
+        tmp_path,
+    ):
+        """uvicorn failure triggers Docker cleanup (H3)."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        with patch(f"{_SERVE}._stop_docker_quiet") as mock_stop:
+            runner = CliRunner()
+            result = runner.invoke(serve, [], obj={})
+
+            assert result.exit_code != 0
+            mock_stop.assert_called_once()

--- a/tests/unit/test_serve_command.py
+++ b/tests/unit/test_serve_command.py
@@ -1,0 +1,261 @@
+"""tests/unit/test_serve_command.py
+
+Unit tests for the ``dango serve`` CLI command
+(dango/cli/commands/serve.py).
+
+All startup helpers are mocked — no Docker, Metabase, or network calls.
+Patches target origin modules because serve.py uses lazy imports.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.serve import serve
+
+# Patch targets — lazy imports mean we patch at origin, not at consumption site.
+_UTILS = "dango.cli.utils"
+_CONFIG = "dango.config"
+_STARTUP = "dango.platform.common.startup"
+
+
+def _make_config_mock(port: int = 8800) -> MagicMock:
+    """Return a mock ConfigLoader whose load_config() returns a config with the given port."""
+    config = MagicMock()
+    config.project.name = "test-project"
+    config.project.organization = None
+    config.platform.port = port
+    loader = MagicMock()
+    loader.load_config.return_value = config
+    return loader
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestServeHappyPath:
+    @patch("uvicorn.run")
+    @patch(f"{_STARTUP}.import_dashboards")
+    @patch(f"{_STARTUP}.setup_metabase_if_needed")
+    @patch(f"{_STARTUP}.start_docker_services")
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_all_helpers_called(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        mock_metabase,
+        mock_dashboards,
+        mock_uvicorn_run,
+        tmp_path,
+    ):
+        """All startup helpers are called in order, uvicorn runs."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock(port=8800)
+
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        mock_migrate.assert_called_once_with(tmp_path)
+        mock_schemas.assert_called_once_with(tmp_path)
+        mock_driver.assert_called_once_with(tmp_path)
+        mock_docker.assert_called_once_with(tmp_path)
+        mock_metabase.assert_called_once_with(tmp_path, "test-project", None)
+        mock_dashboards.assert_called_once_with(tmp_path)
+        mock_uvicorn_run.assert_called_once_with(
+            "dango.web.app:app", host="0.0.0.0", port=8800, log_level="info"
+        )
+
+    @patch("uvicorn.run")
+    @patch(f"{_STARTUP}.import_dashboards")
+    @patch(f"{_STARTUP}.setup_metabase_if_needed")
+    @patch(f"{_STARTUP}.start_docker_services")
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_cli_port_overrides_config(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        mock_metabase,
+        mock_dashboards,
+        mock_uvicorn_run,
+        tmp_path,
+    ):
+        """--port CLI flag overrides config port."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock(port=8800)
+
+        runner = CliRunner()
+        result = runner.invoke(serve, ["--port", "9000"], obj={})
+
+        assert result.exit_code == 0, result.output
+        mock_uvicorn_run.assert_called_once_with(
+            "dango.web.app:app", host="0.0.0.0", port=9000, log_level="info"
+        )
+
+    @patch("uvicorn.run")
+    @patch(f"{_STARTUP}.import_dashboards")
+    @patch(f"{_STARTUP}.setup_metabase_if_needed")
+    @patch(f"{_STARTUP}.start_docker_services")
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_host_option(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        mock_metabase,
+        mock_dashboards,
+        mock_uvicorn_run,
+        tmp_path,
+    ):
+        """--host CLI flag is passed to uvicorn."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(serve, ["--host", "127.0.0.1"], obj={})
+
+        assert result.exit_code == 0, result.output
+        mock_uvicorn_run.assert_called_once_with(
+            "dango.web.app:app", host="127.0.0.1", port=8800, log_level="info"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestServeFailures:
+    @patch(f"{_STARTUP}.run_pending_migrations", side_effect=RuntimeError("migration err"))
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_migration_failure_exits(self, mock_ctx, mock_loader_cls, mock_migrate, tmp_path):
+        """Migration failure causes SystemExit(1)."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 1
+        assert "Migration failed" in result.output
+
+    @patch(f"{_STARTUP}.start_docker_services", side_effect=RuntimeError("docker err"))
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_docker_failure_stops_and_exits(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        tmp_path,
+    ):
+        """Docker failure stops Docker services and exits."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        with patch("dango.cli.commands.serve._stop_docker_quiet") as mock_stop:
+            runner = CliRunner()
+            result = runner.invoke(serve, [], obj={})
+
+            assert result.exit_code == 1
+            assert "Docker services failed" in result.output
+            mock_stop.assert_called_once()
+
+    @patch(f"{_STARTUP}.setup_metabase_if_needed", side_effect=RuntimeError("metabase err"))
+    @patch(f"{_STARTUP}.start_docker_services")
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_metabase_failure_stops_and_exits(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        mock_metabase,
+        tmp_path,
+    ):
+        """Metabase failure stops Docker services and exits."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        with patch("dango.cli.commands.serve._stop_docker_quiet") as mock_stop:
+            runner = CliRunner()
+            result = runner.invoke(serve, [], obj={})
+
+            assert result.exit_code == 1
+            assert "Metabase setup failed" in result.output
+            mock_stop.assert_called_once()
+
+    @patch("uvicorn.run")
+    @patch(f"{_STARTUP}.import_dashboards", side_effect=RuntimeError("dashboard err"))
+    @patch(f"{_STARTUP}.setup_metabase_if_needed")
+    @patch(f"{_STARTUP}.start_docker_services")
+    @patch(f"{_STARTUP}.ensure_duckdb_driver")
+    @patch(f"{_STARTUP}.ensure_dbt_schemas")
+    @patch(f"{_STARTUP}.run_pending_migrations", return_value={})
+    @patch(f"{_CONFIG}.ConfigLoader")
+    @patch(f"{_UTILS}.require_project_context")
+    def test_dashboard_failure_non_critical(
+        self,
+        mock_ctx,
+        mock_loader_cls,
+        mock_migrate,
+        mock_schemas,
+        mock_driver,
+        mock_docker,
+        mock_metabase,
+        mock_dashboards,
+        mock_uvicorn_run,
+        tmp_path,
+    ):
+        """Dashboard import failure is swallowed — server still starts."""
+        mock_ctx.return_value = tmp_path
+        mock_loader_cls.return_value = _make_config_mock()
+
+        runner = CliRunner()
+        result = runner.invoke(serve, [], obj={})
+
+        assert result.exit_code == 0, result.output
+        mock_uvicorn_run.assert_called_once()

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -19,6 +19,26 @@ from dango.exceptions import CloudProvisioningError
 # Helpers
 # ---------------------------------------------------------------------------
 
+# All 16 step names, in the order they must execute.
+_ALL_STEP_NAMES = [
+    "apt_packages",
+    "create_user",
+    "install_docker",
+    "docker_group",
+    "install_caddy",
+    "directories",
+    "python_venv",
+    "ssh_hardening",
+    "ssh_key_copy",
+    "docker_daemon",
+    "journald",
+    "logrotate",
+    "systemd_unit",
+    "caddyfile",
+    "fail2ban",
+    "unattended_upgrades",
+]
+
 
 def _make_ssh_mock(
     *,
@@ -27,7 +47,7 @@ def _make_ssh_mock(
     """Return a mock SSHManager with configurable exec_command results.
 
     Args:
-        exec_results: Map of command substring → (stdout, stderr, exit_code).
+        exec_results: Map of command substring -> (stdout, stderr, exit_code).
             If a command matches multiple substrings, the first match wins.
             Commands not matched default to success ("", "", 0).
     """
@@ -72,30 +92,41 @@ class TestSetupResult:
 @pytest.mark.unit
 class TestSetupServer:
     def test_all_steps_complete(self):
-        """setup_server() runs all steps when nothing is pre-installed."""
+        """setup_server() runs all 16 steps when nothing is pre-installed."""
         from dango.platform.cloud.server_setup import setup_server
 
-        # Docker and Caddy not installed, user doesn't exist
+        # Docker/Caddy not installed, user doesn't exist, venv doesn't exist
         ssh = _make_ssh_mock(
             exec_results={
                 "id -u dango": ("", "no such user", 1),
                 "docker --version": ("", "", 1),
                 "caddy version": ("", "", 1),
+                "test -x /srv/dango/venv/bin/dango": ("", "", 1),
+                # cat for config files returns not-found (triggers write)
+                "cat /etc/docker/daemon.json": ("", "No such file", 1),
+                "cat /etc/systemd/journald.conf.d/dango.conf": ("", "", 1),
+                "cat /etc/logrotate.d/dango": ("", "", 1),
+                "cat /etc/systemd/system/dango-web.service": ("", "", 1),
+                "cat /etc/caddy/Caddyfile": ("", "", 1),
+                "cat /etc/fail2ban/jail.local": ("", "", 1),
+                "cat /etc/apt/apt.conf.d/51unattended-upgrades-dango": ("", "", 1),
             }
         )
 
         result = setup_server(ssh)
 
-        assert "apt_packages" in result.steps_completed
-        assert "create_user" in result.steps_completed
-        assert "install_docker" in result.steps_completed
-        assert "install_caddy" in result.steps_completed
-        assert "systemd_unit" in result.steps_completed
-        assert "caddyfile" in result.steps_completed
+        # L1: Verify ALL 16 steps are accounted for
+        total = len(result.steps_completed) + len(result.steps_skipped)
+        assert total == 16, (
+            f"Expected 16 steps, got {total}: "
+            f"completed={result.steps_completed}, skipped={result.steps_skipped}"
+        )
         assert len(result.steps_skipped) == 0
+        for name in _ALL_STEP_NAMES:
+            assert name in result.steps_completed, f"Step '{name}' missing from completed"
 
     def test_idempotent_skips(self):
-        """Docker, Caddy, and user are skipped when already present."""
+        """Docker, Caddy, user, and venv are skipped when already present."""
         from dango.platform.cloud.server_setup import setup_server
 
         ssh = _make_ssh_mock(
@@ -103,6 +134,15 @@ class TestSetupServer:
                 "id -u dango": ("1001", "", 0),
                 "docker --version": ("Docker version 24.0", "", 0),
                 "caddy version": ("v2.7.5", "", 0),
+                "test -x /srv/dango/venv/bin/dango": ("", "", 0),
+                # Config files return "not found" so they still get written
+                "cat /etc/docker/daemon.json": ("", "", 1),
+                "cat /etc/systemd/journald.conf.d/dango.conf": ("", "", 1),
+                "cat /etc/logrotate.d/dango": ("", "", 1),
+                "cat /etc/systemd/system/dango-web.service": ("", "", 1),
+                "cat /etc/caddy/Caddyfile": ("", "", 1),
+                "cat /etc/fail2ban/jail.local": ("", "", 1),
+                "cat /etc/apt/apt.conf.d/51unattended-upgrades-dango": ("", "", 1),
             }
         )
 
@@ -111,9 +151,40 @@ class TestSetupServer:
         assert "create_user" in result.steps_skipped
         assert "install_docker" in result.steps_skipped
         assert "install_caddy" in result.steps_skipped
+        assert "python_venv" in result.steps_skipped
         # Steps that always run should still be completed
         assert "apt_packages" in result.steps_completed
         assert "directories" in result.steps_completed
+        # L1: total must still be 16
+        total = len(result.steps_completed) + len(result.steps_skipped)
+        assert total == 16
+
+    def test_step_ordering(self):
+        """Steps execute in the correct order (L3)."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "id -u dango": ("", "", 1),
+                "docker --version": ("", "", 1),
+                "caddy version": ("", "", 1),
+                "test -x /srv/dango/venv/bin/dango": ("", "", 1),
+                "cat /etc/docker/daemon.json": ("", "", 1),
+                "cat /etc/systemd/journald.conf.d/dango.conf": ("", "", 1),
+                "cat /etc/logrotate.d/dango": ("", "", 1),
+                "cat /etc/systemd/system/dango-web.service": ("", "", 1),
+                "cat /etc/caddy/Caddyfile": ("", "", 1),
+                "cat /etc/fail2ban/jail.local": ("", "", 1),
+                "cat /etc/apt/apt.conf.d/51unattended-upgrades-dango": ("", "", 1),
+            }
+        )
+        progress_calls: list[tuple[str, str]] = []
+
+        setup_server(ssh, on_progress=lambda s, st: progress_calls.append((s, st)))
+
+        # Extract step names in order (take "running" events to get execution order)
+        order = [s for s, st in progress_calls if st == "running"]
+        assert order == _ALL_STEP_NAMES
 
     def test_progress_callback(self):
         """on_progress is called with (step, status) for each step."""
@@ -124,6 +195,13 @@ class TestSetupServer:
                 "id -u dango": ("1001", "", 0),
                 "docker --version": ("Docker version 24.0", "", 0),
                 "caddy version": ("v2.7.5", "", 0),
+                "cat /etc/docker/daemon.json": ("", "", 1),
+                "cat /etc/systemd/journald.conf.d/dango.conf": ("", "", 1),
+                "cat /etc/logrotate.d/dango": ("", "", 1),
+                "cat /etc/systemd/system/dango-web.service": ("", "", 1),
+                "cat /etc/caddy/Caddyfile": ("", "", 1),
+                "cat /etc/fail2ban/jail.local": ("", "", 1),
+                "cat /etc/apt/apt.conf.d/51unattended-upgrades-dango": ("", "", 1),
             }
         )
         progress_calls: list[tuple[str, str]] = []
@@ -219,8 +297,18 @@ class TestSetupSteps:
 
         assert "install_caddy" in result.steps_skipped
 
+    def test_venv_skipped_when_installed(self):
+        """Venv step skipped when /srv/dango/venv/bin/dango exists."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_venv
+
+        ssh = _make_ssh_mock(exec_results={"test -x /srv/dango/venv/bin/dango": ("", "", 0)})
+        result = SetupResult()
+        _setup_venv(ssh, result, None)
+
+        assert "python_venv" in result.steps_skipped
+
     def test_directories_creates_structure(self):
-        """Directory step creates /srv/dango structure."""
+        """Directory step creates /srv/dango structure including logs dir."""
         from dango.platform.cloud.server_setup import SetupResult, _setup_directories
 
         ssh = _make_ssh_mock()
@@ -228,25 +316,27 @@ class TestSetupSteps:
         _setup_directories(ssh, result, None)
 
         cmd = ssh.exec_command.call_args_list[0][0][0]
-        assert "/srv/dango/project/.dango" in cmd
+        assert "/srv/dango/project/.dango/logs" in cmd
         assert "/srv/dango/project/data" in cmd
         assert "chown -R dango:dango" in cmd
         assert "directories" in result.steps_completed
 
     def test_venv_installs_getdango(self):
-        """Venv step creates venv and installs getdango."""
+        """Venv step creates venv and installs getdango when not present."""
         from dango.platform.cloud.server_setup import SetupResult, _setup_venv
 
-        ssh = _make_ssh_mock()
+        ssh = _make_ssh_mock(exec_results={"test -x /srv/dango/venv/bin/dango": ("", "", 1)})
         result = SetupResult()
         _setup_venv(ssh, result, None)
 
-        cmd = ssh.exec_command.call_args_list[0][0][0]
-        assert "python3 -m venv" in cmd
-        assert "pip install getdango" in cmd
+        # Find the command that has python3 -m venv (skip the test -x check)
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        venv_cmds = [c for c in cmds if "python3 -m venv" in c]
+        assert len(venv_cmds) == 1
+        assert "pip install getdango" in venv_cmds[0]
 
     def test_ssh_hardening_disables_password(self):
-        """SSH hardening step disables password auth."""
+        """SSH hardening step disables password auth and KbdInteractive."""
         from dango.platform.cloud.server_setup import SetupResult, _setup_ssh_hardening
 
         ssh = _make_ssh_mock()
@@ -255,27 +345,34 @@ class TestSetupSteps:
 
         cmd = ssh.exec_command.call_args_list[0][0][0]
         assert "PasswordAuthentication no" in cmd
+        assert "KbdInteractiveAuthentication no" in cmd
         assert "systemctl reload sshd" in cmd
 
-    def test_systemd_unit_content(self):
-        """Systemd unit file contains correct paths and settings."""
+    def test_systemd_unit_writes_correct_content(self):
+        """Systemd unit writes template content to remote file (L2)."""
         from dango.platform.cloud._server_templates import SYSTEMD_UNIT
         from dango.platform.cloud.server_setup import SetupResult, _setup_systemd_unit
 
-        ssh = _make_ssh_mock()
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /etc/systemd/system/dango-web.service": ("", "", 1),
+            }
+        )
         result = SetupResult()
         _setup_systemd_unit(ssh, result, None)
 
-        assert "WorkingDirectory=/srv/dango/project" in SYSTEMD_UNIT
-        assert "DLT_DATA_DIR=/srv/dango/project/.dlt" in SYSTEMD_UNIT
-        assert "/srv/dango/venv/bin/dango serve" in SYSTEMD_UNIT
-        assert "User=dango" in SYSTEMD_UNIT
+        # L2: Verify write_remote_file was called with the actual template
+        ssh.write_remote_file.assert_called_once()
+        written_path, written_content = ssh.write_remote_file.call_args[0]
+        assert written_path == "/etc/systemd/system/dango-web.service"
+        assert written_content == SYSTEMD_UNIT
+        assert "WorkingDirectory=/srv/dango/project" in written_content
+        assert "/srv/dango/venv/bin/dango serve" in written_content
 
         # Verify daemon-reload + enable (not start)
         cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
         enable_cmd = [c for c in cmds if "systemctl" in c and "enable" in c]
         assert len(enable_cmd) > 0
-        # Should NOT start the service
         start_cmds = [c for c in cmds if "systemctl start dango-web" in c]
         assert len(start_cmds) == 0
 
@@ -294,11 +391,29 @@ class TestSetupSteps:
         assert "10m" in DOCKER_DAEMON_JSON
 
     def test_fail2ban_config(self):
-        """Fail2ban config has sshd jail."""
+        """Fail2ban config has sshd jail with systemd backend."""
         from dango.platform.cloud._server_templates import FAIL2BAN_JAIL
 
         assert "sshd" in FAIL2BAN_JAIL
         assert "maxretry = 5" in FAIL2BAN_JAIL
+        assert "backend = systemd" in FAIL2BAN_JAIL
+
+    def test_config_steps_skip_when_unchanged(self):
+        """Config-writing steps skip when file content matches (M3)."""
+        from dango.platform.cloud._server_templates import DOCKER_DAEMON_JSON
+        from dango.platform.cloud.server_setup import SetupResult, _setup_docker_daemon
+
+        # Return the exact config content from cat -> skips write
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /etc/docker/daemon.json": (DOCKER_DAEMON_JSON, "", 0),
+            }
+        )
+        result = SetupResult()
+        _setup_docker_daemon(ssh, result, None)
+
+        assert "docker_daemon" in result.steps_skipped
+        ssh.write_remote_file.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -324,21 +439,28 @@ class TestHelpers:
         with pytest.raises(CloudProvisioningError, match="test_step"):
             _run_checked(ssh, "bad command", step="test_step")
 
-    def test_write_remote_config(self):
+    def test_write_remote_config_creates_and_writes(self):
         """_write_remote_config creates parent dir and writes file."""
         from dango.platform.cloud.server_setup import _write_remote_config
 
-        ssh = _make_ssh_mock()
-        _write_remote_config(
-            ssh,
-            "/etc/caddy/Caddyfile",
-            "content",
-            step="test",
-            mode=0o644,
+        ssh = _make_ssh_mock(exec_results={"cat /etc/caddy/Caddyfile": ("", "", 1)})
+        changed = _write_remote_config(
+            ssh, "/etc/caddy/Caddyfile", "content", step="test", mode=0o644
         )
 
-        # Should have called mkdir -p for parent
+        assert changed is True
         cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
         assert any("/etc/caddy" in cmd for cmd in cmds)
-        # Should have called write_remote_file
         ssh.write_remote_file.assert_called_once_with("/etc/caddy/Caddyfile", "content", mode=0o644)
+
+    def test_write_remote_config_skips_when_unchanged(self):
+        """_write_remote_config returns False when content matches."""
+        from dango.platform.cloud.server_setup import _write_remote_config
+
+        ssh = _make_ssh_mock(exec_results={"cat /etc/caddy/Caddyfile": ("content", "", 0)})
+        changed = _write_remote_config(
+            ssh, "/etc/caddy/Caddyfile", "content", step="test", mode=0o644
+        )
+
+        assert changed is False
+        ssh.write_remote_file.assert_not_called()

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -1,0 +1,344 @@
+"""tests/unit/test_server_setup.py
+
+Unit tests for SSH-based server setup orchestration
+(dango/platform/cloud/server_setup.py).
+
+Mocks SSHManager.exec_command() and write_remote_file() to verify each
+setup step calls the correct commands and handles idempotency.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dango.exceptions import CloudProvisioningError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ssh_mock(
+    *,
+    exec_results: dict[str, tuple[str, str, int]] | None = None,
+) -> MagicMock:
+    """Return a mock SSHManager with configurable exec_command results.
+
+    Args:
+        exec_results: Map of command substring → (stdout, stderr, exit_code).
+            If a command matches multiple substrings, the first match wins.
+            Commands not matched default to success ("", "", 0).
+    """
+    from dango.platform.cloud.ssh import CommandResult
+
+    results = exec_results or {}
+
+    def _exec_side_effect(command, timeout=None):
+        for substr, (stdout, stderr, exit_code) in results.items():
+            if substr in command:
+                return CommandResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    ssh = MagicMock()
+    ssh.exec_command.side_effect = _exec_side_effect
+    ssh.write_remote_file = MagicMock()
+    return ssh
+
+
+# ---------------------------------------------------------------------------
+# 1. SetupResult
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetupResult:
+    def test_defaults(self):
+        """SetupResult initialises with empty lists."""
+        from dango.platform.cloud.server_setup import SetupResult
+
+        result = SetupResult()
+        assert result.steps_completed == []
+        assert result.steps_skipped == []
+        assert result.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Full orchestrator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetupServer:
+    def test_all_steps_complete(self):
+        """setup_server() runs all steps when nothing is pre-installed."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        # Docker and Caddy not installed, user doesn't exist
+        ssh = _make_ssh_mock(
+            exec_results={
+                "id -u dango": ("", "no such user", 1),
+                "docker --version": ("", "", 1),
+                "caddy version": ("", "", 1),
+            }
+        )
+
+        result = setup_server(ssh)
+
+        assert "apt_packages" in result.steps_completed
+        assert "create_user" in result.steps_completed
+        assert "install_docker" in result.steps_completed
+        assert "install_caddy" in result.steps_completed
+        assert "systemd_unit" in result.steps_completed
+        assert "caddyfile" in result.steps_completed
+        assert len(result.steps_skipped) == 0
+
+    def test_idempotent_skips(self):
+        """Docker, Caddy, and user are skipped when already present."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "id -u dango": ("1001", "", 0),
+                "docker --version": ("Docker version 24.0", "", 0),
+                "caddy version": ("v2.7.5", "", 0),
+            }
+        )
+
+        result = setup_server(ssh)
+
+        assert "create_user" in result.steps_skipped
+        assert "install_docker" in result.steps_skipped
+        assert "install_caddy" in result.steps_skipped
+        # Steps that always run should still be completed
+        assert "apt_packages" in result.steps_completed
+        assert "directories" in result.steps_completed
+
+    def test_progress_callback(self):
+        """on_progress is called with (step, status) for each step."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "id -u dango": ("1001", "", 0),
+                "docker --version": ("Docker version 24.0", "", 0),
+                "caddy version": ("v2.7.5", "", 0),
+            }
+        )
+        progress_calls: list[tuple[str, str]] = []
+
+        def on_progress(step: str, status: str) -> None:
+            progress_calls.append((step, status))
+
+        setup_server(ssh, on_progress=on_progress)
+
+        # Every step should have at least "running" then "done" or "skipped"
+        step_names = [c[0] for c in progress_calls]
+        assert "apt_packages" in step_names
+        assert "create_user" in step_names
+        # Skipped steps should show running then skipped
+        assert ("create_user", "running") in progress_calls
+        assert ("create_user", "skipped") in progress_calls
+
+    def test_failure_raises_provisioning_error(self):
+        """A failing step raises CloudProvisioningError."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "apt-get update": ("", "apt lock held", 100),
+            }
+        )
+
+        with pytest.raises(CloudProvisioningError, match="apt_packages"):
+            setup_server(ssh)
+
+
+# ---------------------------------------------------------------------------
+# 3. Individual step tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetupSteps:
+    def test_apt_packages_runs_install(self):
+        """apt step runs update + install."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_apt_packages
+
+        ssh = _make_ssh_mock()
+        result = SetupResult()
+        _setup_apt_packages(ssh, result, None)
+
+        cmd = ssh.exec_command.call_args_list[0][0][0]
+        assert "apt-get update" in cmd
+        assert "apt-get install" in cmd
+        assert "fail2ban" in cmd
+        assert "apt_packages" in result.steps_completed
+
+    def test_dango_user_created(self):
+        """User step creates dango user when not present."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_dango_user
+
+        ssh = _make_ssh_mock(exec_results={"id -u dango": ("", "no such user", 1)})
+        result = SetupResult()
+        _setup_dango_user(ssh, result, None)
+
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        assert any("useradd" in cmd for cmd in cmds)
+        assert "create_user" in result.steps_completed
+
+    def test_dango_user_skipped(self):
+        """User step skipped when dango user exists."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_dango_user
+
+        ssh = _make_ssh_mock(exec_results={"id -u dango": ("1001", "", 0)})
+        result = SetupResult()
+        _setup_dango_user(ssh, result, None)
+
+        assert "create_user" in result.steps_skipped
+        assert "create_user" not in result.steps_completed
+
+    def test_docker_skipped_when_installed(self):
+        """Docker install skipped when docker is already available."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_docker
+
+        ssh = _make_ssh_mock(exec_results={"docker --version": ("Docker version 24.0", "", 0)})
+        result = SetupResult()
+        _setup_docker(ssh, result, None)
+
+        assert "install_docker" in result.steps_skipped
+
+    def test_caddy_skipped_when_installed(self):
+        """Caddy install skipped when caddy is already available."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_caddy
+
+        ssh = _make_ssh_mock(exec_results={"caddy version": ("v2.7.5", "", 0)})
+        result = SetupResult()
+        _setup_caddy(ssh, result, None)
+
+        assert "install_caddy" in result.steps_skipped
+
+    def test_directories_creates_structure(self):
+        """Directory step creates /srv/dango structure."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_directories
+
+        ssh = _make_ssh_mock()
+        result = SetupResult()
+        _setup_directories(ssh, result, None)
+
+        cmd = ssh.exec_command.call_args_list[0][0][0]
+        assert "/srv/dango/project/.dango" in cmd
+        assert "/srv/dango/project/data" in cmd
+        assert "chown -R dango:dango" in cmd
+        assert "directories" in result.steps_completed
+
+    def test_venv_installs_getdango(self):
+        """Venv step creates venv and installs getdango."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_venv
+
+        ssh = _make_ssh_mock()
+        result = SetupResult()
+        _setup_venv(ssh, result, None)
+
+        cmd = ssh.exec_command.call_args_list[0][0][0]
+        assert "python3 -m venv" in cmd
+        assert "pip install getdango" in cmd
+
+    def test_ssh_hardening_disables_password(self):
+        """SSH hardening step disables password auth."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_ssh_hardening
+
+        ssh = _make_ssh_mock()
+        result = SetupResult()
+        _setup_ssh_hardening(ssh, result, None)
+
+        cmd = ssh.exec_command.call_args_list[0][0][0]
+        assert "PasswordAuthentication no" in cmd
+        assert "systemctl reload sshd" in cmd
+
+    def test_systemd_unit_content(self):
+        """Systemd unit file contains correct paths and settings."""
+        from dango.platform.cloud._server_templates import SYSTEMD_UNIT
+        from dango.platform.cloud.server_setup import SetupResult, _setup_systemd_unit
+
+        ssh = _make_ssh_mock()
+        result = SetupResult()
+        _setup_systemd_unit(ssh, result, None)
+
+        assert "WorkingDirectory=/srv/dango/project" in SYSTEMD_UNIT
+        assert "DLT_DATA_DIR=/srv/dango/project/.dlt" in SYSTEMD_UNIT
+        assert "/srv/dango/venv/bin/dango serve" in SYSTEMD_UNIT
+        assert "User=dango" in SYSTEMD_UNIT
+
+        # Verify daemon-reload + enable (not start)
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        enable_cmd = [c for c in cmds if "systemctl" in c and "enable" in c]
+        assert len(enable_cmd) > 0
+        # Should NOT start the service
+        start_cmds = [c for c in cmds if "systemctl start dango-web" in c]
+        assert len(start_cmds) == 0
+
+    def test_caddyfile_content(self):
+        """Caddyfile has :80 reverse proxy to localhost:8800."""
+        from dango.platform.cloud._server_templates import CADDYFILE
+
+        assert ":80" in CADDYFILE
+        assert "reverse_proxy localhost:8800" in CADDYFILE
+
+    def test_docker_daemon_config(self):
+        """Docker daemon config has log rotation."""
+        from dango.platform.cloud._server_templates import DOCKER_DAEMON_JSON
+
+        assert "json-file" in DOCKER_DAEMON_JSON
+        assert "10m" in DOCKER_DAEMON_JSON
+
+    def test_fail2ban_config(self):
+        """Fail2ban config has sshd jail."""
+        from dango.platform.cloud._server_templates import FAIL2BAN_JAIL
+
+        assert "sshd" in FAIL2BAN_JAIL
+        assert "maxretry = 5" in FAIL2BAN_JAIL
+
+
+# ---------------------------------------------------------------------------
+# 4. Helper functions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHelpers:
+    def test_run_checked_success(self):
+        """_run_checked returns stdout on success."""
+        from dango.platform.cloud.server_setup import _run_checked
+
+        ssh = _make_ssh_mock(exec_results={"echo": ("hello\n", "", 0)})
+        result = _run_checked(ssh, "echo hello", step="test_step")
+        assert result == "hello\n"
+
+    def test_run_checked_failure(self):
+        """_run_checked raises CloudProvisioningError on non-zero exit."""
+        from dango.platform.cloud.server_setup import _run_checked
+
+        ssh = _make_ssh_mock(exec_results={"bad": ("", "error msg", 1)})
+        with pytest.raises(CloudProvisioningError, match="test_step"):
+            _run_checked(ssh, "bad command", step="test_step")
+
+    def test_write_remote_config(self):
+        """_write_remote_config creates parent dir and writes file."""
+        from dango.platform.cloud.server_setup import _write_remote_config
+
+        ssh = _make_ssh_mock()
+        _write_remote_config(
+            ssh,
+            "/etc/caddy/Caddyfile",
+            "content",
+            step="test",
+            mode=0o644,
+        )
+
+        # Should have called mkdir -p for parent
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        assert any("/etc/caddy" in cmd for cmd in cmds)
+        # Should have called write_remote_file
+        ssh.write_remote_file.assert_called_once_with("/etc/caddy/Caddyfile", "content", mode=0o644)

--- a/tests/unit/test_spaces_client.py
+++ b/tests/unit/test_spaces_client.py
@@ -2,8 +2,8 @@
 
 Unit tests for SpacesClient (dango/platform/cloud/spaces.py).
 
-boto3 is injected via sys.modules patching so these tests run without
-installing the [cloud] extra.  botocore.exceptions.ClientError is used
+boto3 is injected via sys.modules patching for test isolation (boto3 is a
+core dependency but lazy-imported at runtime).  botocore.exceptions.ClientError is used
 for the real exception class (botocore is a boto3 dependency, but it is also
 used directly to construct ClientError in tests).
 """

--- a/tests/unit/test_spaces_client.py
+++ b/tests/unit/test_spaces_client.py
@@ -149,7 +149,7 @@ class TestBoto3Missing:
         with patch.dict(sys.modules, {"boto3": None}):  # type: ignore[dict-item]
             # Force _s3_client to None so _get_client() runs
             client._s3_client = None
-            with pytest.raises(CloudError, match="pip install getdango\\[cloud\\]"):
+            with pytest.raises(CloudError, match="pip install getdango"):
                 client._get_client()
 
     def test_get_client_cached_after_first_call(self):

--- a/tests/unit/test_ssh_manager.py
+++ b/tests/unit/test_ssh_manager.py
@@ -3,8 +3,8 @@
 Unit tests for SSHManager key management, connection, and command execution
 (dango/platform/cloud/ssh.py).
 
-paramiko is injected via sys.modules patching — these tests run without
-installing the [cloud] extra.  Follows the same pattern as test_spaces_client.py.
+paramiko is injected via sys.modules patching for test isolation (paramiko
+is a core dependency but lazy-imported at runtime).
 """
 
 from __future__ import annotations

--- a/tests/unit/test_ssh_sftp.py
+++ b/tests/unit/test_ssh_sftp.py
@@ -3,8 +3,8 @@
 Unit tests for SSHManager SFTP operations, wait_for_ssh, known hosts
 policy, and error wrapping (dango/platform/cloud/ssh.py).
 
-paramiko is injected via sys.modules patching — these tests run without
-installing the [cloud] extra.
+paramiko is injected via sys.modules patching for test isolation (paramiko
+is a core dependency but lazy-imported at runtime).
 """
 
 from __future__ import annotations

--- a/tests/unit/test_ssh_sftp.py
+++ b/tests/unit/test_ssh_sftp.py
@@ -650,7 +650,7 @@ class TestErrorWrapping:
         import dango.platform.cloud.ssh as ssh_mod
 
         with patch.dict(sys.modules, {"paramiko": None}):  # type: ignore[dict-item]
-            with pytest.raises(CloudError, match="pip install getdango\\[cloud\\]"):
+            with pytest.raises(CloudError, match="pip install getdango"):
                 ssh_mod._ensure_paramiko()
 
     def test_paramiko_not_installed_reset_on_next_call(self):


### PR DESCRIPTION
## Summary

- **Move boto3/paramiko to main dependencies** — removes `[cloud]` optional extra entirely, updates error messages and tests
- **Add `CloudProvisioningError`** exception (`DANGO-D005`) for server setup failures
- **Add `server_setup.py`** — SSH-based server setup orchestration with 16 idempotent steps (apt packages, Docker, Caddy, systemd unit, fail2ban, etc.). Config templates extracted to `_server_templates.py`
- **Add `dango serve`** — production foreground server command for systemd. Runs all startup helpers (migrations, Docker, Metabase) then blocks on uvicorn. Binds 0.0.0.0, no file watcher, no browser open

## Test plan

- [x] 20 unit tests for `server_setup.py` (idempotency, progress callback, failure handling, config content)
- [x] 7 unit tests for `serve.py` (happy path, port/host override, failure paths)
- [x] Full unit suite: 1405 passed, 0 failed
- [x] Pre-commit: ruff, mypy, file sizes, headers, docstrings all pass
- [x] Verified: `dango serve --help`, `from dango.platform.cloud import setup_server, SetupResult`, `from dango.exceptions import CloudProvisioningError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)