### PR TITLE
Add project file sync and remote push deploy (TASK-028, TASK-030)

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -23,7 +23,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
-| `commands/remote.py` (~220 lines) | `remote` group → `firewall` subgroup (`list`, `allow-ip`, `allow-all`) | `remote`, `firewall` |
+| `commands/remote.py` (~300 lines) | `remote` group → `push`, `firewall` subgroup (`list`, `allow-ip`, `allow-all`) | `remote`, `firewall`, `remote_push()` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~110 lines) | `serve` production foreground server | `serve()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
@@ -76,6 +76,7 @@ dango (top-level group)
 ├── migrate (group)             ← commands/migrate.py
 │   ├── status, run
 ├── remote (group)              ← commands/remote.py
+│   ├── push
 │   └── firewall (subgroup)
 │       ├── list, allow-ip, allow-all
 └── metabase (group)            ← commands/metabase_cmd.py

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -23,7 +23,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
-| `commands/remote.py` (~300 lines) | `remote` group → `push`, `firewall` subgroup (`list`, `allow-ip`, `allow-all`) | `remote`, `firewall`, `remote_push()` |
+| `commands/remote.py` (~650 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~110 lines) | `serve` production foreground server | `serve()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -382,8 +382,8 @@ def remote_push(ctx: click.Context, dry_run: bool, force: bool, yes: bool) -> No
         console.print(f"[red]Error:[/red] Push failed: {exc}")
         if not dry_run:
             console.print(
-                "[dim]A pre-deploy backup was created. "
-                "Use [bold]dango remote rollback[/bold] to restore.[/dim]"
+                "[dim]A pre-deploy backup may have been created. "
+                "Use [bold]dango remote rollback[/bold] to check and restore.[/dim]"
             )
         raise SystemExit(1) from exc
     finally:

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -9,6 +9,7 @@ Command hierarchy::
     ├── logs                — View service logs (with optional streaming)
     ├── ssh                 — Open interactive SSH session
     ├── query               — Run read-only SQL against remote DuckDB
+    ├── push                — Push local files and rebuild
     ├── rollback            — Restore from a backup
     ├── env (subgroup)
     │   ├── set K=V         — Set an environment variable
@@ -55,6 +56,7 @@ def remote(ctx: click.Context) -> None:
       dango remote logs                    View service logs
       dango remote ssh                     Open interactive SSH session
       dango remote query "SQL"             Run read-only SQL query
+      dango remote push                    Push local files and rebuild
       dango remote rollback                Restore from a backup
       dango remote firewall list           Show current firewall rules
       dango remote firewall allow-ip       Restrict web to a specific IP
@@ -271,7 +273,121 @@ def remote_rollback(ctx: click.Context, backup: str | None, yes: bool) -> None:
         console.print(f"[red]Error:[/red] Rollback failed: {exc}")
         raise SystemExit(1) from exc
     finally:
-        ssh.close()
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# push
+# ---------------------------------------------------------------------------
+
+
+@remote.command("push")
+@click.option("--dry-run", is_flag=True, help="Show changes without applying.")
+@click.option("--force", is_flag=True, help="Override an existing deploy lock.")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+@click.pass_context
+def remote_push(ctx: click.Context, dry_run: bool, force: bool, yes: bool) -> None:
+    """Push local project files to the remote server and rebuild.
+
+    Syncs config and dbt files, creates a pre-deploy backup, runs
+    ``dbt compile`` and selectively rebuilds changed models.
+
+    Use ``--dry-run`` to preview changes without applying them.
+
+    Examples:
+      dango remote push
+      dango remote push --dry-run
+      dango remote push --force --yes
+    """
+    from rich.status import Status
+
+    from dango.platform.cloud.deployer import push_deploy
+
+    cloud_cfg, project_root = _require_cloud_deployment(ctx)
+
+    if cloud_cfg.droplet_ip is None:
+        console.print("[red]Error:[/red] No droplet IP found in cloud.yml.")
+        raise SystemExit(1)
+
+    if not dry_run and not yes:
+        if not click.confirm(
+            "This will push local files to the remote server and rebuild. Continue?"
+        ):
+            console.print("[yellow]Push cancelled.[/yellow]")
+            return
+
+    ssh = _connect_ssh(cloud_cfg, project_root)
+
+    try:
+        with Status("[bold blue]Deploying...", console=console) as status:
+
+            def _on_progress(step: str, step_status: str) -> None:
+                if step_status == "running":
+                    labels = {
+                        "acquire_lock": "Acquiring deploy lock...",
+                        "create_backup": "Creating pre-deploy backup...",
+                        "stop_web": "Stopping web service...",
+                        "sync_files": "Syncing files...",
+                        "detect_changes": "Detecting changes...",
+                        "upload_config": "Uploading config files...",
+                        "sync_dbt": "Syncing dbt directories...",
+                        "fix_ownership": "Fixing file ownership...",
+                        "validate_sources": "Validating sources...",
+                        "dbt_deps": "Installing dbt packages...",
+                        "dbt_compile": "Compiling dbt project...",
+                        "dbt_run": "Running dbt models...",
+                        "start_web": "Starting web service...",
+                    }
+                    status.update(f"[bold blue]{labels.get(step, step)}")
+
+            result = push_deploy(
+                ssh,
+                project_root,
+                cloud_cfg.droplet_ip,
+                dry_run=dry_run,
+                force=force,
+                on_progress=_on_progress,
+            )
+
+        # --- Summary ---
+        if dry_run:
+            console.print("\n[bold cyan]Dry-run summary:[/bold cyan]")
+        else:
+            console.print("\n[green]Push complete.[/green]")
+
+        sr = result.sync_result
+        console.print(f"  Files synced: {len(sr.synced_files)}")
+        if sr.added_models:
+            console.print(f"  New models: {', '.join(sr.added_models)}")
+        if sr.changed_models:
+            console.print(f"  Changed models: {', '.join(sr.changed_models)}")
+        if sr.removed_models:
+            console.print(f"  Removed models: {', '.join(sr.removed_models)}")
+        if sr.packages_changed:
+            console.print("  packages.yml: [yellow]changed[/yellow]")
+
+        if not dry_run:
+            if result.dbt_deps_run:
+                console.print("  dbt deps: [green]ran[/green]")
+            if result.dbt_compile_success:
+                console.print("  dbt compile: [green]success[/green]")
+            if result.models_rebuilt:
+                console.print(f"  Models rebuilt: {', '.join(result.models_rebuilt)}")
+            console.print(f"  Duration: {result.duration_seconds}s")
+
+        for warning in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {warning}")
+
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Push failed: {exc}")
+        if not dry_run:
+            console.print(
+                "[dim]A pre-deploy backup was created. "
+                "Use [bold]dango remote rollback[/bold] to restore.[/dim]"
+            )
+        raise SystemExit(1) from exc
+    finally:
+        ssh.disconnect()
 
 
 # ---------------------------------------------------------------------------
@@ -461,7 +577,7 @@ def domain_set(ctx: click.Context, domain_name: str) -> None:
         console.print(f"[red]Error:[/red] {exc}")
         raise SystemExit(1) from exc
     finally:
-        ssh.close()
+        ssh.disconnect()
 
     if result["dns_ok"]:
         console.print(f"[green]DNS OK:[/green] {result['dns_message']}")
@@ -508,7 +624,7 @@ def domain_remove(ctx: click.Context) -> None:
         console.print(f"[red]Error:[/red] {exc}")
         raise SystemExit(1) from exc
     finally:
-        ssh.close()
+        ssh.disconnect()
 
     prev = result.get("previous_domain")
     if prev:

--- a/dango/cli/commands/remote_backup.py
+++ b/dango/cli/commands/remote_backup.py
@@ -132,7 +132,7 @@ def backup_group(ctx: click.Context) -> None:
         console.print(f"[red]Error:[/red] {exc}")
         raise SystemExit(1) from exc
     finally:
-        ssh.close()
+        ssh.disconnect()
 
 
 # ---------------------------------------------------------------------------
@@ -202,7 +202,7 @@ def backup_list(ctx: click.Context) -> None:
 
         console.print(table)
     finally:
-        ssh.close()
+        ssh.disconnect()
 
 
 # ---------------------------------------------------------------------------
@@ -269,7 +269,7 @@ def backup_enable(ctx: click.Context) -> None:
         console.print("  Timer: dango-backup.timer")
         console.print("  Service: dango-backup.service")
     finally:
-        ssh.close()
+        ssh.disconnect()
 
 
 # ---------------------------------------------------------------------------
@@ -294,7 +294,7 @@ def backup_disable(ctx: click.Context) -> None:
         )
         console.print("[green]Scheduled backups disabled.[/green]")
     finally:
-        ssh.close()
+        ssh.disconnect()
 
 
 # ---------------------------------------------------------------------------
@@ -411,7 +411,7 @@ def backup_restore(ctx: click.Context, source: str, yes: bool) -> None:
         console.print(f"[red]Error:[/red] {exc}")
         raise SystemExit(1) from exc
     finally:
-        ssh.close()
+        ssh.disconnect()
 
 
 #: Path to venv Python on the remote server.

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -36,6 +36,8 @@ platform/
 │   ├── server_setup.py  # SSH-based server setup orchestration (TASK-026)
 │   ├── domain.py        # DNS check, set_domain(), remove_domain() (TASK-027)
 │   ├── backup.py        # SSH-based backup + rollback (TASK-035)
+│   ├── file_sync.py     # Project file sync: SFTP + rsync (TASK-028)
+│   ├── deployer.py      # Push deployment workflow + deploy lock (TASK-030)
 │   ├── scheduled_backup.py  # Server-side scheduled backup (TASK-103)
 │   └── _server_templates.py  # Config file templates (incl. build_caddyfile(), backup timer)
 │
@@ -64,6 +66,8 @@ platform/
 | `cloud/server_setup.py` | SSH-based server setup orchestration (16 idempotent steps) | `setup_server`, `SetupResult` |
 | `cloud/domain.py` | DNS check, domain set/remove for HTTPS via Caddy | `check_dns`, `set_domain`, `remove_domain` |
 | `cloud/backup.py` | SSH-based backup and rollback | `create_backup`, `rollback`, `list_local_backups`, `rotate_local_backups`, `BackupManifest`, `BackupResult`, `RestoreResult` |
+| `cloud/file_sync.py` | Project file sync (SFTP + rsync) with change detection | `sync_project_files`, `SyncResult` |
+| `cloud/deployer.py` | Push deployment workflow with deploy lock | `push_deploy`, `DeployLock`, `DeployResult` |
 | `cloud/scheduled_backup.py` | Server-side scheduled backup to Spaces | `run_scheduled_backup`, `list_spaces_backups`, `restore_from_spaces`, `enable_scheduled_backup`, `disable_scheduled_backup` |
 | `cloud/_server_templates.py` | Config file templates (systemd, Caddy, fail2ban, backup timer, etc.) | `build_caddyfile`, `SYSTEMD_UNIT`, `CADDYFILE`, `SYSTEMD_BACKUP_SERVICE`, `SYSTEMD_BACKUP_TIMER`, etc. |
 
@@ -101,6 +105,14 @@ from dango.platform.cloud import check_dns, set_domain, remove_domain, build_cad
 # Backup & rollback (TASK-035)
 from dango.platform.cloud import create_backup, rollback, list_local_backups
 from dango.platform.cloud.backup import BackupManifest, BackupResult, RestoreResult
+
+# File sync (TASK-028)
+from dango.platform.cloud import SyncResult, sync_project_files
+from dango.platform.cloud.file_sync import SyncResult, sync_project_files  # also valid
+
+# Push deploy (TASK-030)
+from dango.platform.cloud import DeployLock, DeployResult, push_deploy
+from dango.platform.cloud.deployer import DeployLock, DeployResult, push_deploy  # also valid
 
 # Scheduled backup (TASK-103, runs on server)
 from dango.platform.cloud.scheduled_backup import run_scheduled_backup, list_spaces_backups
@@ -141,6 +153,8 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | Configure domain / HTTPS | `cloud/domain.py` → `set_domain()` / `remove_domain()` | `pytest tests/unit/test_domain.py` |
 | Create pre-deploy backup | `cloud/backup.py` → `create_backup()` | `pytest tests/unit/test_backup.py` |
 | Rollback from backup | `cloud/backup.py` → `rollback()` | `pytest tests/unit/test_backup.py` |
+| Sync files to remote | `cloud/file_sync.py` → `sync_project_files()` | `pytest tests/unit/test_file_sync.py` |
+| Push deploy to remote | `cloud/deployer.py` → `push_deploy()` | `pytest tests/unit/test_deployer.py` |
 | Scheduled backup (server-side) | `cloud/scheduled_backup.py` → `run_scheduled_backup()` | `pytest tests/unit/test_scheduled_backup.py` |
 | CLI backup commands | `cli/commands/remote_backup.py` | `pytest tests/unit/test_remote_backup_cli.py` |
 | Modify watcher logic | `local/watcher.py` | `pytest tests/unit/test_watcher_lifecycle.py` |

--- a/dango/platform/cloud/__init__.py
+++ b/dango/platform/cloud/__init__.py
@@ -15,8 +15,10 @@ from .backup import (
     rollback,
     rotate_local_backups,
 )
