### PR TITLE
Add Caddy HTTPS/domain management and cloud security fixes (TASK-027, TASK-102)

### DIFF
--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -5,13 +5,17 @@ Remote server management commands for Dango cloud deployments.
 Command hierarchy::
 
     dango remote (group)
-    └── firewall (subgroup)
-        ├── list       — Show current firewall rules
-        ├── allow-ip   — Restrict ports 80/443 to a specific IP
-        └── allow-all  — Revert ports 80/443 to public access
+    ├── firewall (subgroup)
+    │   ├── list       — Show current firewall rules
+    │   ├── allow-ip   — Restrict ports 80/443 to a specific IP
+    │   └── allow-all  — Revert ports 80/443 to public access
+    └── domain (subgroup)
+        ├── set        — Configure HTTPS with Let's Encrypt
+        └── remove     — Revert to IP-only HTTP
 
-All commands require an active cloud deployment (``droplet_id`` and
-``firewall_id`` set in ``.dango/cloud.yml``).
+All commands require an active cloud deployment (``droplet_id``
+set in ``.dango/cloud.yml``).  Firewall commands additionally
+require ``firewall_id``.
 """
 
 from __future__ import annotations
@@ -37,6 +41,8 @@ def remote(ctx: click.Context) -> None:
       dango remote firewall list        Show current firewall rules
       dango remote firewall allow-ip    Restrict web to a specific IP
       dango remote firewall allow-all   Revert web access to public
+      dango remote domain set DOMAIN    Configure HTTPS with Let's Encrypt
+      dango remote domain remove        Revert to IP-only HTTP
     """
     ctx.ensure_object(dict)
 
@@ -64,14 +70,16 @@ def firewall(ctx: click.Context) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _load_cloud_config_or_fail(ctx: click.Context) -> tuple[Any, str]:
-    """Load CloudConfig and return (config, firewall_id), or exit with an error.
+def _require_cloud_deployment(ctx: click.Context) -> tuple[Any, Path]:
+    """Load CloudConfig and return (config, project_root), or exit with an error.
+
+    Only requires ``droplet_id`` — does NOT check for ``firewall_id``.
 
     Returns:
-        Tuple of (CloudConfig, firewall_id string).
+        Tuple of (CloudConfig, project_root Path).
 
     Raises:
-        SystemExit: If no deployment or no firewall is configured.
+        SystemExit: If no cloud deployment is configured.
     """
     from dango.cli.utils import require_project_context
     from dango.config.loader import ConfigLoader
@@ -86,6 +94,22 @@ def _load_cloud_config_or_fail(ctx: click.Context) -> tuple[Any, str]:
             "Run [bold]dango deploy[/bold] to provision a server first."
         )
         raise SystemExit(1)
+
+    return cloud_cfg, project_root
+
+
+def _load_cloud_config_or_fail(ctx: click.Context) -> tuple[Any, str]:
+    """Load CloudConfig and return (config, firewall_id), or exit with an error.
+
+    Requires both ``droplet_id`` and ``firewall_id``.
+
+    Returns:
+        Tuple of (CloudConfig, firewall_id string).
+
+    Raises:
+        SystemExit: If no deployment or no firewall is configured.
+    """
+    cloud_cfg, _project_root = _require_cloud_deployment(ctx)
 
     if cloud_cfg.firewall_id is None:
         console.print(
@@ -230,3 +254,121 @@ def firewall_allow_all(ctx: click.Context) -> None:
 
     console.print("[green]Firewall updated.[/green] Ports 80/443 are now open to all traffic.")
     console.print(f"  Firewall: {fw.get('name', firewall_id)}")
+
+
+# ---------------------------------------------------------------------------
+# domain subgroup
+# ---------------------------------------------------------------------------
+
+
+@remote.group("domain")
+@click.pass_context
+def domain(ctx: click.Context) -> None:
+    """Manage the custom domain and HTTPS for this deployment.
+
+    Commands:
+      set DOMAIN   Configure HTTPS with automatic Let's Encrypt certificates
+      remove       Revert to IP-only HTTP access
+    """
+    ctx.ensure_object(dict)
+
+
+def _connect_ssh(cloud_cfg: Any, project_root: Path) -> Any:
+    """Create and connect an SSHManager for the deployment."""
+    from dango.platform.cloud.ssh import SSHManager
+
+    key_path = project_root / cloud_cfg.ssh_key_path
+    ssh = SSHManager(key_path=key_path)
+    ssh.connect(cloud_cfg.droplet_ip, username="root")
+    return ssh
+
+
+# ---------------------------------------------------------------------------
+# domain set
+# ---------------------------------------------------------------------------
+
+
+@domain.command("set")
+@click.argument("domain_name")
+@click.pass_context
+def domain_set(ctx: click.Context, domain_name: str) -> None:
+    """Configure HTTPS for DOMAIN_NAME with automatic Let's Encrypt.
+
+    Caddy acquires and renews TLS certificates automatically.  DNS must
+    point DOMAIN_NAME to the droplet IP for certificate issuance to
+    succeed.  If DNS hasn't propagated yet, a warning is shown but the
+    configuration is still applied (Caddy retries automatically).
+
+    Example:
+      dango remote domain set app.example.com
+    """
+    from dango.platform.cloud.domain import set_domain
+
+    cloud_cfg, project_root = _require_cloud_deployment(ctx)
+
+    if cloud_cfg.droplet_ip is None:
+        console.print("[red]Error:[/red] No droplet IP found in cloud.yml.")
+        raise SystemExit(1)
+
+    ssh = _connect_ssh(cloud_cfg, project_root)
+    try:
+        result = set_domain(ssh, project_root, domain_name)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.close()
+
+    if result["dns_ok"]:
+        console.print(f"[green]DNS OK:[/green] {result['dns_message']}")
+    else:
+        console.print(f"[yellow]DNS warning:[/yellow] {result['dns_message']}")
+
+    if result["caddyfile_updated"]:
+        console.print(
+            f"[green]HTTPS configured.[/green] "
+            f"Caddy will serve [bold]{domain_name}[/bold] with automatic TLS."
+        )
+    else:
+        console.print(f"Caddyfile already configured for [bold]{domain_name}[/bold].")
+
+
+# ---------------------------------------------------------------------------
+# domain remove
+# ---------------------------------------------------------------------------
+
+
+@domain.command("remove")
+@click.pass_context
+def domain_remove(ctx: click.Context) -> None:
+    """Revert to IP-only HTTP access.
+
+    Removes the domain configuration and rewrites the Caddyfile for
+    plain HTTP on port 80.  The domain is cleared from cloud.yml.
+
+    Example:
+      dango remote domain remove
+    """
+    from dango.platform.cloud.domain import remove_domain
+
+    cloud_cfg, project_root = _require_cloud_deployment(ctx)
+
+    ssh = _connect_ssh(cloud_cfg, project_root)
+    try:
+        result = remove_domain(ssh, project_root)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.close()
+
+    prev = result.get("previous_domain")
+    if prev:
+        console.print(f"[green]Domain removed.[/green] Was: [bold]{prev}[/bold]")
+    else:
+        console.print("[yellow]No domain was configured.[/yellow]")
+
+    if result["caddyfile_updated"]:
+        console.print("Caddyfile reverted to HTTP-only (port 80).")
+    else:
+        console.print("Caddyfile was already HTTP-only.")

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -353,6 +353,10 @@ def domain_remove(ctx: click.Context) -> None:
 
     cloud_cfg, project_root = _require_cloud_deployment(ctx)
 
+    if cloud_cfg.droplet_ip is None:
+        console.print("[red]Error:[/red] No droplet IP found in cloud.yml.")
+        raise SystemExit(1)
+
     ssh = _connect_ssh(cloud_cfg, project_root)
     try:
         result = remove_domain(ssh, project_root)

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -116,7 +116,14 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
 
     print(f"Starting Dango on {host}:{effective_port}")
     try:
-        uvicorn.run("dango.web.app:app", host=host, port=effective_port, log_level="info")
+        uvicorn.run(
+            "dango.web.app:app",
+            host=host,
+            port=effective_port,
+            log_level="info",
+            proxy_headers=True,
+            forwarded_allow_ips="127.0.0.1",
+        )
     finally:
         _stop_docker_quiet(project_root)
 

--- a/dango/config/helpers.py
+++ b/dango/config/helpers.py
@@ -12,7 +12,7 @@ from .exceptions import ProjectNotFoundError
 from .loader import ConfigLoader
 
 if TYPE_CHECKING:
-    from .models import DangoConfig, SourcesConfig
+    from .models import CloudConfig, DangoConfig, SourcesConfig
 
 
 def find_project_root(start_path: Path | None = None) -> Path:
@@ -76,6 +76,34 @@ def save_config(config: DangoConfig, project_root: Path | None = None) -> None:
     """
     loader = ConfigLoader(project_root)
     loader.save_config(config)
