### PR TITLE
TASK-101: Secrets + OAuth management

### DIFF
--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -50,6 +50,10 @@ class AuditEvent(str, Enum):
     RECOVERY_CODE_USED = "recovery_code_used"
     INVITE_ACCEPTED    = "invite_accepted"
     INVITE_RESENT      = "invite_resent"
+    SECRET_SET         = "secret_set"
+    SECRET_DELETED     = "secret_deleted"
+    OAUTH_SOURCE_CONNECTED    = "oauth_source_connected"
+    OAUTH_SOURCE_DISCONNECTED = "oauth_source_disconnected"
     # fmt: on
 
 

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -5,6 +5,11 @@ Remote server management commands for Dango cloud deployments.
 Command hierarchy::
 
     dango remote (group)
+    ├── env (subgroup)
+    │   ├── set K=V    — Set an environment variable
+    │   ├── get K      — Display a variable (masked)
+    │   ├── list       — List all variables (masked)
+    │   └── delete K   — Remove a variable
     └── firewall (subgroup)
         ├── list       — Show current firewall rules
         ├── allow-ip   — Restrict ports 80/443 to a specific IP
@@ -96,6 +101,47 @@ def _load_cloud_config_or_fail(ctx: click.Context) -> tuple[Any, str]:
         raise SystemExit(1)
 
     return cloud_cfg, cloud_cfg.firewall_id
+
+
+def _ssh_connect_or_fail(ctx: click.Context) -> tuple[Any, Any, Path]:
+    """Load cloud config, connect SSH as ``dango`` user, return context.
+
+    Returns:
+        Tuple of (CloudConfig, connected SSHManager, project_root Path).
+        Caller **must** call ``ssh.disconnect()`` when done.
+
+    Raises:
+        SystemExit: If no deployment or SSH connection fails.
+    """
+    from dango.cli.utils import require_project_context
+    from dango.config.loader import ConfigLoader
+    from dango.platform.cloud.ssh import SSHManager
+
+    project_root: Path = require_project_context(ctx)
+    loader = ConfigLoader(project_root)
+    cloud_cfg = loader.load_cloud_config()
+
+    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+        console.print(
+            "[red]Error:[/red] No cloud deployment found. "
+            "Run [bold]dango deploy[/bold] to provision a server first."
+        )
+        raise SystemExit(1)
+
+    server_ip = cloud_cfg.droplet_ip
+    if server_ip is None:
+        console.print("[red]Error:[/red] No server IP in cloud config.")
+        raise SystemExit(1)
+
+    key_path = Path(cloud_cfg.ssh_key_path) if cloud_cfg.ssh_key_path else None
+    ssh = SSHManager(key_path=key_path)
+    try:
+        ssh.connect(server_ip, username="dango")
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] SSH connection failed: {exc}")
+        raise SystemExit(1) from exc
+
+    return cloud_cfg, ssh, project_root
 
 
 def _make_client() -> Any:
@@ -230,3 +276,12 @@ def firewall_allow_all(ctx: click.Context) -> None:
 
     console.print("[green]Firewall updated.[/green] Ports 80/443 are now open to all traffic.")
     console.print(f"  Firewall: {fw.get('name', firewall_id)}")
+
+
+# ---------------------------------------------------------------------------
+# Register subgroups from separate modules
+# ---------------------------------------------------------------------------
+
+from dango.cli.commands.remote_env import env  # noqa: E402
+
+remote.add_command(env)

--- a/dango/cli/commands/remote_env.py
+++ b/dango/cli/commands/remote_env.py
@@ -18,6 +18,10 @@ from typing import Any
 import click
 
 from dango.cli import console
+from dango.logging import get_logger
+from dango.utils.env_file import parse_env_file, serialize_env_file
+
+logger = get_logger(__name__)
 
 # Remote .env path on the server (set by TASK-026 server setup)
 _REMOTE_ENV_PATH = "/srv/dango/project/.env"
@@ -43,64 +47,23 @@ def env(ctx: click.Context) -> None:
 
 
 # ---------------------------------------------------------------------------
-# .env parsing helpers
+# Remote .env helpers
 # ---------------------------------------------------------------------------
-
-
-def _parse_env_file(content: str) -> dict[str, str]:
-    """Parse .env file content into a dict, preserving order.
-
-    Handles ``KEY=VALUE``, ``KEY="VALUE"``, ``KEY='VALUE'``.
-    Skips blank lines and ``#`` comments.
-    """
-    env_vars: dict[str, str] = {}
-    for line in content.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if "=" not in stripped:
-            continue
-        key, _, value = stripped.partition("=")
-        key = key.strip()
-        value = value.strip()
-        # Strip surrounding quotes
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
-            value = value[1:-1]
-        if key:
-            env_vars[key] = value
-    return env_vars
-
-
-def _serialize_env_file(env_vars: dict[str, str]) -> str:
-    """Serialize a dict back to .env format.
-
-    Values containing spaces, quotes, or special characters are
-    double-quoted.  Simple values are written bare.
-    """
-    lines: list[str] = []
-    for key, value in env_vars.items():
-        # Quote values that contain spaces, quotes, #, or shell-special chars
-        needs_quoting = any(c in value for c in (" ", '"', "'", "#", "$", "\n", "\t"))
-        if needs_quoting:
-            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-            lines.append(f'{key}="{escaped}"')
-        else:
-            lines.append(f"{key}={value}")
-    return "\n".join(lines) + "\n" if lines else ""
 
 
 def _read_remote_env(ssh: Any) -> dict[str, str]:
     """Read and parse the remote .env file. Returns empty dict if missing."""
     try:
         content = ssh.read_remote_file(_REMOTE_ENV_PATH)
-        return _parse_env_file(content)
+        return parse_env_file(content)
     except Exception:
+        logger.debug("remote_env_read_failed", path=_REMOTE_ENV_PATH, exc_info=True)
         return {}
 
 
 def _write_remote_env(ssh: Any, env_vars: dict[str, str]) -> None:
     """Write env vars to the remote .env file with mode 0o600."""
-    content = _serialize_env_file(env_vars)
+    content = serialize_env_file(env_vars)
     ssh.write_remote_file(_REMOTE_ENV_PATH, content, mode=0o600)
 
 