+from .deployer import DeployLock, DeployResult, push_deploy
 from .digitalocean import DigitalOceanClient
 from .domain import check_dns, remove_domain, set_domain
+from .file_sync import SyncResult, sync_project_files
 from .firewall import (
     add_allowed_ip,
     allow_all_web,
@@ -111,4 +113,11 @@ __all__ = [
     "list_local_backups",
     "rollback",
     "rotate_local_backups",
+    # File sync (TASK-028)
+    "SyncResult",
+    "sync_project_files",
+    # Deploy (TASK-030)
+    "DeployLock",
+    "DeployResult",
+    "push_deploy",
 ]

--- a/dango/platform/cloud/backup.py
+++ b/dango/platform/cloud/backup.py
@@ -258,12 +258,21 @@ def create_backup(
     ssh: SSHManager,
     *,
     backup_type: str = "pre-deploy",
+    restart_services: bool = True,
     on_progress: Callable[[str, str], None] | None = None,
 ) -> BackupResult:
     """Create a backup of all project data on the remote server.
 
     Stops services, checkpoints databases, creates a tar.gz archive,
-    then restarts services.  Returns BackupResult with archive path and manifest.
+    then (optionally) restarts services.
+
+    Args:
+        ssh: Connected SSHManager (as root).
+        backup_type: Label for the backup manifest (e.g. ``"pre-deploy"``).
+        restart_services: If False, services remain stopped after backup.
+            Caller is responsible for restarting them.  Useful when the
+            caller needs services to stay down (e.g. ``push_deploy``).
+        on_progress: Optional ``(step, status)`` callback.
     """
     start_time = time.monotonic()
     warnings: list[str] = []
@@ -295,9 +304,10 @@ def create_backup(
         archive_path, manifest = _create_archive(ssh, timestamp, metabase_vol, backup_type)
         _notify(on_progress, "create_archive", "done")
     finally:
-        _notify(on_progress, "start_services", "running")
-        _start_services(ssh)
-        _notify(on_progress, "start_services", "done")
+        if restart_services:
+            _notify(on_progress, "start_services", "running")
+            _start_services(ssh)
+            _notify(on_progress, "start_services", "done")
 
     _notify(on_progress, "rotate_backups", "running")
     rotate_local_backups(ssh)

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -1,0 +1,438 @@
+"""dango/platform/cloud/deployer.py
+
+Full push deployment workflow for Dango cloud deployments.
+
+Orchestrates file sync, pre-deploy backup, dbt operations, and service
+management into a single ``push_deploy()`` function.  Uses a deploy lock
+to prevent concurrent deployments.
+
+Deploy lock
+-----------
+Lock file at ``/srv/dango/deploy.lock`` contains JSON with deployer
+identity, start time, and expiry (30 minutes).  ``--force`` overrides
+any existing lock.  Lock is always released in a ``finally`` block.
+
+Push workflow
+-------------
+1. Acquire deploy lock
+2. Create pre-deploy backup (stops/starts services internally)
+3. Stop dango-web service (DuckDB single-writer constraint)
+4. Sync files (via ``file_sync.sync_project_files``)
+5. Fix file ownership (rsync runs as root, creates root-owned files)
+6. Validate sources (check credentials exist on remote)
+7. ``dbt deps`` (if packages.yml changed)
+8. ``dbt compile`` (abort on failure)
+9. ``dbt run --select <changed models>`` (if any)
+10. Start dango-web service
+11. Release deploy lock
+12. Report results
+
+Error handling: ``finally`` block always releases the lock and restarts
+dango-web.  On failure, the pre-deploy backup is available for
+``dango remote rollback``.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from dango.exceptions import CloudProvisioningError
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.backup import BackupResult
+    from dango.platform.cloud.file_sync import SyncResult
+    from dango.platform.cloud.ssh import SSHManager
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEPLOY_LOCK_PATH = "/srv/dango/deploy.lock"
+LOCK_TIMEOUT_MINUTES = 30
+REMOTE_PROJECT_DIR = "/srv/dango/project"
+VENV_BIN = "/srv/dango/venv/bin"
+DBT_PROJECT_DIR = "/srv/dango/project/dbt"
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeployLock:
+    """Metadata about an active deploy lock."""
+
+    deployer: str
+    started_at: str
+    expires_at: str
+
+
+@dataclass
+class DeployResult:
+    """Result returned by :func:`push_deploy`."""
+
+    sync_result: SyncResult
+    backup_result: BackupResult | None = None
+    dbt_deps_run: bool = False
+    dbt_compile_success: bool = False
+    models_rebuilt: list[str] = field(default_factory=list)
+    duration_seconds: float = 0.0
+    warnings: list[str] = field(default_factory=list)
+    dry_run: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _notify(callback: Callable[[str, str], None] | None, step: str, status: str) -> None:
+    """Call the progress callback if provided."""
+    if callback is not None:
+        callback(step, status)
+
+
+def _get_deployer_identity() -> str:
+    """Return a human-readable deployer identity string."""
+    import getpass
+
+    try:
+        user = getpass.getuser()
+    except Exception:
+        user = "unknown"
+    host = platform.node() or "unknown"
+    return f"{user}@{host}"
+
+
+def _check_existing_lock(ssh: SSHManager) -> DeployLock | None:
+    """Read the deploy lock file from the remote server.
+
+    Returns:
+        ``DeployLock`` if a lock file exists, ``None`` otherwise.
+    """
+    result = ssh.exec_command(f"cat {DEPLOY_LOCK_PATH} 2>/dev/null")
+    if not result.success or not result.stdout.strip():
+        return None
+
+    try:
+        data: dict[str, Any] = json.loads(result.stdout.strip())
+        return DeployLock(
+            deployer=data.get("deployer", "unknown"),
+            started_at=data.get("started_at", ""),
+            expires_at=data.get("expires_at", ""),
+        )
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def _is_lock_expired(lock: DeployLock) -> bool:
+    """Return True if the lock has passed its expiration time."""
+    if not lock.expires_at:
+        return True
+    try:
+        expires = datetime.fromisoformat(lock.expires_at)
+        return datetime.now(tz=timezone.utc) > expires
+    except ValueError:
+        return True
+
+
+def _acquire_lock(ssh: SSHManager, *, force: bool = False) -> DeployLock:
+    """Acquire the deploy lock on the remote server.
+
+    Args:
+        ssh: Connected SSHManager.
+        force: Override any existing lock.
+
+    Returns:
+        The newly created :class:`DeployLock`.
+
+    Raises:
+        CloudProvisioningError: If a valid lock exists and *force* is False.
+    """
+    existing = _check_existing_lock(ssh)
+    if existing is not None and not force:
+        if not _is_lock_expired(existing):
+            raise CloudProvisioningError(
+                f"Deploy lock held by {existing.deployer} "
+                f"(started {existing.started_at}). "
+                "Use --force to override."
+            )
+
+    now = datetime.now(tz=timezone.utc)
+    from datetime import timedelta
+
+    expires = now + timedelta(minutes=LOCK_TIMEOUT_MINUTES)
+
+    lock = DeployLock(
+        deployer=_get_deployer_identity(),
+        started_at=now.isoformat(),
+        expires_at=expires.isoformat(),
+    )
+    lock_json = json.dumps(
+        {
+            "deployer": lock.deployer,
+            "started_at": lock.started_at,
+            "expires_at": lock.expires_at,
+        }
+    )
+
+    ssh.exec_command(f"mkdir -p {Path(DEPLOY_LOCK_PATH).parent}")
+    result = ssh.exec_command(f"cat > {DEPLOY_LOCK_PATH} << 'LOCK_EOF'\n{lock_json}\nLOCK_EOF")
+    if not result.success:
+        raise CloudProvisioningError(f"Failed to write deploy lock: {result.stderr.strip()}")
+
+    return lock
+
+
+def _release_lock(ssh: SSHManager) -> None:
+    """Remove the deploy lock file from the remote server."""
+    ssh.exec_command(f"rm -f {DEPLOY_LOCK_PATH}")
+
+
+def _stop_web_service(ssh: SSHManager) -> None:
+    """Stop the dango-web systemd service."""
+    ssh.exec_command("systemctl stop dango-web || true", timeout=60)
+
+
+def _start_web_service(ssh: SSHManager) -> None:
+    """Start the dango-web systemd service."""
+    ssh.exec_command("systemctl start dango-web || true", timeout=60)
+
+
+def _validate_remote_sources(ssh: SSHManager) -> list[str]:
+    """Validate that remote sources have corresponding credentials.
+
+    Parses ``.dango/sources.yml`` on the remote and checks that
+    ``.dlt/secrets.toml`` has entries for each source.
+
+    Returns:
+        List of error messages.  Empty list means all sources are valid.
+    """
+    errors: list[str] = []
+
+    # Read sources.yml
+    sources_result = ssh.exec_command(f"cat {REMOTE_PROJECT_DIR}/.dango/sources.yml 2>/dev/null")
+    if not sources_result.success or not sources_result.stdout.strip():
+        return errors  # No sources configured — nothing to validate
+
+    # Read secrets.toml
+    secrets_result = ssh.exec_command(f"cat {REMOTE_PROJECT_DIR}/.dlt/secrets.toml 2>/dev/null")
+    secrets_content = secrets_result.stdout if secrets_result.success else ""
+
+    # Parse source names from sources.yml (look for name: fields)
+    try:
+        import yaml
+
+        sources_data: dict[str, Any] = yaml.safe_load(sources_result.stdout) or {}
+    except Exception:
+        # If YAML parsing fails, skip validation
+        return errors
+
+    sources = sources_data.get("sources", [])
+    if not isinstance(sources, list):
+        return errors
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        name = source.get("name", "")
+        if name and f"[sources.{name}]" not in secrets_content:
+            errors.append(f"Source '{name}' has no credentials in .dlt/secrets.toml on the server")
+
+    return errors
+
+
+def _run_remote_dbt(
+    ssh: SSHManager,
+    subcommand: str,
+    extra_args: str = "",
+) -> Any:
+    """Run a dbt command on the remote server as the ``dango`` user.
+
+    Returns:
+        ``CommandResult`` from the SSH command.
+    """
+    cmd = (
+        f"sudo -u dango {VENV_BIN}/dbt {subcommand}"
+        f" --project-dir {DBT_PROJECT_DIR}"
+        f" --profiles-dir {DBT_PROJECT_DIR}"
+    )
+    if extra_args:
+        cmd = f"{cmd} {extra_args}"
+    return ssh.exec_command(cmd, timeout=600)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def push_deploy(
+    ssh: SSHManager,
+    local_project_root: Path,
+    remote_host: str,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> DeployResult:
+    """Execute full push deployment workflow.
+
+    Syncs local project files to the remote server, runs dbt operations
+    for changed models, and manages service lifecycle.
+
+    Args:
+        ssh: Connected SSHManager (as root).
+        local_project_root: Path to the local Dango project root.
+        remote_host: Hostname or IP for rsync transport.
+        dry_run: If True, show what would change without applying.
+        force: Override any existing deploy lock.
+        on_progress: Optional ``(step, status)`` callback for UI updates.
+
+    Returns:
+        :class:`DeployResult` with deployment details.
+
+    Raises:
+        CloudProvisioningError: On lock conflict, dbt compile failure,
+            or other deployment errors.
+    """
+    from dango.platform.cloud.backup import create_backup
+    from dango.platform.cloud.file_sync import SyncResult, sync_project_files
+
+    start_time = time.monotonic()
+    warnings: list[str] = []
+    backup_result: BackupResult | None = None
+    dbt_deps_run = False
+    dbt_compile_success = False
+    models_rebuilt: list[str] = []
+    sync_result = SyncResult(dry_run=dry_run)
+
+    if dry_run:
+        # --- Dry-run mode ---
+        _notify(on_progress, "sync_files", "running")
+        sync_result = sync_project_files(
+            ssh,
+            local_project_root,
+            remote_host=remote_host,
+            dry_run=True,
+            on_progress=on_progress,
+        )
+        _notify(on_progress, "sync_files", "done")
+
+        return DeployResult(
+            sync_result=sync_result,
+            backup_result=None,
+            dbt_deps_run=sync_result.packages_changed,
+            dbt_compile_success=False,
+            models_rebuilt=[],
+            duration_seconds=round(time.monotonic() - start_time, 1),
+            warnings=warnings,
+            dry_run=True,
+        )
+
+    # --- Full deploy ---
+    lock: DeployLock | None = None
+    web_stopped = False
+
+    try:
+        # Step 1: Acquire deploy lock
+        _notify(on_progress, "acquire_lock", "running")
+        lock = _acquire_lock(ssh, force=force)
+        _notify(on_progress, "acquire_lock", "done")
+
+        # Step 2: Pre-deploy backup (stops/starts services internally)
+        _notify(on_progress, "create_backup", "running")
+        backup_result = create_backup(ssh, backup_type="pre-deploy", on_progress=on_progress)
+        if backup_result.warnings:
+            warnings.extend(backup_result.warnings)
+        _notify(on_progress, "create_backup", "done")
+
+        # Step 3: Stop dango-web (DuckDB single-writer constraint)
+        _notify(on_progress, "stop_web", "running")
+        _stop_web_service(ssh)
+        web_stopped = True
+        _notify(on_progress, "stop_web", "done")
+
+        # Step 4: Sync files
+        _notify(on_progress, "sync_files", "running")
+        sync_result = sync_project_files(
+            ssh, local_project_root, remote_host=remote_host, on_progress=on_progress
+        )
+        _notify(on_progress, "sync_files", "done")
+
+        # Step 5: Fix file ownership
+        _notify(on_progress, "fix_ownership", "running")
+        ssh.exec_command(f"chown -R dango:dango {REMOTE_PROJECT_DIR}", timeout=60)
+        _notify(on_progress, "fix_ownership", "done")
+
+        # Step 6: Validate sources
+        _notify(on_progress, "validate_sources", "running")
+        source_errors = _validate_remote_sources(ssh)
+        if source_errors:
+            for err in source_errors:
+                warnings.append(err)
+        _notify(on_progress, "validate_sources", "done")
+
+        # Step 7: dbt deps (if packages.yml changed)
+        if sync_result.packages_changed:
+            _notify(on_progress, "dbt_deps", "running")
+            deps_result = _run_remote_dbt(ssh, "deps")
+            dbt_deps_run = True
+            if not deps_result.success:
+                warnings.append(
+                    f"dbt deps failed: {deps_result.stderr.strip() or deps_result.stdout.strip()}"
+                )
+            _notify(on_progress, "dbt_deps", "done")
+
+        # Step 8: dbt compile
+        _notify(on_progress, "dbt_compile", "running")
+        compile_result = _run_remote_dbt(ssh, "compile")
+        if not compile_result.success:
+            raise CloudProvisioningError(
+                f"dbt compile failed: {compile_result.stderr.strip() or compile_result.stdout.strip()}"
+            )
+        dbt_compile_success = True
+        _notify(on_progress, "dbt_compile", "done")
+
+        # Step 9: dbt run (if models changed)
+        all_changed = sync_result.added_models + sync_result.changed_models
+        if all_changed:
+            _notify(on_progress, "dbt_run", "running")
+            select_arg = " ".join(all_changed)
+            run_result = _run_remote_dbt(ssh, "run", f"--select {select_arg}")
+            if run_result.success:
+                models_rebuilt = list(all_changed)
+            else:
+                warnings.append(
+                    f"dbt run failed: {run_result.stderr.strip() or run_result.stdout.strip()}"
+                )
+            _notify(on_progress, "dbt_run", "done")
+
+    finally:
+        # Always restart web service and release lock
+        if web_stopped:
+            _notify(on_progress, "start_web", "running")
+            _start_web_service(ssh)
+            _notify(on_progress, "start_web", "done")
+
+        if lock is not None:
+            _release_lock(ssh)
+
+    return DeployResult(
+        sync_result=sync_result,
+        backup_result=backup_result,
+        dbt_deps_run=dbt_deps_run,
+        dbt_compile_success=dbt_compile_success,
+        models_rebuilt=models_rebuilt,
+        duration_seconds=round(time.monotonic() - start_time, 1),
+        warnings=warnings,
+        dry_run=False,
+    )

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -1,45 +1,21 @@
 """dango/platform/cloud/deployer.py
 
-Full push deployment workflow for Dango cloud deployments.
+Push deployment workflow: lock → stop services → backup → sync → dbt → restart.
 
-Orchestrates file sync, pre-deploy backup, dbt operations, and service
-management into a single ``push_deploy()`` function.  Uses a deploy lock
-to prevent concurrent deployments.
-
-Deploy lock
------------
-Lock file at ``/srv/dango/deploy.lock`` contains JSON with deployer
-identity, start time, and expiry (30 minutes).  ``--force`` overrides
-any existing lock.  Lock is always released in a ``finally`` block.
-
-Push workflow
--------------
-1. Acquire deploy lock
-2. Create pre-deploy backup (stops/starts services internally)
-3. Stop dango-web service (DuckDB single-writer constraint)
-4. Sync files (via ``file_sync.sync_project_files``)
-5. Fix file ownership (rsync runs as root, creates root-owned files)
-6. Validate sources (check credentials exist on remote)
-7. ``dbt deps`` (if packages.yml changed)
-8. ``dbt compile`` (abort on failure)
-9. ``dbt run --select <changed models>`` (if any)
-10. Start dango-web service
-11. Release deploy lock
-12. Report results
-
-Error handling: ``finally`` block always releases the lock and restarts
-dango-web.  On failure, the pre-deploy backup is available for
-``dango remote rollback``.
+Uses a deploy lock (``/srv/dango/deploy.lock``, 30-min timeout, atomic
+via ``set -C``) to prevent concurrent deployments.  ``finally`` block
+always restarts services and releases the lock.
 """
 
 from __future__ import annotations
 
 import json
 import platform
+import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -59,6 +35,9 @@ LOCK_TIMEOUT_MINUTES = 30
 REMOTE_PROJECT_DIR = "/srv/dango/project"
 VENV_BIN = "/srv/dango/venv/bin"
 DBT_PROJECT_DIR = "/srv/dango/project/dbt"
+
+#: Pattern for valid dbt model/macro names (shell-safe for SSH commands).
+_SAFE_DBT_NAME = re.compile(r"^[a-zA-Z0-9_]+$")
 
 
 # ---------------------------------------------------------------------------
@@ -138,14 +117,24 @@ def _is_lock_expired(lock: DeployLock) -> bool:
     if not lock.expires_at:
         return True
     try:
-        expires = datetime.fromisoformat(lock.expires_at)
+        expires_str = lock.expires_at
+        # Python 3.10 fromisoformat does not parse timezone suffixes;
+        # strip them and treat as UTC (we always write UTC timestamps).
+        for suffix in ("+00:00", "Z"):
+            if expires_str.endswith(suffix):
+                expires_str = expires_str[: -len(suffix)]
+                break
+        expires = datetime.fromisoformat(expires_str).replace(tzinfo=timezone.utc)
         return datetime.now(tz=timezone.utc) > expires
-    except ValueError:
+    except (ValueError, TypeError):
         return True
 
 
 def _acquire_lock(ssh: SSHManager, *, force: bool = False) -> DeployLock:
     """Acquire the deploy lock on the remote server.
+
+    Uses shell ``set -C`` (noclobber) for atomic lock creation so that
+    two concurrent ``dango remote push`` invocations cannot both succeed.
 
     Args:
         ssh: Connected SSHManager.
@@ -155,20 +144,21 @@ def _acquire_lock(ssh: SSHManager, *, force: bool = False) -> DeployLock:
         The newly created :class:`DeployLock`.
 
     Raises:
-        CloudProvisioningError: If a valid lock exists and *force* is False.
+        CloudProvisioningError: If a valid lock exists and *force* is False,
+            or if another deployer grabbed the lock concurrently.
     """
     existing = _check_existing_lock(ssh)
-    if existing is not None and not force:
-        if not _is_lock_expired(existing):
+    if existing is not None:
+        if not force and not _is_lock_expired(existing):
             raise CloudProvisioningError(
                 f"Deploy lock held by {existing.deployer} "
                 f"(started {existing.started_at}). "
                 "Use --force to override."
             )
+        # Remove stale or force-overridden lock before creating new one
+        ssh.exec_command(f"rm -f {DEPLOY_LOCK_PATH}")
 
     now = datetime.now(tz=timezone.utc)
-    from datetime import timedelta
-
     expires = now + timedelta(minutes=LOCK_TIMEOUT_MINUTES)
 
     lock = DeployLock(
@@ -185,9 +175,15 @@ def _acquire_lock(ssh: SSHManager, *, force: bool = False) -> DeployLock:
     )
 
     ssh.exec_command(f"mkdir -p {Path(DEPLOY_LOCK_PATH).parent}")
-    result = ssh.exec_command(f"cat > {DEPLOY_LOCK_PATH} << 'LOCK_EOF'\n{lock_json}\nLOCK_EOF")
+    # Atomic creation: noclobber (set -C) makes > fail if the file
+    # already exists, preventing a concurrent deployer from silently
+    # overwriting our lock.
+    result = ssh.exec_command(f"(set -C; echo '{lock_json}' > {DEPLOY_LOCK_PATH}) 2>/dev/null")
     if not result.success:
-        raise CloudProvisioningError(f"Failed to write deploy lock: {result.stderr.strip()}")
+        raise CloudProvisioningError(
+            "Failed to acquire deploy lock — another deployment may have "
+            "started concurrently. Use --force to override."
+        )
 
     return lock
 
@@ -207,11 +203,21 @@ def _start_web_service(ssh: SSHManager) -> None:
     ssh.exec_command("systemctl start dango-web || true", timeout=60)
 
 
+def _start_all_services(ssh: SSHManager) -> None:
+    """Start Metabase then dango-web (same order as backup._start_services)."""
+    ssh.exec_command(
+        f"docker compose -f {REMOTE_PROJECT_DIR}/docker-compose.yml "
+        "start metabase 2>/dev/null || true",
+        timeout=120,
+    )
+    ssh.exec_command("systemctl start dango-web || true", timeout=60)
+
+
 def _validate_remote_sources(ssh: SSHManager) -> list[str]:
     """Validate that remote sources have corresponding credentials.
 
     Parses ``.dango/sources.yml`` on the remote and checks that
-    ``.dlt/secrets.toml`` has entries for each source.
+    ``.dlt/secrets.toml`` has section headers for each source.
 
     Returns:
         List of error messages.  Empty list means all sources are valid.
@@ -244,10 +250,29 @@ def _validate_remote_sources(ssh: SSHManager) -> list[str]:
         if not isinstance(source, dict):
             continue
         name = source.get("name", "")
-        if name and f"[sources.{name}]" not in secrets_content:
+        if not name:
+            continue
+        # Check for TOML section header at start of line
+        pattern = rf"^\[sources\.{re.escape(name)}\]"
+        if not re.search(pattern, secrets_content, re.MULTILINE):
             errors.append(f"Source '{name}' has no credentials in .dlt/secrets.toml on the server")
 
     return errors
+
+
+def _validate_model_names(names: list[str]) -> None:
+    """Validate that model names are safe for shell interpolation.
+
+    Raises:
+        CloudProvisioningError: If any name contains characters outside
+            ``[a-zA-Z0-9_]``.
+    """
+    for name in names:
+        if not _SAFE_DBT_NAME.match(name):
+            raise CloudProvisioningError(
+                f"Invalid model name for remote execution: {name!r}. "
+                "Model names must contain only alphanumeric characters and underscores."
+            )
 
 
 def _run_remote_dbt(
@@ -302,7 +327,7 @@ def push_deploy(
 
     Raises:
         CloudProvisioningError: On lock conflict, dbt compile failure,
-            or other deployment errors.
+            dbt run failure, or other deployment errors.
     """
     from dango.platform.cloud.backup import create_backup
     from dango.platform.cloud.file_sync import SyncResult, sync_project_files
@@ -340,7 +365,7 @@ def push_deploy(
 
     # --- Full deploy ---
     lock: DeployLock | None = None
-    web_stopped = False
+    services_stopped = False
 
     try:
         # Step 1: Acquire deploy lock
@@ -348,18 +373,27 @@ def push_deploy(
         lock = _acquire_lock(ssh, force=force)
         _notify(on_progress, "acquire_lock", "done")
 
-        # Step 2: Pre-deploy backup (stops/starts services internally)
+        # Step 2: Stop dango-web BEFORE backup (DuckDB single-writer).
+        # Backup will also stop services (web already stopped = noop,
+        # Metabase stopped for consistent H2 backup).  With
+        # restart_services=False, services remain stopped throughout
+        # the entire sync + dbt workflow.
+        _notify(on_progress, "stop_web", "running")
+        _stop_web_service(ssh)
+        services_stopped = True
+        _notify(on_progress, "stop_web", "done")
+
+        # Step 3: Pre-deploy backup (services stay down after backup)
         _notify(on_progress, "create_backup", "running")
-        backup_result = create_backup(ssh, backup_type="pre-deploy", on_progress=on_progress)
+        backup_result = create_backup(
+            ssh,
+            backup_type="pre-deploy",
+            restart_services=False,
+            on_progress=on_progress,
+        )
         if backup_result.warnings:
             warnings.extend(backup_result.warnings)
         _notify(on_progress, "create_backup", "done")
-
-        # Step 3: Stop dango-web (DuckDB single-writer constraint)
-        _notify(on_progress, "stop_web", "running")
-        _stop_web_service(ssh)
-        web_stopped = True
-        _notify(on_progress, "stop_web", "done")
 
         # Step 4: Sync files
         _notify(on_progress, "sync_files", "running")
@@ -402,26 +436,40 @@ def push_deploy(
         dbt_compile_success = True
         _notify(on_progress, "dbt_compile", "done")
 
-        # Step 9: dbt run (if models changed)
+        # Step 9: dbt run
+        # If macros changed, any model could be affected → full rebuild.
+        # If only models changed, selective rebuild by name.
         all_changed = sync_result.added_models + sync_result.changed_models
-        if all_changed:
+        if sync_result.has_macro_changes:
+            _notify(on_progress, "dbt_run", "running")
+            run_result = _run_remote_dbt(ssh, "run")
+            if run_result.success:
+                models_rebuilt = ["(full rebuild — macros changed)"]
+            else:
+                raise CloudProvisioningError(
+                    f"dbt run failed: {run_result.stderr.strip() or run_result.stdout.strip()}"
+                )
+            _notify(on_progress, "dbt_run", "done")
+        elif all_changed:
+            _validate_model_names(all_changed)
             _notify(on_progress, "dbt_run", "running")
             select_arg = " ".join(all_changed)
             run_result = _run_remote_dbt(ssh, "run", f"--select {select_arg}")
             if run_result.success:
                 models_rebuilt = list(all_changed)
             else:
-                warnings.append(
-                    f"dbt run failed: {run_result.stderr.strip() or run_result.stdout.strip()}"
+                raise CloudProvisioningError(
+                    f"dbt run failed for models [{select_arg}]: "
+                    f"{run_result.stderr.strip() or run_result.stdout.strip()}"
                 )
             _notify(on_progress, "dbt_run", "done")
 
     finally:
-        # Always restart web service and release lock
-        if web_stopped:
-            _notify(on_progress, "start_web", "running")
-            _start_web_service(ssh)
-            _notify(on_progress, "start_web", "done")
+        # Always restart all services and release lock
+        if services_stopped:
+            _notify(on_progress, "start_services", "running")
+            _start_all_services(ssh)
+            _notify(on_progress, "start_services", "done")
 
         if lock is not None:
             _release_lock(ssh)

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -1,0 +1,376 @@
+"""dango/platform/cloud/file_sync.py
+
+Sync local project files to the remote Dango cloud server.
+
+Uses a hybrid approach: SFTP for individual config files (reuses
+SSHManager, no subprocess) and rsync for dbt directories (handles
+``--delete`` natively for directory sync).
+
+Change detection compares MD5 hashes of dbt model/macro SQL files
+before and after sync to identify added, changed, and removed models
+for selective dbt rebuilds.
+
+rsync SSH transport
+-------------------
+rsync uses system SSH, not paramiko.  Since the host was already verified
+via paramiko TOFU, rsync bypasses host key checking::
+
+    rsync -avz --delete -e "ssh -i <key> -o StrictHostKeyChecking=no ..." ...
+
+File sync scope
+---------------
+Synced: ``.dango/sources.yml``, ``.dango/schedules.yml``,
+``dbt/models/``, ``dbt/macros/``, ``dbt/dbt_project.yml``,
+``dbt/packages.yml``.
+
+Never synced: ``.env``, ``.dlt/secrets.toml``, ``*.duckdb``,
+``metabase.db``, ``dbt/profiles.yml``, ``dbt/target/``, ``__pycache__/``,
+``.git/``, ``venv/``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from dango.exceptions import CloudProvisioningError
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.ssh import SSHManager
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REMOTE_PROJECT_DIR = "/srv/dango/project"
+
+#: Config files to upload via SFTP.  Tuples of (local_relative, remote_relative).
+#: Files that may not exist locally are skipped gracefully.
+SYNC_CONFIG_FILES: list[tuple[str, str]] = [
+    (".dango/sources.yml", f"{REMOTE_PROJECT_DIR}/.dango/sources.yml"),
+    (".dango/schedules.yml", f"{REMOTE_PROJECT_DIR}/.dango/schedules.yml"),
+    ("dbt/dbt_project.yml", f"{REMOTE_PROJECT_DIR}/dbt/dbt_project.yml"),
+    ("dbt/packages.yml", f"{REMOTE_PROJECT_DIR}/dbt/packages.yml"),
+]
+
+#: Directories to sync via rsync (with ``--delete``).
+SYNC_DBT_DIRS: list[str] = ["dbt/models", "dbt/macros"]
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SyncResult:
+    """Result returned by :func:`sync_project_files`."""
+
+    synced_files: list[str] = field(default_factory=list)
+    changed_models: list[str] = field(default_factory=list)
+    added_models: list[str] = field(default_factory=list)
+    removed_models: list[str] = field(default_factory=list)
+    packages_changed: bool = False
+    is_first_deploy: bool = False
+    dry_run: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _notify(callback: Callable[[str, str], None] | None, step: str, status: str) -> None:
+    """Call the progress callback if provided."""
+    if callback is not None:
+        callback(step, status)
+
+
+def _compute_remote_hashes(ssh: SSHManager, remote_dir: str, glob_pattern: str) -> dict[str, str]:
+    """Compute MD5 hashes of files matching *glob_pattern* under *remote_dir*.
+
+    Returns:
+        Dict mapping relative paths (from *remote_dir*) to hex MD5 hashes.
+    """
+    cmd = f"find {remote_dir} -name '{glob_pattern}' -type f -exec md5sum {{}} \\;"
+    result = ssh.exec_command(cmd, timeout=60)
+    if not result.success or not result.stdout.strip():
+        return {}
+
+    hashes: dict[str, str] = {}
+    for line in result.stdout.strip().splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) == 2:
+            md5_hash, abs_path = parts
+            rel_path = abs_path.replace(f"{remote_dir}/", "", 1)
+            hashes[rel_path] = md5_hash
+    return hashes
+
+
+def _compute_local_hashes(local_dir: Path, glob_pattern: str) -> dict[str, str]:
+    """Compute MD5 hashes of files matching *glob_pattern* under *local_dir*.
+
+    Returns:
+        Dict mapping relative paths (from *local_dir*) to hex MD5 hashes.
+    """
+    if not local_dir.is_dir():
+        return {}
+
+    hashes: dict[str, str] = {}
+    for fpath in local_dir.rglob(glob_pattern):
+        if fpath.is_file():
+            md5_hash = hashlib.md5(fpath.read_bytes()).hexdigest()  # noqa: S324
+            rel_path = str(fpath.relative_to(local_dir))
+            hashes[rel_path] = md5_hash
+    return hashes
+
+
+def _extract_model_name(file_path: str) -> str:
+    """Extract the dbt model name from a SQL file path.
+
+    Example: ``"staging/stg_orders.sql"`` -> ``"stg_orders"``
+    """
+    return Path(file_path).stem
+
+
+def _detect_dbt_changes(
+    before_hashes: dict[str, str],
+    local_hashes: dict[str, str],
+) -> tuple[list[str], list[str], list[str]]:
+    """Compare before (remote) and local hashes to detect dbt model changes.
+
+    Returns:
+        Tuple of (added_models, changed_models, removed_models).
+    """
+    added: list[str] = []
+    changed: list[str] = []
+    removed: list[str] = []
+
+    all_paths = set(before_hashes) | set(local_hashes)
+    for path in sorted(all_paths):
+        remote_hash = before_hashes.get(path)
+        local_hash = local_hashes.get(path)
+        if remote_hash is None and local_hash is not None:
+            added.append(_extract_model_name(path))
+        elif remote_hash is not None and local_hash is None:
+            removed.append(_extract_model_name(path))
+        elif remote_hash != local_hash:
+            changed.append(_extract_model_name(path))
+
+    return added, changed, removed
+
+
+def _build_rsync_ssh_arg(ssh_key_path: Path) -> str:
+    """Build the ``-e`` argument for rsync to use the correct SSH key."""
+    return f"ssh -i {ssh_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+
+def _rsync_directory(
+    local_dir: Path,
+    remote_user_host_dir: str,
+    ssh_key_path: Path,
+    *,
+    delete: bool = True,
+    dry_run: bool = False,
+) -> str:
+    """Sync *local_dir* to *remote_user_host_dir* via rsync.
+
+    Returns:
+        rsync stdout output.
+
+    Raises:
+        CloudProvisioningError: If rsync exits with a non-zero code.
+    """
+    cmd: list[str] = [
+        "rsync",
+        "-avz",
+        "-e",
+        _build_rsync_ssh_arg(ssh_key_path),
+    ]
+    if delete:
+        cmd.append("--delete")
+    if dry_run:
+        cmd.append("--dry-run")
+
+    # Trailing slash on source ensures contents are synced, not the dir itself
+    cmd.append(f"{local_dir}/")
+    cmd.append(remote_user_host_dir)
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)  # noqa: S603
+    if result.returncode != 0:
+        raise CloudProvisioningError(
+            f"rsync failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def _upload_file_if_exists(
+    ssh: SSHManager,
+    local_path: Path,
+    remote_path: str,
+    *,
+    dry_run: bool = False,
+) -> bool:
+    """Upload *local_path* to *remote_path* via SFTP if the local file exists.
+
+    Returns:
+        True if the file was uploaded (or would be in dry-run), False if missing.
+    """
+    if not local_path.is_file():
+        return False
+    if dry_run:
+        return True
+    # Ensure remote parent directory exists
+    remote_dir = remote_path.rsplit("/", 1)[0]
+    ssh.exec_command(f"mkdir -p {remote_dir}")
+    ssh.upload_file(local_path, remote_path)
+    return True
+
+
+def _check_packages_changed(
+    ssh: SSHManager,
+    local_project_root: Path,
+) -> bool:
+    """Check whether ``dbt/packages.yml`` content has changed on the remote."""
+    local_pkg = local_project_root / "dbt" / "packages.yml"
+    if not local_pkg.is_file():
+        return False
+
+    local_hash = hashlib.md5(local_pkg.read_bytes()).hexdigest()  # noqa: S324
+    remote_path = f"{REMOTE_PROJECT_DIR}/dbt/packages.yml"
+    result = ssh.exec_command(f"md5sum {remote_path} 2>/dev/null")
+    if not result.success or not result.stdout.strip():
+        # File doesn't exist on remote yet — counts as changed
+        return True
+
+    remote_hash = result.stdout.strip().split(None, 1)[0]
+    return local_hash != remote_hash
+
+
+def _is_first_deploy(ssh: SSHManager) -> bool:
+    """Check whether this is the first deployment (no sources.yml on remote)."""
+    result = ssh.exec_command(f"test -f {REMOTE_PROJECT_DIR}/.dango/sources.yml")
+    return not result.success
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def sync_project_files(
+    ssh: SSHManager,
+    local_project_root: Path,
+    *,
+    remote_host: str | None = None,
+    dry_run: bool = False,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> SyncResult:
+    """Sync local project files to the remote server.
+
+    Uses SFTP for individual config files and rsync for dbt directories.
+    Detects changes in dbt models/macros for selective rebuilds.
+
+    Args:
+        ssh: Connected SSHManager (as root).
+        local_project_root: Path to the local Dango project root.
+        remote_host: Hostname or IP for rsync transport.  Required unless
+            *dry_run* is ``True`` and no dbt directories exist locally.
+        dry_run: If True, report what would change without transferring files.
+        on_progress: Optional ``(step, status)`` callback for UI updates.
+
+    Returns:
+        :class:`SyncResult` with sync details and change detection results.
+
+    Raises:
+        CloudProvisioningError: If rsync fails or a critical file is missing.
+    """
+    if shutil.which("rsync") is None:
+        raise CloudProvisioningError(
+            "rsync is not installed. Install it with your system package manager "
+            "(e.g. brew install rsync on macOS, apt install rsync on Ubuntu)."
+        )
+
+    synced_files: list[str] = []
+    first_deploy = _is_first_deploy(ssh)
+
+    # --- Step 1: Pre-sync change detection (dbt models + macros) ---
+    _notify(on_progress, "detect_changes", "running")
+    packages_changed = False
+
+    if first_deploy:
+        before_model_hashes: dict[str, str] = {}
+        before_macro_hashes: dict[str, str] = {}
+    else:
+        before_model_hashes = _compute_remote_hashes(
+            ssh, f"{REMOTE_PROJECT_DIR}/dbt/models", "*.sql"
+        )
+        before_macro_hashes = _compute_remote_hashes(
+            ssh, f"{REMOTE_PROJECT_DIR}/dbt/macros", "*.sql"
+        )
+        packages_changed = _check_packages_changed(ssh, local_project_root)
+
+    # Compute local hashes
+    local_model_hashes = _compute_local_hashes(local_project_root / "dbt" / "models", "*.sql")
+    local_macro_hashes = _compute_local_hashes(local_project_root / "dbt" / "macros", "*.sql")
+
+    _notify(on_progress, "detect_changes", "done")
+
+    # --- Step 2: Upload config files via SFTP ---
+    _notify(on_progress, "upload_config", "running")
+    for local_rel, remote_abs in SYNC_CONFIG_FILES:
+        local_path = local_project_root / local_rel
+        uploaded = _upload_file_if_exists(ssh, local_path, remote_abs, dry_run=dry_run)
+        if uploaded:
+            synced_files.append(local_rel)
+    _notify(on_progress, "upload_config", "done")
+
+    # --- Step 3: Sync dbt directories via rsync ---
+    _notify(on_progress, "sync_dbt", "running")
+    ssh_key_path = ssh.key_path
+    for dbt_dir in SYNC_DBT_DIRS:
+        local_dir = local_project_root / dbt_dir
+        if not local_dir.is_dir():
+            continue
+        if remote_host is None:
+            raise CloudProvisioningError("remote_host is required for rsync-based directory sync")
+        remote_dest = f"root@{remote_host}:{REMOTE_PROJECT_DIR}/{dbt_dir}"
+        # Ensure remote directory exists before rsync
+        if not dry_run:
+            ssh.exec_command(f"mkdir -p {REMOTE_PROJECT_DIR}/{dbt_dir}")
+        _rsync_directory(local_dir, remote_dest, ssh_key_path, delete=True, dry_run=dry_run)
+        synced_files.append(f"{dbt_dir}/")
+    _notify(on_progress, "sync_dbt", "done")
+
+    # --- Step 4: Detect model changes ---
+    if first_deploy:
+        # All local models are "added" on first deploy
+        added_models = sorted(_extract_model_name(p) for p in local_model_hashes)
+        changed_models: list[str] = []
+        removed_models: list[str] = []
+        # packages.yml is always "changed" on first deploy if it exists
+        if (local_project_root / "dbt" / "packages.yml").is_file():
+            packages_changed = True
+    else:
+        added_m, changed_m, removed_m = _detect_dbt_changes(before_model_hashes, local_model_hashes)
+        added_mac, changed_mac, removed_mac = _detect_dbt_changes(
+            before_macro_hashes, local_macro_hashes
+        )
+        added_models = sorted(set(added_m + added_mac))
+        changed_models = sorted(set(changed_m + changed_mac))
+        removed_models = sorted(set(removed_m + removed_mac))
+
+    return SyncResult(
+        synced_files=synced_files,
+        changed_models=changed_models,
+        added_models=added_models,
+        removed_models=removed_models,
+        packages_changed=packages_changed,
+        is_first_deploy=first_deploy,
+        dry_run=dry_run,
+    )

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -76,6 +76,7 @@ class SyncResult:
     added_models: list[str] = field(default_factory=list)
     removed_models: list[str] = field(default_factory=list)
     packages_changed: bool = False
+    has_macro_changes: bool = False
     is_first_deploy: bool = False
     dry_run: bool = False
 
@@ -167,7 +168,7 @@ def _detect_dbt_changes(
 
 def _build_rsync_ssh_arg(ssh_key_path: Path) -> str:
     """Build the ``-e`` argument for rsync to use the correct SSH key."""
-    return f"ssh -i {ssh_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    return f'ssh -i "{ssh_key_path}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 
 
 def _rsync_directory(
@@ -347,23 +348,30 @@ def sync_project_files(
         synced_files.append(f"{dbt_dir}/")
     _notify(on_progress, "sync_dbt", "done")
 
-    # --- Step 4: Detect model changes ---
+    # --- Step 4: Detect model and macro changes ---
+    has_macro_changes = False
     if first_deploy:
         # All local models are "added" on first deploy
         added_models = sorted(_extract_model_name(p) for p in local_model_hashes)
         changed_models: list[str] = []
         removed_models: list[str] = []
+        # Any macros present = macro changes on first deploy
+        if local_macro_hashes:
+            has_macro_changes = True
         # packages.yml is always "changed" on first deploy if it exists
         if (local_project_root / "dbt" / "packages.yml").is_file():
             packages_changed = True
     else:
-        added_m, changed_m, removed_m = _detect_dbt_changes(before_model_hashes, local_model_hashes)
+        # Model changes — reported individually for selective dbt run
+        added_models, changed_models, removed_models = _detect_dbt_changes(
+            before_model_hashes, local_model_hashes
+        )
+        # Macro changes — any change triggers full dbt run (macros aren't
+        # individually selectable in dbt run --select)
         added_mac, changed_mac, removed_mac = _detect_dbt_changes(
             before_macro_hashes, local_macro_hashes
         )
-        added_models = sorted(set(added_m + added_mac))
-        changed_models = sorted(set(changed_m + changed_mac))
-        removed_models = sorted(set(removed_m + removed_mac))
+        has_macro_changes = bool(added_mac or changed_mac or removed_mac)
 
     return SyncResult(
         synced_files=synced_files,
@@ -371,6 +379,7 @@ def sync_project_files(
         added_models=added_models,
         removed_models=removed_models,
         packages_changed=packages_changed,
+        has_macro_changes=has_macro_changes,
         is_first_deploy=first_deploy,
         dry_run=dry_run,
     )

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -68,9 +68,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/remote.py
-    lines: 521
+    lines: 650
     category: exempt
-    reason: "Remote server management: rollback + firewall subgroup + domain subgroup + registration of management and backup subgroups. Each subgroup is a thin CLI layer delegating to platform/cloud modules."
+    reason: "Remote server management: push + rollback + firewall subgroup + domain subgroup + registration of management and backup subgroups. Each subgroup is a thin CLI layer delegating to platform/cloud modules."
     review_by: "v1.1"
 
   # --- Exempt (stable, not modified in v1) ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ module = [
     "tests.unit.test_remote_backup_cli",
     "tests.unit.test_file_sync",
     "tests.unit.test_deployer",
+    "tests.unit.test_deployer_push",
 ]
 ignore_errors = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,8 @@ module = [
     "tests.unit.test_backup",
     "tests.unit.test_scheduled_backup",
     "tests.unit.test_remote_backup_cli",
+    "tests.unit.test_file_sync",
+    "tests.unit.test_deployer",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_deployer.py
+++ b/tests/unit/test_deployer.py
@@ -1,9 +1,9 @@
 """tests/unit/test_deployer.py
 
-Unit tests for push deployment (dango/platform/cloud/deployer.py).
+Unit tests for deployer helpers: lock management, source validation,
+model name validation, dbt commands, and dataclasses.
 
-Uses mocked SSHManager, file_sync, and backup to avoid real network
-or filesystem access.
+push_deploy() orchestration tests are in test_deployer_push.py.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,8 +26,8 @@ from dango.platform.cloud.deployer import (
     _is_lock_expired,
     _release_lock,
     _run_remote_dbt,
+    _validate_model_names,
     _validate_remote_sources,
-    push_deploy,
 )
 from dango.platform.cloud.ssh import CommandResult
 
@@ -42,33 +42,6 @@ def _make_ssh_mock() -> MagicMock:
     ssh.key_path = Path("/tmp/test_key")
     ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
     return ssh
-
-
-def _make_sync_result(**kwargs: object) -> MagicMock:
-    """Return a mock SyncResult with defaults."""
-    from dango.platform.cloud.file_sync import SyncResult
-
-    defaults = {
-        "synced_files": ["dbt/models/", ".dango/sources.yml"],
-        "changed_models": ["stg_orders"],
-        "added_models": [],
-        "removed_models": [],
-        "packages_changed": False,
-        "is_first_deploy": False,
-        "dry_run": False,
-    }
-    defaults.update(kwargs)
-    return SyncResult(**defaults)
-
-
-def _make_backup_result() -> MagicMock:
-    """Return a mock BackupResult."""
-    result = MagicMock()
-    result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
-    result.manifest_path = "/srv/dango/backups/deploy/backup-test.json"
-    result.duration_seconds = 5.0
-    result.warnings = []
-    return result
 
 
 def _make_lock_json(*, expired: bool = False) -> str:
@@ -161,12 +134,38 @@ class TestLockManagement:
         lock = DeployLock(deployer="x", started_at="", expires_at="")
         assert _is_lock_expired(lock) is True
 
+    def test_is_lock_expired_handles_utc_suffix(self):
+        """Python 3.10 compat: +00:00 suffix is stripped before parsing."""
+        future = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+        # Explicitly include the +00:00 suffix
+        lock = DeployLock(deployer="x", started_at="", expires_at=future.isoformat())
+        assert _is_lock_expired(lock) is False
+
+    def test_is_lock_expired_handles_z_suffix(self):
+        """Python 3.10 compat: Z suffix is stripped before parsing."""
+        future = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+        ts = future.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+        lock = DeployLock(deployer="x", started_at="", expires_at=ts)
+        assert _is_lock_expired(lock) is False
+
     def test_acquire_lock_no_existing(self):
         ssh = _make_ssh_mock()
         # No existing lock
         ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
         lock = _acquire_lock(ssh)
         assert lock.deployer != ""
+
+    def test_acquire_lock_uses_noclobber(self):
+        """Lock creation uses atomic noclobber (set -C)."""
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
+        _acquire_lock(ssh)
+        # Find the lock creation command
+        lock_cmds = [
+            args[0][0] for args in ssh.exec_command.call_args_list if "set -C" in args[0][0]
+        ]
+        assert len(lock_cmds) == 1
+        assert DEPLOY_LOCK_PATH in lock_cmds[0]
 
     def test_acquire_lock_active_lock_raises(self):
         ssh = _make_ssh_mock()
@@ -204,6 +203,27 @@ class TestLockManagement:
         ssh.exec_command.side_effect = _side_effect
         lock = _acquire_lock(ssh, force=True)
         assert lock.deployer != ""
+
+    def test_acquire_lock_concurrent_race_fails(self):
+        """If noclobber fails (another deployer grabbed it), raise error."""
+        ssh = _make_ssh_mock()
+        call_count = 0
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            nonlocal call_count
+            call_count += 1
+            # No existing lock on read
+            if f"cat {DEPLOY_LOCK_PATH}" in cmd:
+                return CommandResult(stdout="", stderr="", exit_code=1)
+            # Noclobber write fails (another deployer beat us)
+            if "set -C" in cmd:
+                return CommandResult(stdout="", stderr="cannot overwrite", exit_code=1)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        with pytest.raises(CloudProvisioningError, match="another deployment"):
+            _acquire_lock(ssh)
 
     def test_release_lock(self):
         ssh = _make_ssh_mock()
@@ -269,6 +289,34 @@ class TestSourceValidation:
 
 
 # ---------------------------------------------------------------------------
+# Model name validation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelNameValidation:
+    """Test _validate_model_names shell safety check."""
+
+    def test_valid_names_pass(self):
+        _validate_model_names(["stg_orders", "stg_users", "dim_customer_v2"])
+
+    def test_empty_list_passes(self):
+        _validate_model_names([])
+
+    def test_invalid_name_with_semicolon_raises(self):
+        with pytest.raises(CloudProvisioningError, match="Invalid model name"):
+            _validate_model_names(["stg_orders; rm -rf /"])
+
+    def test_invalid_name_with_spaces_raises(self):
+        with pytest.raises(CloudProvisioningError, match="Invalid model name"):
+            _validate_model_names(["stg orders"])
+
+    def test_invalid_name_with_slash_raises(self):
+        with pytest.raises(CloudProvisioningError, match="Invalid model name"):
+            _validate_model_names(["staging/stg_orders"])
+
+
+# ---------------------------------------------------------------------------
 # Remote dbt command tests
 # ---------------------------------------------------------------------------
 
@@ -305,177 +353,3 @@ class TestDeployerIdentity:
     def test_returns_user_at_host(self):
         identity = _get_deployer_identity()
         assert "@" in identity
-
-
-# ---------------------------------------------------------------------------
-# push_deploy tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestPushDeploy:
-    """Test push_deploy orchestration."""
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_dry_run(self, mock_sync, mock_backup, tmp_path):
-        mock_sync.return_value = _make_sync_result(dry_run=True)
-        ssh = _make_ssh_mock()
-
-        result = push_deploy(ssh, tmp_path, "10.0.0.1", dry_run=True)
-
-        assert result.dry_run is True
-        assert result.backup_result is None
-        mock_backup.assert_not_called()
-        mock_sync.assert_called_once()
-        # Verify sync was called with dry_run=True
-        assert mock_sync.call_args[1]["dry_run"] is True
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_full_deploy_workflow(self, mock_sync, mock_backup, tmp_path):
-        mock_sync.return_value = _make_sync_result(
-            changed_models=["stg_orders"],
-            packages_changed=True,
-        )
-        mock_backup.return_value = _make_backup_result()
-        ssh = _make_ssh_mock()
-
-        # Track command order
-        commands: list[str] = []
-
-        def _tracking_exec(cmd: str, **kwargs: object) -> CommandResult:
-            commands.append(cmd)
-            return CommandResult(stdout="", stderr="", exit_code=0)
-
-        ssh.exec_command.side_effect = _tracking_exec
-
-        result = push_deploy(ssh, tmp_path, "10.0.0.1")
-
-        assert result.dry_run is False
-        assert result.backup_result is not None
-        assert result.dbt_deps_run is True
-        assert result.dbt_compile_success is True
-        assert "stg_orders" in result.models_rebuilt
-
-        # Verify correct step order
-        lock_acquired = any(DEPLOY_LOCK_PATH in c and "cat >" in c for c in commands)
-        web_stopped = any("systemctl stop dango-web" in c for c in commands)
-        ownership_fixed = any("chown -R dango:dango" in c for c in commands)
-        web_started = any("systemctl start dango-web" in c for c in commands)
-        lock_released = any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in commands)
-
-        assert lock_acquired
-        assert web_stopped
-        assert ownership_fixed
-        assert web_started
-        assert lock_released
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_dbt_compile_failure_aborts(self, mock_sync, mock_backup, tmp_path):
-        mock_sync.return_value = _make_sync_result()
-        mock_backup.return_value = _make_backup_result()
-        ssh = _make_ssh_mock()
-
-        call_count = 0
-
-        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
-            nonlocal call_count
-            call_count += 1
-            if "dbt compile" in cmd:
-                return CommandResult(stdout="", stderr="Compilation Error", exit_code=1)
-            return CommandResult(stdout="", stderr="", exit_code=0)
-
-        ssh.exec_command.side_effect = _side_effect
-
-        with pytest.raises(CloudProvisioningError, match="dbt compile failed"):
-            push_deploy(ssh, tmp_path, "10.0.0.1")
-
-        # Verify the lock was released (rm -f deploy.lock called)
-        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
-        assert any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in all_calls)
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_no_models_changed_skips_dbt_run(self, mock_sync, mock_backup, tmp_path):
-        mock_sync.return_value = _make_sync_result(
-            changed_models=[],
-            added_models=[],
-        )
-        mock_backup.return_value = _make_backup_result()
-        ssh = _make_ssh_mock()
-
-        result = push_deploy(ssh, tmp_path, "10.0.0.1")
-
-        assert result.models_rebuilt == []
-        # No dbt run command should have been issued
-        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
-        assert not any("dbt run" in c for c in all_calls)
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_packages_not_changed_skips_dbt_deps(self, mock_sync, mock_backup, tmp_path):
-        mock_sync.return_value = _make_sync_result(packages_changed=False)
-        mock_backup.return_value = _make_backup_result()
-        ssh = _make_ssh_mock()
-
-        result = push_deploy(ssh, tmp_path, "10.0.0.1")
-
-        assert result.dbt_deps_run is False
-        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
-        assert not any("dbt deps" in c for c in all_calls)
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_lock_released_on_error(self, mock_sync, mock_backup, tmp_path):
-        mock_backup.side_effect = CloudProvisioningError("backup failed")
-        ssh = _make_ssh_mock()
-
-        with pytest.raises(CloudProvisioningError, match="backup failed"):
-            push_deploy(ssh, tmp_path, "10.0.0.1")
-
-        # Lock should still be released
-        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
-        assert any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in all_calls)
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_progress_callback(self, mock_sync, mock_backup, tmp_path):
-        mock_sync.return_value = _make_sync_result()
-        mock_backup.return_value = _make_backup_result()
-        ssh = _make_ssh_mock()
-
-        steps: list[tuple[str, str]] = []
-        push_deploy(ssh, tmp_path, "10.0.0.1", on_progress=lambda s, st: steps.append((s, st)))
-
-        step_names = [s for s, _ in steps]
-        assert "acquire_lock" in step_names
-        assert "create_backup" in step_names
-        assert "stop_web" in step_names
-        assert "sync_files" in step_names
-        assert "fix_ownership" in step_names
-        assert "dbt_compile" in step_names
-
-    @patch("dango.platform.cloud.backup.create_backup")
-    @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_source_validation_warnings(self, mock_sync, mock_backup, tmp_path):
-        mock_sync.return_value = _make_sync_result()
-        mock_backup.return_value = _make_backup_result()
-        ssh = _make_ssh_mock()
-
-        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
-            if "sources.yml" in cmd and "cat" in cmd:
-                return CommandResult(
-                    stdout="sources:\n  - name: missing_source\n",
-                    stderr="",
-                    exit_code=0,
-                )
-            if "secrets.toml" in cmd and "cat" in cmd:
-                return CommandResult(stdout="# empty", stderr="", exit_code=0)
-            return CommandResult(stdout="", stderr="", exit_code=0)
-
-        ssh.exec_command.side_effect = _side_effect
-
-        result = push_deploy(ssh, tmp_path, "10.0.0.1")
-        assert any("missing_source" in w for w in result.warnings)

--- a/tests/unit/test_deployer.py
+++ b/tests/unit/test_deployer.py
@@ -1,0 +1,481 @@
+"""tests/unit/test_deployer.py
+
+Unit tests for push deployment (dango/platform/cloud/deployer.py).
+
+Uses mocked SSHManager, file_sync, and backup to avoid real network
+or filesystem access.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import CloudProvisioningError
+from dango.platform.cloud.deployer import (
+    DEPLOY_LOCK_PATH,
+    DeployLock,
+    DeployResult,
+    _acquire_lock,
+    _check_existing_lock,
+    _get_deployer_identity,
+    _is_lock_expired,
+    _release_lock,
+    _run_remote_dbt,
+    _validate_remote_sources,
+    push_deploy,
+)
+from dango.platform.cloud.ssh import CommandResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ssh_mock() -> MagicMock:
+    """Return a mock SSHManager with sensible defaults."""
+    ssh = MagicMock()
+    ssh.key_path = Path("/tmp/test_key")
+    ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
+    return ssh
+
+
+def _make_sync_result(**kwargs: object) -> MagicMock:
+    """Return a mock SyncResult with defaults."""
+    from dango.platform.cloud.file_sync import SyncResult
+
+    defaults = {
+        "synced_files": ["dbt/models/", ".dango/sources.yml"],
+        "changed_models": ["stg_orders"],
+        "added_models": [],
+        "removed_models": [],
+        "packages_changed": False,
+        "is_first_deploy": False,
+        "dry_run": False,
+    }
+    defaults.update(kwargs)
+    return SyncResult(**defaults)
+
+
+def _make_backup_result() -> MagicMock:
+    """Return a mock BackupResult."""
+    result = MagicMock()
+    result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+    result.manifest_path = "/srv/dango/backups/deploy/backup-test.json"
+    result.duration_seconds = 5.0
+    result.warnings = []
+    return result
+
+
+def _make_lock_json(*, expired: bool = False) -> str:
+    """Return JSON for a deploy lock."""
+    now = datetime.now(tz=timezone.utc)
+    if expired:
+        started = now - timedelta(hours=1)
+        expires = now - timedelta(minutes=30)
+    else:
+        started = now - timedelta(minutes=5)
+        expires = now + timedelta(minutes=25)
+    return json.dumps(
+        {
+            "deployer": "testuser@testhost",
+            "started_at": started.isoformat(),
+            "expires_at": expires.isoformat(),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# DeployLock / DeployResult tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDataclasses:
+    """Test DeployLock and DeployResult."""
+
+    def test_deploy_lock_fields(self):
+        lock = DeployLock(
+            deployer="me@host", started_at="2026-01-01T00:00:00", expires_at="2026-01-01T00:30:00"
+        )
+        assert lock.deployer == "me@host"
+        assert lock.started_at == "2026-01-01T00:00:00"
+        assert lock.expires_at == "2026-01-01T00:30:00"
+
+    def test_deploy_result_defaults(self):
+        from dango.platform.cloud.file_sync import SyncResult
+
+        result = DeployResult(sync_result=SyncResult())
+        assert result.backup_result is None
+        assert result.dbt_deps_run is False
+        assert result.dbt_compile_success is False
+        assert result.models_rebuilt == []
+        assert result.duration_seconds == 0.0
+        assert result.warnings == []
+        assert result.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# Lock management tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLockManagement:
+    """Test deploy lock acquisition and release."""
+
+    def test_check_no_existing_lock(self):
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=1)
+        assert _check_existing_lock(ssh) is None
+
+    def test_check_existing_lock(self):
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(
+            stdout=_make_lock_json(), stderr="", exit_code=0
+        )
+        lock = _check_existing_lock(ssh)
+        assert lock is not None
+        assert lock.deployer == "testuser@testhost"
+
+    def test_check_corrupt_lock(self):
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(stdout="not json", stderr="", exit_code=0)
+        assert _check_existing_lock(ssh) is None
+
+    def test_is_lock_expired_true(self):
+        past = (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat()
+        lock = DeployLock(deployer="x", started_at="", expires_at=past)
+        assert _is_lock_expired(lock) is True
+
+    def test_is_lock_expired_false(self):
+        future = (datetime.now(tz=timezone.utc) + timedelta(hours=1)).isoformat()
+        lock = DeployLock(deployer="x", started_at="", expires_at=future)
+        assert _is_lock_expired(lock) is False
+
+    def test_is_lock_expired_empty_expiry(self):
+        lock = DeployLock(deployer="x", started_at="", expires_at="")
+        assert _is_lock_expired(lock) is True
+
+    def test_acquire_lock_no_existing(self):
+        ssh = _make_ssh_mock()
+        # No existing lock
+        ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
+        lock = _acquire_lock(ssh)
+        assert lock.deployer != ""
+
+    def test_acquire_lock_active_lock_raises(self):
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if f"cat {DEPLOY_LOCK_PATH}" in cmd:
+                return CommandResult(stdout=_make_lock_json(expired=False), stderr="", exit_code=0)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        with pytest.raises(CloudProvisioningError, match="Deploy lock held by"):
+            _acquire_lock(ssh)
+
+    def test_acquire_lock_stale_lock_succeeds(self):
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if f"cat {DEPLOY_LOCK_PATH}" in cmd:
+                return CommandResult(stdout=_make_lock_json(expired=True), stderr="", exit_code=0)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+        lock = _acquire_lock(ssh)
+        assert lock.deployer != ""
+
+    def test_acquire_lock_force_overrides(self):
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if f"cat {DEPLOY_LOCK_PATH}" in cmd:
+                return CommandResult(stdout=_make_lock_json(expired=False), stderr="", exit_code=0)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+        lock = _acquire_lock(ssh, force=True)
+        assert lock.deployer != ""
+
+    def test_release_lock(self):
+        ssh = _make_ssh_mock()
+        _release_lock(ssh)
+        ssh.exec_command.assert_called_once_with(f"rm -f {DEPLOY_LOCK_PATH}")
+
+
+# ---------------------------------------------------------------------------
+# Source validation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSourceValidation:
+    """Test _validate_remote_sources."""
+
+    def test_valid_sources(self):
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "sources.yml" in cmd:
+                return CommandResult(
+                    stdout="sources:\n  - name: google_sheets\n  - name: facebook_ads\n",
+                    stderr="",
+                    exit_code=0,
+                )
+            if "secrets.toml" in cmd:
+                return CommandResult(
+                    stdout='[sources.google_sheets]\nkey = "abc"\n[sources.facebook_ads]\ntoken = "xyz"\n',
+                    stderr="",
+                    exit_code=0,
+                )
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+        errors = _validate_remote_sources(ssh)
+        assert errors == []
+
+    def test_missing_credentials(self):
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "sources.yml" in cmd:
+                return CommandResult(
+                    stdout="sources:\n  - name: google_sheets\n",
+                    stderr="",
+                    exit_code=0,
+                )
+            if "secrets.toml" in cmd:
+                return CommandResult(stdout="# empty", stderr="", exit_code=0)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+        errors = _validate_remote_sources(ssh)
+        assert len(errors) == 1
+        assert "google_sheets" in errors[0]
+
+    def test_no_sources_configured(self):
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=1)
+        errors = _validate_remote_sources(ssh)
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Remote dbt command tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunRemoteDbt:
+    """Test _run_remote_dbt."""
+
+    def test_basic_command(self):
+        ssh = _make_ssh_mock()
+        _run_remote_dbt(ssh, "compile")
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "sudo -u dango" in cmd
+        assert "dbt compile" in cmd
+        assert "--project-dir" in cmd
+        assert "--profiles-dir" in cmd
+
+    def test_extra_args(self):
+        ssh = _make_ssh_mock()
+        _run_remote_dbt(ssh, "run", "--select stg_orders stg_users")
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "--select stg_orders stg_users" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Deployer identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeployerIdentity:
+    """Test _get_deployer_identity."""
+
+    def test_returns_user_at_host(self):
+        identity = _get_deployer_identity()
+        assert "@" in identity
+
+
+# ---------------------------------------------------------------------------
+# push_deploy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPushDeploy:
+    """Test push_deploy orchestration."""
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_dry_run(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(dry_run=True)
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1", dry_run=True)
+
+        assert result.dry_run is True
+        assert result.backup_result is None
+        mock_backup.assert_not_called()
+        mock_sync.assert_called_once()
+        # Verify sync was called with dry_run=True
+        assert mock_sync.call_args[1]["dry_run"] is True
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_full_deploy_workflow(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(
+            changed_models=["stg_orders"],
+            packages_changed=True,
+        )
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        # Track command order
+        commands: list[str] = []
+
+        def _tracking_exec(cmd: str, **kwargs: object) -> CommandResult:
+            commands.append(cmd)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _tracking_exec
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert result.dry_run is False
+        assert result.backup_result is not None
+        assert result.dbt_deps_run is True
+        assert result.dbt_compile_success is True
+        assert "stg_orders" in result.models_rebuilt
+
+        # Verify correct step order
+        lock_acquired = any(DEPLOY_LOCK_PATH in c and "cat >" in c for c in commands)
+        web_stopped = any("systemctl stop dango-web" in c for c in commands)
+        ownership_fixed = any("chown -R dango:dango" in c for c in commands)
+        web_started = any("systemctl start dango-web" in c for c in commands)
+        lock_released = any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in commands)
+
+        assert lock_acquired
+        assert web_stopped
+        assert ownership_fixed
+        assert web_started
+        assert lock_released
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_dbt_compile_failure_aborts(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        call_count = 0
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            nonlocal call_count
+            call_count += 1
+            if "dbt compile" in cmd:
+                return CommandResult(stdout="", stderr="Compilation Error", exit_code=1)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        with pytest.raises(CloudProvisioningError, match="dbt compile failed"):
+            push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        # Verify the lock was released (rm -f deploy.lock called)
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_no_models_changed_skips_dbt_run(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(
+            changed_models=[],
+            added_models=[],
+        )
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert result.models_rebuilt == []
+        # No dbt run command should have been issued
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert not any("dbt run" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_packages_not_changed_skips_dbt_deps(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(packages_changed=False)
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert result.dbt_deps_run is False
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert not any("dbt deps" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_lock_released_on_error(self, mock_sync, mock_backup, tmp_path):
+        mock_backup.side_effect = CloudProvisioningError("backup failed")
+        ssh = _make_ssh_mock()
+
+        with pytest.raises(CloudProvisioningError, match="backup failed"):
+            push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        # Lock should still be released
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_progress_callback(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        steps: list[tuple[str, str]] = []
+        push_deploy(ssh, tmp_path, "10.0.0.1", on_progress=lambda s, st: steps.append((s, st)))
+
+        step_names = [s for s, _ in steps]
+        assert "acquire_lock" in step_names
+        assert "create_backup" in step_names
+        assert "stop_web" in step_names
+        assert "sync_files" in step_names
+        assert "fix_ownership" in step_names
+        assert "dbt_compile" in step_names
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_source_validation_warnings(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "sources.yml" in cmd and "cat" in cmd:
+                return CommandResult(
+                    stdout="sources:\n  - name: missing_source\n",
+                    stderr="",
+                    exit_code=0,
+                )
+            if "secrets.toml" in cmd and "cat" in cmd:
+                return CommandResult(stdout="# empty", stderr="", exit_code=0)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+        assert any("missing_source" in w for w in result.warnings)

--- a/tests/unit/test_deployer_push.py
+++ b/tests/unit/test_deployer_push.py
@@ -1,0 +1,277 @@
+"""tests/unit/test_deployer_push.py
+
+Unit tests for push_deploy() orchestration (dango/platform/cloud/deployer.py).
+
+Split from test_deployer.py for file-size compliance. Tests here exercise
+the full push_deploy workflow: dry-run, step ordering, error handling,
+service restart, and dbt command decisions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import CloudProvisioningError
+from dango.platform.cloud.deployer import DEPLOY_LOCK_PATH, push_deploy
+from dango.platform.cloud.file_sync import SyncResult
+from dango.platform.cloud.ssh import CommandResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ssh_mock() -> MagicMock:
+    """Return a mock SSHManager with sensible defaults."""
+    ssh = MagicMock()
+    ssh.key_path = Path("/tmp/test_key")
+    ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
+    return ssh
+
+
+def _make_sync_result(**kwargs: object) -> SyncResult:
+    """Return a SyncResult with defaults."""
+    defaults = {
+        "synced_files": ["dbt/models/", ".dango/sources.yml"],
+        "changed_models": ["stg_orders"],
+        "added_models": [],
+        "removed_models": [],
+        "packages_changed": False,
+        "has_macro_changes": False,
+        "is_first_deploy": False,
+        "dry_run": False,
+    }
+    defaults.update(kwargs)
+    return SyncResult(**defaults)
+
+
+def _make_backup_result() -> MagicMock:
+    """Return a mock BackupResult."""
+    result = MagicMock()
+    result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+    result.manifest_path = "/srv/dango/backups/deploy/backup-test.json"
+    result.duration_seconds = 5.0
+    result.warnings = []
+    return result
+
+
+# ---------------------------------------------------------------------------
+# push_deploy tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPushDeploy:
+    """Test push_deploy orchestration."""
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_dry_run(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(dry_run=True)
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1", dry_run=True)
+
+        assert result.dry_run is True
+        assert result.backup_result is None
+        mock_backup.assert_not_called()
+        mock_sync.assert_called_once()
+        assert mock_sync.call_args[1]["dry_run"] is True
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_full_deploy_workflow(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(
+            changed_models=["stg_orders"],
+            packages_changed=True,
+        )
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        commands: list[str] = []
+
+        def _tracking_exec(cmd: str, **kwargs: object) -> CommandResult:
+            commands.append(cmd)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _tracking_exec
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert result.dry_run is False
+        assert result.backup_result is not None
+        assert result.dbt_deps_run is True
+        assert result.dbt_compile_success is True
+        assert "stg_orders" in result.models_rebuilt
+
+        # Verify correct step order
+        assert any("set -C" in c and DEPLOY_LOCK_PATH in c for c in commands)
+        assert any("systemctl stop dango-web" in c for c in commands)
+        assert any("chown -R dango:dango" in c for c in commands)
+        assert any("systemctl start dango-web" in c for c in commands)
+        assert any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in commands)
+
+        # Verify backup called with restart_services=False
+        mock_backup.assert_called_once()
+        assert mock_backup.call_args[1]["restart_services"] is False
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_dbt_compile_failure_aborts(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "dbt compile" in cmd:
+                return CommandResult(stdout="", stderr="Compilation Error", exit_code=1)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        with pytest.raises(CloudProvisioningError, match="dbt compile failed"):
+            push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_dbt_run_failure_raises(self, mock_sync, mock_backup, tmp_path):
+        """dbt run failure should raise CloudProvisioningError, not just warn."""
+        mock_sync.return_value = _make_sync_result(changed_models=["stg_orders"])
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "dbt run" in cmd:
+                return CommandResult(stdout="", stderr="Runtime Error", exit_code=1)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        with pytest.raises(CloudProvisioningError, match="dbt run failed"):
+            push_deploy(ssh, tmp_path, "10.0.0.1")
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_no_models_changed_skips_dbt_run(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(changed_models=[], added_models=[])
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert result.models_rebuilt == []
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert not any("dbt run" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_packages_not_changed_skips_dbt_deps(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result(packages_changed=False)
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert result.dbt_deps_run is False
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert not any("dbt deps" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_macro_changes_trigger_full_rebuild(self, mock_sync, mock_backup, tmp_path):
+        """When macros change, dbt run runs without --select (full rebuild)."""
+        mock_sync.return_value = _make_sync_result(
+            changed_models=[], added_models=[], has_macro_changes=True
+        )
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        dbt_run_calls = [c for c in all_calls if "dbt run" in c]
+        assert len(dbt_run_calls) == 1
+        assert "--select" not in dbt_run_calls[0]
+        assert result.models_rebuilt == ["(full rebuild \u2014 macros changed)"]
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_lock_released_on_error(self, mock_sync, mock_backup, tmp_path):
+        mock_backup.side_effect = CloudProvisioningError("backup failed")
+        ssh = _make_ssh_mock()
+
+        with pytest.raises(CloudProvisioningError, match="backup failed"):
+            push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert any(f"rm -f {DEPLOY_LOCK_PATH}" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_services_restarted_on_error(self, mock_sync, mock_backup, tmp_path):
+        """Services are restarted in finally block even when deploy fails."""
+        mock_backup.return_value = _make_backup_result()
+        mock_sync.return_value = _make_sync_result()
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "dbt compile" in cmd:
+                return CommandResult(stdout="", stderr="fail", exit_code=1)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        with pytest.raises(CloudProvisioningError):
+            push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        all_calls = [args[0][0] for args in ssh.exec_command.call_args_list]
+        assert any("systemctl start dango-web" in c for c in all_calls)
+        assert any("start metabase" in c for c in all_calls)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_progress_callback(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        steps: list[tuple[str, str]] = []
+        push_deploy(ssh, tmp_path, "10.0.0.1", on_progress=lambda s, st: steps.append((s, st)))
+
+        step_names = [s for s, _ in steps]
+        assert "acquire_lock" in step_names
+        assert "stop_web" in step_names
+        assert "create_backup" in step_names
+        assert "sync_files" in step_names
+        assert "fix_ownership" in step_names
+        assert "dbt_compile" in step_names
+        assert "start_services" in step_names
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_source_validation_warnings(self, mock_sync, mock_backup, tmp_path):
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "sources.yml" in cmd and "cat" in cmd:
+                return CommandResult(
+                    stdout="sources:\n  - name: missing_source\n",
+                    stderr="",
+                    exit_code=0,
+                )
+            if "secrets.toml" in cmd and "cat" in cmd:
+                return CommandResult(stdout="# empty", stderr="", exit_code=0)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+        assert any("missing_source" in w for w in result.warnings)

--- a/tests/unit/test_file_sync.py
+++ b/tests/unit/test_file_sync.py
@@ -1,0 +1,348 @@
+"""tests/unit/test_file_sync.py
+
+Unit tests for project file sync (dango/platform/cloud/file_sync.py).
+
+Uses mocked SSHManager and subprocess to avoid real network or
+filesystem access.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.platform.cloud.file_sync import (
+    REMOTE_PROJECT_DIR,
+    SyncResult,
+    _build_rsync_ssh_arg,
+    _compute_local_hashes,
+    _detect_dbt_changes,
+    _extract_model_name,
+    sync_project_files,
+)
+from dango.platform.cloud.ssh import CommandResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ssh_mock(*, first_deploy: bool = False) -> MagicMock:
+    """Return a mock SSHManager with sensible defaults."""
+    ssh = MagicMock()
+    ssh.key_path = Path("/tmp/test_key")
+
+    def _exec_side_effect(cmd: str, **kwargs: object) -> CommandResult:
+        # First deploy detection
+        if f"test -f {REMOTE_PROJECT_DIR}/.dango/sources.yml" in cmd:
+            if first_deploy:
+                return CommandResult(stdout="", stderr="", exit_code=1)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+        # Remote hash computation
+        if cmd.startswith("find ") and "md5sum" in cmd:
+            return CommandResult(stdout="", stderr="", exit_code=0)
+        # md5sum for packages.yml check
+        if "md5sum" in cmd and "packages.yml" in cmd:
+            return CommandResult(
+                stdout="abc123  /srv/dango/project/dbt/packages.yml", stderr="", exit_code=0
+            )
+        # mkdir -p (always succeeds)
+        if cmd.startswith("mkdir"):
+            return CommandResult(stdout="", stderr="", exit_code=0)
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    ssh.exec_command.side_effect = _exec_side_effect
+    ssh.upload_file.return_value = None
+    return ssh
+
+
+def _make_project(tmp_path: Path, *, with_packages: bool = True) -> Path:
+    """Create a minimal local project structure under *tmp_path*."""
+    root = tmp_path / "project"
+    (root / ".dango").mkdir(parents=True)
+    (root / ".dango" / "sources.yml").write_text("sources: []")
+    (root / "dbt" / "models" / "staging").mkdir(parents=True)
+    (root / "dbt" / "macros").mkdir(parents=True)
+    (root / "dbt" / "dbt_project.yml").write_text("name: test")
+    (root / "dbt" / "models" / "staging" / "stg_orders.sql").write_text("SELECT 1")
+    (root / "dbt" / "models" / "stg_users.sql").write_text("SELECT 2")
+    (root / "dbt" / "macros" / "my_macro.sql").write_text("{% macro foo() %}1{% endmacro %}")
+    if with_packages:
+        (root / "dbt" / "packages.yml").write_text("packages: []")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# SyncResult tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSyncResult:
+    """Test SyncResult dataclass defaults."""
+
+    def test_default_values(self):
+        result = SyncResult()
+        assert result.synced_files == []
+        assert result.changed_models == []
+        assert result.added_models == []
+        assert result.removed_models == []
+        assert result.packages_changed is False
+        assert result.is_first_deploy is False
+        assert result.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# Change detection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestChangeDetection:
+    """Test dbt change detection helpers."""
+
+    def test_extract_model_name_simple(self):
+        assert _extract_model_name("stg_orders.sql") == "stg_orders"
+
+    def test_extract_model_name_nested(self):
+        assert _extract_model_name("staging/stg_orders.sql") == "stg_orders"
+
+    def test_detect_added_models(self):
+        before: dict[str, str] = {}
+        local = {"stg_orders.sql": "abc123"}
+        added, changed, removed = _detect_dbt_changes(before, local)
+        assert added == ["stg_orders"]
+        assert changed == []
+        assert removed == []
+
+    def test_detect_changed_models(self):
+        before = {"stg_orders.sql": "abc123"}
+        local = {"stg_orders.sql": "def456"}
+        added, changed, removed = _detect_dbt_changes(before, local)
+        assert added == []
+        assert changed == ["stg_orders"]
+        assert removed == []
+
+    def test_detect_removed_models(self):
+        before = {"stg_orders.sql": "abc123"}
+        local: dict[str, str] = {}
+        added, changed, removed = _detect_dbt_changes(before, local)
+        assert added == []
+        assert changed == []
+        assert removed == ["stg_orders"]
+
+    def test_detect_mixed_changes(self):
+        before = {
+            "stg_orders.sql": "aaa",
+            "stg_deleted.sql": "bbb",
+            "stg_unchanged.sql": "ccc",
+        }
+        local = {
+            "stg_orders.sql": "xxx",
+            "stg_new.sql": "ddd",
+            "stg_unchanged.sql": "ccc",
+        }
+        added, changed, removed = _detect_dbt_changes(before, local)
+        assert added == ["stg_new"]
+        assert changed == ["stg_orders"]
+        assert removed == ["stg_deleted"]
+
+    def test_no_changes(self):
+        hashes = {"stg_orders.sql": "aaa", "stg_users.sql": "bbb"}
+        added, changed, removed = _detect_dbt_changes(hashes, dict(hashes))
+        assert added == []
+        assert changed == []
+        assert removed == []
+
+
+# ---------------------------------------------------------------------------
+# Local hash computation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputeLocalHashes:
+    """Test _compute_local_hashes."""
+
+    def test_computes_hashes(self, tmp_path):
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        (models_dir / "stg_orders.sql").write_text("SELECT 1")
+        hashes = _compute_local_hashes(models_dir, "*.sql")
+        assert "stg_orders.sql" in hashes
+        assert len(hashes["stg_orders.sql"]) == 32  # MD5 hex digest
+
+    def test_empty_directory(self, tmp_path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        assert _compute_local_hashes(empty_dir, "*.sql") == {}
+
+    def test_nonexistent_directory(self, tmp_path):
+        assert _compute_local_hashes(tmp_path / "nope", "*.sql") == {}
+
+    def test_nested_files(self, tmp_path):
+        models_dir = tmp_path / "models"
+        (models_dir / "staging").mkdir(parents=True)
+        (models_dir / "staging" / "stg_orders.sql").write_text("SELECT 1")
+        hashes = _compute_local_hashes(models_dir, "*.sql")
+        assert "staging/stg_orders.sql" in hashes
+
+
+# ---------------------------------------------------------------------------
+# rsync SSH argument
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildRsyncSshArg:
+    """Test _build_rsync_ssh_arg construction."""
+
+    def test_contains_key_path(self):
+        arg = _build_rsync_ssh_arg(Path("/home/user/.dango/ssh/key"))
+        assert "-i /home/user/.dango/ssh/key" in arg
+
+    def test_disables_host_key_checking(self):
+        arg = _build_rsync_ssh_arg(Path("/tmp/key"))
+        assert "StrictHostKeyChecking=no" in arg
+        assert "UserKnownHostsFile=/dev/null" in arg
+
+
+# ---------------------------------------------------------------------------
+# sync_project_files integration (mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSyncProjectFiles:
+    """Test sync_project_files with mocked SSH and subprocess."""
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_first_deploy_all_models_added(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=True)
+        project = _make_project(tmp_path)
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+        assert result.is_first_deploy is True
+        assert "stg_orders" in result.added_models
+        assert "stg_users" in result.added_models
+        assert result.changed_models == []
+        assert result.removed_models == []
+        assert result.packages_changed is True
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_existing_deploy_no_changes(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=False)
+        project = _make_project(tmp_path)
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+        assert result.is_first_deploy is False
+        # All models are "added" because remote hashes are empty
+        assert len(result.added_models) > 0
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_dry_run_no_upload(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=False)
+        project = _make_project(tmp_path)
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1", dry_run=True)
+
+        assert result.dry_run is True
+        # SFTP upload_file should NOT be called in dry-run
+        ssh.upload_file.assert_not_called()
+        # rsync should be called with --dry-run flag
+        for call in mock_run.call_args_list:
+            cmd_list = call[0][0]
+            assert "--dry-run" in cmd_list
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_missing_optional_files(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=True)
+        project = _make_project(tmp_path, with_packages=False)
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+        # packages.yml not in synced files
+        assert "dbt/packages.yml" not in result.synced_files
+        # schedules.yml not in synced files (doesn't exist)
+        assert ".dango/schedules.yml" not in result.synced_files
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_config_files_uploaded(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=True)
+        project = _make_project(tmp_path)
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+        assert ".dango/sources.yml" in result.synced_files
+        assert "dbt/dbt_project.yml" in result.synced_files
+        assert "dbt/packages.yml" in result.synced_files
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_rsync_command_construction(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=True)
+        project = _make_project(tmp_path)
+
+        sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+        # rsync should have been called for models and macros dirs
+        assert mock_run.call_count == 2
+        for call in mock_run.call_args_list:
+            cmd_list = call[0][0]
+            assert cmd_list[0] == "rsync"
+            assert "-avz" in cmd_list
+            assert "--delete" in cmd_list
+            # -e flag with SSH key
+            e_idx = cmd_list.index("-e")
+            ssh_arg = cmd_list[e_idx + 1]
+            assert "-i /tmp/test_key" in ssh_arg
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value=None)
+    def test_rsync_not_installed(self, mock_which, tmp_path):
+        ssh = _make_ssh_mock()
+        project = _make_project(tmp_path)
+
+        with pytest.raises(Exception, match="rsync is not installed"):
+            sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_rsync_failure_raises(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="connection refused")
+        ssh = _make_ssh_mock(first_deploy=True)
+        project = _make_project(tmp_path)
+
+        with pytest.raises(Exception, match="rsync failed"):
+            sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_progress_callback(self, mock_run, mock_which, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=True)
+        project = _make_project(tmp_path)
+
+        steps: list[tuple[str, str]] = []
+        sync_project_files(
+            ssh, project, remote_host="10.0.0.1", on_progress=lambda s, st: steps.append((s, st))
+        )
+
+        step_names = [s for s, _ in steps]
+        assert "detect_changes" in step_names
+        assert "upload_config" in step_names
+        assert "sync_dbt" in step_names

--- a/tests/unit/test_file_sync.py
+++ b/tests/unit/test_file_sync.py
@@ -90,6 +90,7 @@ class TestSyncResult:
         assert result.added_models == []
         assert result.removed_models == []
         assert result.packages_changed is False
+        assert result.has_macro_changes is False
         assert result.is_first_deploy is False
         assert result.dry_run is False
 
@@ -201,7 +202,11 @@ class TestBuildRsyncSshArg:
 
     def test_contains_key_path(self):
         arg = _build_rsync_ssh_arg(Path("/home/user/.dango/ssh/key"))
-        assert "-i /home/user/.dango/ssh/key" in arg
+        assert '-i "/home/user/.dango/ssh/key"' in arg
+
+    def test_key_path_with_spaces(self):
+        arg = _build_rsync_ssh_arg(Path("/home/John Doe/.dango/ssh/key"))
+        assert '-i "/home/John Doe/.dango/ssh/key"' in arg
 
     def test_disables_host_key_checking(self):
         arg = _build_rsync_ssh_arg(Path("/tmp/key"))
@@ -233,6 +238,8 @@ class TestSyncProjectFiles:
         assert result.changed_models == []
         assert result.removed_models == []
         assert result.packages_changed is True
+        # Macros exist locally → has_macro_changes on first deploy
+        assert result.has_macro_changes is True
 
     @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
     @patch("dango.platform.cloud.file_sync.subprocess.run")
@@ -307,10 +314,10 @@ class TestSyncProjectFiles:
             assert cmd_list[0] == "rsync"
             assert "-avz" in cmd_list
             assert "--delete" in cmd_list
-            # -e flag with SSH key
+            # -e flag with SSH key (quoted for paths with spaces)
             e_idx = cmd_list.index("-e")
             ssh_arg = cmd_list[e_idx + 1]
-            assert "-i /tmp/test_key" in ssh_arg
+            assert '-i "/tmp/test_key"' in ssh_arg
 
     @patch("dango.platform.cloud.file_sync.shutil.which", return_value=None)
     def test_rsync_not_installed(self, mock_which, tmp_path):
@@ -346,3 +353,68 @@ class TestSyncProjectFiles:
         assert "detect_changes" in step_names
         assert "upload_config" in step_names
         assert "sync_dbt" in step_names
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_packages_unchanged_not_flagged(self, mock_run, mock_which, tmp_path):
+        """When remote and local packages.yml have the same hash, packages_changed is False."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        project = _make_project(tmp_path)
+        # Compute the actual local hash so the mock returns the same one
+        import hashlib
+
+        local_hash = hashlib.md5((project / "dbt" / "packages.yml").read_bytes()).hexdigest()
+
+        ssh = MagicMock()
+        ssh.key_path = Path("/tmp/test_key")
+
+        def _exec_side_effect(cmd, **kwargs):
+            if f"test -f {REMOTE_PROJECT_DIR}/.dango/sources.yml" in cmd:
+                return CommandResult(stdout="", stderr="", exit_code=0)  # existing deploy
+            if "md5sum" in cmd and "packages.yml" in cmd:
+                return CommandResult(
+                    stdout=f"{local_hash}  {REMOTE_PROJECT_DIR}/dbt/packages.yml",
+                    stderr="",
+                    exit_code=0,
+                )
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _exec_side_effect
+        ssh.upload_file.return_value = None
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+        assert result.packages_changed is False
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_no_macro_changes_when_macros_unchanged(self, mock_run, mock_which, tmp_path):
+        """has_macro_changes is False when macro hashes match remote."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        project = _make_project(tmp_path)
+        import hashlib
+
+        macro_hash = hashlib.md5(
+            (project / "dbt" / "macros" / "my_macro.sql").read_bytes()
+        ).hexdigest()
+
+        ssh = MagicMock()
+        ssh.key_path = Path("/tmp/test_key")
+
+        def _exec_side_effect(cmd, **kwargs):
+            if f"test -f {REMOTE_PROJECT_DIR}/.dango/sources.yml" in cmd:
+                return CommandResult(stdout="", stderr="", exit_code=0)
+            if "find" in cmd and "macros" in cmd and "md5sum" in cmd:
+                return CommandResult(
+                    stdout=f"{macro_hash}  {REMOTE_PROJECT_DIR}/dbt/macros/my_macro.sql",
+                    stderr="",
+                    exit_code=0,
+                )
+            if "md5sum" in cmd and "packages.yml" in cmd:
+                return CommandResult(stdout="abc123  path", stderr="", exit_code=0)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _exec_side_effect
+        ssh.upload_file.return_value = None
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+        assert result.has_macro_changes is False

--- a/tests/unit/test_remote_backup_cli.py
+++ b/tests/unit/test_remote_backup_cli.py
@@ -57,7 +57,7 @@ def _make_ssh_mock() -> MagicMock:
     ssh = MagicMock()
     ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
     ssh.connect.return_value = ssh
-    ssh.close.return_value = None
+    ssh.disconnect.return_value = None
     return ssh
 
 
@@ -100,7 +100,7 @@ class TestBackupOnDemand:
 
         assert result.exit_code == 0
         assert "completed" in result.output.lower()
-        ssh.close.assert_called_once()
+        ssh.disconnect.assert_called_once()
 
     def test_no_deployment_exits_with_error(self, tmp_path):
         """Exits when no cloud deployment is configured."""
@@ -146,7 +146,7 @@ class TestBackupList:
 
         assert result.exit_code == 0
         assert "backup-20260224-143000" in result.output
-        ssh.close.assert_called_once()
+        ssh.disconnect.assert_called_once()
 
     def test_empty_shows_no_backups(self, tmp_path):
         """Shows message when no backups exist."""
@@ -190,7 +190,7 @@ class TestBackupEnable:
         assert "enabled" in result.output.lower()
         # Verify systemd files were written
         assert ssh.write_remote_file.call_count == 2
-        ssh.close.assert_called_once()
+        ssh.disconnect.assert_called_once()
 
     def test_missing_spaces_credentials_fails(self, tmp_path):
         """Fails when SPACES_ACCESS_KEY is not in .env."""
@@ -226,7 +226,7 @@ class TestBackupDisable:
 
         assert result.exit_code == 0
         assert "disabled" in result.output.lower()
-        ssh.close.assert_called_once()
+        ssh.disconnect.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -345,4 +345,4 @@ class TestRollbackCommand:
 
         assert result.exit_code == 0
         assert "complete" in result.output.lower()
-        ssh.close.assert_called_once()
+        ssh.disconnect.assert_called_once()


### PR DESCRIPTION
## Summary

- **TASK-028 — File Sync:** Hybrid SFTP + rsync sync engine (`file_sync.py`) that uploads config files via SFTP and syncs dbt directories via rsync with `--delete`. Includes MD5-based change detection to identify added/changed/removed dbt models for selective rebuilds.
- **TASK-030 — Remote Push + Deploy Lock:** Full push deployment workflow (`deployer.py`) with deploy locking (30-min timeout, `--force` override), pre-deploy backup, service stop/start around dbt operations (DuckDB single-writer), source credential validation, and selective `dbt run`.
- **CLI:** Adds `dango remote push` command with `--dry-run`, `--force`, `--yes` flags and Rich status output.
- **Bug fix:** `ssh.close()` → `ssh.disconnect()` across `remote.py` (3 sites) and `remote_backup.py` (5 sites).

## Test plan

- [x] 19 unit tests for file_sync (change detection, hash computation, rsync construction, dry-run, first deploy, missing files, progress callback)
- [x] 27 unit tests for deployer (lock acquire/release/stale/force, source validation, dbt commands, full workflow, compile failure abort, lock release on error, dry-run, progress callback)
- [x] 16 existing remote_backup_cli tests updated and passing (ssh.disconnect assertions)
- [x] All 62 tests pass (`pytest tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_remote_backup_cli.py`)
- [x] ruff check + ruff format + mypy pass on all source files
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)