+
+
+def is_cloud_mode(project_root: Path) -> bool:
+    """Check if this project has an active cloud deployment.
+
+    Returns True if ``.dango/cloud.yml`` exists and contains a ``droplet_id``.
+    """
+    loader = ConfigLoader(project_root)
+    cloud_cfg: CloudConfig | None = loader.load_cloud_config()
+    return cloud_cfg is not None and cloud_cfg.droplet_id is not None
+
+
+def get_cloud_origin(project_root: Path) -> str | None:
+    """Return the public origin URL for a cloud deployment.
+
+    Returns ``https://{domain}`` if a domain is configured,
+    ``http://{ip}`` if only an IP is available, or ``None`` if
+    there is no cloud deployment.
+    """
+    loader = ConfigLoader(project_root)
+    cloud_cfg: CloudConfig | None = loader.load_cloud_config()
+    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+        return None
+    if cloud_cfg.domain:
+        return f"https://{cloud_cfg.domain}"
+    if cloud_cfg.droplet_ip:
+        return f"http://{cloud_cfg.droplet_ip}"
+    return None
 
 
 def check_unreferenced_custom_sources(

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -447,6 +447,10 @@ class RateLimitConfig(BaseModel):
     enabled: bool = Field(default=True, description="Enable rate limiting")
     login: RateLimitGroupConfig = Field(default_factory=lambda: RateLimitGroupConfig(requests=10))
     api: RateLimitGroupConfig = Field(default_factory=lambda: RateLimitGroupConfig(requests=200))
+    trusted_proxies: list[str] = Field(
+        default_factory=list,
+        description="IPs of trusted reverse proxies for X-Forwarded-For extraction",
+    )
 
 
 class AccountLockoutConfig(BaseModel):

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -34,7 +34,8 @@ platform/
 │   ├── spaces.py        # DO Spaces client (S3-compatible via boto3)
 │   ├── ssh.py           # SSH key management, TOFU known-hosts, exec/SFTP (TASK-024)
 │   ├── server_setup.py  # SSH-based server setup orchestration (TASK-026)
-│   └── _server_templates.py  # Config file templates for server_setup.py
+│   ├── domain.py        # DNS check, set_domain(), remove_domain() (TASK-027)
+│   └── _server_templates.py  # Config file templates (incl. build_caddyfile())
 │
 │   # Backwards-compatible shims (re-export from local/)
 ├── network.py           # → platform.local.network
@@ -59,7 +60,8 @@ platform/
 | `cloud/spaces.py` | DigitalOcean Spaces (S3-compatible) client | `SpacesClient` |
 | `cloud/ssh.py` | SSH key management, TOFU known-hosts, command exec, SFTP | `SSHManager`, `CommandResult` |
 | `cloud/server_setup.py` | SSH-based server setup orchestration (16 idempotent steps) | `setup_server`, `SetupResult` |
-| `cloud/_server_templates.py` | Config file templates (systemd, Caddy, fail2ban, etc.) | `SYSTEMD_UNIT`, `CADDYFILE`, etc. |
+| `cloud/domain.py` | DNS check, domain set/remove for HTTPS via Caddy | `check_dns`, `set_domain`, `remove_domain` |
+| `cloud/_server_templates.py` | Config file templates (systemd, Caddy, fail2ban, etc.) | `build_caddyfile`, `CADDYFILE`, `SYSTEMD_UNIT`, etc. |
 
 ## Import Patterns
 
@@ -88,6 +90,9 @@ from dango.platform.cloud import provision_droplet, suggest_nearest_region, SIZE
 
 # Firewall management (TASK-025)
 from dango.platform.cloud import create_default_firewall, add_allowed_ip, restrict_web_to_ips
+
+# Domain management (TASK-027)
+from dango.platform.cloud import check_dns, set_domain, remove_domain, build_caddyfile
 ```
 
 ### Also valid (backwards-compatible shims):
@@ -122,6 +127,7 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | Backup to Spaces | `cloud/spaces.py` → `SpacesClient` | `pytest tests/unit/test_spaces_client.py` |
 | Manage SSH keys / remote exec | `cloud/ssh.py` → `SSHManager` | `pytest tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py` |
 | Setup server after provisioning | `cloud/server_setup.py` → `setup_server()` | `pytest tests/unit/test_server_setup.py` |
+| Configure domain / HTTPS | `cloud/domain.py` → `set_domain()` / `remove_domain()` | `pytest tests/unit/test_domain.py` |
 | Modify watcher logic | `local/watcher.py` | `pytest tests/unit/test_watcher_lifecycle.py` |
 | Change Docker service startup | `docker.py` | `dango start` manually |
 | Load/save cloud.yml | `from dango.config import ConfigLoader` → `load_cloud_config()` / `save_cloud_config()` | `pytest tests/unit/test_cloud_config_loader.py` |

--- a/dango/platform/cloud/__init__.py
+++ b/dango/platform/cloud/__init__.py
@@ -5,7 +5,9 @@ Cloud deployment platform components.
 Populated by TASK-022+ (cloud provisioning, Caddy, remote sync).
 """
 
+from ._server_templates import build_caddyfile
 from .digitalocean import DigitalOceanClient
+from .domain import check_dns, remove_domain, set_domain
 from .firewall import (
     add_allowed_ip,
     allow_all_web,
@@ -74,4 +76,9 @@ __all__ = [
     # Server setup
     "setup_server",
     "SetupResult",
+    # Domain management (TASK-027)
+    "build_caddyfile",
+    "check_dns",
+    "set_domain",
+    "remove_domain",
 ]

--- a/dango/platform/cloud/_server_templates.py
+++ b/dango/platform/cloud/_server_templates.py
@@ -2,11 +2,50 @@
 
 Config file templates for server setup (server_setup.py).
 
-These are plain string constants written to the remote host during setup.
+String constants and builder functions for remote host configuration.
 Extracted from server_setup.py to keep that module under 500 lines.
 """
 
 from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Security headers shared by HTTP and HTTPS Caddyfile configurations
+# ---------------------------------------------------------------------------
+
+_COMMON_HEADERS = """\
+\theader {
+\t\tX-Content-Type-Options nosniff
+\t\tX-Frame-Options SAMEORIGIN
+\t\tReferrer-Policy strict-origin-when-cross-origin
+\t\tPermissions-Policy "interest-cohort=()"
+\t}"""
+
+_HSTS_HEADER = '\t\tStrict-Transport-Security "max-age=63072000; includeSubDomains"'
+
+
+def build_caddyfile(domain: str | None = None) -> str:
+    """Build a Caddyfile for Caddy reverse proxy.
+
+    Args:
+        domain: FQDN for HTTPS (e.g. ``"app.example.com"``).
+            When ``None``, generates an HTTP-only config on port 80.
+
+    Returns:
+        Complete Caddyfile content as a string.
+    """
+    if domain:
+        # HTTPS mode — Caddy auto-obtains Let's Encrypt certs
+        headers = _COMMON_HEADERS.replace(
+            "\n\t}",
+            f"\n{_HSTS_HEADER}\n\t}}",
+        )
+        return f"{domain} {{\n\treverse_proxy localhost:8800\n{headers}\n}}\n"
+    # HTTP-only mode (IP access, no HSTS)
+    return f":80 {{\n\treverse_proxy localhost:8800\n{_COMMON_HEADERS}\n}}\n"
+
+
+# Backward-compatible alias — existing code imports ``CADDYFILE`` directly.
+CADDYFILE = build_caddyfile()
 
 SYSTEMD_UNIT = """\
 [Unit]
@@ -28,11 +67,6 @@ RestartSec=5
 WantedBy=multi-user.target
 """
 
-CADDYFILE = """\
-:80 {
-\treverse_proxy localhost:8800
-}
-"""
 
 DOCKER_DAEMON_JSON = """\
 {

--- a/dango/platform/cloud/domain.py
+++ b/dango/platform/cloud/domain.py
@@ -1,0 +1,135 @@
+"""dango/platform/cloud/domain.py
+
+DNS validation and domain management for cloud deployments.
+
+Provides ``set_domain()`` and ``remove_domain()`` to configure HTTPS
+via Caddy's automatic Let's Encrypt integration, and ``check_dns()``
+for pre-flight DNS propagation checks.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from dango.exceptions import CloudProvisioningError
+from dango.platform.cloud._server_templates import build_caddyfile
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.ssh import SSHManager
+
+
+def check_dns(domain: str, expected_ip: str) -> tuple[bool, str]:
+    """Check whether *domain* resolves to *expected_ip*.
+
+    Uses ``socket.getaddrinfo()`` for A-record lookup.  This is a
+    best-effort check — Caddy retries certificate acquisition
+    automatically, so a temporary DNS mismatch is not fatal.
+
+    Returns:
+        ``(matches, message)`` — *matches* is ``True`` when at least one
+        resolved address equals *expected_ip*.
+    """
+    try:
+        results = socket.getaddrinfo(domain, None, socket.AF_INET, socket.SOCK_STREAM)
+        resolved_ips: list[str] = sorted({str(r[4][0]) for r in results})
+    except socket.gaierror as exc:
+        return (False, f"DNS lookup failed for {domain}: {exc}")
+
+    if not resolved_ips:
+        return (False, f"No A records found for {domain}")
+
+    if expected_ip in resolved_ips:
+        return (True, f"{domain} resolves to {expected_ip}")
+
+    return (
+        False,
+        f"{domain} resolves to {', '.join(resolved_ips)} "
+        f"(expected {expected_ip}). DNS may still be propagating.",
+    )
+
+
+def _write_caddyfile(ssh: SSHManager, content: str) -> bool:
+    """Write Caddyfile and reload Caddy if changed. Returns whether changed."""
+    check = ssh.exec_command("cat /etc/caddy/Caddyfile 2>/dev/null")
+    if check.success and check.stdout == content:
+        return False
+    ssh.write_remote_file("/etc/caddy/Caddyfile", content, mode=0o644)
+    result = ssh.exec_command("systemctl reload-or-restart caddy")
+    if not result.success:
+        raise CloudProvisioningError(
+            f"Failed to reload Caddy: {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return True
+
+
+def set_domain(
+    ssh: SSHManager,
+    project_root: Path,
+    domain: str,
+) -> dict[str, Any]:
+    """Configure HTTPS for *domain* on the remote server.
+
+    1. Loads cloud.yml to get ``droplet_ip``
+    2. Runs a DNS pre-flight check (warning only)
+    3. Writes an HTTPS Caddyfile and reloads Caddy
+    4. Saves the domain to cloud.yml
+
+    Returns:
+        Dict with ``domain``, ``dns_ok``, ``dns_message``, ``caddyfile_updated``.
+    """
+    from dango.config.loader import ConfigLoader
+
+    loader = ConfigLoader(project_root)
+    cloud_cfg = loader.load_cloud_config()
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
+        raise CloudProvisioningError("No droplet IP found in cloud.yml")
+
+    dns_ok, dns_message = check_dns(domain, cloud_cfg.droplet_ip)
+
+    content = build_caddyfile(domain)
+    caddyfile_updated = _write_caddyfile(ssh, content)
+
+    cloud_cfg.domain = domain
+    loader.save_cloud_config(cloud_cfg)
+
+    return {
+        "domain": domain,
+        "dns_ok": dns_ok,
+        "dns_message": dns_message,
+        "caddyfile_updated": caddyfile_updated,
+    }
+
+
+def remove_domain(
+    ssh: SSHManager,
+    project_root: Path,
+) -> dict[str, Any]:
+    """Revert to HTTP-only access (remove domain configuration).
+
+    Writes an HTTP-only Caddyfile on port 80, reloads Caddy, and clears
+    the ``domain`` field from cloud.yml.
+
+    Returns:
+        Dict with ``previous_domain`` and ``caddyfile_updated``.
+    """
+    from dango.config.loader import ConfigLoader
+
+    loader = ConfigLoader(project_root)
+    cloud_cfg = loader.load_cloud_config()
+    if cloud_cfg is None:
+        raise CloudProvisioningError("No cloud configuration found in cloud.yml")
+
+    previous_domain = cloud_cfg.domain
+
+    content = build_caddyfile(None)
+    caddyfile_updated = _write_caddyfile(ssh, content)
+
+    cloud_cfg.domain = None
+    loader.save_cloud_config(cloud_cfg)
+
+    return {
+        "previous_domain": previous_domain,
+        "caddyfile_updated": caddyfile_updated,
+    }

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -20,13 +20,13 @@ from typing import TYPE_CHECKING
 
 from dango.exceptions import CloudProvisioningError
 from dango.platform.cloud._server_templates import (
-    CADDYFILE,
     DOCKER_DAEMON_JSON,
     FAIL2BAN_JAIL,
     JOURNALD_CONF,
     LOGROTATE_CONF,
     SYSTEMD_UNIT,
     UNATTENDED_UPGRADES_CONF,
+    build_caddyfile,
 )
 
 if TYPE_CHECKING:
@@ -389,11 +389,14 @@ def _setup_caddyfile(
     ssh: SSHManager,
     result: SetupResult,
     on_progress: Callable[[str, str], None] | None,
+    *,
+    domain: str | None = None,
 ) -> None:
-    """Step 14: Write minimal HTTP Caddyfile."""
+    """Step 14: Write Caddyfile (HTTPS with domain or HTTP-only)."""
     step = "caddyfile"
     _notify(on_progress, step, "running")
-    changed = _write_remote_config(ssh, "/etc/caddy/Caddyfile", CADDYFILE, step=step)
+    content = build_caddyfile(domain)
+    changed = _write_remote_config(ssh, "/etc/caddy/Caddyfile", content, step=step)
     if changed:
         _run_checked(ssh, "systemctl reload-or-restart caddy", step=step)
     _mark(result, on_progress, step, changed)
@@ -467,22 +470,16 @@ def setup_server(
     ssh: SSHManager,
     *,
     on_progress: Callable[[str, str], None] | None = None,
+    domain: str | None = None,
 ) -> SetupResult:
     """Run all server setup steps on a connected droplet.
 
-    The SSH connection must already be established as **root**.  Each step
-    is idempotent — safe to re-run on a partially or fully configured server.
-
-    The systemd service is **enabled but not started**; the deploy wizard
-    (TASK-029) starts it after file sync.
+    SSH must be established as **root**.  Each step is idempotent.
 
     Args:
         ssh: A connected ``SSHManager`` (as root).
-        on_progress: Optional callback ``(step_name, status)`` where status
-            is ``"running"``, ``"done"``, or ``"skipped"``.
-
-    Returns:
-        ``SetupResult`` with completed, skipped, and warning lists.
+        on_progress: ``(step_name, status)`` callback.
+        domain: FQDN for HTTPS (Caddy auto-TLS). ``None`` → HTTP-only.
 
     Raises:
         CloudProvisioningError: If any step fails.
@@ -490,6 +487,9 @@ def setup_server(
     result = SetupResult()
 
     for step_fn in _SETUP_STEPS:
-        step_fn(ssh, result, on_progress)
+        if step_fn is _setup_caddyfile:
+            _setup_caddyfile(ssh, result, on_progress, domain=domain)
+        else:
+            step_fn(ssh, result, on_progress)
 
     return result

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -187,13 +187,16 @@ def setup_metabase_if_needed(
     Raises:
         RuntimeError: If DuckDB connection fails (critical — services must stop)
     """
+    from dango.config.helpers import is_cloud_mode
     from dango.visualization.metabase import setup_metabase
 
     credentials_file = project_root / ".dango" / "metabase.yml"
     if credentials_file.exists():
         return {"already_configured": True, "success": True}
 
-    setup_result = setup_metabase(project_root, project_name, organization)
+    setup_result = setup_metabase(
+        project_root, project_name, organization, cloud_mode=is_cloud_mode(project_root)
+    )
 
     # DuckDB connection failure is critical — caller must roll back Docker
     if not setup_result.get("success") and not setup_result.get("duckdb_connected"):

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -534,6 +534,7 @@ def setup_metabase(
     project_name: str,
     organization: str | None = None,
     metabase_url: str = "http://localhost:3000",
+    cloud_mode: bool = False,
 ) -> dict[str, Any]:
     """
     Auto-setup Metabase on first start
@@ -545,6 +546,9 @@ def setup_metabase(
         project_name: Project name
         organization: Organization name (optional)
         metabase_url: Metabase URL
+        cloud_mode: When True, generate a random admin password instead
+            of the default local password. SSO session bridging handles
+            user-facing access, so the random password is invisible.
 
     Returns:
         Setup summary with credentials
@@ -585,10 +589,13 @@ def setup_metabase(
         properties = response.json()
         setup_token = properties.get("setup-token")
 
-        # Use default credentials for all Dango installations
-        # This allows auto-login to work even if Metabase volume persists
         admin_email = "admin@dango.local"
-        admin_password = "dangolocal123"
+        if cloud_mode:
+            import secrets as _secrets
+
+            admin_password = _secrets.token_urlsafe(32)
+        else:
+            admin_password = "dangolocal123"
         org_name = organization or project_name
 
         if not setup_token:

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -120,14 +120,18 @@ def _load_rate_limit_config(project_root: Path | None) -> RateLimitConfig | None
     connects to uvicorn via localhost.
     """
     try:
-        from dango.config.helpers import is_cloud_mode, load_config
+        from dango.config.helpers import load_config
+        from dango.config.loader import ConfigLoader
 
         root = project_root or Path.cwd()
         config = load_config(root)
         rl = config.auth.rate_limit
 
-        if not rl.trusted_proxies and is_cloud_mode(root):
-            rl = rl.model_copy(update={"trusted_proxies": ["127.0.0.1"]})
+        if not rl.trusted_proxies:
+            loader = ConfigLoader(root)
+            cloud_cfg = loader.load_cloud_config()
+            if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+                rl = rl.model_copy(update={"trusted_proxies": ["127.0.0.1"]})
 
         return rl
     except Exception:

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -81,15 +81,16 @@ def create_app(project_root: Path | None = None) -> FastAPI:
         AuthMiddleware, project_root=project_root, idle_timeout_minutes=idle_timeout
     )
 
-    # Rate limiting (middle)
+    # Rate limiting (middle) — auto-inject trusted_proxies for cloud
     rate_limit_config = _load_rate_limit_config(project_root)
     if rate_limit_config is not None:
         application.add_middleware(RateLimitMiddleware, config=rate_limit_config)
 
     # CORS (outermost — handles OPTIONS preflight first)
+    cors_origins = _get_cors_origins(project_root)
     application.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # In production, restrict to specific origins
+        allow_origins=cors_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -112,18 +113,42 @@ def _load_auth_config(project_root: Path | None) -> AuthConfig | None:
 
 
 def _load_rate_limit_config(project_root: Path | None) -> RateLimitConfig | None:
-    """Try to load rate limit config from project.yml. Returns None on failure."""
+    """Try to load rate limit config from project.yml. Returns None on failure.
+
+    On cloud deployments, auto-injects ``["127.0.0.1"]`` into
+    ``trusted_proxies`` when the user hasn't configured any — Caddy
+    connects to uvicorn via localhost.
+    """
     try:
-        from dango.config.helpers import load_config
+        from dango.config.helpers import is_cloud_mode, load_config
 
         root = project_root or Path.cwd()
         config = load_config(root)
-        return config.auth.rate_limit
+        rl = config.auth.rate_limit
+
+        if not rl.trusted_proxies and is_cloud_mode(root):
+            rl = rl.model_copy(update={"trusted_proxies": ["127.0.0.1"]})
+
+        return rl
     except Exception:
         logger.debug(
             "rate_limit_config_not_loaded", reason="no project config found, using defaults"
         )
         return None
+
+
+def _get_cors_origins(project_root: Path | None) -> list[str]:
+    """Determine CORS allowed origins based on deployment mode."""
+    try:
+        from dango.config.helpers import get_cloud_origin
+
+        root = project_root or Path.cwd()
+        origin = get_cloud_origin(root)
+        if origin is not None:
+            return [origin]
+    except Exception:
+        pass
+    return ["*"]
 
 
 app = create_app()

--- a/dango/web/middleware/rate_limit.py
+++ b/dango/web/middleware/rate_limit.py
@@ -55,6 +55,7 @@ class RateLimitMiddleware:
     def __init__(self, app: Any, config: RateLimitConfig | None = None) -> None:
         self.app = app
         self.config = config if config is not None else RateLimitConfig()
+        self._trusted_proxies: frozenset[str] = frozenset(self.config.trusted_proxies)
         # group -> IP -> deque of timestamps (monotonic seconds)
         self._windows: dict[str, dict[str, deque[float]]] = {}
         self._last_cleanup: float = time.monotonic()
@@ -103,11 +104,33 @@ class RateLimitMiddleware:
         await self.app(scope, receive, send)
 
     def _get_client_ip(self, scope: Scope) -> str:
-        """Extract client IP address from the ASGI scope."""
+        """Extract client IP address from the ASGI scope.
+
+        When the direct TCP peer is in ``trusted_proxies``, walks the
+        ``X-Forwarded-For`` header right-to-left to find the rightmost
+        non-trusted IP (the actual client).  An attacker can spoof the
+        left side of XFF but not the right — the rightmost entry is
+        appended by the first trusted proxy that received the connection.
+        """
         client: tuple[str, int] | None = scope.get("client")
-        if client is not None:
-            return client[0]
-        return ""
+        peer_ip = client[0] if client is not None else ""
+
+        if not self._trusted_proxies or peer_ip not in self._trusted_proxies:
+            return peer_ip
+
+        # Peer is trusted — extract real IP from X-Forwarded-For
+        headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+        for name, value in headers:
+            if name == b"x-forwarded-for":
+                parts = [p.strip() for p in value.decode("latin-1").split(",")]
+                # Walk right-to-left, skip trusted proxies
+                for ip in reversed(parts):
+                    if ip not in self._trusted_proxies:
+                        return ip
+                # All IPs in the chain are trusted — use the leftmost
+                return parts[0] if parts else peer_ip
+
+        return peer_ip
 
     def _classify_route(self, path: str) -> str | None:
         """Map a request path to a rate limit group name, or None if unlimited."""

--- a/dango/web/routes/users.py
+++ b/dango/web/routes/users.py
@@ -202,9 +202,10 @@ async def admin_create_user(
         details={"role": role.value, "created_by": user.email, "method": "invite"},
     )
     resp = UserResponse.model_validate(new_user)
+    base = str(request.base_url).rstrip("/")
     return JSONResponse(
         status_code=201,
-        content={"user": resp.model_dump(mode="json"), "invite_url": f"/invite/{raw_token}"},
+        content={"user": resp.model_dump(mode="json"), "invite_url": f"{base}/invite/{raw_token}"},
     )
 
 
@@ -248,7 +249,8 @@ async def admin_reinvite_user(
         ip=_get_client_ip(request),
         details={"resent_by": user.email},
     )
-    return JSONResponse(content={"invite_url": f"/invite/{raw_token}"})
+    base = str(request.base_url).rstrip("/")
+    return JSONResponse(content={"invite_url": f"{base}/invite/{raw_token}"})
 
 
 @router.put("/api/admin/users/{user_id}/role")

--- a/dango/web/templates/admin_users.html
+++ b/dango/web/templates/admin_users.html
@@ -277,7 +277,7 @@ function adminUsers() {
                 if (data.invite_url) {
                     this.credentialTitle = 'Invite Link';
                     this.credentialMessage = 'Share this link with the user. It expires in 72 hours.';
-                    this.credentialValue = window.location.origin + data.invite_url;
+                    this.credentialValue = data.invite_url;
                 } else {
                     this.credentialTitle = 'Temporary Password';
                     this.credentialMessage = 'Share this password securely. The user must change it on first login.';

--- a/dango/web/templates/admin_users.html
+++ b/dango/web/templates/admin_users.html
@@ -337,7 +337,7 @@ function adminUsers() {
                 if (!res.ok) { this.error = data.message; this.actionLoading = false; return; }
                 this.credentialTitle = 'Invite Link';
                 this.credentialMessage = 'Share this link with the user. It expires in 72 hours.';
-                this.credentialValue = window.location.origin + data.invite_url;
+                this.credentialValue = data.invite_url;
                 this.showCredentialModal = true;
                 await this.loadUsers();
             } catch (e) { this.error = 'Failed to resend invite'; }

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -199,6 +199,12 @@ exemptions:
     reason: "TASK-024: 33 tests covering SFTP upload/download (with timeout and not-connected guards), write/read remote file, wait_for_ssh (including permanent-error fast-fail), known-hosts TOFU policy, and error wrapping. Test files are verbose by design."
     review_by: "v1.1"
 
+  - file: tests/unit/test_server_setup.py
+    lines: 525
+    category: exempt
+    reason: "TASK-026+027: Added domain parameter tests for setup_server(). Each test requires isolated mock setup with full exec_results map."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,10 @@ module = [
     "tests.unit.test_remote_cli",
     "tests.unit.test_server_setup",
     "tests.unit.test_serve_command",
+    "tests.unit.test_caddyfile",
+    "tests.unit.test_domain",
+    "tests.unit.test_rate_limit_proxy",
+    "tests.unit.test_domain_cli",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_caddyfile.py
+++ b/tests/unit/test_caddyfile.py
@@ -1,0 +1,95 @@
+"""tests/unit/test_caddyfile.py
+
+Unit tests for Caddyfile template generation
+(dango/platform/cloud/_server_templates.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+class TestBuildCaddyfile:
+    """Tests for build_caddyfile() function."""
+
+    def test_http_mode_listens_port_80(self):
+        """No domain → Caddyfile listens on :80."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile()
+        assert result.startswith(":80 {")
+
+    def test_http_mode_reverse_proxy(self):
+        """HTTP mode proxies to localhost:8800."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile()
+        assert "reverse_proxy localhost:8800" in result
+
+    def test_http_mode_has_security_headers(self):
+        """HTTP mode includes X-Content-Type-Options and friends."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile()
+        assert "X-Content-Type-Options nosniff" in result
+        assert "X-Frame-Options SAMEORIGIN" in result
+        assert "Referrer-Policy strict-origin-when-cross-origin" in result
+        assert "interest-cohort=()" in result
+
+    def test_http_mode_no_hsts(self):
+        """HTTP mode must NOT include HSTS (can't enforce on HTTP)."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile()
+        assert "Strict-Transport-Security" not in result
+
+    def test_https_mode_uses_domain(self):
+        """Domain provided → Caddyfile uses domain as address."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile("app.example.com")
+        assert result.startswith("app.example.com {")
+
+    def test_https_mode_reverse_proxy(self):
+        """HTTPS mode still proxies to localhost:8800."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile("app.example.com")
+        assert "reverse_proxy localhost:8800" in result
+
+    def test_https_mode_has_hsts(self):
+        """HTTPS mode includes Strict-Transport-Security header."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile("app.example.com")
+        assert "Strict-Transport-Security" in result
+        assert "max-age=63072000" in result
+
+    def test_https_mode_has_security_headers(self):
+        """HTTPS mode includes all security headers."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        result = build_caddyfile("app.example.com")
+        assert "X-Content-Type-Options nosniff" in result
+        assert "X-Frame-Options SAMEORIGIN" in result
+        assert "Referrer-Policy strict-origin-when-cross-origin" in result
+
+    def test_backward_compat_alias(self):
+        """CADDYFILE constant equals build_caddyfile() with no args."""
+        from dango.platform.cloud._server_templates import CADDYFILE, build_caddyfile
+
+        assert CADDYFILE == build_caddyfile()
+
+    def test_none_domain_same_as_no_args(self):
+        """Passing domain=None produces the same output as no args."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        assert build_caddyfile(None) == build_caddyfile()
+
+    def test_output_ends_with_newline(self):
+        """Output ends with a newline for clean file writing."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+
+        assert build_caddyfile().endswith("\n")
+        assert build_caddyfile("example.com").endswith("\n")

--- a/tests/unit/test_domain.py
+++ b/tests/unit/test_domain.py
@@ -1,0 +1,248 @@
+"""tests/unit/test_domain.py
+
+Unit tests for DNS check and domain management
+(dango/platform/cloud/domain.py).
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import CloudProvisioningError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cloud_config(
+    *,
+    droplet_id: int = 123,
+    droplet_ip: str = "203.0.113.42",
+    domain: str | None = None,
+):
+    """Create a mock CloudConfig with the given attributes."""
+    cfg = MagicMock()
+    cfg.droplet_id = droplet_id
+    cfg.droplet_ip = droplet_ip
+    cfg.domain = domain
+    cfg.ssh_key_path = ".dango/cloud_key"
+    return cfg
+
+
+def _make_ssh_mock(*, cat_stdout: str = "", cat_success: bool = False):
+    """Create a mock SSHManager for domain tests."""
+    from dango.platform.cloud.ssh import CommandResult
+
+    ssh = MagicMock()
+    # cat command to check existing Caddyfile
+    cat_result = CommandResult(
+        stdout=cat_stdout,
+        stderr="" if cat_success else "No such file",
+        exit_code=0 if cat_success else 1,
+    )
+    # reload command always succeeds
+    reload_result = CommandResult(stdout="", stderr="", exit_code=0)
+
+    def _exec_side_effect(command, timeout=None):
+        if command.startswith("cat "):
+            return cat_result
+        return reload_result
+
+    ssh.exec_command.side_effect = _exec_side_effect
+    ssh.write_remote_file = MagicMock()
+    return ssh
+
+
+# ---------------------------------------------------------------------------
+# 1. check_dns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckDns:
+    @patch("dango.platform.cloud.domain.socket.getaddrinfo")
+    def test_dns_matches(self, mock_getaddr):
+        """Returns (True, message) when domain resolves to expected IP."""
+        from dango.platform.cloud.domain import check_dns
+
+        mock_getaddr.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("203.0.113.42", 0)),
+        ]
+        ok, msg = check_dns("app.example.com", "203.0.113.42")
+        assert ok is True
+        assert "203.0.113.42" in msg
+
+    @patch("dango.platform.cloud.domain.socket.getaddrinfo")
+    def test_dns_mismatch(self, mock_getaddr):
+        """Returns (False, message) when domain resolves to wrong IP."""
+        from dango.platform.cloud.domain import check_dns
+
+        mock_getaddr.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.51.100.1", 0)),
+        ]
+        ok, msg = check_dns("app.example.com", "203.0.113.42")
+        assert ok is False
+        assert "expected 203.0.113.42" in msg
+
+    @patch("dango.platform.cloud.domain.socket.getaddrinfo")
+    def test_dns_lookup_failure(self, mock_getaddr):
+        """Returns (False, message) when DNS lookup fails."""
+        from dango.platform.cloud.domain import check_dns
+
+        mock_getaddr.side_effect = socket.gaierror("Name or service not known")
+        ok, msg = check_dns("nonexistent.example.com", "203.0.113.42")
+        assert ok is False
+        assert "DNS lookup failed" in msg
+
+    @patch("dango.platform.cloud.domain.socket.getaddrinfo")
+    def test_dns_multiple_ips_one_matches(self, mock_getaddr):
+        """Returns True when at least one resolved IP matches."""
+        from dango.platform.cloud.domain import check_dns
+
+        mock_getaddr.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.51.100.1", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("203.0.113.42", 0)),
+        ]
+        ok, msg = check_dns("app.example.com", "203.0.113.42")
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# 2. set_domain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetDomain:
+    @patch("dango.platform.cloud.domain.check_dns")
+    @patch("dango.config.loader.ConfigLoader")
+    def test_sets_domain_and_saves(self, mock_loader_cls, mock_check_dns, tmp_path):
+        """set_domain writes HTTPS Caddyfile and saves domain to cloud.yml."""
+        from dango.platform.cloud.domain import set_domain
+
+        cloud_cfg = _make_cloud_config()
+        mock_loader = MagicMock()
+        mock_loader.load_cloud_config.return_value = cloud_cfg
+        mock_loader_cls.return_value = mock_loader
+        mock_check_dns.return_value = (True, "DNS OK")
+
+        ssh = _make_ssh_mock()
+        result = set_domain(ssh, tmp_path, "app.example.com")
+
+        assert result["domain"] == "app.example.com"
+        assert result["dns_ok"] is True
+        assert result["caddyfile_updated"] is True
+        assert cloud_cfg.domain == "app.example.com"
+        mock_loader.save_cloud_config.assert_called_once_with(cloud_cfg)
+
+    @patch("dango.platform.cloud.domain.check_dns")
+    @patch("dango.config.loader.ConfigLoader")
+    def test_dns_warning_non_blocking(self, mock_loader_cls, mock_check_dns, tmp_path):
+        """DNS mismatch produces a warning but doesn't block the operation."""
+        from dango.platform.cloud.domain import set_domain
+
+        cloud_cfg = _make_cloud_config()
+        mock_loader = MagicMock()
+        mock_loader.load_cloud_config.return_value = cloud_cfg
+        mock_loader_cls.return_value = mock_loader
+        mock_check_dns.return_value = (False, "DNS not propagated")
+
+        ssh = _make_ssh_mock()
+        result = set_domain(ssh, tmp_path, "app.example.com")
+
+        assert result["dns_ok"] is False
+        assert result["dns_message"] == "DNS not propagated"
+        # Should still succeed
+        assert result["domain"] == "app.example.com"
+
+    @patch("dango.config.loader.ConfigLoader")
+    def test_no_droplet_ip_raises(self, mock_loader_cls, tmp_path):
+        """Raises CloudProvisioningError when droplet_ip is missing."""
+        from dango.platform.cloud.domain import set_domain
+
+        cloud_cfg = _make_cloud_config(droplet_ip=None)
+        mock_loader = MagicMock()
+        mock_loader.load_cloud_config.return_value = cloud_cfg
+        mock_loader_cls.return_value = mock_loader
+
+        ssh = _make_ssh_mock()
+        with pytest.raises(CloudProvisioningError, match="No droplet IP"):
+            set_domain(ssh, tmp_path, "app.example.com")
+
+    @patch("dango.platform.cloud.domain.check_dns")
+    @patch("dango.config.loader.ConfigLoader")
+    def test_caddyfile_unchanged_skips_write(self, mock_loader_cls, mock_check_dns, tmp_path):
+        """If the Caddyfile already has correct content, skip the write."""
+        from dango.platform.cloud._server_templates import build_caddyfile
+        from dango.platform.cloud.domain import set_domain
+
+        cloud_cfg = _make_cloud_config()
+        mock_loader = MagicMock()
+        mock_loader.load_cloud_config.return_value = cloud_cfg
+        mock_loader_cls.return_value = mock_loader
+        mock_check_dns.return_value = (True, "DNS OK")
+
+        expected_content = build_caddyfile("app.example.com")
+        ssh = _make_ssh_mock(cat_stdout=expected_content, cat_success=True)
+        result = set_domain(ssh, tmp_path, "app.example.com")
+
+        assert result["caddyfile_updated"] is False
+        ssh.write_remote_file.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. remove_domain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoveDomain:
+    @patch("dango.config.loader.ConfigLoader")
+    def test_removes_domain_and_saves(self, mock_loader_cls, tmp_path):
+        """remove_domain writes HTTP-only Caddyfile and clears domain."""
+        from dango.platform.cloud.domain import remove_domain
+
+        cloud_cfg = _make_cloud_config(domain="app.example.com")
+        mock_loader = MagicMock()
+        mock_loader.load_cloud_config.return_value = cloud_cfg
+        mock_loader_cls.return_value = mock_loader
+
+        ssh = _make_ssh_mock()
+        result = remove_domain(ssh, tmp_path)
+
+        assert result["previous_domain"] == "app.example.com"
+        assert result["caddyfile_updated"] is True
+        assert cloud_cfg.domain is None
+        mock_loader.save_cloud_config.assert_called_once()
+
+    @patch("dango.config.loader.ConfigLoader")
+    def test_no_previous_domain(self, mock_loader_cls, tmp_path):
+        """remove_domain works even when no domain was set."""
+        from dango.platform.cloud.domain import remove_domain
+
+        cloud_cfg = _make_cloud_config(domain=None)
+        mock_loader = MagicMock()
+        mock_loader.load_cloud_config.return_value = cloud_cfg
+        mock_loader_cls.return_value = mock_loader
+
+        ssh = _make_ssh_mock()
+        result = remove_domain(ssh, tmp_path)
+
+        assert result["previous_domain"] is None
+
+    @patch("dango.config.loader.ConfigLoader")
+    def test_no_cloud_config_raises(self, mock_loader_cls, tmp_path):
+        """Raises CloudProvisioningError when cloud.yml doesn't exist."""
+        from dango.platform.cloud.domain import remove_domain
+
+        mock_loader = MagicMock()
+        mock_loader.load_cloud_config.return_value = None
+        mock_loader_cls.return_value = mock_loader
+
+        ssh = _make_ssh_mock()
+        with pytest.raises(CloudProvisioningError, match="No cloud configuration"):
+            remove_domain(ssh, tmp_path)

--- a/tests/unit/test_domain_cli.py
+++ b/tests/unit/test_domain_cli.py
@@ -1,0 +1,206 @@
+"""tests/unit/test_domain_cli.py
+
+Unit tests for ``dango remote domain set/remove`` CLI commands
+(dango/cli/commands/remote.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cloud_config(
+    *,
+    droplet_id: int = 123,
+    droplet_ip: str = "203.0.113.42",
+    domain: str | None = None,
+    firewall_id: str | None = "fw-abc",
+    ssh_key_path: str = ".dango/cloud_key",
+):
+    """Create a mock CloudConfig."""
+    cfg = MagicMock()
+    cfg.droplet_id = droplet_id
+    cfg.droplet_ip = droplet_ip
+    cfg.domain = domain
+    cfg.firewall_id = firewall_id
+    cfg.ssh_key_path = ssh_key_path
+    return cfg
+
+
+def _invoke_domain_cmd(args, cloud_cfg=None, domain_result=None, connect_error=None):
+    """Run a domain CLI command with mocked dependencies.
+
+    Returns the CliRunner Result.
+    """
+    from dango.cli.commands.remote import remote
+
+    runner = CliRunner()
+
+    if cloud_cfg is None:
+        cloud_cfg = _make_cloud_config()
+
+    patches = {
+        "dango.cli.commands.remote.require_project_context": MagicMock(
+            return_value=Path("/tmp/project")
+        ),
+        "dango.config.loader.ConfigLoader": MagicMock(),
+    }
+
+    loader_mock = MagicMock()
+    loader_mock.load_cloud_config.return_value = cloud_cfg
+    patches["dango.config.loader.ConfigLoader"].return_value = loader_mock
+
+    ssh_mock = MagicMock()
+    if connect_error:
+        ssh_mock.connect.side_effect = connect_error
+
+    with (
+        patch.dict("os.environ", {}, clear=False),
+        patch("dango.cli.commands.remote._require_cloud_deployment") as mock_req,
+        patch("dango.cli.commands.remote._connect_ssh") as mock_ssh,
+    ):
+        mock_req.return_value = (cloud_cfg, Path("/tmp/project"))
+        mock_ssh.return_value = ssh_mock
+
+        if "set" in args:
+            with patch("dango.platform.cloud.domain.set_domain") as mock_set:
+                mock_set.return_value = domain_result or {
+                    "domain": args[-1],
+                    "dns_ok": True,
+                    "dns_message": "DNS OK",
+                    "caddyfile_updated": True,
+                }
+                return runner.invoke(remote, args, catch_exceptions=False)
+        else:
+            with patch("dango.platform.cloud.domain.remove_domain") as mock_rm:
+                mock_rm.return_value = domain_result or {
+                    "previous_domain": "app.example.com",
+                    "caddyfile_updated": True,
+                }
+                return runner.invoke(remote, args, catch_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDomainSet:
+    def test_set_domain_success(self):
+        """Successful domain set shows DNS OK and HTTPS configured."""
+        result = _invoke_domain_cmd(
+            ["domain", "set", "app.example.com"],
+            domain_result={
+                "domain": "app.example.com",
+                "dns_ok": True,
+                "dns_message": "app.example.com resolves to 203.0.113.42",
+                "caddyfile_updated": True,
+            },
+        )
+        assert result.exit_code == 0
+        assert "DNS OK" in result.output
+        assert "HTTPS configured" in result.output
+
+    def test_set_domain_dns_warning(self):
+        """DNS mismatch shows a warning but still succeeds."""
+        result = _invoke_domain_cmd(
+            ["domain", "set", "app.example.com"],
+            domain_result={
+                "domain": "app.example.com",
+                "dns_ok": False,
+                "dns_message": "DNS not propagated",
+                "caddyfile_updated": True,
+            },
+        )
+        assert result.exit_code == 0
+        assert "DNS warning" in result.output
+        assert "HTTPS configured" in result.output
+
+    def test_set_domain_caddyfile_unchanged(self):
+        """When Caddyfile already correct, shows 'already configured'."""
+        result = _invoke_domain_cmd(
+            ["domain", "set", "app.example.com"],
+            domain_result={
+                "domain": "app.example.com",
+                "dns_ok": True,
+                "dns_message": "DNS OK",
+                "caddyfile_updated": False,
+            },
+        )
+        assert result.exit_code == 0
+        assert "already configured" in result.output
+
+    def test_set_domain_no_ip(self):
+        """Exits with error when droplet_ip is None."""
+        cloud_cfg = _make_cloud_config(droplet_ip=None)
+        result = _invoke_domain_cmd(
+            ["domain", "set", "app.example.com"],
+            cloud_cfg=cloud_cfg,
+        )
+        assert result.exit_code == 1
+        assert "No droplet IP" in result.output
+
+
+@pytest.mark.unit
+class TestDomainRemove:
+    def test_remove_domain_success(self):
+        """Successful domain removal shows previous domain."""
+        result = _invoke_domain_cmd(
+            ["domain", "remove"],
+            domain_result={
+                "previous_domain": "app.example.com",
+                "caddyfile_updated": True,
+            },
+        )
+        assert result.exit_code == 0
+        assert "Domain removed" in result.output
+        assert "app.example.com" in result.output
+
+    def test_remove_domain_none_configured(self):
+        """When no domain was configured, shows appropriate message."""
+        result = _invoke_domain_cmd(
+            ["domain", "remove"],
+            domain_result={
+                "previous_domain": None,
+                "caddyfile_updated": True,
+            },
+        )
+        assert result.exit_code == 0
+        assert "No domain was configured" in result.output
+
+    def test_remove_domain_caddyfile_unchanged(self):
+        """When Caddyfile was already HTTP-only, shows appropriate message."""
+        result = _invoke_domain_cmd(
+            ["domain", "remove"],
+            domain_result={
+                "previous_domain": None,
+                "caddyfile_updated": False,
+            },
+        )
+        assert result.exit_code == 0
+        assert "already HTTP-only" in result.output
+
+
+@pytest.mark.unit
+class TestRequireCloudDeployment:
+    def test_no_deployment_exits(self):
+        """_require_cloud_deployment exits when no droplet_id."""
+        from dango.cli.commands.remote import remote
+
+        runner = CliRunner()
+
+        with (
+            patch("dango.cli.commands.remote._require_cloud_deployment") as mock_req,
+        ):
+            mock_req.side_effect = SystemExit(1)
+            result = runner.invoke(remote, ["domain", "set", "x.com"])
+            assert result.exit_code == 1

--- a/tests/unit/test_rate_limit_proxy.py
+++ b/tests/unit/test_rate_limit_proxy.py
@@ -1,0 +1,158 @@
+"""tests/unit/test_rate_limit_proxy.py
+
+Unit tests for X-Forwarded-For extraction in the rate limit middleware
+behind a trusted reverse proxy (dango/web/middleware/rate_limit.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dango.config.models import RateLimitConfig
+
+
+def _make_scope(
+    *,
+    client_ip: str = "127.0.0.1",
+    xff: str | None = None,
+    path: str = "/api/sources",
+    method: str = "GET",
+) -> dict:
+    """Build a minimal ASGI HTTP scope for testing."""
+    headers: list[tuple[bytes, bytes]] = []
+    if xff is not None:
+        headers.append((b"x-forwarded-for", xff.encode("latin-1")))
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "client": (client_ip, 12345),
+        "headers": headers,
+    }
+
+
+@pytest.mark.unit
+class TestGetClientIpProxy:
+    """Tests for _get_client_ip() with trusted proxy support."""
+
+    def test_no_trusted_proxies_returns_peer(self):
+        """Without trusted proxies, returns the direct peer IP."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=[])
+        mw = RateLimitMiddleware(app=None, config=config)
+        scope = _make_scope(client_ip="203.0.113.42", xff="10.0.0.1")
+        assert mw._get_client_ip(scope) == "203.0.113.42"
+
+    def test_untrusted_peer_returns_peer(self):
+        """If peer is NOT in trusted_proxies, returns peer regardless of XFF."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=["127.0.0.1"])
+        mw = RateLimitMiddleware(app=None, config=config)
+        scope = _make_scope(client_ip="203.0.113.42", xff="10.0.0.1")
+        assert mw._get_client_ip(scope) == "203.0.113.42"
+
+    def test_trusted_peer_extracts_xff(self):
+        """When peer is trusted, extracts real IP from X-Forwarded-For."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=["127.0.0.1"])
+        mw = RateLimitMiddleware(app=None, config=config)
+        scope = _make_scope(client_ip="127.0.0.1", xff="203.0.113.42")
+        assert mw._get_client_ip(scope) == "203.0.113.42"
+
+    def test_multi_hop_xff_rightmost_non_trusted(self):
+        """Multi-hop XFF: use rightmost non-trusted IP."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=["127.0.0.1", "10.0.0.1"])
+        mw = RateLimitMiddleware(app=None, config=config)
+        # XFF: client, proxy1, proxy2 (rightmost)
+        scope = _make_scope(
+            client_ip="127.0.0.1",
+            xff="spoofed.ip, 203.0.113.42, 10.0.0.1",
+        )
+        assert mw._get_client_ip(scope) == "203.0.113.42"
+
+    def test_all_trusted_in_xff_returns_leftmost(self):
+        """When all IPs in XFF are trusted, return the leftmost."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=["127.0.0.1", "10.0.0.1"])
+        mw = RateLimitMiddleware(app=None, config=config)
+        scope = _make_scope(client_ip="127.0.0.1", xff="10.0.0.1, 127.0.0.1")
+        assert mw._get_client_ip(scope) == "10.0.0.1"
+
+    def test_no_xff_header_returns_peer(self):
+        """When peer is trusted but no XFF header, returns peer."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=["127.0.0.1"])
+        mw = RateLimitMiddleware(app=None, config=config)
+        scope = _make_scope(client_ip="127.0.0.1", xff=None)
+        assert mw._get_client_ip(scope) == "127.0.0.1"
+
+    def test_no_client_returns_empty(self):
+        """No client tuple in scope → empty string."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=["127.0.0.1"])
+        mw = RateLimitMiddleware(app=None, config=config)
+        scope = {"type": "http", "method": "GET", "path": "/api/test", "headers": []}
+        assert mw._get_client_ip(scope) == ""
+
+    def test_xff_with_spaces(self):
+        """XFF values with extra whitespace are handled correctly."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        config = RateLimitConfig(trusted_proxies=["127.0.0.1"])
+        mw = RateLimitMiddleware(app=None, config=config)
+        scope = _make_scope(client_ip="127.0.0.1", xff=" 203.0.113.42 , 127.0.0.1 ")
+        assert mw._get_client_ip(scope) == "203.0.113.42"
+
+
+@pytest.mark.unit
+class TestRateLimitWithProxy:
+    """Integration-style test: proxied requests get rate-limited by real IP."""
+
+    @pytest.mark.anyio
+    async def test_proxied_requests_rate_limited_by_real_ip(self):
+        """Requests via trusted proxy are rate-limited by the real client IP."""
+        from dango.web.middleware.rate_limit import RateLimitMiddleware
+
+        call_count = 0
+
+        async def _app(scope, receive, send):
+            nonlocal call_count
+            call_count += 1
+
+        config = RateLimitConfig(
+            trusted_proxies=["127.0.0.1"],
+            api={"requests": 2, "window_seconds": 60},
+        )
+        mw = RateLimitMiddleware(app=_app, config=config)
+
+        scope = _make_scope(client_ip="127.0.0.1", xff="203.0.113.42")
+
+        # First 2 requests should pass
+        for _ in range(2):
+            sent_status = None
+
+            async def _send(msg):
+                nonlocal sent_status
+                if msg.get("type") == "http.response.start":
+                    sent_status = msg.get("status")
+
+            await mw(scope, None, _send)
+
+        # 3rd request should be rate-limited (429)
+        sent_status = None
+
+        async def _send_429(msg):
+            nonlocal sent_status
+            if msg.get("type") == "http.response.start":
+                sent_status = msg.get("status")
+
+        await mw(scope, None, _send_429)
+        assert sent_status == 429

--- a/tests/unit/test_serve_command.py
+++ b/tests/unit/test_serve_command.py
@@ -82,7 +82,12 @@ class TestServeHappyPath:
         mock_dashboards.assert_called_once_with(tmp_path)
         mock_check_port.assert_called_once_with(8800)
         mock_uvicorn_run.assert_called_once_with(
-            "dango.web.app:app", host="0.0.0.0", port=8800, log_level="info"
+            "dango.web.app:app",
+            host="0.0.0.0",
+            port=8800,
+            log_level="info",
+            proxy_headers=True,
+            forwarded_allow_ips="127.0.0.1",
         )
 
     @patch("uvicorn.run")
@@ -119,7 +124,12 @@ class TestServeHappyPath:
         assert result.exit_code == 0, result.output
         mock_check_port.assert_called_once_with(9000)
         mock_uvicorn_run.assert_called_once_with(
-            "dango.web.app:app", host="0.0.0.0", port=9000, log_level="info"
+            "dango.web.app:app",
+            host="0.0.0.0",
+            port=9000,
+            log_level="info",
+            proxy_headers=True,
+            forwarded_allow_ips="127.0.0.1",
         )
 
     @patch("uvicorn.run")
@@ -155,7 +165,12 @@ class TestServeHappyPath:
 
         assert result.exit_code == 0, result.output
         mock_uvicorn_run.assert_called_once_with(
-            "dango.web.app:app", host="127.0.0.1", port=8800, log_level="info"
+            "dango.web.app:app",
+            host="127.0.0.1",
+            port=8800,
+            log_level="info",
+            proxy_headers=True,
+            forwarded_allow_ips="127.0.0.1",
         )
 
 

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -383,6 +383,65 @@ class TestSetupSteps:
         assert ":80" in CADDYFILE
         assert "reverse_proxy localhost:8800" in CADDYFILE
 
+    def test_setup_server_with_domain_writes_https_caddyfile(self):
+        """setup_server(domain=...) writes an HTTPS Caddyfile."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "id -u dango": ("1001", "", 0),
+                "docker --version": ("Docker 24", "", 0),
+                "caddy version": ("v2.7", "", 0),
+                "test -x /srv/dango/venv/bin/dango": ("", "", 0),
+                "cat /etc/docker/daemon.json": ("", "", 1),
+                "cat /etc/systemd/journald.conf.d/dango.conf": ("", "", 1),
+                "cat /etc/logrotate.d/dango": ("", "", 1),
+                "cat /etc/systemd/system/dango-web.service": ("", "", 1),
+                "cat /etc/caddy/Caddyfile": ("", "", 1),
+                "cat /etc/fail2ban/jail.local": ("", "", 1),
+                "cat /etc/apt/apt.conf.d/51unattended-upgrades-dango": ("", "", 1),
+            }
+        )
+
+        setup_server(ssh, domain="app.example.com")
+
+        # Find the Caddyfile write
+        written_calls = ssh.write_remote_file.call_args_list
+        caddy_writes = [c for c in written_calls if c[0][0] == "/etc/caddy/Caddyfile"]
+        assert len(caddy_writes) == 1
+        content = caddy_writes[0][0][1]
+        assert "app.example.com" in content
+        assert "Strict-Transport-Security" in content
+
+    def test_setup_server_no_domain_writes_http_caddyfile(self):
+        """setup_server() without domain writes an HTTP-only Caddyfile."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "id -u dango": ("1001", "", 0),
+                "docker --version": ("Docker 24", "", 0),
+                "caddy version": ("v2.7", "", 0),
+                "test -x /srv/dango/venv/bin/dango": ("", "", 0),
+                "cat /etc/docker/daemon.json": ("", "", 1),
+                "cat /etc/systemd/journald.conf.d/dango.conf": ("", "", 1),
+                "cat /etc/logrotate.d/dango": ("", "", 1),
+                "cat /etc/systemd/system/dango-web.service": ("", "", 1),
+                "cat /etc/caddy/Caddyfile": ("", "", 1),
+                "cat /etc/fail2ban/jail.local": ("", "", 1),
+                "cat /etc/apt/apt.conf.d/51unattended-upgrades-dango": ("", "", 1),
+            }
+        )
+
+        setup_server(ssh)
+
+        written_calls = ssh.write_remote_file.call_args_list
+        caddy_writes = [c for c in written_calls if c[0][0] == "/etc/caddy/Caddyfile"]
+        assert len(caddy_writes) == 1
+        content = caddy_writes[0][0][1]
+        assert ":80" in content
+        assert "Strict-Transport-Security" not in content
+
     def test_docker_daemon_config(self):
         """Docker daemon config has log rotation."""
         from dango.platform.cloud._server_templates import DOCKER_DAEMON_JSON

--- a/tests/unit/test_web_auth_invite.py
+++ b/tests/unit/test_web_auth_invite.py
@@ -279,7 +279,7 @@ class TestCreateUserInvite:
         assert resp.status_code == 201
         data = resp.json()
         assert "invite_url" in data
-        assert data["invite_url"].startswith("/invite/")
+        assert "/invite/" in data["invite_url"]
         assert "temp_password" not in data
 
         user = db.get_user_by_email(db_path, "new@example.com")
@@ -332,7 +332,7 @@ class TestReinvite:
 
         resp = client.post(f"/api/admin/users/{user.id}/reinvite", headers=_H)
         assert resp.status_code == 200
-        assert resp.json()["invite_url"].startswith("/invite/")
+        assert "/invite/" in resp.json()["invite_url"]
 
         updated = db.get_user_by_id(db_path, user.id)
         assert updated is not None

--- a/tests/unit/test_web_users.py
+++ b/tests/unit/test_web_users.py
@@ -177,7 +177,7 @@ class TestAdminCreateUser:
         assert data["user"]["email"] == "new@example.com"
         assert data["user"]["role"] == "editor"
         assert "invite_url" in data
-        assert data["invite_url"].startswith("/invite/")
+        assert "/invite/" in data["invite_url"]
 
     def test_create_user_duplicate(self, tmp_path: Path) -> None:
         """Duplicate email returns 409."""


### PR DESCRIPTION
## Summary

- **TASK-027**: Upgrade Caddy reverse proxy for HTTPS with automatic Let's Encrypt certificates. Adds `build_caddyfile(domain)` template builder, `domain.py` module (DNS check, set/remove domain), and `dango remote domain set/remove` CLI commands. Threads `domain` parameter through `setup_server()` so re-runs write the correct Caddyfile.
- **TASK-102 S1**: Rate limiter extracts real client IP from `X-Forwarded-For` behind trusted proxy (right-to-left walk algorithm). Auto-injects `127.0.0.1` as trusted proxy in cloud mode.
- **TASK-102 S2**: Dynamic CORS origins — cloud deployments restrict to `https://{domain}` or `http://{ip}` instead of wildcard `*`.
- **TASK-102 S3**: Enables `proxy_headers=True` in uvicorn so `request.base_url` reflects actual scheme+host. Invite URLs are now absolute (works for future email/CLI/webhook use).
- **TASK-102 S4**: Random Metabase admin password on cloud via `secrets.token_urlsafe(32)` instead of hardcoded default.

**25 files changed** (+1271/−57): 16 source files modified, 1 new module (`domain.py`), 4 new test files, 4 existing test files updated. All 1456 unit tests pass.

## Test plan

- [x] `pytest tests/unit/ -v` — 1456 passed
- [x] `ruff check dango/` — no issues
- [x] `ruff format --check dango/` — 131 files formatted
- [x] `mypy dango/` — no issues (131 files)
- [x] `python scripts/check_file_sizes.py --all` — 152 checked, 31 exempt
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)