--- a/dango/cli/commands/remote_env.py
+++ b/dango/cli/commands/remote_env.py
@@ -1,0 +1,249 @@
+"""dango/cli/commands/remote_env.py
+
+Remote environment variable management via SSH.
+
+Command hierarchy::
+
+    dango remote env (subgroup)
+    ├── set K=V    — Set an environment variable on the remote server
+    ├── get K      — Display a masked environment variable
+    ├── list       — List all environment variables (masked)
+    └── delete K   — Remove an environment variable
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from dango.cli import console
+
+# Remote .env path on the server (set by TASK-026 server setup)
+_REMOTE_ENV_PATH = "/srv/dango/project/.env"
+
+
+# ---------------------------------------------------------------------------
+# env subgroup
+# ---------------------------------------------------------------------------
+
+
+@click.group("env")
+@click.pass_context
+def env(ctx: click.Context) -> None:
+    """Manage environment variables on the remote server.
+
+    Commands:
+      set K=V    Set an environment variable
+      get K      Display a variable (value masked)
+      list       List all variables (values masked)
+      delete K   Remove a variable
+    """
+    ctx.ensure_object(dict)
+
+
+# ---------------------------------------------------------------------------
+# .env parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_env_file(content: str) -> dict[str, str]:
+    """Parse .env file content into a dict, preserving order.
+
+    Handles ``KEY=VALUE``, ``KEY="VALUE"``, ``KEY='VALUE'``.
+    Skips blank lines and ``#`` comments.
+    """
+    env_vars: dict[str, str] = {}
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        value = value.strip()
+        # Strip surrounding quotes
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        if key:
+            env_vars[key] = value
+    return env_vars
+
+
+def _serialize_env_file(env_vars: dict[str, str]) -> str:
+    """Serialize a dict back to .env format.
+
+    Values containing spaces, quotes, or special characters are
+    double-quoted.  Simple values are written bare.
+    """
+    lines: list[str] = []
+    for key, value in env_vars.items():
+        # Quote values that contain spaces, quotes, #, or shell-special chars
+        needs_quoting = any(c in value for c in (" ", '"', "'", "#", "$", "\n", "\t"))
+        if needs_quoting:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            lines.append(f'{key}="{escaped}"')
+        else:
+            lines.append(f"{key}={value}")
+    return "\n".join(lines) + "\n" if lines else ""
+
+
+def _read_remote_env(ssh: Any) -> dict[str, str]:
+    """Read and parse the remote .env file. Returns empty dict if missing."""
+    try:
+        content = ssh.read_remote_file(_REMOTE_ENV_PATH)
+        return _parse_env_file(content)
+    except Exception:
+        return {}
+
+
+def _write_remote_env(ssh: Any, env_vars: dict[str, str]) -> None:
+    """Write env vars to the remote .env file with mode 0o600."""
+    content = _serialize_env_file(env_vars)
+    ssh.write_remote_file(_REMOTE_ENV_PATH, content, mode=0o600)
+
+
+# ---------------------------------------------------------------------------
+# env set
+# ---------------------------------------------------------------------------
+
+
+@env.command("set")
+@click.argument("key_value")
+@click.pass_context
+def env_set(ctx: click.Context, key_value: str) -> None:
+    """Set an environment variable on the remote server.
+
+    KEY_VALUE must be in KEY=VALUE format (e.g. ``MY_KEY=my_value``).
+    Creates the .env file if it doesn't exist.
+
+    Example:
+      dango remote env set GOOGLE_CLIENT_ID=123456.apps.googleusercontent.com
+    """
+    if "=" not in key_value:
+        console.print("[red]Error:[/red] Expected KEY=VALUE format (e.g. MY_KEY=my_value)")
+        raise SystemExit(1)
+
+    key, _, value = key_value.partition("=")
+    key = key.strip()
+    value = value.strip()
+    if not key:
+        console.print("[red]Error:[/red] Key cannot be empty.")
+        raise SystemExit(1)
+
+    from dango.cli.commands.remote import _ssh_connect_or_fail
+
+    _cloud_cfg, ssh, _project_root = _ssh_connect_or_fail(ctx)
+    try:
+        env_vars = _read_remote_env(ssh)
+        action = "Updated" if key in env_vars else "Set"
+        env_vars[key] = value
+        _write_remote_env(ssh, env_vars)
+        console.print(f"[green]{action}[/green] {key}=***")
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Failed to set env var: {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# env get
+# ---------------------------------------------------------------------------
+
+
+@env.command("get")
+@click.argument("key")
+@click.pass_context
+def env_get(ctx: click.Context, key: str) -> None:
+    """Display an environment variable from the remote server (masked).
+
+    Shows KEY=*** if the variable exists, or an error if not found.
+
+    Example:
+      dango remote env get GOOGLE_CLIENT_ID
+    """
+    from dango.cli.commands.remote import _ssh_connect_or_fail
+
+    _cloud_cfg, ssh, _project_root = _ssh_connect_or_fail(ctx)
+    try:
+        env_vars = _read_remote_env(ssh)
+        if key not in env_vars:
+            console.print(f"[yellow]Not found:[/yellow] {key} is not set in remote .env")
+            raise SystemExit(1)
+        console.print(f"{key}=***")
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Failed to read env var: {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# env list
+# ---------------------------------------------------------------------------
+
+
+@env.command("list")
+@click.pass_context
+def env_list(ctx: click.Context) -> None:
+    """List all environment variables on the remote server (masked).
+
+    Shows all KEY=*** pairs from the remote .env file.
+
+    Example:
+      dango remote env list
+    """
+    from dango.cli.commands.remote import _ssh_connect_or_fail
+
+    _cloud_cfg, ssh, _project_root = _ssh_connect_or_fail(ctx)
+    try:
+        env_vars = _read_remote_env(ssh)
+        if not env_vars:
+            console.print("[yellow]No environment variables set.[/yellow]")
+            return
+        for key in env_vars:
+            console.print(f"{key}=***")
+        console.print(f"\n[dim]{len(env_vars)} variable(s) total[/dim]")
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Failed to list env vars: {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# env delete
+# ---------------------------------------------------------------------------
+
+
+@env.command("delete")
+@click.argument("key")
+@click.pass_context
+def env_delete(ctx: click.Context, key: str) -> None:
+    """Remove an environment variable from the remote server.
+
+    Example:
+      dango remote env delete GOOGLE_CLIENT_ID
+    """
+    from dango.cli.commands.remote import _ssh_connect_or_fail
+
+    _cloud_cfg, ssh, _project_root = _ssh_connect_or_fail(ctx)
+    try:
+        env_vars = _read_remote_env(ssh)
+        if key not in env_vars:
+            console.print(f"[yellow]Not found:[/yellow] {key} is not set in remote .env")
+            raise SystemExit(1)
+        del env_vars[key]
+        _write_remote_env(ssh, env_vars)
+        console.print(f"[green]Deleted[/green] {key}")
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Failed to delete env var: {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.disconnect()

--- a/dango/oauth/web_flow.py
+++ b/dango/oauth/web_flow.py
@@ -20,7 +20,7 @@ import requests
 
 from dango.logging import get_logger
 
-_logger = get_logger("dango.oauth.web_flow")
+logger = get_logger(__name__)
 
 
 class OAuthFlowError(Exception):
@@ -133,7 +133,7 @@ def exchange_google_code(
         ) from exc
 
     if resp.status_code != 200:
-        _logger.warning(
+        logger.warning(
             "google_token_exchange_failed",
             status=resp.status_code,
             body=resp.text[:500],
@@ -257,7 +257,7 @@ def exchange_facebook_code(
         ) from exc
 
     if resp.status_code != 200:
-        _logger.warning(
+        logger.warning(
             "facebook_token_exchange_failed",
             status=resp.status_code,
             body=resp.text[:500],
@@ -294,7 +294,7 @@ def exchange_facebook_code(
         ) from exc
 
     if resp2.status_code != 200:
-        _logger.warning(
+        logger.warning(
             "facebook_long_lived_exchange_failed",
             status=resp2.status_code,
             body=resp2.text[:500],

--- a/dango/oauth/web_flow.py
+++ b/dango/oauth/web_flow.py
@@ -1,0 +1,308 @@
+"""dango/oauth/web_flow.py
+
+OAuth token exchange helpers for the web-based OAuth flow.
+
+Provides pure functions for building authorization URLs and exchanging
+authorization codes for tokens.  Used by the web OAuth connect routes
+(``web/routes/oauth_connect.py``) to handle browser-based OAuth for
+cloud-deployed data sources.
+
+These functions are intentionally decoupled from the CLI OAuth flow
+(``providers.py``) — they contain no Rich console output or file I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlencode
+
+import requests
+
+from dango.logging import get_logger
+
+_logger = get_logger("dango.oauth.web_flow")
+
+
+class OAuthFlowError(Exception):
+    """Raised when an OAuth token exchange or user info request fails."""
+
+    def __init__(self, message: str, provider: str = "") -> None:
+        super().__init__(message)
+        self.provider = provider
+
+
+# ---------------------------------------------------------------------------
+# Supported sources
+# ---------------------------------------------------------------------------
+
+SUPPORTED_OAUTH_SOURCES: dict[str, str] = {
+    "google_ads": "google",
+    "google_analytics": "google",
+    "google_sheets": "google",
+    "facebook_ads": "facebook",
+}
+"""Maps dlt source_type to OAuth provider name."""
+
+
+# ---------------------------------------------------------------------------
+# Google OAuth
+# ---------------------------------------------------------------------------
+
+_GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+_GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
+
+_GOOGLE_BASE_SCOPES = [
+    "https://www.googleapis.com/auth/userinfo.email",
+]
+
+_GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
+    "google_ads": ["https://www.googleapis.com/auth/adwords"],
+    "google_analytics": ["https://www.googleapis.com/auth/analytics.readonly"],
+    "google_sheets": ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+}
+
+
+def build_google_auth_url(
+    client_id: str,
+    redirect_uri: str,
+    source_type: str,
+    state: str,
+) -> str:
+    """Build a Google OAuth authorization URL for a specific data source.
+
+    Args:
+        client_id: Google OAuth client ID.
+        redirect_uri: Callback URL registered in Google Cloud Console.
+        source_type: dlt source type (e.g. ``"google_ads"``).
+        state: CSRF state token.
+
+    Returns:
+        Full authorization URL to redirect the user to.
+    """
+    scopes = _GOOGLE_BASE_SCOPES + _GOOGLE_SERVICE_SCOPES.get(source_type, [])
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(scopes),
+        "state": state,
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    return f"{_GOOGLE_AUTH_URL}?{urlencode(params)}"
+
+
+def exchange_google_code(
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+) -> dict[str, Any]:
+    """Exchange a Google authorization code for tokens.
+
+    Args:
+        code: Authorization code from the OAuth callback.
+        client_id: Google OAuth client ID.
+        client_secret: Google OAuth client secret.
+        redirect_uri: The same redirect URI used in the authorization request.
+
+    Returns:
+        Token response dict containing ``access_token``, ``refresh_token``,
+        ``expires_in``, etc.
+
+    Raises:
+        OAuthFlowError: If the token exchange fails.
+    """
+    try:
+        resp = requests.post(
+            _GOOGLE_TOKEN_URL,
+            data={
+                "code": code,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
+            },
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        raise OAuthFlowError(
+            f"Failed to contact Google token endpoint: {exc}",
+            provider="google",
+        ) from exc
+
+    if resp.status_code != 200:
+        _logger.warning(
+            "google_token_exchange_failed",
+            status=resp.status_code,
+            body=resp.text[:500],
+        )
+        raise OAuthFlowError(
+            "Google token exchange failed. Please try again.",
+            provider="google",
+        )
+
+    result: dict[str, Any] = resp.json()
+    return result
+
+
+def fetch_google_user_info(access_token: str) -> dict[str, Any]:
+    """Fetch Google user info (email, name) using an access token.
+
+    Args:
+        access_token: A valid Google OAuth access token.
+
+    Returns:
+        User info dict containing ``email``, ``name``, etc.
+
+    Raises:
+        OAuthFlowError: If the request fails.
+    """
+    try:
+        resp = requests.get(
+            _GOOGLE_USERINFO_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=15,
+        )
+    except requests.RequestException as exc:
+        raise OAuthFlowError(
+            f"Failed to fetch Google user info: {exc}",
+            provider="google",
+        ) from exc
+
+    if resp.status_code != 200:
+        raise OAuthFlowError(
+            "Failed to fetch Google user info.",
+            provider="google",
+        )
+
+    result: dict[str, Any] = resp.json()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Facebook OAuth
+# ---------------------------------------------------------------------------
+
+_FACEBOOK_AUTH_URL = "https://www.facebook.com/v18.0/dialog/oauth"
+_FACEBOOK_TOKEN_URL = "https://graph.facebook.com/v18.0/oauth/access_token"
+
+
+def build_facebook_auth_url(
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+) -> str:
+    """Build a Facebook OAuth authorization URL.
+
+    Args:
+        client_id: Facebook App ID.
+        redirect_uri: Callback URL registered in Facebook Developer Portal.
+        state: CSRF state token.
+
+    Returns:
+        Full authorization URL to redirect the user to.
+    """
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "scope": "ads_read,ads_management",
+        "response_type": "code",
+    }
+    return f"{_FACEBOOK_AUTH_URL}?{urlencode(params)}"
+
+
+def exchange_facebook_code(
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+) -> dict[str, Any]:
+    """Exchange a Facebook authorization code for a long-lived token.
+
+    First exchanges the code for a short-lived token, then exchanges the
+    short-lived token for a long-lived token (~60 days).
+
+    Args:
+        code: Authorization code from the OAuth callback.
+        client_id: Facebook App ID.
+        client_secret: Facebook App Secret.
+        redirect_uri: The same redirect URI used in the authorization request.
+
+    Returns:
+        Long-lived token response dict containing ``access_token``,
+        ``token_type``, ``expires_in``.
+
+    Raises:
+        OAuthFlowError: If either token exchange fails.
+    """
+    # Step 1: Exchange code for short-lived token
+    try:
+        resp = requests.get(
+            _FACEBOOK_TOKEN_URL,
+            params={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": redirect_uri,
+                "code": code,
+            },
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        raise OAuthFlowError(
+            f"Failed to contact Facebook token endpoint: {exc}",
+            provider="facebook",
+        ) from exc
+
+    if resp.status_code != 200:
+        _logger.warning(
+            "facebook_token_exchange_failed",
+            status=resp.status_code,
+            body=resp.text[:500],
+        )
+        raise OAuthFlowError(
+            "Facebook token exchange failed. Please try again.",
+            provider="facebook",
+        )
+
+    short_lived: dict[str, Any] = resp.json()
+    short_token = short_lived.get("access_token")
+    if not short_token:
+        raise OAuthFlowError(
+            "Facebook did not return an access token.",
+            provider="facebook",
+        )
+
+    # Step 2: Exchange short-lived token for long-lived token
+    try:
+        resp2 = requests.get(
+            _FACEBOOK_TOKEN_URL,
+            params={
+                "grant_type": "fb_exchange_token",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "fb_exchange_token": short_token,
+            },
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        raise OAuthFlowError(
+            f"Failed to exchange for long-lived Facebook token: {exc}",
+            provider="facebook",
+        ) from exc
+
+    if resp2.status_code != 200:
+        _logger.warning(
+            "facebook_long_lived_exchange_failed",
+            status=resp2.status_code,
+            body=resp2.text[:500],
+        )
+        raise OAuthFlowError(
+            "Failed to obtain long-lived Facebook token.",
+            provider="facebook",
+        )
+
+    result: dict[str, Any] = resp2.json()
+    return result

--- a/dango/utils/env_file.py
+++ b/dango/utils/env_file.py
@@ -1,0 +1,50 @@
+"""dango/utils/env_file.py
+
+Shared helpers for parsing and serializing ``.env`` files.
+
+Used by ``web/routes/secrets.py`` (local file I/O),
+``web/routes/oauth_connect.py`` (credential lookup),
+and ``cli/commands/remote_env.py`` (remote file I/O via SSH).
+"""
+
+from __future__ import annotations
+
+
+def parse_env_file(content: str) -> dict[str, str]:
+    """Parse ``.env`` content into a dict.
+
+    Handles ``KEY=VALUE``, ``KEY="VALUE"``, ``KEY='VALUE'``.
+    Skips blank lines and ``#`` comments.
+    """
+    env_vars: dict[str, str] = {}
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        if key:
+            env_vars[key] = value
+    return env_vars
+
+
+def serialize_env_file(env_vars: dict[str, str]) -> str:
+    """Serialize a dict back to ``.env`` format.
+
+    Values containing spaces, quotes, or special characters are
+    double-quoted.  Simple values are written bare.
+    """
+    lines: list[str] = []
+    for key, value in env_vars.items():
+        needs_quoting = any(c in value for c in (" ", '"', "'", "#", "$", "\n", "\t"))
+        if needs_quoting:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            lines.append(f'{key}="{escaped}"')
+        else:
+            lines.append(f"{key}={value}")
+    return "\n".join(lines) + "\n" if lines else ""

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -223,6 +223,7 @@ from dango.web.routes.dbt import router as dbt_router  # noqa: E402
 from dango.web.routes.health import router as health_router  # noqa: E402
 from dango.web.routes.logs import router as logs_router  # noqa: E402
 from dango.web.routes.metabase_proxy import router as metabase_proxy_router  # noqa: E402
+from dango.web.routes.secrets import router as secrets_router  # noqa: E402
 from dango.web.routes.sources import router as sources_router  # noqa: E402
 from dango.web.routes.sync import router as sync_router  # noqa: E402
 from dango.web.routes.ui import router as ui_router  # noqa: E402
@@ -240,6 +241,7 @@ app.include_router(sources_router)
 app.include_router(sync_router)
 app.include_router(logs_router)
 app.include_router(upload_router)
+app.include_router(secrets_router)
 app.include_router(dbt_router)
 app.include_router(websocket_router)
 app.include_router(ui_router)

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -223,6 +223,7 @@ from dango.web.routes.dbt import router as dbt_router  # noqa: E402
 from dango.web.routes.health import router as health_router  # noqa: E402
 from dango.web.routes.logs import router as logs_router  # noqa: E402
 from dango.web.routes.metabase_proxy import router as metabase_proxy_router  # noqa: E402
+from dango.web.routes.oauth_connect import router as oauth_connect_router  # noqa: E402
 from dango.web.routes.secrets import router as secrets_router  # noqa: E402
 from dango.web.routes.sources import router as sources_router  # noqa: E402
 from dango.web.routes.sync import router as sync_router  # noqa: E402
@@ -242,6 +243,7 @@ app.include_router(sync_router)
 app.include_router(logs_router)
 app.include_router(upload_router)
 app.include_router(secrets_router)
+app.include_router(oauth_connect_router)
 app.include_router(dbt_router)
 app.include_router(websocket_router)
 app.include_router(ui_router)

--- a/dango/web/routes/oauth_connect.py
+++ b/dango/web/routes/oauth_connect.py
@@ -1,0 +1,389 @@
+"""dango/web/routes/oauth_connect.py
+
+Web-based OAuth connect/callback routes for cloud deployments.
+
+Handles browser-based OAuth flows for data sources that require OAuth
+(Google Ads, Google Analytics, Google Sheets, Facebook Ads).  The CLI's
+local callback server cannot be used on headless cloud servers, so these
+routes provide an equivalent flow through the admin web UI.
+
+All endpoints require ``config.manage`` permission (admin-only).
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.models import User
+from dango.auth.permissions import require_permission
+from dango.logging import get_logger
+from dango.oauth.web_flow import (
+    SUPPORTED_OAUTH_SOURCES,
+    OAuthFlowError,
+    build_facebook_auth_url,
+    build_google_auth_url,
+    exchange_facebook_code,
+    exchange_google_code,
+    fetch_google_user_info,
+)
+
+router = APIRouter(tags=["oauth-connect"])
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_STATE_COOKIE = "dango_source_oauth_state"
+_SOURCE_COOKIE = "dango_source_oauth_type"
+_STATE_MAX_AGE = 600  # 10 minutes
+
+
+def _get_client_ip(request: Request) -> str | None:
+    """Extract client IP address from the request."""
+    if request.client is not None:
+        return request.client.host
+    return None
+
+
+def _get_redirect_uri(domain: str, source_type: str) -> str:
+    """Build the OAuth callback URI for a given source type."""
+    return f"https://{domain}/oauth/callback/{source_type}"
+
+
+def _get_client_credentials(project_root: Path, provider: str) -> tuple[str, str] | None:
+    """Read OAuth client credentials from the project ``.env`` file.
+
+    Returns:
+        Tuple of ``(client_id, client_secret)`` or ``None`` if not configured.
+    """
+    from dango.web.routes.secrets import _read_env_file
+
+    env_vars = _read_env_file(project_root)
+
+    if provider == "google":
+        client_id = env_vars.get("GOOGLE_CLIENT_ID", "")
+        client_secret = env_vars.get("GOOGLE_CLIENT_SECRET", "")
+    elif provider == "facebook":
+        client_id = env_vars.get("FACEBOOK_APP_ID", "")
+        client_secret = env_vars.get("FACEBOOK_APP_SECRET", "")
+    else:
+        return None
+
+    if not client_id or not client_secret:
+        return None
+
+    return client_id, client_secret
+
+
+def _load_cloud_domain(project_root: Path) -> str | None:
+    """Load the configured domain from cloud config, if any."""
+    try:
+        from dango.config.loader import ConfigLoader
+
+        loader = ConfigLoader(project_root)
+        cloud_cfg = loader.load_cloud_config()
+        if cloud_cfg is not None:
+            return cloud_cfg.domain
+    except Exception:
+        logger.debug("cloud_domain_not_available", exc_info=True)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GET /oauth/connect/{source_type} — initiate OAuth flow
+# ---------------------------------------------------------------------------
+
+
+@router.get("/oauth/connect/{source_type}", response_model=None)
+async def oauth_connect(
+    source_type: str,
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> RedirectResponse | JSONResponse:
+    """Initiate an OAuth flow for a data source.
+
+    Validates prerequisites (domain, client credentials), builds the
+    authorization URL, sets CSRF state cookies, and redirects the user
+    to the OAuth provider.
+    """
+    # Validate source type
+    provider = SUPPORTED_OAUTH_SOURCES.get(source_type)
+    if provider is None:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "message": f"Unsupported OAuth source: '{source_type}'. "
+                f"Supported: {', '.join(sorted(SUPPORTED_OAUTH_SOURCES))}."
+            },
+        )
+
+    project_root: Path = request.app.state.project_root
+
+    # Check domain is configured (HTTPS required for OAuth)
+    domain = _load_cloud_domain(project_root)
+    if not domain:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "message": "A custom domain with HTTPS is required for OAuth. "
+                "Configure a domain first via the deployment settings."
+            },
+        )
+
+    # Check client credentials exist
+    creds = _get_client_credentials(project_root, provider)
+    if creds is None:
+        env_keys = {
+            "google": ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"),
+            "facebook": ("FACEBOOK_APP_ID", "FACEBOOK_APP_SECRET"),
+        }
+        keys = env_keys.get(provider, ("CLIENT_ID", "CLIENT_SECRET"))
+        return JSONResponse(
+            status_code=400,
+            content={
+                "message": f"OAuth client credentials not configured. "
+                f"Set {keys[0]} and {keys[1]} in the Secrets page first."
+            },
+        )
+
+    client_id, client_secret = creds
+    redirect_uri = _get_redirect_uri(domain, source_type)
+
+    # Generate CSRF state token
+    state = secrets.token_urlsafe(32)
+
+    # Build authorization URL
+    if provider == "google":
+        auth_url = build_google_auth_url(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            source_type=source_type,
+            state=state,
+        )
+    elif provider == "facebook":
+        auth_url = build_facebook_auth_url(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            state=state,
+        )
+    else:
+        return JSONResponse(
+            status_code=400,
+            content={"message": f"Provider '{provider}' not implemented."},
+        )
+
+    # Set state cookies and redirect
+    response = RedirectResponse(url=auth_url, status_code=302)
+    response.set_cookie(
+        key=_STATE_COOKIE,
+        value=state,
+        max_age=_STATE_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+        secure=True,
+    )
+    response.set_cookie(
+        key=_SOURCE_COOKIE,
+        value=source_type,
+        max_age=_STATE_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+        secure=True,
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# GET /oauth/callback/{source_type} — handle provider redirect
+# ---------------------------------------------------------------------------
+
+
+@router.get("/oauth/callback/{source_type}")
+async def oauth_callback(
+    source_type: str,
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> RedirectResponse:
+    """Handle OAuth provider callback.
+
+    Validates the CSRF state, exchanges the authorization code for
+    tokens, saves credentials via ``OAuthStorage``, logs an audit
+    event, and redirects back to the secrets page.
+    """
+    secrets_url = "/settings/secrets"
+
+    # Verify state parameter (CSRF protection)
+    expected_state = request.cookies.get(_STATE_COOKIE)
+    actual_state = request.query_params.get("state")
+    if not expected_state or expected_state != actual_state:
+        logger.warning(
+            "oauth_state_mismatch",
+            source_type=source_type,
+            has_expected=bool(expected_state),
+            has_actual=bool(actual_state),
+        )
+        return RedirectResponse(url=f"{secrets_url}?error=state_mismatch")
+
+    # Verify source type cookie matches path
+    cookie_source = request.cookies.get(_SOURCE_COOKIE)
+    if cookie_source != source_type:
+        logger.warning(
+            "oauth_source_mismatch",
+            path_source=source_type,
+            cookie_source=cookie_source,
+        )
+        return RedirectResponse(url=f"{secrets_url}?error=state_mismatch")
+
+    # Check for error from provider
+    error = request.query_params.get("error")
+    if error:
+        logger.warning("oauth_provider_error", source_type=source_type, error=error)
+        return RedirectResponse(url=f"{secrets_url}?error=provider_denied")
+
+    # Get authorization code
+    code = request.query_params.get("code")
+    if not code:
+        return RedirectResponse(url=f"{secrets_url}?error=no_code")
+
+    provider = SUPPORTED_OAUTH_SOURCES.get(source_type)
+    if provider is None:
+        return RedirectResponse(url=f"{secrets_url}?error=unsupported_source")
+
+    project_root: Path = request.app.state.project_root
+
+    # Load domain and client credentials
+    domain = _load_cloud_domain(project_root)
+    if not domain:
+        return RedirectResponse(url=f"{secrets_url}?error=no_domain")
+
+    creds = _get_client_credentials(project_root, provider)
+    if creds is None:
+        return RedirectResponse(url=f"{secrets_url}?error=no_credentials")
+
+    client_id, client_secret = creds
+    redirect_uri = _get_redirect_uri(domain, source_type)
+
+    # Exchange code for tokens
+    try:
+        token_data = _exchange_code(
+            provider=provider,
+            code=code,
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+        )
+    except OAuthFlowError as exc:
+        logger.warning(
+            "oauth_token_exchange_failed",
+            source_type=source_type,
+            error=str(exc),
+        )
+        return RedirectResponse(url=f"{secrets_url}?error=token_exchange_failed")
+
+    # Fetch user info (Google only) for account identification
+    identifier = ""
+    account_info = ""
+    if provider == "google":
+        try:
+            user_info: dict[str, Any] = fetch_google_user_info(token_data.get("access_token", ""))
+            identifier = user_info.get("email", "")
+            account_info = user_info.get("name", identifier)
+        except OAuthFlowError:
+            logger.debug("oauth_user_info_failed", source_type=source_type)
+
+    # Save credentials via OAuthStorage
+    try:
+        from dango.oauth.storage import OAuthCredential, OAuthStorage
+
+        storage = OAuthStorage(project_root)
+
+        # Build credential dict
+        credential_data: dict[str, Any] = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+        if provider == "google":
+            credential_data["refresh_token"] = token_data.get("refresh_token", "")
+            credential_data["project_id"] = "dango-oauth"
+        elif provider == "facebook":
+            credential_data["access_token"] = token_data.get("access_token", "")
+
+        expires_at = None
+        expires_in = token_data.get("expires_in")
+        if expires_in and isinstance(expires_in, int):
+            expires_at = datetime.now() + timedelta(seconds=expires_in)
+
+        oauth_cred = OAuthCredential(
+            source_type=source_type,
+            provider=provider,
+            identifier=identifier,
+            account_info=account_info,
+            credentials=credential_data,
+            created_at=datetime.now(),
+            expires_at=expires_at,
+        )
+        storage.save(oauth_cred)
+    except Exception:
+        logger.error("oauth_credential_save_failed", source_type=source_type, exc_info=True)
+        return RedirectResponse(url=f"{secrets_url}?error=save_failed")
+
+    # Log audit event
+    log_auth_event(
+        AuditEvent.OAUTH_SOURCE_CONNECTED,
+        user_id=user.id,
+        email=user.email,
+        ip=_get_client_ip(request),
+        details={"source_type": source_type, "provider": provider, "identifier": identifier},
+    )
+
+    # Clear state cookies and redirect to secrets page
+    response = RedirectResponse(url=f"{secrets_url}?connected={source_type}")
+    response.delete_cookie(_STATE_COOKIE)
+    response.delete_cookie(_SOURCE_COOKIE)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Token exchange dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _exchange_code(
+    provider: str,
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+) -> dict[str, Any]:
+    """Dispatch token exchange to the correct provider helper.
+
+    Returns:
+        Token response dict.
+
+    Raises:
+        OAuthFlowError: If the exchange fails.
+    """
+    if provider == "google":
+        return exchange_google_code(
+            code=code,
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+        )
+    if provider == "facebook":
+        return exchange_facebook_code(
+            code=code,
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+        )
+    raise OAuthFlowError(f"Unsupported provider: {provider}", provider=provider)

--- a/dango/web/routes/oauth_connect.py
+++ b/dango/web/routes/oauth_connect.py
@@ -65,9 +65,9 @@ def _get_client_credentials(project_root: Path, provider: str) -> tuple[str, str
     Returns:
         Tuple of ``(client_id, client_secret)`` or ``None`` if not configured.
     """
-    from dango.web.routes.secrets import _read_env_file
+    from dango.web.routes.secrets import read_env_file
 
-    env_vars = _read_env_file(project_root)
+    env_vars = read_env_file(project_root)
 
     if provider == "google":
         client_id = env_vars.get("GOOGLE_CLIENT_ID", "")

--- a/dango/web/routes/secrets.py
+++ b/dango/web/routes/secrets.py
@@ -21,6 +21,7 @@ from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
 from dango.auth.permissions import require_permission
 from dango.logging import get_logger
+from dango.utils.env_file import parse_env_file, serialize_env_file
 
 router = APIRouter(tags=["secrets"])
 logger = get_logger(__name__)
@@ -38,60 +39,18 @@ def _get_client_ip(request: Request) -> str | None:
     return None
 
 
-def _env_path(request: Request) -> Path:
-    """Return the path to the project ``.env`` file."""
-    project_root: Path = request.app.state.project_root
-    return project_root / ".env"
-
-
-def _parse_env_file(content: str) -> dict[str, str]:
-    """Parse ``.env`` content into a dict.
-
-    Handles ``KEY=VALUE``, ``KEY="VALUE"``, ``KEY='VALUE'``.
-    Skips blank lines and ``#`` comments.
-    """
-    env_vars: dict[str, str] = {}
-    for line in content.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if "=" not in stripped:
-            continue
-        key, _, value = stripped.partition("=")
-        key = key.strip()
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
-            value = value[1:-1]
-        if key:
-            env_vars[key] = value
-    return env_vars
-
-
-def _serialize_env_file(env_vars: dict[str, str]) -> str:
-    """Serialize a dict back to ``.env`` format."""
-    lines: list[str] = []
-    for key, value in env_vars.items():
-        needs_quoting = any(c in value for c in (" ", '"', "'", "#", "$", "\n", "\t"))
-        if needs_quoting:
-            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-            lines.append(f'{key}="{escaped}"')
-        else:
-            lines.append(f"{key}={value}")
-    return "\n".join(lines) + "\n" if lines else ""
-
-
-def _read_env_file(project_root: Path) -> dict[str, str]:
+def read_env_file(project_root: Path) -> dict[str, str]:
     """Read and parse the project ``.env`` file."""
     env_file = project_root / ".env"
     if not env_file.exists():
         return {}
-    return _parse_env_file(env_file.read_text(encoding="utf-8"))
+    return parse_env_file(env_file.read_text(encoding="utf-8"))
 
 
 def _write_env_file(project_root: Path, env_vars: dict[str, str]) -> None:
     """Write env vars to the project ``.env`` file with mode 0o600."""
     env_file = project_root / ".env"
-    content = _serialize_env_file(env_vars)
+    content = serialize_env_file(env_vars)
     # Create with restrictive permissions to avoid TOCTOU window
     fd = os.open(str(env_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
@@ -115,7 +74,7 @@ async def list_secrets(
     project_root: Path = request.app.state.project_root
 
     # Env vars
-    env_vars = _read_env_file(project_root)
+    env_vars = read_env_file(project_root)
     env_items: list[dict[str, str]] = [
         {"key": k, "masked_value": "***", "source": "env"} for k in env_vars
     ]
@@ -167,7 +126,7 @@ async def set_secret(
         return JSONResponse(status_code=400, content={"message": "Value must be a string."})
 
     project_root: Path = request.app.state.project_root
-    env_vars = _read_env_file(project_root)
+    env_vars = read_env_file(project_root)
     action = "updated" if key in env_vars else "created"
     env_vars[key] = value
     _write_env_file(project_root, env_vars)
@@ -199,7 +158,7 @@ async def delete_secret(
 ) -> JSONResponse:
     """Delete an environment variable."""
     project_root: Path = request.app.state.project_root
-    env_vars = _read_env_file(project_root)
+    env_vars = read_env_file(project_root)
 
     if key not in env_vars:
         return JSONResponse(status_code=404, content={"message": f"Key '{key}' not found."})

--- a/dango/web/routes/secrets.py
+++ b/dango/web/routes/secrets.py
@@ -1,0 +1,325 @@
+"""dango/web/routes/secrets.py
+
+Secrets and OAuth credential management API for the admin dashboard.
+
+Provides CRUD for environment variables (stored in ``.env`` on the server)
+and read/delete for OAuth credentials (stored in ``.dlt/secrets.toml``).
+All endpoints require ``config.manage`` permission (admin-only).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+import dango
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.models import User
+from dango.auth.permissions import require_permission
+from dango.logging import get_logger
+
+router = APIRouter(tags=["secrets"])
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_client_ip(request: Request) -> str | None:
+    """Extract client IP address from the request."""
+    if request.client is not None:
+        return request.client.host
+    return None
+
+
+def _env_path(request: Request) -> Path:
+    """Return the path to the project ``.env`` file."""
+    project_root: Path = request.app.state.project_root
+    return project_root / ".env"
+
+
+def _parse_env_file(content: str) -> dict[str, str]:
+    """Parse ``.env`` content into a dict.
+
+    Handles ``KEY=VALUE``, ``KEY="VALUE"``, ``KEY='VALUE'``.
+    Skips blank lines and ``#`` comments.
+    """
+    env_vars: dict[str, str] = {}
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        if key:
+            env_vars[key] = value
+    return env_vars
+
+
+def _serialize_env_file(env_vars: dict[str, str]) -> str:
+    """Serialize a dict back to ``.env`` format."""
+    lines: list[str] = []
+    for key, value in env_vars.items():
+        needs_quoting = any(c in value for c in (" ", '"', "'", "#", "$", "\n", "\t"))
+        if needs_quoting:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            lines.append(f'{key}="{escaped}"')
+        else:
+            lines.append(f"{key}={value}")
+    return "\n".join(lines) + "\n" if lines else ""
+
+
+def _read_env_file(project_root: Path) -> dict[str, str]:
+    """Read and parse the project ``.env`` file."""
+    env_file = project_root / ".env"
+    if not env_file.exists():
+        return {}
+    return _parse_env_file(env_file.read_text(encoding="utf-8"))
+
+
+def _write_env_file(project_root: Path, env_vars: dict[str, str]) -> None:
+    """Write env vars to the project ``.env`` file with mode 0o600."""
+    env_file = project_root / ".env"
+    content = _serialize_env_file(env_vars)
+    # Create with restrictive permissions to avoid TOCTOU window
+    fd = os.open(str(env_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        os.write(fd, content.encode("utf-8"))
+    finally:
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/secrets — list all secrets (masked)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/secrets")
+async def list_secrets(
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> JSONResponse:
+    """List all environment variables and OAuth credentials (masked)."""
+    project_root: Path = request.app.state.project_root
+
+    # Env vars
+    env_vars = _read_env_file(project_root)
+    env_items: list[dict[str, str]] = [
+        {"key": k, "masked_value": "***", "source": "env"} for k in env_vars
+    ]
+
+    # OAuth credentials
+    oauth_items: list[dict[str, Any]] = []
+    try:
+        from dango.oauth.storage import OAuthStorage
+
+        storage = OAuthStorage(project_root)
+        for cred in storage.list():
+            oauth_items.append(
+                {
+                    "source_type": cred.source_type,
+                    "provider": cred.provider,
+                    "identifier": cred.identifier,
+                    "connected_at": cred.created_at.isoformat(),
+                    "expires_at": cred.expires_at.isoformat() if cred.expires_at else None,
+                    "source": "oauth",
+                }
+            )
+    except Exception:
+        logger.warning("secrets_oauth_list_failed", exc_info=True)
+
+    return JSONResponse(content={"env_vars": env_items, "oauth_credentials": oauth_items})
+
+
+# ---------------------------------------------------------------------------
+# POST /api/secrets — add/update an env var
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/secrets")
+async def set_secret(
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> JSONResponse:
+    """Add or update an environment variable."""
+    try:
+        body: dict[str, Any] = await request.json()
+    except Exception:
+        return JSONResponse(status_code=400, content={"message": "Invalid JSON body."})
+
+    key = body.get("key", "").strip()
+    value = body.get("value", "")
+    if not key:
+        return JSONResponse(status_code=400, content={"message": "Key is required."})
+    if not isinstance(value, str):
+        return JSONResponse(status_code=400, content={"message": "Value must be a string."})
+
+    project_root: Path = request.app.state.project_root
+    env_vars = _read_env_file(project_root)
+    action = "updated" if key in env_vars else "created"
+    env_vars[key] = value
+    _write_env_file(project_root, env_vars)
+
+    log_auth_event(
+        AuditEvent.SECRET_SET,
+        user_id=user.id,
+        email=user.email,
+        ip=_get_client_ip(request),
+        details={"key": key, "action": action},
+    )
+
+    return JSONResponse(
+        status_code=200,
+        content={"message": f"Environment variable {action}.", "key": key},
+    )
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/secrets/{key} — remove an env var
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/api/secrets/{key}")
+async def delete_secret(
+    key: str,
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> JSONResponse:
+    """Delete an environment variable."""
+    project_root: Path = request.app.state.project_root
+    env_vars = _read_env_file(project_root)
+
+    if key not in env_vars:
+        return JSONResponse(status_code=404, content={"message": f"Key '{key}' not found."})
+
+    del env_vars[key]
+    _write_env_file(project_root, env_vars)
+
+    log_auth_event(
+        AuditEvent.SECRET_DELETED,
+        user_id=user.id,
+        email=user.email,
+        ip=_get_client_ip(request),
+        details={"key": key},
+    )
+
+    return JSONResponse(status_code=200, content={"message": f"Deleted '{key}'."})
+
+
+# ---------------------------------------------------------------------------
+# GET /api/secrets/oauth — list OAuth credential status
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/secrets/oauth")
+async def list_oauth_credentials(
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> JSONResponse:
+    """List OAuth credential status for connected data sources."""
+    project_root: Path = request.app.state.project_root
+    items: list[dict[str, Any]] = []
+
+    try:
+        from dango.oauth.storage import OAuthStorage
+
+        storage = OAuthStorage(project_root)
+        for cred in storage.list():
+            items.append(
+                {
+                    "source_type": cred.source_type,
+                    "provider": cred.provider,
+                    "identifier": cred.identifier,
+                    "account_info": cred.account_info,
+                    "connected_at": cred.created_at.isoformat(),
+                    "expires_at": cred.expires_at.isoformat() if cred.expires_at else None,
+                    "is_expired": cred.is_expired(),
+                    "days_until_expiry": cred.days_until_expiry(),
+                }
+            )
+    except Exception:
+        logger.warning("secrets_oauth_list_failed", exc_info=True)
+
+    return JSONResponse(content=items)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/secrets/oauth/{source_type} — disconnect OAuth
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/api/secrets/oauth/{source_type}")
+async def disconnect_oauth(
+    source_type: str,
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> JSONResponse:
+    """Disconnect OAuth credentials for a data source."""
+    project_root: Path = request.app.state.project_root
+
+    try:
+        from dango.oauth.storage import OAuthStorage
+
+        storage = OAuthStorage(project_root)
+        if not storage.exists(source_type):
+            return JSONResponse(
+                status_code=404,
+                content={"message": f"No OAuth credentials for '{source_type}'."},
+            )
+
+        storage.delete(source_type)
+    except Exception:
+        logger.warning("secrets_oauth_disconnect_failed", source_type=source_type, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={"message": "Failed to disconnect OAuth credentials."},
+        )
+
+    log_auth_event(
+        AuditEvent.OAUTH_SOURCE_DISCONNECTED,
+        user_id=user.id,
+        email=user.email,
+        ip=_get_client_ip(request),
+        details={"source_type": source_type},
+    )
+
+    return JSONResponse(
+        status_code=200,
+        content={"message": f"Disconnected OAuth for '{source_type}'."},
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/secrets — admin secrets page
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings/secrets")
+async def secrets_page(
+    request: Request,
+    user: User = Depends(require_permission("config.manage")),
+) -> HTMLResponse:
+    """Render the admin secrets management page."""
+    from dango.web.routes.ui import _render_template
+
+    return _render_template(
+        "secrets.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "settings",
+            "subtitle": "Secrets & Credentials",
+        },
+    )

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -99,6 +99,7 @@
                             <a href="/settings/account" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Account Settings</a>
                             {% if request.state.user.role.value == 'admin' %}
                             <a href="/settings/users" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">User Management</a>
+                            <a href="/settings/secrets" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Secrets & Credentials</a>
                             {% endif %}
                             <hr class="my-1">
                             <button @click="fetch('/api/auth/logout', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}}).then(() => window.location.href = '/login').catch(() => window.location.href = '/login')" class="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-gray-100">Logout</button>

--- a/dango/web/templates/secrets.html
+++ b/dango/web/templates/secrets.html
@@ -1,0 +1,327 @@
+{% extends "base.html" %}
+
+{% block title %}Secrets & Credentials - Dango{% endblock %}
+
+{% block content %}
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div x-data="secretsPage()" x-init="init()">
+        <!-- Header -->
+        <div class="flex items-center justify-between mb-6">
+            <h2 class="text-xl font-bold text-gray-900">Secrets & Credentials</h2>
+            <button @click="showAddModal = true"
+                    class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors">
+                Add Variable
+            </button>
+        </div>
+
+        <!-- Error banner -->
+        <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+            <p class="text-sm text-red-700" x-text="error"></p>
+        </div>
+
+        <!-- Success banner -->
+        <div x-show="success" x-cloak class="mb-4 p-3 bg-green-50 border border-green-200 rounded-md">
+            <p class="text-sm text-green-700" x-text="success"></p>
+        </div>
+
+        <!-- URL params feedback -->
+        <template x-if="connectedSource">
+            <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded-md">
+                <p class="text-sm text-green-700">
+                    Successfully connected <span class="font-medium" x-text="connectedSource"></span>.
+                </p>
+            </div>
+        </template>
+        <template x-if="connectError">
+            <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+                <p class="text-sm text-red-700" x-text="connectErrorMessage"></p>
+            </div>
+        </template>
+
+        <!-- Section 1: Environment Variables -->
+        <div class="mb-8">
+            <h3 class="text-lg font-medium text-gray-900 mb-3">Environment Variables</h3>
+            <div class="bg-white shadow rounded-lg overflow-hidden">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Key</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Value</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        <template x-for="v in envVars" :key="v.key">
+                            <tr>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-900" x-text="v.key"></td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">***</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-right text-sm space-x-2">
+                                    <button @click="openEditModal(v.key)"
+                                            class="text-dango-600 hover:text-dango-800 font-medium">Edit</button>
+                                    <button @click="confirmDeleteEnv(v.key)"
+                                            class="text-red-600 hover:text-red-800 font-medium">Delete</button>
+                                </td>
+                            </tr>
+                        </template>
+                        <template x-if="envVars.length === 0">
+                            <tr><td colspan="3" class="px-6 py-8 text-center text-sm text-gray-500">No environment variables set.</td></tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <!-- Section 2: OAuth Connections -->
+        <div>
+            <h3 class="text-lg font-medium text-gray-900 mb-3">OAuth Connections</h3>
+
+            <!-- Connected sources -->
+            <div class="space-y-3 mb-4">
+                <template x-for="cred in oauthCredentials" :key="cred.source_type">
+                    <div class="bg-white shadow rounded-lg p-4 flex items-center justify-between">
+                        <div>
+                            <div class="text-sm font-medium text-gray-900" x-text="formatSourceType(cred.source_type)"></div>
+                            <div class="text-xs text-gray-500">
+                                <span x-text="cred.provider"></span>
+                                <template x-if="cred.identifier"> &mdash; <span x-text="cred.identifier"></span></template>
+                            </div>
+                            <div class="text-xs text-gray-400 mt-1">
+                                Connected <span x-text="cred.connected_at ? new Date(cred.connected_at).toLocaleDateString() : ''"></span>
+                                <template x-if="cred.expires_at">
+                                    <span :class="cred.is_expired ? 'text-red-600' : (cred.days_until_expiry <= 7 ? 'text-yellow-600' : '')">
+                                        &middot; <span x-text="cred.is_expired ? 'Expired' : 'Expires ' + new Date(cred.expires_at).toLocaleDateString()"></span>
+                                    </span>
+                                </template>
+                            </div>
+                        </div>
+                        <button @click="confirmDisconnectOAuth(cred.source_type)"
+                                class="px-3 py-1.5 text-sm text-red-600 border border-red-200 rounded-md hover:bg-red-50">
+                            Disconnect
+                        </button>
+                    </div>
+                </template>
+            </div>
+
+            <!-- Available sources to connect -->
+            <div class="bg-white shadow rounded-lg p-4">
+                <p class="text-sm text-gray-500 mb-3">Connect a data source via OAuth:</p>
+                <div class="flex flex-wrap gap-2">
+                    <template x-for="src in availableSources" :key="src.type">
+                        <button @click="connectOAuth(src.type)"
+                                class="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 transition-colors">
+                            Connect <span x-text="src.label"></span>
+                        </button>
+                    </template>
+                </div>
+            </div>
+        </div>
+
+        <!-- Add / Edit Env Var Modal -->
+        <div x-show="showAddModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showAddModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4" x-text="editKey ? 'Edit Variable' : 'Add Variable'"></h3>
+                    <form @submit.prevent="saveEnvVar()">
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Key</label>
+                            <input type="text" x-model="formKey" :readonly="!!editKey" required
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md font-mono focus:outline-none focus:ring-2 focus:ring-dango-500"
+                                   :class="editKey ? 'bg-gray-50' : ''">
+                        </div>
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Value</label>
+                            <input type="text" x-model="formValue" required
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md font-mono focus:outline-none focus:ring-2 focus:ring-dango-500">
+                        </div>
+                        <div class="flex justify-end space-x-3">
+                            <button type="button" @click="closeAddModal()"
+                                    class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            <button type="submit" :disabled="saving"
+                                    class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">
+                                <span x-show="!saving">Save</span>
+                                <span x-show="saving" x-cloak>Saving...</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Delete Env Var Confirm Modal -->
+        <div x-show="showDeleteModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showDeleteModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-red-600 mb-2">Delete Variable</h3>
+                    <p class="text-sm text-gray-500 mb-4">
+                        Delete <span class="font-mono font-medium" x-text="deleteKey"></span>? This cannot be undone.
+                    </p>
+                    <div class="flex justify-end space-x-3">
+                        <button @click="showDeleteModal = false"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="deleteEnvVar()" :disabled="saving"
+                                class="px-4 py-2 text-sm text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50">Delete</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Disconnect OAuth Confirm Modal -->
+        <div x-show="showDisconnectModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showDisconnectModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-red-600 mb-2">Disconnect Source</h3>
+                    <p class="text-sm text-gray-500 mb-4">
+                        Disconnect <span class="font-medium" x-text="formatSourceType(disconnectSource)"></span>?
+                        You will need to re-authenticate to sync this source again.
+                    </p>
+                    <div class="flex justify-end space-x-3">
+                        <button @click="showDisconnectModal = false"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="disconnectOAuth()" :disabled="saving"
+                                class="px-4 py-2 text-sm text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50">Disconnect</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function secretsPage() {
+    const headers = {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'};
+    const params = new URLSearchParams(window.location.search);
+    return {
+        envVars: [], oauthCredentials: [],
+        error: '', success: '',
+        showAddModal: false, formKey: '', formValue: '', editKey: null, saving: false,
+        showDeleteModal: false, deleteKey: '',
+        showDisconnectModal: false, disconnectSource: '',
+        connectedSource: params.get('connected'),
+        connectError: params.get('error'),
+        connectErrorMessage: {
+            'state_mismatch': 'OAuth state mismatch. Please try again.',
+            'provider_denied': 'The OAuth provider denied the request.',
+            'session_expired': 'Your session expired during the OAuth flow. Please log in and try again.',
+            'exchange_failed': 'Failed to exchange OAuth tokens. Please try again.',
+            'missing_credentials': 'Client credentials are not configured. Set them via the environment variables above.',
+            'no_domain': 'A domain with HTTPS is required for OAuth. Configure one first.',
+            'unsupported': 'This source type is not supported for OAuth.',
+        }[params.get('error')] || params.get('error') || '',
+        availableSources: [
+            {type: 'google_ads', label: 'Google Ads'},
+            {type: 'google_analytics', label: 'Google Analytics'},
+            {type: 'google_sheets', label: 'Google Sheets'},
+            {type: 'facebook_ads', label: 'Facebook Ads'},
+        ],
+
+        async init() {
+            await Promise.all([this.loadSecrets(), this.loadOAuth()]);
+        },
+
+        async loadSecrets() {
+            try {
+                const res = await fetch('/api/secrets', {headers});
+                if (!res.ok) throw new Error('Failed to load secrets');
+                const data = await res.json();
+                this.envVars = data.env_vars || [];
+            } catch (e) { this.error = e.message; }
+        },
+
+        async loadOAuth() {
+            try {
+                const res = await fetch('/api/secrets/oauth', {headers});
+                if (!res.ok) throw new Error('Failed to load OAuth credentials');
+                this.oauthCredentials = await res.json();
+            } catch (e) { this.error = e.message; }
+        },
+
+        openEditModal(key) {
+            this.editKey = key;
+            this.formKey = key;
+            this.formValue = '';
+            this.showAddModal = true;
+        },
+
+        closeAddModal() {
+            this.showAddModal = false;
+            this.editKey = null;
+            this.formKey = '';
+            this.formValue = '';
+        },
+
+        async saveEnvVar() {
+            this.saving = true; this.error = '';
+            try {
+                const res = await fetch('/api/secrets', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({key: this.formKey, value: this.formValue})
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.saving = false; return; }
+                this.closeAddModal();
+                this.success = data.message;
+                setTimeout(() => this.success = '', 3000);
+                await this.loadSecrets();
+            } catch (e) { this.error = 'Failed to save variable'; }
+            this.saving = false;
+        },
+
+        confirmDeleteEnv(key) {
+            this.deleteKey = key;
+            this.showDeleteModal = true;
+        },
+
+        async deleteEnvVar() {
+            this.saving = true; this.error = '';
+            try {
+                const res = await fetch(`/api/secrets/${encodeURIComponent(this.deleteKey)}`, {
+                    method: 'DELETE', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.saving = false; return; }
+                this.showDeleteModal = false;
+                this.success = data.message;
+                setTimeout(() => this.success = '', 3000);
+                await this.loadSecrets();
+            } catch (e) { this.error = 'Failed to delete variable'; }
+            this.saving = false;
+        },
+
+        connectOAuth(sourceType) {
+            window.location.href = `/oauth/connect/${sourceType}`;
+        },
+
+        confirmDisconnectOAuth(sourceType) {
+            this.disconnectSource = sourceType;
+            this.showDisconnectModal = true;
+        },
+
+        async disconnectOAuth() {
+            this.saving = true; this.error = '';
+            try {
+                const res = await fetch(`/api/secrets/oauth/${this.disconnectSource}`, {
+                    method: 'DELETE', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message; this.saving = false; return; }
+                this.showDisconnectModal = false;
+                this.success = data.message;
+                setTimeout(() => this.success = '', 3000);
+                await this.loadOAuth();
+            } catch (e) { this.error = 'Failed to disconnect source'; }
+            this.saving = false;
+        },
+
+        formatSourceType(st) {
+            if (!st) return '';
+            return st.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,10 @@ module = [
     "tests.unit.test_remote_cli",
     "tests.unit.test_server_setup",
     "tests.unit.test_serve_command",
+    "tests.unit.test_oauth_web_flow",
+    "tests.unit.test_cli_remote_env",
+    "tests.unit.test_web_secrets",
+    "tests.unit.test_web_oauth_connect",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_cli_remote_env.py
+++ b/tests/unit/test_cli_remote_env.py
@@ -1,0 +1,273 @@
+"""tests/unit/test_cli_remote_env.py
+
+Tests for dango.cli.commands.remote_env — remote environment variable management.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.remote_env import (
+    _parse_env_file,
+    _serialize_env_file,
+    env,
+)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from Rich console output."""
+    return _ANSI_RE.sub("", text)
+
+
+@pytest.mark.unit
+class TestParseEnvFile:
+    """Tests for _parse_env_file."""
+
+    def test_simple_key_value(self):
+        content = "FOO=bar\nBAZ=qux\n"
+        result = _parse_env_file(content)
+        assert result == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_double_quoted_value(self):
+        content = 'KEY="hello world"\n'
+        result = _parse_env_file(content)
+        assert result == {"KEY": "hello world"}
+
+    def test_single_quoted_value(self):
+        content = "KEY='hello world'\n"
+        result = _parse_env_file(content)
+        assert result == {"KEY": "hello world"}
+
+    def test_skips_comments(self):
+        content = "# This is a comment\nFOO=bar\n# Another comment\n"
+        result = _parse_env_file(content)
+        assert result == {"FOO": "bar"}
+
+    def test_skips_blank_lines(self):
+        content = "FOO=bar\n\n\nBAZ=qux\n"
+        result = _parse_env_file(content)
+        assert result == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_skips_lines_without_equals(self):
+        content = "FOO=bar\ninvalid-line\nBAZ=qux\n"
+        result = _parse_env_file(content)
+        assert result == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_empty_value(self):
+        content = "KEY=\n"
+        result = _parse_env_file(content)
+        assert result == {"KEY": ""}
+
+    def test_value_with_equals(self):
+        content = "KEY=value=with=equals\n"
+        result = _parse_env_file(content)
+        assert result == {"KEY": "value=with=equals"}
+
+    def test_empty_content(self):
+        result = _parse_env_file("")
+        assert result == {}
+
+    def test_strips_whitespace(self):
+        content = "  FOO  =  bar  \n"
+        result = _parse_env_file(content)
+        assert result == {"FOO": "bar"}
+
+
+@pytest.mark.unit
+class TestSerializeEnvFile:
+    """Tests for _serialize_env_file."""
+
+    def test_simple_values(self):
+        env_vars = {"FOO": "bar", "BAZ": "qux"}
+        result = _serialize_env_file(env_vars)
+        assert "FOO=bar" in result
+        assert "BAZ=qux" in result
+
+    def test_value_with_spaces_is_quoted(self):
+        env_vars = {"KEY": "hello world"}
+        result = _serialize_env_file(env_vars)
+        assert 'KEY="hello world"' in result
+
+    def test_empty_dict(self):
+        result = _serialize_env_file({})
+        assert result == ""
+
+    def test_roundtrip(self):
+        original = {"FOO": "bar", "BAZ": "qux", "COMPLEX": "has spaces"}
+        serialized = _serialize_env_file(original)
+        parsed = _parse_env_file(serialized)
+        assert parsed == original
+
+
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ssh_mock(env_content: str = "") -> MagicMock:
+    """Create a mock SSHManager that returns *env_content* from read_remote_file."""
+    ssh = MagicMock()
+    ssh.read_remote_file.return_value = env_content
+    ssh.disconnect.return_value = None
+    return ssh
+
+
+def _patch_ssh_connect(ssh_mock: MagicMock, cloud_cfg: MagicMock | None = None):
+    """Return a patch context for _ssh_connect_or_fail."""
+    if cloud_cfg is None:
+        cloud_cfg = MagicMock()
+    from pathlib import Path
+
+    return patch(
+        "dango.cli.commands.remote._ssh_connect_or_fail",
+        return_value=(cloud_cfg, ssh_mock, Path("/test/project")),
+    )
+
+
+@pytest.mark.unit
+class TestEnvSet:
+    """Tests for ``dango remote env set``."""
+
+    def test_set_new_variable(self):
+        ssh = _make_ssh_mock("")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["set", "FOO=bar"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Set" in _strip_ansi(result.output)
+        assert "FOO=***" in _strip_ansi(result.output)
+        ssh.write_remote_file.assert_called_once()
+        written_content = ssh.write_remote_file.call_args[0][1]
+        assert "FOO=bar" in written_content
+
+    def test_update_existing_variable(self):
+        ssh = _make_ssh_mock("FOO=old\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["set", "FOO=new"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Updated" in _strip_ansi(result.output)
+        written_content = ssh.write_remote_file.call_args[0][1]
+        assert "FOO=new" in written_content
+
+    def test_invalid_format_no_equals(self):
+        runner = CliRunner()
+        ssh = _make_ssh_mock()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["set", "INVALID"])
+        assert result.exit_code != 0
+        assert "KEY=VALUE" in _strip_ansi(result.output)
+
+    def test_empty_key_rejected(self):
+        runner = CliRunner()
+        ssh = _make_ssh_mock()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["set", "=value"])
+        assert result.exit_code != 0
+        assert "Key cannot be empty" in _strip_ansi(result.output)
+
+    def test_disconnects_on_success(self):
+        ssh = _make_ssh_mock("")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            runner.invoke(env, ["set", "K=V"], catch_exceptions=False)
+        ssh.disconnect.assert_called_once()
+
+
+@pytest.mark.unit
+class TestEnvGet:
+    """Tests for ``dango remote env get``."""
+
+    def test_get_existing_variable(self):
+        ssh = _make_ssh_mock("FOO=bar\nBAZ=qux\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["get", "FOO"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "FOO=***" in _strip_ansi(result.output)
+
+    def test_get_missing_variable(self):
+        ssh = _make_ssh_mock("FOO=bar\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["get", "MISSING"])
+        assert result.exit_code != 0
+        assert "Not found" in _strip_ansi(result.output)
+
+    def test_disconnects_on_get(self):
+        ssh = _make_ssh_mock("FOO=bar\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            runner.invoke(env, ["get", "FOO"], catch_exceptions=False)
+        ssh.disconnect.assert_called_once()
+
+
+@pytest.mark.unit
+class TestEnvList:
+    """Tests for ``dango remote env list``."""
+
+    def test_list_variables(self):
+        ssh = _make_ssh_mock("FOO=bar\nBAZ=secret\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["list"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "FOO=***" in _strip_ansi(result.output)
+        assert "BAZ=***" in _strip_ansi(result.output)
+        assert "2 variable(s)" in _strip_ansi(result.output)
+        # Ensure raw values are never shown
+        assert "bar" not in _strip_ansi(result.output)
+        assert "secret" not in _strip_ansi(result.output)
+
+    def test_list_empty(self):
+        ssh = _make_ssh_mock("")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["list"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "No environment variables" in _strip_ansi(result.output)
+
+    def test_disconnects_on_list(self):
+        ssh = _make_ssh_mock("")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            runner.invoke(env, ["list"], catch_exceptions=False)
+        ssh.disconnect.assert_called_once()
+
+
+@pytest.mark.unit
+class TestEnvDelete:
+    """Tests for ``dango remote env delete``."""
+
+    def test_delete_existing_variable(self):
+        ssh = _make_ssh_mock("FOO=bar\nBAZ=qux\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["delete", "FOO"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Deleted" in _strip_ansi(result.output)
+        assert "FOO" in _strip_ansi(result.output)
+        written_content = ssh.write_remote_file.call_args[0][1]
+        assert "FOO" not in written_content
+        assert "BAZ=qux" in written_content
+
+    def test_delete_missing_variable(self):
+        ssh = _make_ssh_mock("FOO=bar\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            result = runner.invoke(env, ["delete", "MISSING"])
+        assert result.exit_code != 0
+        assert "Not found" in _strip_ansi(result.output)
+
+    def test_disconnects_on_delete(self):
+        ssh = _make_ssh_mock("FOO=bar\n")
+        runner = CliRunner()
+        with _patch_ssh_connect(ssh):
+            runner.invoke(env, ["delete", "FOO"], catch_exceptions=False)
+        ssh.disconnect.assert_called_once()

--- a/tests/unit/test_cli_remote_env.py
+++ b/tests/unit/test_cli_remote_env.py
@@ -11,11 +11,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from dango.cli.commands.remote_env import (
-    _parse_env_file,
-    _serialize_env_file,
-    env,
-)
+from dango.cli.commands.remote_env import env
+from dango.utils.env_file import parse_env_file, serialize_env_file
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -31,51 +28,51 @@ class TestParseEnvFile:
 
     def test_simple_key_value(self):
         content = "FOO=bar\nBAZ=qux\n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"FOO": "bar", "BAZ": "qux"}
 
     def test_double_quoted_value(self):
         content = 'KEY="hello world"\n'
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"KEY": "hello world"}
 
     def test_single_quoted_value(self):
         content = "KEY='hello world'\n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"KEY": "hello world"}
 
     def test_skips_comments(self):
         content = "# This is a comment\nFOO=bar\n# Another comment\n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"FOO": "bar"}
 
     def test_skips_blank_lines(self):
         content = "FOO=bar\n\n\nBAZ=qux\n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"FOO": "bar", "BAZ": "qux"}
 
     def test_skips_lines_without_equals(self):
         content = "FOO=bar\ninvalid-line\nBAZ=qux\n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"FOO": "bar", "BAZ": "qux"}
 
     def test_empty_value(self):
         content = "KEY=\n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"KEY": ""}
 
     def test_value_with_equals(self):
         content = "KEY=value=with=equals\n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"KEY": "value=with=equals"}
 
     def test_empty_content(self):
-        result = _parse_env_file("")
+        result = parse_env_file("")
         assert result == {}
 
     def test_strips_whitespace(self):
         content = "  FOO  =  bar  \n"
-        result = _parse_env_file(content)
+        result = parse_env_file(content)
         assert result == {"FOO": "bar"}
 
 
@@ -85,23 +82,23 @@ class TestSerializeEnvFile:
 
     def test_simple_values(self):
         env_vars = {"FOO": "bar", "BAZ": "qux"}
-        result = _serialize_env_file(env_vars)
+        result = serialize_env_file(env_vars)
         assert "FOO=bar" in result
         assert "BAZ=qux" in result
 
     def test_value_with_spaces_is_quoted(self):
         env_vars = {"KEY": "hello world"}
-        result = _serialize_env_file(env_vars)
+        result = serialize_env_file(env_vars)
         assert 'KEY="hello world"' in result
 
     def test_empty_dict(self):
-        result = _serialize_env_file({})
+        result = serialize_env_file({})
         assert result == ""
 
     def test_roundtrip(self):
         original = {"FOO": "bar", "BAZ": "qux", "COMPLEX": "has spaces"}
-        serialized = _serialize_env_file(original)
-        parsed = _parse_env_file(serialized)
+        serialized = serialize_env_file(original)
+        parsed = parse_env_file(serialized)
         assert parsed == original
 
 

--- a/tests/unit/test_oauth_web_flow.py
+++ b/tests/unit/test_oauth_web_flow.py
@@ -1,0 +1,304 @@
+"""tests/unit/test_oauth_web_flow.py
+
+Tests for dango.oauth.web_flow — OAuth token exchange helpers for the web flow.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.oauth.web_flow import (
+    SUPPORTED_OAUTH_SOURCES,
+    OAuthFlowError,
+    build_facebook_auth_url,
+    build_google_auth_url,
+    exchange_facebook_code,
+    exchange_google_code,
+    fetch_google_user_info,
+)
+
+
+@pytest.mark.unit
+class TestSupportedOAuthSources:
+    """Verify the SUPPORTED_OAUTH_SOURCES mapping."""
+
+    def test_google_sources_present(self):
+        assert "google_ads" in SUPPORTED_OAUTH_SOURCES
+        assert "google_analytics" in SUPPORTED_OAUTH_SOURCES
+        assert "google_sheets" in SUPPORTED_OAUTH_SOURCES
+
+    def test_facebook_source_present(self):
+        assert "facebook_ads" in SUPPORTED_OAUTH_SOURCES
+
+    def test_provider_values(self):
+        assert SUPPORTED_OAUTH_SOURCES["google_ads"] == "google"
+        assert SUPPORTED_OAUTH_SOURCES["facebook_ads"] == "facebook"
+
+
+@pytest.mark.unit
+class TestBuildGoogleAuthUrl:
+    """Tests for build_google_auth_url."""
+
+    def test_basic_url_structure(self):
+        url = build_google_auth_url(
+            client_id="test-client-id",
+            redirect_uri="https://example.com/oauth/callback/google_ads",
+            source_type="google_ads",
+            state="random-state-token",
+        )
+        assert url.startswith("https://accounts.google.com/o/oauth2/v2/auth?")
+        assert "client_id=test-client-id" in url
+        assert "state=random-state-token" in url
+        assert "response_type=code" in url
+        assert "access_type=offline" in url
+        assert "prompt=consent" in url
+
+    def test_redirect_uri_encoded(self):
+        url = build_google_auth_url(
+            client_id="cid",
+            redirect_uri="https://example.com/oauth/callback/google_ads",
+            source_type="google_ads",
+            state="s",
+        )
+        assert "redirect_uri=https" in url
+
+    def test_google_ads_scopes(self):
+        url = build_google_auth_url(
+            client_id="cid",
+            redirect_uri="https://example.com/cb",
+            source_type="google_ads",
+            state="s",
+        )
+        assert "userinfo.email" in url
+        assert "adwords" in url
+
+    def test_google_analytics_scopes(self):
+        url = build_google_auth_url(
+            client_id="cid",
+            redirect_uri="https://example.com/cb",
+            source_type="google_analytics",
+            state="s",
+        )
+        assert "analytics.readonly" in url
+
+    def test_google_sheets_scopes(self):
+        url = build_google_auth_url(
+            client_id="cid",
+            redirect_uri="https://example.com/cb",
+            source_type="google_sheets",
+            state="s",
+        )
+        assert "spreadsheets.readonly" in url
+
+    def test_unknown_source_uses_base_scopes(self):
+        url = build_google_auth_url(
+            client_id="cid",
+            redirect_uri="https://example.com/cb",
+            source_type="unknown_source",
+            state="s",
+        )
+        assert "userinfo.email" in url
+
+
+@pytest.mark.unit
+class TestExchangeGoogleCode:
+    """Tests for exchange_google_code."""
+
+    @patch("dango.oauth.web_flow.requests.post")
+    def test_successful_exchange(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "access_token": "ya29.test",
+            "refresh_token": "1//test",
+            "expires_in": 3600,
+        }
+        mock_post.return_value = mock_resp
+
+        result = exchange_google_code(
+            code="auth-code",
+            client_id="cid",
+            client_secret="csecret",
+            redirect_uri="https://example.com/cb",
+        )
+        assert result["access_token"] == "ya29.test"
+        assert result["refresh_token"] == "1//test"
+        mock_post.assert_called_once()
+
+    @patch("dango.oauth.web_flow.requests.post")
+    def test_failed_exchange_raises(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "Bad Request"
+        mock_post.return_value = mock_resp
+
+        with pytest.raises(OAuthFlowError, match="Google token exchange failed"):
+            exchange_google_code("code", "cid", "cs", "https://example.com/cb")
+
+    @patch("dango.oauth.web_flow.requests.post")
+    def test_network_error_raises(self, mock_post):
+        import requests
+
+        mock_post.side_effect = requests.ConnectionError("refused")
+
+        with pytest.raises(OAuthFlowError, match="Failed to contact Google"):
+            exchange_google_code("code", "cid", "cs", "https://example.com/cb")
+
+    @patch("dango.oauth.web_flow.requests.post")
+    def test_error_has_provider_attribute(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "err"
+        mock_post.return_value = mock_resp
+
+        with pytest.raises(OAuthFlowError) as exc_info:
+            exchange_google_code("code", "cid", "cs", "https://example.com/cb")
+        assert exc_info.value.provider == "google"
+
+
+@pytest.mark.unit
+class TestFetchGoogleUserInfo:
+    """Tests for fetch_google_user_info."""
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_successful_fetch(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "email": "user@example.com",
+            "name": "Test User",
+        }
+        mock_get.return_value = mock_resp
+
+        result = fetch_google_user_info("ya29.test")
+        assert result["email"] == "user@example.com"
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args
+        assert "Bearer ya29.test" in str(call_kwargs)
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_failed_fetch_raises(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(OAuthFlowError, match="Failed to fetch Google user info"):
+            fetch_google_user_info("bad-token")
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_network_error_raises(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.ConnectionError("refused")
+
+        with pytest.raises(OAuthFlowError, match="Failed to fetch Google user info"):
+            fetch_google_user_info("token")
+
+
+@pytest.mark.unit
+class TestBuildFacebookAuthUrl:
+    """Tests for build_facebook_auth_url."""
+
+    def test_basic_url_structure(self):
+        url = build_facebook_auth_url(
+            client_id="fb-app-id",
+            redirect_uri="https://example.com/oauth/callback/facebook_ads",
+            state="random-state",
+        )
+        assert url.startswith("https://www.facebook.com/v18.0/dialog/oauth?")
+        assert "client_id=fb-app-id" in url
+        assert "state=random-state" in url
+        assert "response_type=code" in url
+
+    def test_scopes_included(self):
+        url = build_facebook_auth_url(
+            client_id="fid",
+            redirect_uri="https://example.com/cb",
+            state="s",
+        )
+        assert "ads_read" in url
+        assert "ads_management" in url
+
+
+@pytest.mark.unit
+class TestExchangeFacebookCode:
+    """Tests for exchange_facebook_code."""
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_successful_exchange(self, mock_get):
+        # First call: short-lived token
+        short_resp = MagicMock()
+        short_resp.status_code = 200
+        short_resp.json.return_value = {"access_token": "short-token"}
+
+        # Second call: long-lived token
+        long_resp = MagicMock()
+        long_resp.status_code = 200
+        long_resp.json.return_value = {
+            "access_token": "long-lived-token",
+            "token_type": "bearer",
+            "expires_in": 5184000,
+        }
+
+        mock_get.side_effect = [short_resp, long_resp]
+
+        result = exchange_facebook_code("code", "fid", "fsecret", "https://example.com/cb")
+        assert result["access_token"] == "long-lived-token"
+        assert mock_get.call_count == 2
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_short_lived_exchange_fails(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "Bad request"
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(OAuthFlowError, match="Facebook token exchange failed"):
+            exchange_facebook_code("code", "fid", "fsecret", "https://example.com/cb")
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_missing_access_token_raises(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(OAuthFlowError, match="did not return an access token"):
+            exchange_facebook_code("code", "fid", "fsecret", "https://example.com/cb")
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_long_lived_exchange_fails(self, mock_get):
+        short_resp = MagicMock()
+        short_resp.status_code = 200
+        short_resp.json.return_value = {"access_token": "short-token"}
+
+        long_resp = MagicMock()
+        long_resp.status_code = 400
+        long_resp.text = "Error"
+
+        mock_get.side_effect = [short_resp, long_resp]
+
+        with pytest.raises(OAuthFlowError, match="long-lived Facebook token"):
+            exchange_facebook_code("code", "fid", "fsecret", "https://example.com/cb")
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_network_error_raises(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.ConnectionError("refused")
+
+        with pytest.raises(OAuthFlowError, match="Failed to contact Facebook"):
+            exchange_facebook_code("code", "fid", "fsecret", "https://example.com/cb")
+
+    @patch("dango.oauth.web_flow.requests.get")
+    def test_error_has_provider_attribute(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = "err"
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(OAuthFlowError) as exc_info:
+            exchange_facebook_code("code", "fid", "fs", "https://example.com/cb")
+        assert exc_info.value.provider == "facebook"

--- a/tests/unit/test_web_oauth_connect.py
+++ b/tests/unit/test_web_oauth_connect.py
@@ -1,0 +1,386 @@
+"""tests/unit/test_web_oauth_connect.py
+
+Tests for dango.web.routes.oauth_connect — OAuth connect/callback routes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import DangoError
+from dango.web.routes.oauth_connect import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_admin() -> User:
+    """Create an admin user for tests."""
+    return User(
+        id="u-admin-1",
+        email="admin@test.com",
+        password_hash="hashed",
+        role=Role.ADMIN,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the oauth connect router."""
+    from dango.exceptions import AuthenticationError, AuthorizationError
+
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_admin_client(tmp_path: Path) -> tuple[TestClient, Path]:
+    """Create a test client with admin user injected via middleware."""
+    admin = _make_admin()
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = admin
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+HEADERS: dict[str, str] = {
+    "X-Requested-With": "XMLHttpRequest",
+}
+
+
+@pytest.fixture()
+def setup(tmp_path: Path) -> tuple[TestClient, Path]:
+    client, project_root = _setup_admin_client(tmp_path)
+    return client, project_root
+
+
+# ---------------------------------------------------------------------------
+# GET /oauth/connect/{source_type} tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOAuthConnect:
+    """Tests for GET /oauth/connect/{source_type}."""
+
+    def test_unsupported_source_rejected(self, setup: tuple[TestClient, Path]) -> None:
+        client, _tmp = setup
+        resp = client.get(
+            "/oauth/connect/unsupported_source",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 400
+        assert "Unsupported" in resp.json()["message"]
+
+    @patch("dango.web.routes.oauth_connect._load_cloud_domain", return_value=None)
+    def test_no_domain_rejected(
+        self, mock_domain: MagicMock, setup: tuple[TestClient, Path]
+    ) -> None:
+        client, _tmp = setup
+        resp = client.get(
+            "/oauth/connect/google_ads",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 400
+        assert "domain" in resp.json()["message"].lower()
+
+    @patch("dango.web.routes.oauth_connect._load_cloud_domain", return_value="example.com")
+    @patch("dango.web.routes.oauth_connect._get_client_credentials", return_value=None)
+    def test_no_credentials_rejected(
+        self,
+        mock_creds: MagicMock,
+        mock_domain: MagicMock,
+        setup: tuple[TestClient, Path],
+    ) -> None:
+        client, _tmp = setup
+        resp = client.get(
+            "/oauth/connect/google_ads",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 400
+        assert "credentials" in resp.json()["message"].lower()
+
+    @patch("dango.web.routes.oauth_connect._load_cloud_domain", return_value="example.com")
+    @patch(
+        "dango.web.routes.oauth_connect._get_client_credentials",
+        return_value=("client-id", "client-secret"),
+    )
+    def test_google_redirect(
+        self,
+        mock_creds: MagicMock,
+        mock_domain: MagicMock,
+        setup: tuple[TestClient, Path],
+    ) -> None:
+        client, _tmp = setup
+        resp = client.get(
+            "/oauth/connect/google_ads",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert "accounts.google.com" in location
+        assert "client-id" in location
+        # State cookies should be set
+        cookies = resp.cookies
+        assert "dango_source_oauth_state" in cookies
+        assert "dango_source_oauth_type" in cookies
+
+    @patch("dango.web.routes.oauth_connect._load_cloud_domain", return_value="example.com")
+    @patch(
+        "dango.web.routes.oauth_connect._get_client_credentials",
+        return_value=("fb-app-id", "fb-secret"),
+    )
+    def test_facebook_redirect(
+        self,
+        mock_creds: MagicMock,
+        mock_domain: MagicMock,
+        setup: tuple[TestClient, Path],
+    ) -> None:
+        client, _tmp = setup
+        resp = client.get(
+            "/oauth/connect/facebook_ads",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert "facebook.com" in location
+        assert "fb-app-id" in location
+
+
+# ---------------------------------------------------------------------------
+# GET /oauth/callback/{source_type} tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOAuthCallback:
+    """Tests for GET /oauth/callback/{source_type}."""
+
+    def test_state_mismatch_redirects(self, setup: tuple[TestClient, Path]) -> None:
+        client, _tmp = setup
+        resp = client.get(
+            "/oauth/callback/google_ads?state=wrong&code=abc",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307 or resp.status_code == 302
+        location = resp.headers.get("location", "")
+        assert "error=state_mismatch" in location
+
+    def test_provider_error_redirects(self, setup: tuple[TestClient, Path]) -> None:
+        client, _tmp = setup
+        # Set a matching state cookie
+        client.cookies.set("dango_source_oauth_state", "test-state")
+        client.cookies.set("dango_source_oauth_type", "google_ads")
+        resp = client.get(
+            "/oauth/callback/google_ads?state=test-state&error=access_denied",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307 or resp.status_code == 302
+        location = resp.headers.get("location", "")
+        assert "error=provider_denied" in location
+
+    def test_no_code_redirects(self, setup: tuple[TestClient, Path]) -> None:
+        client, _tmp = setup
+        client.cookies.set("dango_source_oauth_state", "test-state")
+        client.cookies.set("dango_source_oauth_type", "google_ads")
+        resp = client.get(
+            "/oauth/callback/google_ads?state=test-state",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307 or resp.status_code == 302
+        location = resp.headers.get("location", "")
+        assert "error=no_code" in location
+
+    @patch("dango.web.routes.oauth_connect._load_cloud_domain", return_value="example.com")
+    @patch(
+        "dango.web.routes.oauth_connect._get_client_credentials",
+        return_value=("client-id", "client-secret"),
+    )
+    @patch("dango.web.routes.oauth_connect.exchange_google_code")
+    @patch("dango.web.routes.oauth_connect.fetch_google_user_info")
+    @patch("dango.oauth.storage.OAuthStorage.save", return_value=True)
+    @patch("dango.web.routes.oauth_connect.log_auth_event")
+    def test_google_callback_success(
+        self,
+        mock_log: MagicMock,
+        mock_save: MagicMock,
+        mock_user_info: MagicMock,
+        mock_exchange: MagicMock,
+        mock_creds: MagicMock,
+        mock_domain: MagicMock,
+        setup: tuple[TestClient, Path],
+    ) -> None:
+        client, tmp_path = setup
+        # Set up .dlt directory for OAuthStorage
+        (tmp_path / ".dlt").mkdir()
+        (tmp_path / ".dlt" / "secrets.toml").write_text("")
+
+        mock_exchange.return_value = {
+            "access_token": "at-123",
+            "refresh_token": "rt-456",
+            "expires_in": 3600,
+        }
+        mock_user_info.return_value = {
+            "email": "user@example.com",
+            "name": "Test User",
+        }
+
+        client.cookies.set("dango_source_oauth_state", "test-state")
+        client.cookies.set("dango_source_oauth_type", "google_ads")
+        resp = client.get(
+            "/oauth/callback/google_ads?state=test-state&code=auth-code-123",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307 or resp.status_code == 302
+        location = resp.headers.get("location", "")
+        assert "connected=google_ads" in location
+
+        # Verify exchange was called
+        mock_exchange.assert_called_once()
+        # Verify audit event logged
+        mock_log.assert_called_once()
+        from dango.auth.audit import AuditEvent
+
+        assert mock_log.call_args[0][0] == AuditEvent.OAUTH_SOURCE_CONNECTED
+
+    @patch("dango.web.routes.oauth_connect._load_cloud_domain", return_value="example.com")
+    @patch(
+        "dango.web.routes.oauth_connect._get_client_credentials",
+        return_value=("client-id", "client-secret"),
+    )
+    @patch("dango.web.routes.oauth_connect._exchange_code")
+    def test_token_exchange_failure_redirects(
+        self,
+        mock_exchange: MagicMock,
+        mock_creds: MagicMock,
+        mock_domain: MagicMock,
+        setup: tuple[TestClient, Path],
+    ) -> None:
+        client, _tmp = setup
+        from dango.oauth.web_flow import OAuthFlowError
+
+        mock_exchange.side_effect = OAuthFlowError("Token exchange failed", provider="google")
+
+        client.cookies.set("dango_source_oauth_state", "test-state")
+        client.cookies.set("dango_source_oauth_type", "google_ads")
+        resp = client.get(
+            "/oauth/callback/google_ads?state=test-state&code=bad-code",
+            headers=HEADERS,
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307 or resp.status_code == 302
+        location = resp.headers.get("location", "")
+        assert "error=token_exchange_failed" in location
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHelpers:
+    """Tests for internal helper functions."""
+
+    def test_get_redirect_uri(self) -> None:
+        from dango.web.routes.oauth_connect import _get_redirect_uri
+
+        uri = _get_redirect_uri("example.com", "google_ads")
+        assert uri == "https://example.com/oauth/callback/google_ads"
+
+    def test_get_client_credentials_google(self, tmp_path: Path) -> None:
+        from dango.web.routes.oauth_connect import _get_client_credentials
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("GOOGLE_CLIENT_ID=gid\nGOOGLE_CLIENT_SECRET=gsec\n")
+        result = _get_client_credentials(tmp_path, "google")
+        assert result == ("gid", "gsec")
+
+    def test_get_client_credentials_facebook(self, tmp_path: Path) -> None:
+        from dango.web.routes.oauth_connect import _get_client_credentials
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("FACEBOOK_APP_ID=fid\nFACEBOOK_APP_SECRET=fsec\n")
+        result = _get_client_credentials(tmp_path, "facebook")
+        assert result == ("fid", "fsec")
+
+    def test_get_client_credentials_missing(self, tmp_path: Path) -> None:
+        from dango.web.routes.oauth_connect import _get_client_credentials
+
+        result = _get_client_credentials(tmp_path, "google")
+        assert result is None
+
+    def test_get_client_credentials_unsupported_provider(self, tmp_path: Path) -> None:
+        from dango.web.routes.oauth_connect import _get_client_credentials
+
+        result = _get_client_credentials(tmp_path, "shopify")
+        assert result is None
+
+    def test_exchange_code_google(self) -> None:
+        from dango.web.routes.oauth_connect import _exchange_code
+
+        with patch("dango.web.routes.oauth_connect.exchange_google_code") as mock:
+            mock.return_value = {"access_token": "at"}
+            result = _exchange_code("google", "code", "cid", "cs", "uri")
+            assert result == {"access_token": "at"}
+            mock.assert_called_once()
+
+    def test_exchange_code_facebook(self) -> None:
+        from dango.web.routes.oauth_connect import _exchange_code
+
+        with patch("dango.web.routes.oauth_connect.exchange_facebook_code") as mock:
+            mock.return_value = {"access_token": "at"}
+            result = _exchange_code("facebook", "code", "cid", "cs", "uri")
+            assert result == {"access_token": "at"}
+            mock.assert_called_once()
+
+    def test_exchange_code_unsupported(self) -> None:
+        from dango.oauth.web_flow import OAuthFlowError
+        from dango.web.routes.oauth_connect import _exchange_code
+
+        with pytest.raises(OAuthFlowError, match="Unsupported"):
+            _exchange_code("shopify", "code", "cid", "cs", "uri")

--- a/tests/unit/test_web_secrets.py
+++ b/tests/unit/test_web_secrets.py
@@ -1,0 +1,282 @@
+"""tests/unit/test_web_secrets.py
+
+Tests for dango.web.routes.secrets — secrets management API endpoints.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import DangoError
+from dango.web.routes.secrets import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_admin() -> User:
+    """Create an admin user for tests."""
+    return User(
+        id="u-admin-1",
+        email="admin@test.com",
+        password_hash="hashed",
+        role=Role.ADMIN,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the secrets router."""
+    from dango.exceptions import AuthenticationError, AuthorizationError
+
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_admin_client(tmp_path: Path) -> tuple[TestClient, Path]:
+    """Create a test client with an admin user injected via middleware."""
+    admin = _make_admin()
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = admin
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+HEADERS: dict[str, str] = {
+    "X-Requested-With": "XMLHttpRequest",
+    "Content-Type": "application/json",
+}
+
+
+@pytest.fixture()
+def setup(tmp_path):
+    client, project_root = _setup_admin_client(tmp_path)
+    return client, project_root
+
+
+# ---------------------------------------------------------------------------
+# .env CRUD tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestListSecrets:
+    """Tests for GET /api/secrets."""
+
+    def test_empty_list(self, setup):
+        client, tmp_path = setup
+        resp = client.get("/api/secrets", headers=HEADERS)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["env_vars"] == []
+
+    def test_list_with_env_vars(self, setup):
+        client, tmp_path = setup
+        (tmp_path / ".env").write_text("FOO=bar\nBAZ=qux\n")
+        resp = client.get("/api/secrets", headers=HEADERS)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["env_vars"]) == 2
+        keys = [v["key"] for v in data["env_vars"]]
+        assert "FOO" in keys
+        assert "BAZ" in keys
+        for v in data["env_vars"]:
+            assert v["masked_value"] == "***"
+
+
+@pytest.mark.unit
+class TestSetSecret:
+    """Tests for POST /api/secrets."""
+
+    def test_set_new_variable(self, setup):
+        client, tmp_path = setup
+        resp = client.post(
+            "/api/secrets", json={"key": "NEW_KEY", "value": "new_value"}, headers=HEADERS
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "created" in data["message"]
+        content = (tmp_path / ".env").read_text()
+        assert "NEW_KEY=new_value" in content
+
+    def test_update_existing_variable(self, setup):
+        client, tmp_path = setup
+        (tmp_path / ".env").write_text("KEY=old\n")
+        resp = client.post("/api/secrets", json={"key": "KEY", "value": "new"}, headers=HEADERS)
+        assert resp.status_code == 200
+        assert "updated" in resp.json()["message"]
+        content = (tmp_path / ".env").read_text()
+        assert "KEY=new" in content
+
+    def test_empty_key_rejected(self, setup):
+        client, _tmp = setup
+        resp = client.post("/api/secrets", json={"key": "", "value": "v"}, headers=HEADERS)
+        assert resp.status_code == 400
+
+    def test_missing_key_rejected(self, setup):
+        client, _tmp = setup
+        resp = client.post("/api/secrets", json={"value": "v"}, headers=HEADERS)
+        assert resp.status_code == 400
+
+    @patch("dango.web.routes.secrets.log_auth_event")
+    def test_audit_event_logged(self, mock_log, setup):
+        client, _tmp = setup
+        client.post("/api/secrets", json={"key": "K", "value": "V"}, headers=HEADERS)
+        mock_log.assert_called_once()
+        from dango.auth.audit import AuditEvent
+
+        assert mock_log.call_args[0][0] == AuditEvent.SECRET_SET
+
+
+@pytest.mark.unit
+class TestDeleteSecret:
+    """Tests for DELETE /api/secrets/{key}."""
+
+    def test_delete_existing_key(self, setup):
+        client, tmp_path = setup
+        (tmp_path / ".env").write_text("FOO=bar\nBAZ=qux\n")
+        resp = client.delete("/api/secrets/FOO", headers=HEADERS)
+        assert resp.status_code == 200
+        content = (tmp_path / ".env").read_text()
+        assert "FOO" not in content
+        assert "BAZ=qux" in content
+
+    def test_delete_missing_key(self, setup):
+        client, _tmp = setup
+        resp = client.delete("/api/secrets/MISSING", headers=HEADERS)
+        assert resp.status_code == 404
+
+    @patch("dango.web.routes.secrets.log_auth_event")
+    def test_audit_event_logged(self, mock_log, setup):
+        client, tmp_path = setup
+        (tmp_path / ".env").write_text("K=V\n")
+        client.delete("/api/secrets/K", headers=HEADERS)
+        mock_log.assert_called_once()
+        from dango.auth.audit import AuditEvent
+
+        assert mock_log.call_args[0][0] == AuditEvent.SECRET_DELETED
+
+
+# ---------------------------------------------------------------------------
+# OAuth credential tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestListOAuthCredentials:
+    """Tests for GET /api/secrets/oauth."""
+
+    def test_empty_list(self, setup):
+        client, tmp_path = setup
+        # OAuthStorage needs .dlt dir
+        (tmp_path / ".dlt").mkdir()
+        (tmp_path / ".dlt" / "secrets.toml").write_text("")
+        resp = client.get("/api/secrets/oauth", headers=HEADERS)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+@pytest.mark.unit
+class TestDisconnectOAuth:
+    """Tests for DELETE /api/secrets/oauth/{source_type}."""
+
+    def test_disconnect_nonexistent(self, setup):
+        client, tmp_path = setup
+        (tmp_path / ".dlt").mkdir()
+        (tmp_path / ".dlt" / "secrets.toml").write_text("")
+        resp = client.delete("/api/secrets/oauth/google_ads", headers=HEADERS)
+        assert resp.status_code == 404
+
+    @patch("dango.web.routes.secrets.log_auth_event")
+    def test_audit_on_disconnect(self, mock_log, setup):
+        client, tmp_path = setup
+        (tmp_path / ".dlt").mkdir()
+        (tmp_path / ".dlt" / "secrets.toml").write_text("")
+
+        with (
+            patch("dango.oauth.storage.OAuthStorage.exists", return_value=True),
+            patch("dango.oauth.storage.OAuthStorage.delete", return_value=True),
+        ):
+            resp = client.delete("/api/secrets/oauth/google_ads", headers=HEADERS)
+
+        assert resp.status_code == 200
+        mock_log.assert_called_once()
+        from dango.auth.audit import AuditEvent
+
+        assert mock_log.call_args[0][0] == AuditEvent.OAUTH_SOURCE_DISCONNECTED
+
+
+# ---------------------------------------------------------------------------
+# .env file helpers (unit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEnvFileHelpers:
+    """Tests for _read_env_file and _write_env_file."""
+
+    def test_read_nonexistent_returns_empty(self, tmp_path):
+        from dango.web.routes.secrets import _read_env_file
+
+        assert _read_env_file(tmp_path) == {}
+
+    def test_write_creates_file(self, tmp_path):
+        from dango.web.routes.secrets import _write_env_file
+
+        _write_env_file(tmp_path, {"KEY": "VALUE"})
+        env_file = tmp_path / ".env"
+        assert env_file.exists()
+        mode = env_file.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_roundtrip(self, tmp_path):
+        from dango.web.routes.secrets import _read_env_file, _write_env_file
+
+        original = {"FOO": "bar", "BAZ": "qux"}
+        _write_env_file(tmp_path, original)
+        result = _read_env_file(tmp_path)
+        assert result == original
+
+    def test_file_permissions_600(self, tmp_path):
+        from dango.web.routes.secrets import _write_env_file
+
+        _write_env_file(tmp_path, {"A": "1"})
+        env_file = tmp_path / ".env"
+        mode = env_file.stat().st_mode & 0o777
+        assert mode == 0o600

--- a/tests/unit/test_web_secrets.py
+++ b/tests/unit/test_web_secrets.py
@@ -243,18 +243,35 @@ class TestDisconnectOAuth:
 
 
 # ---------------------------------------------------------------------------
+# Page route tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSecretsPage:
+    """Tests for GET /settings/secrets page route."""
+
+    def test_page_returns_html(self, setup):
+        client, _tmp = setup
+        resp = client.get("/settings/secrets", headers=HEADERS)
+        assert resp.status_code == 200
+        content_type = resp.headers.get("content-type", "")
+        assert "text/html" in content_type
+
+
+# ---------------------------------------------------------------------------
 # .env file helpers (unit)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestEnvFileHelpers:
-    """Tests for _read_env_file and _write_env_file."""
+    """Tests for read_env_file and _write_env_file."""
 
     def test_read_nonexistent_returns_empty(self, tmp_path):
-        from dango.web.routes.secrets import _read_env_file
+        from dango.web.routes.secrets import read_env_file
 
-        assert _read_env_file(tmp_path) == {}
+        assert read_env_file(tmp_path) == {}
 
     def test_write_creates_file(self, tmp_path):
         from dango.web.routes.secrets import _write_env_file
@@ -266,11 +283,11 @@ class TestEnvFileHelpers:
         assert mode == 0o600
 
     def test_roundtrip(self, tmp_path):
-        from dango.web.routes.secrets import _read_env_file, _write_env_file
+        from dango.web.routes.secrets import _write_env_file, read_env_file
 
         original = {"FOO": "bar", "BAZ": "qux"}
         _write_env_file(tmp_path, original)
-        result = _read_env_file(tmp_path)
+        result = read_env_file(tmp_path)
         assert result == original
 
     def test_file_permissions_600(self, tmp_path):


### PR DESCRIPTION
## Summary

- **CLI `remote env` commands** — `dango remote env set/get/list/delete` for SSH-based .env management on cloud servers
- **Web secrets page + API** — Admin-only CRUD for environment variables (masked values), OAuth credential listing/disconnect, audit logging, Alpine.js UI at `/settings/secrets`
- **Web OAuth connect/callback** — Browser-based OAuth flow for Google (Ads, Analytics, Sheets) and Facebook (Ads) on cloud deployments with CSRF state cookies and OAuthStorage persistence
- **OAuth web flow helpers** — Pure functions for Google/Facebook token exchange, decoupled from CLI's `providers.py`
- **4 new audit events** — `SECRET_SET`, `SECRET_DELETED`, `OAUTH_SOURCE_CONNECTED`, `OAUTH_SOURCE_DISCONNECTED`

### New files (8)
| File | Lines | Purpose |
|------|-------|---------|
| `dango/cli/commands/remote_env.py` | 249 | CLI `remote env` subgroup |
| `dango/oauth/web_flow.py` | 308 | Token exchange helpers for web OAuth |
| `dango/web/routes/secrets.py` | 325 | Secrets API endpoints + page route |
| `dango/web/routes/oauth_connect.py` | 389 | OAuth connect/callback routes |
| `dango/web/templates/secrets.html` | 327 | Admin secrets page (Alpine.js) |
| `tests/unit/test_cli_remote_env.py` | 273 | 28 CLI command tests |
| `tests/unit/test_web_secrets.py` | 282 | 17 secrets API tests |
| `tests/unit/test_web_oauth_connect.py` | 386 | 18 OAuth flow tests |
| `tests/unit/test_oauth_web_flow.py` | 304 | 24 token exchange tests |

### Modified files (5)
| File | Change |
|------|--------|
| `dango/auth/audit.py` | +4 AuditEvent members |
| `dango/cli/commands/remote.py` | `_ssh_connect_or_fail()` helper, register `env` subgroup |
| `dango/web/app.py` | Register secrets + oauth_connect routers |
| `dango/web/templates/base.html` | Nav link to Secrets & Credentials |
| `pyproject.toml` | mypy exemptions for 4 new test files |

## Test plan

- [x] 87 new tests across 4 test files (all passing)
- [x] Full test suite: 1555 tests pass, 0 regressions
- [x] ruff check + ruff format + mypy clean on all new files
- [ ] Manual: verify `/settings/secrets` page renders correctly
- [ ] Manual: verify `dango remote env set/get/list/delete` against a deployed server
- [ ] Manual: verify OAuth connect flow with a configured domain + Google credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)