### PR TITLE
Add deployment wizard and initial sync workflow (TASK-029, TASK-107)

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -26,6 +26,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote.py` (~650 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~110 lines) | `serve` production foreground server | `serve()` |
+| `commands/deploy.py` (~410 lines) | `deploy` group (wizard default, destroy) | `deploy`, `deploy_destroy()` |
+| `commands/deploy_wizard.py` (~430 lines) | Interactive wizard steps 1-9 + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig` |
+| `commands/deploy_provision.py` (~400 lines) | Provisioning orchestration + cleanup | `run_provisioning()`, `ProvisionResult`, `_ResourceTracker` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
 | `init.py` (965 lines) | Project initialization wizard | `ProjectInitializer` |
@@ -79,6 +82,9 @@ dango (top-level group)
 │   ├── push
 │   └── firewall (subgroup)
 │       ├── list, allow-ip, allow-all
+├── deploy (group)              ← commands/deploy.py
+│   ├── (default)  interactive wizard → commands/deploy_wizard.py + deploy_provision.py
+│   └── destroy    tear down cloud infrastructure
 └── metabase (group)            ← commands/metabase_cmd.py
     ├── save, load, refresh
 ```

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -4,11 +4,9 @@ Deploy group and destroy command for Dango cloud deployments.
 
 Command hierarchy::
 
-    dango deploy (group)
-    └── destroy   — Tear down cloud infrastructure
-
-The ``deploy`` group is a stub — future tasks (TASK-029) will add provisioning
-and deployment commands here.
+    dango deploy             — Interactive deployment wizard (default)
+    dango deploy --reconnect — Reconnect to existing server
+    dango deploy destroy     — Tear down cloud infrastructure
 """
 
 from __future__ import annotations
@@ -26,20 +24,148 @@ from dango.cli import console
 # ---------------------------------------------------------------------------
 
 
-@click.group()
+@click.group(invoke_without_command=True)
+@click.option("--non-interactive", is_flag=True, help="Non-interactive mode (requires flags/env).")
+@click.option("--reconnect", is_flag=True, help="Reconnect to an existing server.")
+@click.option("--ip", type=str, default=None, help="Server IP for --reconnect.")
+@click.option("--region", type=str, default=None, help="DO region slug.")
+@click.option("--size", type=str, default=None, help="Droplet size slug.")
+@click.option("--domain", type=str, default=None, help="Custom domain for HTTPS.")
+@click.option("--admin-email", type=str, default=None, help="Admin user email.")
+@click.option(
+    "--admin-password", type=str, default=None, help="Admin password (or DANGO_ADMIN_PASSWORD env)."
+)
+@click.option("--skip-backups", is_flag=True, help="Skip automated backup setup.")
+@click.option("--skip-initial-sync", is_flag=True, help="Skip initial data sync.")
 @click.pass_context
-def deploy(ctx: click.Context) -> None:
+def deploy(  # noqa: PLR0913
+    ctx: click.Context,
+    non_interactive: bool,
+    reconnect: bool,
+    ip: str | None,
+    region: str | None,
+    size: str | None,
+    domain: str | None,
+    admin_email: str | None,
+    admin_password: str | None,
+    skip_backups: bool,
+    skip_initial_sync: bool,
+) -> None:
     """Deploy and manage Dango cloud infrastructure.
 
-    Commands:
-      dango deploy destroy    Tear down cloud infrastructure
+    Run without a subcommand to start the interactive deployment wizard.
+
+    \b
+    Examples:
+      dango deploy                     Interactive wizard
+      dango deploy --non-interactive   All params via flags/env
+      dango deploy --reconnect --ip X  Reconnect to existing server
+      dango deploy destroy             Tear down cloud infrastructure
     """
     ctx.ensure_object(dict)
+
+    if ctx.invoked_subcommand is not None:
+        return
+
+    from dango.cli.utils import require_project_context
+
+    project_root: Path = require_project_context(ctx)
+
+    # --- Existing deployment guard ---
+    if not reconnect:
+        from dango.config.loader import ConfigLoader
+
+        loader = ConfigLoader(project_root)
+        cloud_cfg = loader.load_cloud_config()
+        if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+            console.print(
+                "[yellow]A cloud deployment already exists.[/yellow] "
+                "Did you mean [bold]dango remote push[/bold]?"
+            )
+            console.print("  To destroy and redeploy: [bold]dango deploy destroy[/bold] first.")
+            raise SystemExit(1)
+
+    # --- Reconnect mode ---
+    if reconnect:
+        _handle_reconnect(project_root, ip)
+        return
+
+    # --- Wizard or non-interactive ---
+    from dango.cli.commands.deploy_provision import run_provisioning
+    from dango.cli.commands.deploy_wizard import run_non_interactive, run_wizard
+
+    if non_interactive:
+        config = run_non_interactive(
+            project_root,
+            region=region,
+            size=size,
+            domain=domain,
+            admin_email=admin_email,
+            admin_password=admin_password,
+            skip_backups=skip_backups,
+            skip_initial_sync=skip_initial_sync,
+        )
+    else:
+        config = run_wizard(project_root)
+
+    result = run_provisioning(project_root, config)
+
+    # --- Success output ---
+    console.print("\n[bold green]Deployment complete![/bold green]")
+    console.print(f"  URL:    {result.url}")
+    console.print(f"  IP:     {result.droplet_ip}")
+    console.print(f"  Admin:  {config.admin_email}")
+    if result.warnings:
+        for w in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {w}")
+    console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
+    if not config.skip_initial_sync:
+        console.print("  Initial data sync is running in the background.")
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _handle_reconnect(project_root: Path, ip: str | None) -> None:
+    """Reconnect to an existing Dango server and write cloud.yml."""
+    from dango.config.loader import ConfigLoader
+    from dango.config.models import CloudConfig
+    from dango.platform.cloud.ssh import SSHManager
+
+    if not ip:
+        console.print("[red]Error:[/red] --ip is required with --reconnect.")
+        raise SystemExit(1)
+
+    key_path = project_root / ".dango" / "cloud_key"
+    if not key_path.exists():
+        console.print(f"[red]Error:[/red] SSH key not found at {key_path}")
+        console.print("  Cannot reconnect without the original SSH key.")
+        raise SystemExit(1)
+
+    ssh = SSHManager(key_path=key_path)
+    try:
+        ssh.connect(ip, username="root")
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] SSH connection failed: {exc}")
+        raise SystemExit(1) from exc
+
+    try:
+        result = ssh.exec_command("cat /srv/dango/project/.dango/project.yml 2>/dev/null | head -5")
+        if not result.success or not result.stdout.strip():
+            console.print("[red]Error:[/red] Server does not appear to be a Dango deployment.")
+            raise SystemExit(1)
+    finally:
+        ssh.disconnect()
+
+    # Write minimal cloud.yml
+    loader = ConfigLoader(project_root)
+    config = CloudConfig(droplet_ip=ip)
+    loader.save_cloud_config(config)
+
+    console.print(f"[green]Reconnected[/green] to server at {ip}.")
+    console.print("  Run [bold]dango remote status[/bold] for details.")
 
 
 def _load_deploy_config(ctx: click.Context) -> tuple[Any, Path]:

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -13,7 +13,6 @@ that were created (no orphans).
 from __future__ import annotations
 
 import base64
-import re
 import secrets
 import time
 from dataclasses import dataclass, field
@@ -21,13 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from dango.cli import console
-from dango.cli.commands.deploy_wizard import WizardConfig
-
-# ---------------------------------------------------------------------------
-# Resource tracker — teardown on failure
-# ---------------------------------------------------------------------------
-
-_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+from dango.cli.commands.deploy_wizard import _EMAIL_RE, WizardConfig
 
 
 @dataclass
@@ -356,6 +349,11 @@ def _create_admin_and_enable_auth(
     if not _EMAIL_RE.match(email):
         raise ValueError(f"Invalid email format: {email}")
 
+    # Hash password locally — never send plaintext to remote server
+    from dango.auth.security import hash_password
+
+    pw_hash = hash_password(password)
+
     # Generate one-time deploy token
     deploy_token = secrets.token_urlsafe(32)
 
@@ -367,9 +365,8 @@ def _create_admin_and_enable_auth(
         "from pathlib import Path\n"
         "from dango.auth.database import create_user, init_db\n"
         "from dango.auth.models import Role, User\n"
-        "from dango.auth.security import hash_password\n"
         f"email = {email!r}\n"
-        f"pw_hash = hash_password({password!r})\n"
+        f"pw_hash = {pw_hash!r}\n"
         "db_path = Path('.dango/auth.db')\n"
         "db_path.parent.mkdir(parents=True, exist_ok=True)\n"
         "init_db(db_path)\n"

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -1,0 +1,547 @@
+"""dango/cli/commands/deploy_provision.py
+
+Provisioning orchestration for ``dango deploy`` — Step 10.
+
+Orchestrates the full deployment pipeline: SSH key generation, droplet
+provisioning, firewall, server setup, file sync, secrets push, admin
+creation, optional backup setup, and service start with health check.
+
+On failure, ``_ResourceTracker.cleanup()`` tears down any DO resources
+that were created (no orphans).
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import secrets
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from dango.cli import console
+from dango.cli.commands.deploy_wizard import WizardConfig
+
+# ---------------------------------------------------------------------------
+# Resource tracker — teardown on failure
+# ---------------------------------------------------------------------------
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+
+
+@dataclass
+class _ResourceTracker:
+    """Tracks provisioned DO resources for cleanup on failure."""
+
+    client: Any = None  # DigitalOceanClient
+    droplet_id: int | None = None
+    firewall_id: str | None = None
+    ssh_key_id: int | None = None
+    spaces_bucket: str | None = None
+    spaces_client: Any = None  # SpacesClient
+
+    def cleanup(self) -> list[str]:
+        """Delete all tracked resources. Returns list of error messages."""
+        errors: list[str] = []
+
+        if self.droplet_id and self.client:
+            try:
+                self.client.delete_droplet(self.droplet_id)
+            except Exception as exc:
+                errors.append(f"Droplet {self.droplet_id}: {exc}")
+
+        if self.firewall_id and self.client:
+            try:
+                self.client.delete_firewall(self.firewall_id)
+            except Exception as exc:
+                errors.append(f"Firewall {self.firewall_id}: {exc}")
+
+        if self.ssh_key_id and self.client:
+            try:
+                self.client.delete_ssh_key(self.ssh_key_id)
+            except Exception as exc:
+                errors.append(f"SSH key {self.ssh_key_id}: {exc}")
+
+        if self.spaces_bucket and self.spaces_client:
+            try:
+                self.spaces_client.delete_bucket()
+            except Exception as exc:
+                errors.append(f"Spaces bucket {self.spaces_bucket}: {exc}")
+
+        return errors
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProvisionResult:
+    """Result of a successful provisioning run."""
+
+    droplet_ip: str
+    droplet_id: int
+    firewall_id: str
+    ssh_key_id: int
+    domain: str | None = None
+    url: str = ""
+    warnings: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Main provisioning function
+# ---------------------------------------------------------------------------
+
+
+def run_provisioning(
+    project_root: Path,
+    config: WizardConfig,
+) -> ProvisionResult:
+    """Execute the full provisioning pipeline (sub-steps 1-10).
+
+    Args:
+        project_root: Path to the local Dango project root.
+        config: Wizard configuration from steps 1-9.
+
+    Returns:
+        ``ProvisionResult`` with deployment details.
+
+    Raises:
+        SystemExit: On unrecoverable failure (after cleanup).
+    """
+    from dango.platform.cloud.digitalocean import DigitalOceanClient
+    from dango.platform.cloud.ssh import SSHManager
+
+    tracker = _ResourceTracker()
+
+    try:
+        client = DigitalOceanClient()
+        tracker.client = client
+
+        # --- Sub-step 1: Generate SSH key ---
+        _status("Generating SSH key pair...")
+        key_path = project_root / ".dango" / "cloud_key"
+        ssh = SSHManager(key_path=key_path)
+        public_key = ssh.generate_key_pair()
+
+        # --- Sub-step 2: Upload SSH key to DO ---
+        _status("Uploading SSH key to DigitalOcean...")
+        key_name = f"dango-{project_root.name}-{int(time.time())}"
+        key_data = client.upload_ssh_key(key_name, public_key)
+        ssh_key_id: int = key_data["ssh_key"]["id"]
+        tracker.ssh_key_id = ssh_key_id
+
+        # --- Sub-step 3: Provision droplet ---
+        _status("Provisioning droplet (this takes ~60s)...")
+        from dango.platform.cloud.provisioning import provision_droplet
+
+        hostname = f"dango-{project_root.name}"[:63]  # DO limit
+        droplet = provision_droplet(
+            client,
+            name=hostname,
+            region=config.region,
+            size=config.size_slug,
+            ssh_key_ids=[ssh_key_id],
+        )
+        droplet_id: int = droplet["id"]
+        tracker.droplet_id = droplet_id
+
+        # Extract IP
+        droplet_ip = _extract_ip(droplet)
+
+        # --- Sub-step 4: Create firewall ---
+        _status("Creating firewall...")
+        from dango.platform.cloud.firewall import create_default_firewall
+
+        fw = create_default_firewall(client, droplet_id)
+        firewall_id: str = fw["id"]
+        tracker.firewall_id = firewall_id
+
+        # --- Sub-step 5: Server setup ---
+        _status("Setting up server (installs Docker, Caddy, Python, etc.)...")
+        from dango.platform.cloud.server_setup import setup_server
+
+        ssh.connect(droplet_ip, username="root")
+        try:
+            setup_result = setup_server(ssh, on_progress=_setup_progress, domain=config.domain)
+            if setup_result.warnings:
+                for w in setup_result.warnings:
+                    console.print(f"  [yellow]Warning:[/yellow] {w}")
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 6: Sync project files ---
+        _status("Syncing project files...")
+        from dango.platform.cloud.file_sync import sync_project_files
+
+        ssh.connect(droplet_ip, username="root")
+        try:
+            sync_project_files(
+                ssh,
+                project_root,
+                remote_host=droplet_ip,
+                on_progress=_setup_progress,
+            )
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 7: Push secrets ---
+        warnings: list[str] = []
+        _status("Pushing secrets to server...")
+        ssh.connect(droplet_ip, username="root")
+        try:
+            _push_secrets(ssh, project_root, warnings)
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 8: Create admin + enable auth ---
+        _status("Creating admin account and enabling auth...")
+        ssh.connect(droplet_ip, username="root")
+        try:
+            deploy_token = _create_admin_and_enable_auth(
+                ssh, config.admin_email, config.admin_password
+            )
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 9: Setup backups (if opted in) ---
+        if config.enable_backups and config.spaces_access_key and config.spaces_secret_key:
+            _status("Setting up automated backups...")
+            ssh.connect(droplet_ip, username="root")
+            try:
+                _setup_backups(
+                    ssh,
+                    client,
+                    project_root,
+                    config,
+                    tracker,
+                )
+            finally:
+                ssh.disconnect()
+
+        # --- Save provisioning metadata ---
+        _status("Saving deployment configuration...")
+        from dango.platform.cloud.provisioning import save_provisioning_metadata
+
+        save_provisioning_metadata(
+            project_root,
+            droplet_id=droplet_id,
+            droplet_ip=droplet_ip,
+            region=config.region,
+            size=config.size_slug,
+        )
+
+        # Save additional metadata (firewall, ssh key, domain)
+        _save_extra_metadata(
+            project_root,
+            firewall_id=firewall_id,
+            ssh_key_id=ssh_key_id,
+            domain=config.domain,
+            spaces_config=_build_spaces_config(config, tracker),
+        )
+
+        # --- Sub-step 10: Start services + health check + trigger initial sync ---
+        _status("Starting services...")
+        ssh.connect(droplet_ip, username="root")
+        try:
+            _start_services(ssh)
+        finally:
+            ssh.disconnect()
+
+        url = f"https://{config.domain}" if config.domain else f"http://{droplet_ip}"
+        health_ok = _health_check(url)
+        if not health_ok:
+            warnings.append(f"Health check failed. Server may still be starting. Try: {url}")
+
+        # Trigger initial sync
+        if not config.skip_initial_sync and health_ok:
+            _trigger_initial_sync(url, deploy_token)
+
+        return ProvisionResult(
+            droplet_ip=droplet_ip,
+            droplet_id=droplet_id,
+            firewall_id=firewall_id,
+            ssh_key_id=ssh_key_id,
+            domain=config.domain,
+            url=url,
+            warnings=warnings,
+        )
+
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"\n[red]Provisioning failed:[/red] {exc}")
+        console.print("Cleaning up resources...")
+        errors = tracker.cleanup()
+        if errors:
+            console.print("[yellow]Cleanup errors:[/yellow]")
+            for err in errors:
+                console.print(f"  - {err}")
+        else:
+            console.print("[green]All resources cleaned up.[/green]")
+        raise SystemExit(1) from exc
+
+
+# ---------------------------------------------------------------------------
+# Sub-step helpers
+# ---------------------------------------------------------------------------
+
+
+def _status(msg: str) -> None:
+    """Print a provisioning status message."""
+    console.print(f"\n[bold blue]>>>[/bold blue] {msg}")
+
+
+def _setup_progress(step: str, status: str) -> None:
+    """Progress callback for setup_server / sync_project_files."""
+    if status == "done":
+        console.print(f"    [green]Done:[/green] {step}")
+    elif status == "skipped":
+        console.print(f"    [dim]Skipped:[/dim] {step}")
+
+
+def _extract_ip(droplet: dict[str, Any]) -> str:
+    """Extract public IPv4 from droplet dict."""
+    networks = droplet.get("networks", {})
+    for net in networks.get("v4", []):
+        if net.get("type") == "public":
+            ip = net.get("ip_address")
+            if ip:
+                return str(ip)
+    raise RuntimeError("Droplet has no public IPv4 address")
+
+
+def _push_secrets(
+    ssh: Any,
+    project_root: Path,
+    warnings: list[str],
+) -> None:
+    """Push .dlt/secrets.toml and .env to remote server."""
+    # .dlt/secrets.toml
+    secrets_path = project_root / ".dlt" / "secrets.toml"
+    if secrets_path.exists():
+        content = secrets_path.read_text()
+        ssh.write_remote_file("/srv/dango/project/.dlt/secrets.toml", content, mode=0o600)
+    else:
+        warnings.append("No .dlt/secrets.toml found locally — skipped.")
+
+    # .env
+    env_path = project_root / ".env"
+    if env_path.exists():
+        content = env_path.read_text()
+        ssh.write_remote_file("/srv/dango/project/.env", content, mode=0o600)
+
+    # Fix ownership
+    ssh.exec_command(
+        "chown dango:dango "
+        "/srv/dango/project/.dlt/secrets.toml "
+        "/srv/dango/project/.env "
+        "2>/dev/null; true"
+    )
+
+
+def _create_admin_and_enable_auth(
+    ssh: Any,
+    email: str,
+    password: str,
+) -> str:
+    """Create admin user and enable auth on remote server.
+
+    Returns:
+        One-time deploy token for triggering initial sync.
+    """
+    # Validate email (shell injection prevention)
+    if not _EMAIL_RE.match(email):
+        raise ValueError(f"Invalid email format: {email}")
+
+    # Generate one-time deploy token
+    deploy_token = secrets.token_urlsafe(32)
+
+    # Build Python script and base64-encode it (avoids shell injection)
+    script = (
+        "import sys, os, json\n"
+        "sys.path.insert(0, '/srv/dango/project')\n"
+        "os.chdir('/srv/dango/project')\n"
+        "from pathlib import Path\n"
+        "from dango.auth.database import create_user, init_db\n"
+        "from dango.auth.models import Role, User\n"
+        "from dango.auth.security import hash_password\n"
+        f"email = {email!r}\n"
+        f"pw_hash = hash_password({password!r})\n"
+        "db_path = Path('.dango/auth.db')\n"
+        "db_path.parent.mkdir(parents=True, exist_ok=True)\n"
+        "init_db(db_path)\n"
+        "user = User(email=email, password_hash=pw_hash, role=Role.ADMIN)\n"
+        "try:\n"
+        "    create_user(db_path, user)\n"
+        "except Exception:\n"
+        "    pass  # user may already exist\n"
+        # Write deploy token
+        f"token = {deploy_token!r}\n"
+        "state_dir = Path('.dango/state')\n"
+        "state_dir.mkdir(parents=True, exist_ok=True)\n"
+        "(state_dir / 'deploy_token').write_text(token)\n"
+    )
+    encoded = base64.b64encode(script.encode()).decode()
+
+    ssh.exec_command(
+        f"sudo -u dango /srv/dango/venv/bin/python -c "
+        f"\"import base64; exec(base64.b64decode('{encoded}'))\"",
+        timeout=30,
+    )
+
+    # Enable auth
+    ssh.write_remote_file("/srv/dango/project/.dango/auth.yml", "enabled: true\n", mode=0o644)
+    ssh.exec_command("chown dango:dango /srv/dango/project/.dango/auth.yml")
+
+    return deploy_token
+
+
+def _setup_backups(
+    ssh: Any,
+    client: Any,
+    project_root: Path,
+    config: WizardConfig,
+    tracker: _ResourceTracker,
+) -> None:
+    """Set up automated backups: create bucket, write credentials, enable timer."""
+    from dango.platform.cloud._server_templates import (
+        SYSTEMD_BACKUP_SERVICE,
+        SYSTEMD_BACKUP_TIMER,
+    )
+    from dango.platform.cloud.spaces import SpacesClient
+
+    bucket_name = f"dango-backup-{project_root.name}-{config.region}"
+    spaces = SpacesClient(
+        bucket=bucket_name,
+        region=config.region,
+        access_key=config.spaces_access_key,
+        secret_key=config.spaces_secret_key,
+    )
+    tracker.spaces_client = spaces
+    tracker.spaces_bucket = bucket_name
+
+    # Create bucket (idempotent)
+    spaces.create_bucket()
+
+    # Write Spaces credentials to remote .env
+    env_lines = (
+        f"\n# Spaces backup credentials (added by dango deploy)\n"
+        f"SPACES_ACCESS_KEY={config.spaces_access_key}\n"
+        f"SPACES_SECRET_KEY={config.spaces_secret_key}\n"
+        f"SPACES_BUCKET={bucket_name}\n"
+        f"SPACES_REGION={config.region}\n"
+    )
+    # Append to existing .env
+    result = ssh.exec_command("cat /srv/dango/project/.env 2>/dev/null || true")
+    existing = result.stdout if result.stdout else ""
+    ssh.write_remote_file("/srv/dango/project/.env", existing + env_lines, mode=0o600)
+    ssh.exec_command("chown dango:dango /srv/dango/project/.env")
+
+    # Write systemd timer/service files
+    ssh.write_remote_file(
+        "/etc/systemd/system/dango-backup.service",
+        SYSTEMD_BACKUP_SERVICE,
+        mode=0o644,
+    )
+    ssh.write_remote_file(
+        "/etc/systemd/system/dango-backup.timer",
+        SYSTEMD_BACKUP_TIMER,
+        mode=0o644,
+    )
+
+    # Enable timer
+    ssh.exec_command("systemctl daemon-reload")
+    ssh.exec_command("systemctl enable --now dango-backup.timer")
+
+
+def _build_spaces_config(
+    config: WizardConfig,
+    tracker: _ResourceTracker,
+) -> dict[str, Any] | None:
+    """Build SpacesConfig dict if backups are enabled."""
+    if not config.enable_backups or not tracker.spaces_bucket:
+        return None
+    return {
+        "bucket": tracker.spaces_bucket,
+        "region": config.region,
+    }
+
+
+def _save_extra_metadata(
+    project_root: Path,
+    *,
+    firewall_id: str,
+    ssh_key_id: int,
+    domain: str | None,
+    spaces_config: dict[str, Any] | None,
+) -> None:
+    """Save additional metadata to cloud.yml beyond what save_provisioning_metadata writes."""
+    from dango.config.loader import ConfigLoader
+    from dango.config.models import SpacesConfig
+
+    loader = ConfigLoader(project_root)
+    existing = loader.load_cloud_config()
+    if existing is None:
+        return  # save_provisioning_metadata should have created it
+
+    update: dict[str, Any] = {
+        "firewall_id": firewall_id,
+        "ssh_key_id": ssh_key_id,
+    }
+    if domain:
+        update["domain"] = domain
+    if spaces_config:
+        update["spaces"] = SpacesConfig(**spaces_config)
+
+    updated = existing.model_copy(update=update)
+    loader.save_cloud_config(updated)
+
+
+def _start_services(ssh: Any) -> None:
+    """Start Metabase (Docker) and dango-web (systemd) on remote server."""
+    ssh.exec_command(
+        "cd /srv/dango/project && sudo -u dango docker compose up -d",
+        timeout=120,
+    )
+    ssh.exec_command("systemctl start dango-web", timeout=30)
+
+
+def _health_check(url: str, timeout: int = 30, interval: int = 3) -> bool:
+    """Poll server health endpoint until it responds 200.
+
+    Returns:
+        True if healthy, False if timeout.
+    """
+    import httpx
+
+    attempts = timeout // interval
+    for _ in range(attempts):
+        try:
+            resp = httpx.get(f"{url}/api/health", timeout=5, verify=False)
+            if resp.status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(interval)
+    return False
+
+
+def _trigger_initial_sync(url: str, deploy_token: str) -> None:
+    """POST to /api/initial-sync/start to trigger background sync."""
+    import httpx
+
+    try:
+        httpx.post(
+            f"{url}/api/initial-sync/start",
+            headers={
+                "X-Requested-With": "XMLHttpRequest",
+                "Authorization": f"Bearer {deploy_token}",
+            },
+            timeout=10,
+            verify=False,
+        )
+    except Exception:
+        pass  # Non-critical — user can trigger from dashboard

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -164,13 +164,16 @@ def _step_size() -> tuple[str, Any | None]:
             return tier.slug, tier
         if idx == len(SIZE_TIERS):
             # Custom slug
-            slug = click.prompt("  Enter DO size slug (e.g. s-2vcpu-4gb)")
-            if validate_custom_size(slug):
-                return slug, get_size_tier(slug)
-            console.print(
-                "[yellow]Warning: slug format not recognized. Proceeding anyway.[/yellow]"
-            )
-            return slug, None
+            while True:
+                slug = click.prompt("  Enter DO size slug (e.g. s-2vcpu-4gb)")
+                if validate_custom_size(slug):
+                    return slug, get_size_tier(slug)
+                console.print(
+                    "  [red]Invalid slug format.[/red] Expected format: s-{vcpus}vcpu-{ram}gb"
+                )
+                if not click.confirm("  Try again?", default=True):
+                    console.print(f"  Using default: {DEFAULT_TIER.name}")
+                    return DEFAULT_TIER.slug, DEFAULT_TIER
 
     # Fallback to default
     console.print(f"[yellow]Invalid choice, using default: {DEFAULT_TIER.name}[/yellow]")
@@ -560,7 +563,7 @@ def run_non_interactive(
         raise SystemExit(1)
 
     size_tier = get_size_tier(size)
-    monthly_cost = _get_monthly_cost(size, skip_backups is False)
+    monthly_cost = _get_monthly_cost(size, not skip_backups)
 
     return WizardConfig(
         region=region,

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -1,0 +1,576 @@
+"""dango/cli/commands/deploy_wizard.py
+
+Interactive deployment wizard and non-interactive validation for ``dango deploy``.
+
+Steps 1-9 gather configuration (region, size, domain, admin credentials, etc.)
+before handing off to ``deploy_provision.py`` for the actual provisioning.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import click
+
+from dango.cli import console
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+
+
+@dataclass
+class WizardConfig:
+    """Configuration collected from the deployment wizard."""
+
+    region: str
+    size_slug: str
+    size_tier: Any | None  # DropletSizeTier or None if custom slug
+    domain: str | None
+    admin_email: str
+    admin_password: str
+    skip_oauth: bool
+    enable_backups: bool
+    skip_initial_sync: bool
+    monthly_cost: int
+    # Backup credentials (only set if enable_backups is True)
+    spaces_access_key: str | None = None
+    spaces_secret_key: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+
+def _step_prereqs(project_root: Path) -> None:
+    """Step 1: Check deployment prerequisites.
+
+    Raises:
+        SystemExit: If a prerequisite is missing.
+    """
+    # Check DIGITALOCEAN_TOKEN
+    token = os.environ.get("DIGITALOCEAN_TOKEN")
+    if not token:
+        console.print("[red]Error:[/red] DIGITALOCEAN_TOKEN environment variable not set.")
+        console.print(
+            "\n  Create an API token at: "
+            "[link=https://cloud.digitalocean.com/account/api/tokens]"
+            "https://cloud.digitalocean.com/account/api/tokens[/link]"
+        )
+        console.print("  Then: [bold]export DIGITALOCEAN_TOKEN=your_token[/bold]\n")
+        raise SystemExit(1)
+
+    # Check project has sources
+    sources_yml = project_root / ".dango" / "sources.yml"
+    if not sources_yml.exists():
+        console.print(
+            "[red]Error:[/red] No sources.yml found. "
+            "Run [bold]dango source add[/bold] to configure data sources first."
+        )
+        raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# Region selection
+# ---------------------------------------------------------------------------
+
+
+def _step_region() -> str:
+    """Step 2: Select deployment region.
+
+    Returns:
+        DO region slug.
+    """
+    from dango.platform.cloud.provisioning import list_regions, suggest_nearest_region
+
+    suggested = suggest_nearest_region()
+    regions = list_regions()
+
+    console.print("\n[bold]Step 2: Select Region[/bold]")
+    console.print(f"  Suggested (nearest): [green]{suggested.name}[/green] ({suggested.slug})\n")
+
+    for i, r in enumerate(regions, 1):
+        gdpr_tag = " [dim](GDPR)[/dim]" if r.gdpr else ""
+        console.print(f"  {i:2d}. {r.name:<22s} ({r.slug}){gdpr_tag}")
+
+    console.print()
+    choice = click.prompt(
+        "  Region number or slug",
+        default=suggested.slug,
+        show_default=True,
+    )
+
+    # Accept number or slug
+    if choice.isdigit():
+        idx = int(choice) - 1
+        if 0 <= idx < len(regions):
+            return regions[idx].slug
+        console.print(f"[yellow]Invalid number, using default: {suggested.slug}[/yellow]")
+        return suggested.slug
+
+    # Validate slug
+    valid_slugs = {r.slug for r in regions}
+    if choice in valid_slugs:
+        return str(choice)
+
+    console.print(f"[yellow]Unknown region '{choice}', using default: {suggested.slug}[/yellow]")
+    return suggested.slug
+
+
+# ---------------------------------------------------------------------------
+# Size selection
+# ---------------------------------------------------------------------------
+
+
+def _step_size() -> tuple[str, Any | None]:
+    """Step 3: Select droplet size.
+
+    Returns:
+        Tuple of (size_slug, DropletSizeTier or None).
+    """
+    from dango.platform.cloud.provisioning import (
+        DEFAULT_TIER,
+        SIZE_TIERS,
+        get_size_tier,
+        validate_custom_size,
+    )
+
+    console.print("\n[bold]Step 3: Select Server Size[/bold]\n")
+
+    for i, tier in enumerate(SIZE_TIERS, 1):
+        default_marker = " (recommended)" if tier == DEFAULT_TIER else ""
+        warning = f"  [yellow]{tier.warning}[/yellow]" if tier.warning else ""
+        console.print(
+            f"  {i}. {tier.name:<13s} {tier.vcpus} vCPU / {tier.ram_gb}GB RAM / "
+            f"{tier.disk_gb}GB SSD — ${tier.price_monthly}/mo{default_marker}{warning}"
+        )
+
+    console.print(f"  {len(SIZE_TIERS) + 1}. Custom slug")
+    console.print()
+
+    choice = click.prompt("  Size number", default="2", show_default=True)
+
+    if choice.isdigit():
+        idx = int(choice) - 1
+        if 0 <= idx < len(SIZE_TIERS):
+            tier = SIZE_TIERS[idx]
+            return tier.slug, tier
+        if idx == len(SIZE_TIERS):
+            # Custom slug
+            slug = click.prompt("  Enter DO size slug (e.g. s-2vcpu-4gb)")
+            if validate_custom_size(slug):
+                return slug, get_size_tier(slug)
+            console.print(
+                "[yellow]Warning: slug format not recognized. Proceeding anyway.[/yellow]"
+            )
+            return slug, None
+
+    # Fallback to default
+    console.print(f"[yellow]Invalid choice, using default: {DEFAULT_TIER.name}[/yellow]")
+    return DEFAULT_TIER.slug, DEFAULT_TIER
+
+
+# ---------------------------------------------------------------------------
+# Domain
+# ---------------------------------------------------------------------------
+
+
+def _step_domain() -> str | None:
+    """Step 4: Optional custom domain.
+
+    Returns:
+        Domain string or None.
+    """
+    console.print("\n[bold]Step 4: Custom Domain (optional)[/bold]")
+    console.print("  Your server will be accessible by IP address.")
+    console.print("  Add a domain for HTTPS and a friendly URL.\n")
+
+    domain = click.prompt("  Domain (leave blank to skip)", default="", show_default=False)
+    domain = domain.strip().lower()
+
+    if not domain:
+        return None
+
+    console.print(
+        f"\n  [dim]Point a DNS A record for [bold]{domain}[/bold] to your server IP.[/dim]"
+    )
+    console.print("  [dim]Caddy will auto-provision an HTTPS certificate via Let's Encrypt.[/dim]")
+    return str(domain)
+
+
+# ---------------------------------------------------------------------------
+# Admin credentials
+# ---------------------------------------------------------------------------
+
+
+def _step_admin() -> tuple[str, str]:
+    """Step 5: Admin email and password.
+
+    Returns:
+        Tuple of (email, password).
+    """
+    from dango.auth.security import check_password_strength
+
+    console.print("\n[bold]Step 5: Admin Account[/bold]")
+    console.print("  Create the first admin user for your deployment.\n")
+
+    # Email
+    while True:
+        email = click.prompt("  Admin email")
+        if _EMAIL_RE.match(email):
+            break
+        console.print("  [red]Invalid email format.[/red]")
+
+    # Password (from env or prompt)
+    env_password = os.environ.get("DANGO_ADMIN_PASSWORD")
+    if env_password:
+        issues = check_password_strength(env_password)
+        if issues:
+            console.print(f"  [red]DANGO_ADMIN_PASSWORD is weak:[/red] {'; '.join(issues)}")
+            raise SystemExit(1)
+        console.print("  [dim]Using password from DANGO_ADMIN_PASSWORD env var.[/dim]")
+        return email, env_password
+
+    while True:
+        password = click.prompt("  Admin password", hide_input=True)
+        issues = check_password_strength(password)
+        if issues:
+            console.print(f"  [red]Weak password:[/red] {'; '.join(issues)}")
+            continue
+        confirm = click.prompt("  Confirm password", hide_input=True)
+        if password != confirm:
+            console.print("  [red]Passwords don't match.[/red]")
+            continue
+        break
+
+    return email, password
+
+
+# ---------------------------------------------------------------------------
+# Sources check
+# ---------------------------------------------------------------------------
+
+
+def _step_sources(project_root: Path) -> list[dict[str, str]]:
+    """Step 6: List configured sources and check credentials.
+
+    Returns:
+        List of source dicts with 'name' and 'type' keys.
+    """
+    from dango.config.helpers import load_config
+
+    console.print("\n[bold]Step 6: Data Sources[/bold]\n")
+
+    config = load_config(project_root)
+    sources: list[dict[str, str]] = []
+
+    for src in config.sources.sources:
+        sources.append({"name": src.name, "type": src.type.value})
+        console.print(f"  - {src.name} ({src.type.value})")
+
+    if not sources:
+        console.print("  [yellow]No data sources configured.[/yellow]")
+        console.print(
+            "  You can add sources after deployment with [bold]dango source add[/bold].\n"
+        )
+
+    # Check for .dlt/secrets.toml
+    secrets_path = project_root / ".dlt" / "secrets.toml"
+    if secrets_path.exists():
+        console.print(f"\n  [green]Found[/green] {secrets_path.relative_to(project_root)}")
+    elif sources:
+        console.print(
+            "\n  [yellow]Warning:[/yellow] No .dlt/secrets.toml found. "
+            "Source credentials may be missing."
+        )
+
+    return sources
+
+
+# ---------------------------------------------------------------------------
+# OAuth
+# ---------------------------------------------------------------------------
+
+
+def _step_oauth() -> bool:
+    """Step 7: Skip OAuth setup for now?
+
+    Returns:
+        True if OAuth should be skipped.
+    """
+    console.print("\n[bold]Step 7: OAuth Sources[/bold]")
+    console.print("  Some sources (Google, Facebook) require OAuth tokens.")
+    console.print("  You can configure OAuth after deployment.\n")
+
+    return not click.confirm("  Configure OAuth now?", default=False)
+
+
+# ---------------------------------------------------------------------------
+# Backups
+# ---------------------------------------------------------------------------
+
+
+def _step_backups() -> tuple[bool, str | None, str | None]:
+    """Step 8: Enable automated backups?
+
+    Returns:
+        Tuple of (enable_backups, access_key, secret_key).
+    """
+    console.print("\n[bold]Step 8: Automated Backups[/bold]")
+    console.print("  Daily backups to DigitalOcean Spaces ($5/mo for storage).\n")
+
+    enable = click.confirm("  Enable automated backups?", default=True)
+    if not enable:
+        return False, None, None
+
+    console.print(
+        "\n  Create Spaces access keys at: "
+        "[link=https://cloud.digitalocean.com/account/api/spaces]"
+        "https://cloud.digitalocean.com/account/api/spaces[/link]\n"
+    )
+
+    access_key = click.prompt("  Spaces access key")
+    secret_key = click.prompt("  Spaces secret key", hide_input=True)
+
+    # Validate keys by trying to construct client
+    try:
+        from dango.platform.cloud.spaces import SpacesClient
+
+        client = SpacesClient(
+            bucket="dango-validate-test",
+            region="nyc3",
+            access_key=access_key,
+            secret_key=secret_key,
+        )
+        # Try a lightweight operation to confirm auth
+        client.list_objects(prefix="__nonexistent__")
+        console.print("  [green]Spaces credentials verified.[/green]")
+    except Exception:
+        console.print(
+            "  [yellow]Warning:[/yellow] Could not verify Spaces credentials. "
+            "Backups may fail if keys are incorrect."
+        )
+
+    return True, access_key, secret_key
+
+
+# ---------------------------------------------------------------------------
+# Cost summary
+# ---------------------------------------------------------------------------
+
+
+def _get_monthly_cost(size_slug: str, enable_backups: bool) -> int:
+    """Calculate estimated monthly cost."""
+    from dango.platform.cloud.provisioning import get_size_tier
+
+    tier = get_size_tier(size_slug)
+    droplet_cost = tier.price_monthly if tier else 24  # default estimate
+    spaces_cost = 5 if enable_backups else 0
+    return droplet_cost + spaces_cost
+
+
+def _step_cost_summary(
+    region: str,
+    size_slug: str,
+    domain: str | None,
+    enable_backups: bool,
+) -> int:
+    """Step 9: Show cost summary and confirm.
+
+    Returns:
+        Monthly cost in USD.
+
+    Raises:
+        SystemExit: If user declines.
+    """
+    from dango.platform.cloud.provisioning import get_region_info, get_size_tier
+
+    console.print("\n[bold]Step 9: Cost Summary[/bold]\n")
+
+    tier = get_size_tier(size_slug)
+    region_info = get_region_info(region)
+    droplet_cost = tier.price_monthly if tier else 24
+
+    region_display = f"{region_info.name} ({region})" if region_info else region
+    size_display = f"{tier.name} ({size_slug})" if tier else size_slug
+
+    console.print(f"  Region:    {region_display}")
+    console.print(f"  Size:      {size_display} — ${droplet_cost}/mo")
+    if domain:
+        console.print(f"  Domain:    {domain}")
+    if enable_backups:
+        console.print("  Backups:   Enabled — ~$5/mo")
+
+    total = _get_monthly_cost(size_slug, enable_backups)
+    console.print(f"\n  [bold]Estimated total: ${total}/mo[/bold]\n")
+
+    if not click.confirm("  Proceed with deployment?", default=True):
+        console.print("[yellow]Aborted.[/yellow]")
+        raise SystemExit(0)
+
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+
+def run_wizard(project_root: Path) -> WizardConfig:
+    """Run the interactive deployment wizard (steps 1-9).
+
+    Args:
+        project_root: Path to the Dango project root.
+
+    Returns:
+        Completed ``WizardConfig`` ready for provisioning.
+    """
+    console.print("\n[bold blue]Dango Cloud Deployment Wizard[/bold blue]\n")
+
+    # Step 1: Prerequisites
+    _step_prereqs(project_root)
+    console.print("  [green]Prerequisites OK.[/green]")
+
+    # Step 2: Region
+    region = _step_region()
+
+    # Step 3: Size
+    size_slug, size_tier = _step_size()
+
+    # Step 4: Domain
+    domain = _step_domain()
+
+    # Step 5: Admin credentials
+    admin_email, admin_password = _step_admin()
+
+    # Step 6: Sources
+    _step_sources(project_root)
+
+    # Step 7: OAuth
+    skip_oauth = _step_oauth()
+
+    # Step 8: Backups
+    enable_backups, spaces_access_key, spaces_secret_key = _step_backups()
+
+    # Step 9: Cost summary + confirm
+    monthly_cost = _step_cost_summary(region, size_slug, domain, enable_backups)
+
+    return WizardConfig(
+        region=region,
+        size_slug=size_slug,
+        size_tier=size_tier,
+        domain=domain,
+        admin_email=admin_email,
+        admin_password=admin_password,
+        skip_oauth=skip_oauth,
+        enable_backups=enable_backups,
+        skip_initial_sync=False,
+        monthly_cost=monthly_cost,
+        spaces_access_key=spaces_access_key,
+        spaces_secret_key=spaces_secret_key,
+    )
+
+
+def run_non_interactive(
+    project_root: Path,
+    *,
+    region: str | None = None,
+    size: str | None = None,
+    domain: str | None = None,
+    admin_email: str | None = None,
+    admin_password: str | None = None,
+    skip_backups: bool = False,
+    skip_initial_sync: bool = False,
+) -> WizardConfig:
+    """Validate CLI flags for non-interactive deployment.
+
+    Args:
+        project_root: Path to the Dango project root.
+        region: DO region slug. Defaults to nearest.
+        size: Droplet size slug. Defaults to standard tier.
+        domain: Optional custom domain.
+        admin_email: Required admin email.
+        admin_password: Required admin password (or from DANGO_ADMIN_PASSWORD env).
+        skip_backups: Skip backup setup.
+        skip_initial_sync: Skip initial data sync.
+
+    Returns:
+        Validated ``WizardConfig``.
+
+    Raises:
+        SystemExit: If required params are missing or invalid.
+    """
+    from dango.auth.security import check_password_strength
+    from dango.platform.cloud.provisioning import (
+        DEFAULT_TIER,
+        get_size_tier,
+        suggest_nearest_region,
+        validate_custom_size,
+    )
+
+    # Prerequisites
+    _step_prereqs(project_root)
+
+    # Region
+    if region is None:
+        region = suggest_nearest_region().slug
+    else:
+        from dango.platform.cloud.provisioning import get_region_info
+
+        if get_region_info(region) is None:
+            console.print(f"[red]Error:[/red] Unknown region '{region}'.")
+            raise SystemExit(1)
+
+    # Size
+    if size is None:
+        size = DEFAULT_TIER.slug
+    else:
+        tier = get_size_tier(size)
+        if tier is None and not validate_custom_size(size):
+            console.print(f"[red]Error:[/red] Invalid size slug '{size}'.")
+            raise SystemExit(1)
+
+    # Admin email
+    if not admin_email:
+        console.print("[red]Error:[/red] --admin-email is required for --non-interactive.")
+        raise SystemExit(1)
+    if not _EMAIL_RE.match(admin_email):
+        console.print(f"[red]Error:[/red] Invalid email format: {admin_email}")
+        raise SystemExit(1)
+
+    # Admin password
+    if not admin_password:
+        admin_password = os.environ.get("DANGO_ADMIN_PASSWORD")
+    if not admin_password:
+        console.print(
+            "[red]Error:[/red] --admin-password or DANGO_ADMIN_PASSWORD env required "
+            "for --non-interactive."
+        )
+        raise SystemExit(1)
+    issues = check_password_strength(admin_password)
+    if issues:
+        console.print(f"[red]Error:[/red] Weak password: {'; '.join(issues)}")
+        raise SystemExit(1)
+
+    size_tier = get_size_tier(size)
+    monthly_cost = _get_monthly_cost(size, skip_backups is False)
+
+    return WizardConfig(
+        region=region,
+        size_slug=size,
+        size_tier=size_tier,
+        domain=domain,
+        admin_email=admin_email,
+        admin_password=admin_password,
+        skip_oauth=True,
+        enable_backups=not skip_backups,
+        skip_initial_sync=skip_initial_sync,
+        monthly_cost=monthly_cost,
+    )

--- a/dango/platform/cloud/spaces.py
+++ b/dango/platform/cloud/spaces.py
@@ -218,6 +218,28 @@ class SpacesClient:
             _reraise_if_not_client_error(exc)
             raise self._wrap_client_error(exc, "delete", key) from exc
 
+    def create_bucket(self) -> None:
+        """Create the configured S3 bucket. Idempotent (no error if exists).
+
+        Raises:
+            CloudError: If the bucket cannot be created.
+        """
+        client = self._get_client()
+        try:
+            client.create_bucket(
+                Bucket=self.bucket,
+                CreateBucketConfiguration={"LocationConstraint": self.region},
+            )
+        except Exception as exc:
+            _reraise_if_not_client_error(exc)
+            code = _get_boto_error_code(exc)
+            if code == "BucketAlreadyOwnedByYou":
+                return  # Idempotent
+            raise CloudError(
+                f"Failed to create bucket '{self.bucket}': {exc}",
+                context={"bucket": self.bucket, "region": self.region},
+            ) from exc
+
     def delete_bucket(self) -> None:
         """Delete the Spaces bucket.
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -250,6 +250,7 @@ from dango.web.routes.auth_2fa import router as auth_2fa_router  # noqa: E402
 from dango.web.routes.config import router as config_router  # noqa: E402
 from dango.web.routes.dbt import router as dbt_router  # noqa: E402
 from dango.web.routes.health import router as health_router  # noqa: E402
+from dango.web.routes.initial_sync import router as initial_sync_router  # noqa: E402
 from dango.web.routes.logs import router as logs_router  # noqa: E402
 from dango.web.routes.metabase_proxy import router as metabase_proxy_router  # noqa: E402
 from dango.web.routes.oauth_connect import router as oauth_connect_router  # noqa: E402
@@ -269,6 +270,7 @@ app.include_router(health_router)
 app.include_router(config_router)
 app.include_router(sources_router)
 app.include_router(sync_router)
+app.include_router(initial_sync_router)
 app.include_router(logs_router)
 app.include_router(upload_router)
 app.include_router(secrets_router)

--- a/dango/web/middleware/auth.py
+++ b/dango/web/middleware/auth.py
@@ -61,6 +61,7 @@ _PUBLIC_EXACT: frozenset[str] = frozenset({
     "/api/auth/2fa/verify",
     "/api/auth/oauth/callback",
     "/api/auth/accept-invite",
+    "/api/initial-sync/start",  # Uses one-time deploy token (own auth check)
     "/login",
     "/setup",
     "/api/health",

--- a/dango/web/middleware/auth.py
+++ b/dango/web/middleware/auth.py
@@ -61,7 +61,7 @@ _PUBLIC_EXACT: frozenset[str] = frozenset({
     "/api/auth/2fa/verify",
     "/api/auth/oauth/callback",
     "/api/auth/accept-invite",
-    "/api/initial-sync/start",  # Uses one-time deploy token (own auth check)
+    "/api/initial-sync/start",  # Accepts deploy token OR admin session (own auth check)
     "/login",
     "/setup",
     "/api/health",

--- a/dango/web/routes/initial_sync.py
+++ b/dango/web/routes/initial_sync.py
@@ -1,0 +1,394 @@
+"""dango/web/routes/initial_sync.py
+
+Initial data sync state machine, API endpoints, and background task.
+
+Runs all configured sources sequentially after first deployment, broadcasting
+progress via WebSocket for the dashboard banner.  State is persisted to
+``.dango/state/initial_sync.json`` so it survives server restarts.
+
+Authentication: The ``/start`` endpoint accepts a one-time deploy token
+(generated during ``dango deploy``) via ``Authorization: Bearer <token>``.
+Other endpoints require a valid session or API key (handled by auth middleware).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+
+from dango.logging import get_logger
+from dango.web.helpers import get_project_root
+from dango.web.routes.websocket import ws_manager
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/initial-sync", tags=["initial-sync"])
+
+# ---------------------------------------------------------------------------
+# State model
+# ---------------------------------------------------------------------------
+
+
+class SyncPhase(str, Enum):
+    """Phases of the initial sync workflow."""
+
+    IDLE = "idle"
+    SYNCING = "syncing"
+    DBT_DOCS = "dbt_docs"
+    METABASE = "metabase"
+    COMPLETE = "complete"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+@dataclass
+class InitialSyncState:
+    """Mutable state for the initial sync workflow."""
+
+    phase: SyncPhase = SyncPhase.IDLE
+    total_sources: int = 0
+    current_source_index: int = 0
+    current_source_name: str = ""
+    completed_sources: list[str] = field(default_factory=list)
+    failed_sources: list[dict[str, str]] = field(default_factory=list)
+    skipped_sources: list[str] = field(default_factory=list)
+    cancel_requested: bool = False
+    skip_current_requested: bool = False
+    started_at: str = ""
+    completed_at: str = ""
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict."""
+        d = asdict(self)
+        d["phase"] = self.phase.value
+        return d
+
+
+# Module-level singleton
+_sync_state = InitialSyncState()
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def _state_path() -> Path:
+    """Return path to the state JSON file."""
+    return get_project_root() / ".dango" / "state" / "initial_sync.json"
+
+
+def _save_state() -> None:
+    """Persist current state to disk."""
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_sync_state.to_dict(), indent=2))
+
+
+def _load_state() -> None:
+    """Load state from disk if it exists. Mark interrupted syncs as failed."""
+    global _sync_state  # noqa: PLW0603
+    path = _state_path()
+    if not path.exists():
+        return
+
+    try:
+        data: dict[str, Any] = json.loads(path.read_text())
+        _sync_state = InitialSyncState(
+            phase=SyncPhase(data.get("phase", "idle")),
+            total_sources=data.get("total_sources", 0),
+            current_source_index=data.get("current_source_index", 0),
+            current_source_name=data.get("current_source_name", ""),
+            completed_sources=data.get("completed_sources", []),
+            failed_sources=data.get("failed_sources", []),
+            skipped_sources=data.get("skipped_sources", []),
+            cancel_requested=data.get("cancel_requested", False),
+            skip_current_requested=data.get("skip_current_requested", False),
+            started_at=data.get("started_at", ""),
+            completed_at=data.get("completed_at", ""),
+            error=data.get("error"),
+        )
+        # If server restarted mid-sync, mark as failed
+        if _sync_state.phase in (SyncPhase.SYNCING, SyncPhase.DBT_DOCS, SyncPhase.METABASE):
+            _sync_state.phase = SyncPhase.FAILED
+            _sync_state.error = "Sync interrupted by server restart."
+            _save_state()
+    except Exception:
+        logger.warning("initial_sync_state_load_failed", exc_info=True)
+
+
+async def _save_and_broadcast() -> None:
+    """Persist state and broadcast update to WebSocket clients."""
+    _save_state()
+    await ws_manager.broadcast(
+        {
+            "event": "initial_sync_progress",
+            "data": _sync_state.to_dict(),
+            "timestamp": datetime.now().isoformat(),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deploy token validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_deploy_token(token: str) -> bool:
+    """Check and consume the one-time deploy token. Returns True if valid."""
+    token_path = get_project_root() / ".dango" / "state" / "deploy_token"
+    if not token_path.exists():
+        return False
+
+    stored = token_path.read_text().strip()
+    if token != stored:
+        return False
+
+    # One-time use — delete after validation
+    try:
+        token_path.unlink()
+    except OSError:
+        pass
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Background task
+# ---------------------------------------------------------------------------
+
+
+async def _run_initial_sync(project_root: Path, sources: list[dict[str, str]]) -> None:
+    """Run the initial sync for all sources sequentially."""
+    global _sync_state  # noqa: PLW0603
+
+    _sync_state.phase = SyncPhase.SYNCING
+    _sync_state.total_sources = len(sources)
+    _sync_state.started_at = datetime.now().isoformat()
+    await _save_and_broadcast()
+
+    for i, source in enumerate(sources):
+        # Check cancel
+        if _sync_state.cancel_requested:
+            _sync_state.phase = SyncPhase.CANCELLED
+            _sync_state.completed_at = datetime.now().isoformat()
+            await _save_and_broadcast()
+            return
+
+        # Disk check
+        disk_warning = _check_disk_usage()
+        if disk_warning == "abort":
+            _sync_state.phase = SyncPhase.FAILED
+            disk_pct = _get_disk_usage_pct()
+            _sync_state.error = f"Disk at {disk_pct:.0f}%. Free space or resize the server."
+            _sync_state.completed_at = datetime.now().isoformat()
+            await _save_and_broadcast()
+            return
+
+        source_name = source["name"]
+        _sync_state.current_source_index = i + 1
+        _sync_state.current_source_name = source_name
+        _sync_state.skip_current_requested = False
+        await _save_and_broadcast()
+
+        try:
+            await _sync_single_source(project_root, source_name)
+
+            if _sync_state.skip_current_requested:
+                _sync_state.skipped_sources.append(source_name)
+            else:
+                _sync_state.completed_sources.append(source_name)
+        except Exception as exc:
+            logger.error(
+                "initial_sync_source_failed",
+                source=source_name,
+                error=str(exc),
+                exc_info=True,
+            )
+            _sync_state.failed_sources.append({"name": source_name, "error": str(exc)})
+
+        await _save_and_broadcast()
+
+    # Post-sync phases
+    if _sync_state.completed_sources and not _sync_state.cancel_requested:
+        # dbt docs
+        _sync_state.phase = SyncPhase.DBT_DOCS
+        await _save_and_broadcast()
+        _generate_dbt_docs(project_root)
+
+        # Metabase refresh
+        _sync_state.phase = SyncPhase.METABASE
+        await _save_and_broadcast()
+        _refresh_metabase(project_root)
+
+    _sync_state.phase = SyncPhase.COMPLETE
+    _sync_state.completed_at = datetime.now().isoformat()
+    await _save_and_broadcast()
+
+
+async def _sync_single_source(project_root: Path, source_name: str) -> None:
+    """Sync a single source using the existing run_sync pipeline."""
+    from dango.config.helpers import load_config
+    from dango.ingestion import run_sync
+    from dango.utils import DbtLock
+
+    lock = DbtLock(
+        project_root=project_root,
+        source="initial-sync",
+        operation=f"sync {source_name}",
+    )
+    lock.acquire()
+    try:
+        config = load_config(project_root)
+        source_config = config.sources.get_source(source_name)
+        if source_config is None:
+            raise ValueError(f"Source '{source_name}' not found in config")
+        run_sync(project_root=project_root, sources=[source_config])
+    finally:
+        lock.release()
+
+
+def _generate_dbt_docs(project_root: Path) -> None:
+    """Generate dbt documentation after sync."""
+    try:
+        from dango.transformation import generate_dbt_docs
+
+        generate_dbt_docs(project_root)
+    except Exception:
+        logger.warning("initial_sync_dbt_docs_failed", exc_info=True)
+
+
+def _refresh_metabase(project_root: Path) -> None:
+    """Trigger Metabase schema refresh."""
+    try:
+        from dango.visualization.metabase import sync_metabase_schema
+
+        sync_metabase_schema(project_root)
+    except Exception:
+        logger.warning("initial_sync_metabase_refresh_failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Disk usage helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_disk_usage_pct() -> float:
+    """Return disk usage percentage for /srv/dango (or / if not present)."""
+    try:
+        path = "/srv/dango" if Path("/srv/dango").exists() else "/"
+        usage = shutil.disk_usage(path)
+        return (usage.used / usage.total) * 100
+    except Exception:
+        return 0.0
+
+
+def _check_disk_usage() -> str | None:
+    """Check disk usage. Returns 'abort' if >=90%, 'warn' if >=80%, else None."""
+    pct = _get_disk_usage_pct()
+    if pct >= 90:
+        return "abort"
+    if pct >= 80:
+        return "warn"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/start")
+async def start_initial_sync(request: Request, background_tasks: BackgroundTasks) -> dict[str, str]:
+    """Start the initial data sync. Requires deploy token or admin session."""
+    global _sync_state  # noqa: PLW0603
+
+    # Auth: check deploy token first, then fall back to session user
+    auth_header = request.headers.get("authorization", "")
+    user = getattr(request.state, "user", None) if hasattr(request, "state") else None
+
+    token_valid = False
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        token_valid = _validate_deploy_token(token)
+
+    if not token_valid and user is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    if user is not None and getattr(user, "role", None) is not None:
+        from dango.auth.models import Role
+
+        if user.role != Role.ADMIN:
+            raise HTTPException(status_code=403, detail="Admin access required")
+
+    if _sync_state.phase == SyncPhase.SYNCING:
+        raise HTTPException(status_code=409, detail="Sync already in progress")
+
+    # Load sources
+    project_root = get_project_root()
+    try:
+        from dango.config.helpers import load_config
+
+        config = load_config(project_root)
+        sources = [{"name": src.name, "type": src.type.value} for src in config.sources.sources]
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to load sources: {exc}") from exc
+
+    if not sources:
+        return {"status": "skipped", "message": "No sources configured"}
+
+    # Reset state and start
+    _sync_state = InitialSyncState()
+
+    background_tasks.add_task(_run_initial_sync, project_root, sources)
+    return {"status": "started", "message": f"Syncing {len(sources)} source(s)"}
+
+
+@router.get("/status")
+async def get_sync_status(request: Request) -> dict[str, Any]:
+    """Return current initial sync state."""
+    # Lazy load state from disk on first call
+    if _sync_state.phase == SyncPhase.IDLE and _sync_state.total_sources == 0:
+        _load_state()
+    return _sync_state.to_dict()
+
+
+@router.post("/skip-source")
+async def skip_current_source(request: Request) -> dict[str, str]:
+    """Skip the currently syncing source."""
+    user = getattr(request.state, "user", None) if hasattr(request, "state") else None
+    if user is not None and getattr(user, "role", None) is not None:
+        from dango.auth.models import Role
+
+        if user.role != Role.ADMIN:
+            raise HTTPException(status_code=403, detail="Admin access required")
+
+    if _sync_state.phase != SyncPhase.SYNCING:
+        raise HTTPException(status_code=409, detail="No sync in progress")
+
+    _sync_state.skip_current_requested = True
+    return {"status": "ok", "message": f"Skipping {_sync_state.current_source_name}"}
+
+
+@router.post("/cancel")
+async def cancel_sync(request: Request) -> dict[str, str]:
+    """Cancel the entire initial sync."""
+    user = getattr(request.state, "user", None) if hasattr(request, "state") else None
+    if user is not None and getattr(user, "role", None) is not None:
+        from dango.auth.models import Role
+
+        if user.role != Role.ADMIN:
+            raise HTTPException(status_code=403, detail="Admin access required")
+
+    if _sync_state.phase not in (SyncPhase.SYNCING, SyncPhase.DBT_DOCS, SyncPhase.METABASE):
+        raise HTTPException(status_code=409, detail="No sync in progress")
+
+    _sync_state.cancel_requested = True
+    return {"status": "ok", "message": "Cancellation requested"}

--- a/dango/web/routes/initial_sync.py
+++ b/dango/web/routes/initial_sync.py
@@ -13,6 +13,7 @@ Other endpoints require a valid session or API key (handled by auth middleware).
 
 from __future__ import annotations
 
+import hmac
 import json
 import shutil
 from dataclasses import asdict, dataclass, field
@@ -149,7 +150,7 @@ def _validate_deploy_token(token: str) -> bool:
         return False
 
     stored = token_path.read_text().strip()
-    if token != stored:
+    if not hmac.compare_digest(token, stored):
         return False
 
     # One-time use — delete after validation
@@ -158,6 +159,41 @@ def _validate_deploy_token(token: str) -> bool:
     except OSError:
         pass
     return True
+
+
+def _get_admin_user_from_session(request: Request) -> Any:
+    """Validate session cookie and return user if admin, else None.
+
+    This endpoint is in ``_PUBLIC_EXACT`` so the auth middleware skips it.
+    We validate the session explicitly to allow admins to re-trigger sync
+    after the one-time deploy token has been consumed.
+    """
+    from dango.auth.admin import get_auth_db_path, is_auth_enabled
+    from dango.auth.models import Role
+    from dango.auth.sessions import validate_session
+    from dango.web.middleware.auth import COOKIE_NAME
+
+    project_root = get_project_root()
+    if not is_auth_enabled(project_root):
+        return None
+
+    db_path = get_auth_db_path(project_root)
+    if not db_path.exists():
+        return None
+
+    # Extract session cookie from request
+    cookie_value = request.cookies.get(COOKIE_NAME)
+    if not cookie_value:
+        return None
+
+    user = validate_session(db_path, cookie_value)
+    if user is None:
+        return None
+
+    if user.role != Role.ADMIN:
+        return None
+
+    return user
 
 
 # ---------------------------------------------------------------------------
@@ -307,26 +343,30 @@ def _check_disk_usage() -> str | None:
 
 @router.post("/start")
 async def start_initial_sync(request: Request, background_tasks: BackgroundTasks) -> dict[str, str]:
-    """Start the initial data sync. Requires deploy token or admin session."""
+    """Start the initial data sync.
+
+    Accepts either:
+    - A one-time deploy token (``Authorization: Bearer <token>``) — used by
+      ``dango deploy`` immediately after provisioning.
+    - An admin session cookie — used for re-triggering from the dashboard
+      after the deploy token has been consumed.
+    """
     global _sync_state  # noqa: PLW0603
 
     # Auth: check deploy token first, then fall back to session user
     auth_header = request.headers.get("authorization", "")
-    user = getattr(request.state, "user", None) if hasattr(request, "state") else None
 
     token_valid = False
     if auth_header.startswith("Bearer "):
         token = auth_header[7:]
         token_valid = _validate_deploy_token(token)
 
-    if not token_valid and user is None:
-        raise HTTPException(status_code=401, detail="Unauthorized")
-
-    if user is not None and getattr(user, "role", None) is not None:
-        from dango.auth.models import Role
-
-        if user.role != Role.ADMIN:
-            raise HTTPException(status_code=403, detail="Admin access required")
+    if not token_valid:
+        # Fall back to session-based auth (this endpoint is in _PUBLIC_EXACT
+        # so the middleware sets user=None; validate the session explicitly)
+        user = _get_admin_user_from_session(request)
+        if user is None:
+            raise HTTPException(status_code=401, detail="Unauthorized")
 
     if _sync_state.phase == SyncPhase.SYNCING:
         raise HTTPException(status_code=409, detail="Sync already in progress")

--- a/dango/web/templates/dashboard.html
+++ b/dango/web/templates/dashboard.html
@@ -16,6 +16,65 @@
 
 {% block content %}
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+        <!-- Initial Sync Progress Banner -->
+        <div x-data="initialSyncProgress()" x-init="init()" x-show="visible" x-cloak class="mb-6">
+            <div class="rounded-lg shadow p-4 border-l-4"
+                 :class="{
+                     'bg-blue-50 border-blue-500': phase === 'syncing' || phase === 'dbt_docs' || phase === 'metabase',
+                     'bg-green-50 border-green-500': phase === 'complete',
+                     'bg-red-50 border-red-500': phase === 'failed',
+                     'bg-yellow-50 border-yellow-500': phase === 'cancelled'
+                 }">
+                <div class="flex items-center justify-between">
+                    <div class="flex-1">
+                        <div class="flex items-center space-x-3">
+                            <span class="text-xl" x-text="phaseIcon()"></span>
+                            <div class="flex-1">
+                                <p class="text-sm font-medium" :class="{'text-blue-800': isRunning(), 'text-green-800': phase === 'complete', 'text-red-800': phase === 'failed', 'text-yellow-800': phase === 'cancelled'}" x-text="statusText()"></p>
+                                <!-- Progress bar -->
+                                <template x-if="isRunning() && totalSources > 0">
+                                    <div class="mt-2">
+                                        <div class="w-full bg-gray-200 rounded-full h-2">
+                                            <div class="bg-blue-600 h-2 rounded-full transition-all duration-500"
+                                                 :style="'width: ' + progressPct() + '%'"></div>
+                                        </div>
+                                        <p class="text-xs text-gray-600 mt-1" x-text="'Source ' + currentSourceIndex + '/' + totalSources + ': ' + currentSourceName"></p>
+                                    </div>
+                                </template>
+                                <!-- Failed sources -->
+                                <template x-if="failedSources.length > 0">
+                                    <div class="mt-2 text-xs text-amber-700">
+                                        <template x-for="fs in failedSources" :key="fs.name">
+                                            <p>Failed: <span x-text="fs.name"></span> — <span x-text="fs.error"></span></p>
+                                        </template>
+                                    </div>
+                                </template>
+                                <!-- Error message -->
+                                <template x-if="error">
+                                    <p class="mt-1 text-xs text-red-700" x-text="error"></p>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex items-center space-x-2 ml-4">
+                        <template x-if="phase === 'syncing'">
+                            <button @click="skipSource()" class="text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded hover:bg-yellow-200">Skip Source</button>
+                        </template>
+                        <template x-if="isRunning()">
+                            <button @click="cancelSync()" class="text-xs px-3 py-1 bg-red-100 text-red-800 rounded hover:bg-red-200">Cancel</button>
+                        </template>
+                        <template x-if="!isRunning()">
+                            <button @click="dismiss()" class="text-gray-400 hover:text-gray-600">
+                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                </svg>
+                            </button>
+                        </template>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Platform Health Widget -->
         <div class="mb-6">
             <a href="/health" class="block">
@@ -433,4 +492,128 @@
 {% block scripts %}
     <!-- JavaScript -->
     <script src="/static/js/app.js?v=1763651648"></script>
+    <script>
+    function initialSyncProgress() {
+        return {
+            visible: false,
+            phase: 'idle',
+            totalSources: 0,
+            currentSourceIndex: 0,
+            currentSourceName: '',
+            completedSources: [],
+            failedSources: [],
+            skippedSources: [],
+            error: null,
+            dismissed: false,
+
+            async init() {
+                try {
+                    const resp = await fetch('/api/initial-sync/status', {
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                    });
+                    if (resp.ok) {
+                        const data = await resp.json();
+                        this.updateState(data);
+                    }
+                } catch (e) {
+                    // Endpoint may not exist (local dev)
+                }
+
+                // Listen for WebSocket updates
+                if (window.dangoWs) {
+                    const origHandler = window.dangoWs.onmessage;
+                    window.dangoWs.onmessage = (event) => {
+                        if (origHandler) origHandler(event);
+                        try {
+                            const msg = JSON.parse(event.data);
+                            if (msg.event === 'initial_sync_progress' && msg.data) {
+                                this.updateState(msg.data);
+                            }
+                        } catch (e) {}
+                    };
+                }
+            },
+
+            updateState(data) {
+                this.phase = data.phase || 'idle';
+                this.totalSources = data.total_sources || 0;
+                this.currentSourceIndex = data.current_source_index || 0;
+                this.currentSourceName = data.current_source_name || '';
+                this.completedSources = data.completed_sources || [];
+                this.failedSources = data.failed_sources || [];
+                this.skippedSources = data.skipped_sources || [];
+                this.error = data.error || null;
+
+                if (!this.dismissed && this.phase !== 'idle') {
+                    this.visible = true;
+                }
+            },
+
+            isRunning() {
+                return ['syncing', 'dbt_docs', 'metabase'].includes(this.phase);
+            },
+
+            progressPct() {
+                if (this.totalSources === 0) return 0;
+                return Math.round((this.currentSourceIndex / this.totalSources) * 100);
+            },
+
+            statusText() {
+                switch (this.phase) {
+                    case 'syncing':
+                        return 'Initial data sync in progress...';
+                    case 'dbt_docs':
+                        return 'Generating dbt documentation...';
+                    case 'metabase':
+                        return 'Refreshing Metabase...';
+                    case 'complete':
+                        const count = this.completedSources.length;
+                        const failed = this.failedSources.length;
+                        let msg = `Initial sync complete! ${count} source(s) synced.`;
+                        if (failed > 0) msg += ` ${failed} failed.`;
+                        return msg;
+                    case 'cancelled':
+                        return 'Initial sync cancelled.';
+                    case 'failed':
+                        return 'Initial sync failed.';
+                    default:
+                        return '';
+                }
+            },
+
+            phaseIcon() {
+                switch (this.phase) {
+                    case 'syncing': case 'dbt_docs': case 'metabase': return '\u23F3';
+                    case 'complete': return '\u2705';
+                    case 'failed': return '\u274C';
+                    case 'cancelled': return '\u26A0\uFE0F';
+                    default: return '';
+                }
+            },
+
+            async skipSource() {
+                try {
+                    await fetch('/api/initial-sync/skip-source', {
+                        method: 'POST',
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                    });
+                } catch (e) {}
+            },
+
+            async cancelSync() {
+                try {
+                    await fetch('/api/initial-sync/cancel', {
+                        method: 'POST',
+                        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                    });
+                } catch (e) {}
+            },
+
+            dismiss() {
+                this.visible = false;
+                this.dismissed = true;
+            }
+        };
+    }
+    </script>
 {% endblock %}

--- a/dango/web/templates/dashboard.html
+++ b/dango/web/templates/dashboard.html
@@ -58,7 +58,7 @@
                     </div>
                     <div class="flex items-center space-x-2 ml-4">
                         <template x-if="phase === 'syncing'">
-                            <button @click="skipSource()" class="text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded hover:bg-yellow-200">Skip Source</button>
+                            <button @click="skipSource()" class="text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded hover:bg-yellow-200">Skip (after current)</button>
                         </template>
                         <template x-if="isRunning()">
                             <button @click="cancelSync()" class="text-xs px-3 py-1 bg-red-100 text-red-800 rounded hover:bg-red-200">Cancel</button>

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -224,6 +224,12 @@ exemptions:
     reason: "TASK-026+027: Added domain parameter tests for setup_server(). Each test requires isolated mock setup with full exec_results map."
     review_by: "v1.1"
 
+  - file: tests/unit/test_deploy_provision.py
+    lines: 533
+    category: exempt
+    reason: "TASK-029: 9 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, and sync trigger. Each requires isolated mock setup."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -48,6 +48,19 @@ exemptions:
     reason: "TASK-100 added invite link flow to add-user and invite status to list-users (+38 lines)."
     review_by: "v1.1"
 
+  # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
+  - file: dango/cli/commands/deploy_wizard.py
+    lines: 576
+    category: exempt
+    reason: "TASK-029: Interactive wizard steps 1-9 + non-interactive validation mode. Sequential prompt flow with display logic — splitting would scatter closely coupled wizard steps."
+    review_by: "v1.1"
+
+  - file: dango/cli/commands/deploy_provision.py
+    lines: 547
+    category: exempt
+    reason: "TASK-029: 10-step provisioning orchestration with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
+    review_by: "v1.1"
+
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
     lines: 1026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,9 @@ module = [
     "tests.unit.test_file_sync",
     "tests.unit.test_deployer",
     "tests.unit.test_deployer_push",
+    "tests.unit.test_deploy_wizard",
+    "tests.unit.test_deploy_provision",
+    "tests.unit.test_initial_sync",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -1,0 +1,386 @@
+"""tests/unit/test_deploy_provision.py
+
+Unit tests for dango/cli/commands/deploy_provision.py.
+
+All external calls (DO API, SSH, httpx) are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.cli.commands.deploy_provision import (
+    _create_admin_and_enable_auth,
+    _extract_ip,
+    _health_check,
+    _push_secrets,
+    _ResourceTracker,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def project_root(tmp_path):
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "sources.yml").write_text("sources: []")
+    (dango_dir / "project.yml").write_text("project:\n  name: test\n")
+    return tmp_path
+
+
+def _make_mock_ssh():
+    ssh = MagicMock()
+    result = MagicMock()
+    result.success = True
+    result.stdout = ""
+    result.stderr = ""
+    result.exit_code = 0
+    ssh.exec_command.return_value = result
+    return ssh
+
+
+# ---------------------------------------------------------------------------
+# 1. Resource tracker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResourceTracker:
+    def test_cleanup_droplet_only(self):
+        """Cleanup deletes droplet when it's the only resource."""
+        client = MagicMock()
+        tracker = _ResourceTracker(client=client, droplet_id=123)
+        errors = tracker.cleanup()
+        assert errors == []
+        client.delete_droplet.assert_called_once_with(123)
+
+    def test_cleanup_all_resources(self):
+        """Cleanup deletes all tracked resources."""
+        client = MagicMock()
+        spaces = MagicMock()
+        tracker = _ResourceTracker(
+            client=client,
+            droplet_id=123,
+            firewall_id="fw-456",
+            ssh_key_id=789,
+            spaces_bucket="bucket",
+            spaces_client=spaces,
+        )
+        errors = tracker.cleanup()
+        assert errors == []
+        client.delete_droplet.assert_called_once_with(123)
+        client.delete_firewall.assert_called_once_with("fw-456")
+        client.delete_ssh_key.assert_called_once_with(789)
+        spaces.delete_bucket.assert_called_once()
+
+    def test_cleanup_on_exception_collects_errors(self):
+        """Cleanup collects error messages when deletion fails."""
+        client = MagicMock()
+        client.delete_droplet.side_effect = RuntimeError("API timeout")
+        tracker = _ResourceTracker(client=client, droplet_id=123)
+        errors = tracker.cleanup()
+        assert len(errors) == 1
+        assert "Droplet 123" in errors[0]
+
+    def test_cleanup_partial_errors(self):
+        """Cleanup continues after partial failure."""
+        client = MagicMock()
+        client.delete_droplet.side_effect = RuntimeError("fail")
+        client.delete_firewall.return_value = None
+        tracker = _ResourceTracker(
+            client=client,
+            droplet_id=123,
+            firewall_id="fw-456",
+        )
+        errors = tracker.cleanup()
+        assert len(errors) == 1
+        client.delete_firewall.assert_called_once()
+
+    def test_cleanup_empty_tracker(self):
+        """Cleanup on empty tracker does nothing."""
+        tracker = _ResourceTracker()
+        errors = tracker.cleanup()
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# 2. IP extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractIP:
+    def test_extracts_public_ip(self):
+        """Extracts public IPv4 from droplet dict."""
+        droplet = {
+            "networks": {
+                "v4": [
+                    {"type": "private", "ip_address": "10.0.0.1"},
+                    {"type": "public", "ip_address": "203.0.113.1"},
+                ]
+            }
+        }
+        assert _extract_ip(droplet) == "203.0.113.1"
+
+    def test_missing_public_ip_raises(self):
+        """Raises RuntimeError when no public IP."""
+        droplet = {"networks": {"v4": [{"type": "private", "ip_address": "10.0.0.1"}]}}
+        with pytest.raises(RuntimeError, match="no public IPv4"):
+            _extract_ip(droplet)
+
+
+# ---------------------------------------------------------------------------
+# 3. Secrets push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSecretsPush:
+    def test_push_both_files(self, project_root):
+        """Pushes both .dlt/secrets.toml and .env."""
+        dlt_dir = project_root / ".dlt"
+        dlt_dir.mkdir()
+        (dlt_dir / "secrets.toml").write_text("[sources]\nkey = 'value'\n")
+        (project_root / ".env").write_text("DB_URL=postgres://...\n")
+
+        ssh = _make_mock_ssh()
+        warnings: list[str] = []
+        _push_secrets(ssh, project_root, warnings)
+
+        assert warnings == []
+        assert ssh.write_remote_file.call_count == 2
+
+    def test_env_missing_continues(self, project_root):
+        """Missing .env is silently skipped."""
+        dlt_dir = project_root / ".dlt"
+        dlt_dir.mkdir()
+        (dlt_dir / "secrets.toml").write_text("[sources]\n")
+
+        ssh = _make_mock_ssh()
+        warnings: list[str] = []
+        _push_secrets(ssh, project_root, warnings)
+
+        assert warnings == []
+        # Only secrets.toml written
+        assert ssh.write_remote_file.call_count == 1
+
+    def test_secrets_missing_warns(self, project_root):
+        """Missing .dlt/secrets.toml produces a warning."""
+        ssh = _make_mock_ssh()
+        warnings: list[str] = []
+        _push_secrets(ssh, project_root, warnings)
+
+        assert len(warnings) == 1
+        assert "secrets.toml" in warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# 4. Admin creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdminCreation:
+    def test_creates_admin_via_ssh(self):
+        """Admin creation sends base64-encoded Python script over SSH."""
+        ssh = _make_mock_ssh()
+        token = _create_admin_and_enable_auth(ssh, "admin@test.com", "password123")
+
+        assert token  # non-empty token returned
+        # exec_command called for Python script + chown
+        assert ssh.exec_command.call_count >= 1
+        # write_remote_file called for auth.yml
+        ssh.write_remote_file.assert_called()
+
+    def test_invalid_email_raises(self):
+        """Invalid email format raises ValueError."""
+        ssh = _make_mock_ssh()
+        with pytest.raises(ValueError, match="Invalid email"):
+            _create_admin_and_enable_auth(ssh, "not-an-email", "password123")
+
+    def test_auth_yml_written(self):
+        """auth.yml is written with 'enabled: true'."""
+        ssh = _make_mock_ssh()
+        _create_admin_and_enable_auth(ssh, "admin@test.com", "password123")
+
+        # Find the write_remote_file call for auth.yml
+        found = False
+        for call in ssh.write_remote_file.call_args_list:
+            if "auth.yml" in str(call):
+                assert "enabled: true" in str(call)
+                found = True
+        assert found, "auth.yml write not found"
+
+
+# ---------------------------------------------------------------------------
+# 5. Health check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHealthCheck:
+    @patch("httpx.get")
+    @patch("dango.cli.commands.deploy_provision.time.sleep")
+    def test_immediate_success(self, mock_sleep, mock_get):
+        """Health check returns True on immediate 200."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_get.return_value = mock_resp
+
+        assert _health_check("http://1.2.3.4", timeout=6, interval=3) is True
+        mock_sleep.assert_not_called()
+
+    @patch("httpx.get")
+    @patch("dango.cli.commands.deploy_provision.time.sleep")
+    def test_retry_then_success(self, mock_sleep, mock_get):
+        """Health check retries and succeeds on third attempt."""
+        fail_resp = MagicMock()
+        fail_resp.status_code = 502
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+        mock_get.side_effect = [fail_resp, fail_resp, ok_resp]
+
+        assert _health_check("http://1.2.3.4", timeout=15, interval=3) is True
+
+    @patch("httpx.get")
+    @patch("dango.cli.commands.deploy_provision.time.sleep")
+    def test_persistent_failure(self, mock_sleep, mock_get):
+        """Health check returns False after timeout."""
+        mock_get.side_effect = ConnectionError("refused")
+
+        assert _health_check("http://1.2.3.4", timeout=6, interval=3) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Full provisioning sequence (integration-like, all mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProvisionSequence:
+    @patch("httpx.get")
+    @patch("dango.cli.commands.deploy_provision.time.sleep")
+    def test_full_success(self, mock_sleep, mock_get, project_root, monkeypatch):
+        """Full provisioning completes successfully with all steps mocked."""
+        from dango.cli.commands.deploy_provision import run_provisioning
+        from dango.cli.commands.deploy_wizard import WizardConfig
+
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+
+        config = WizardConfig(
+            region="nyc1",
+            size_slug="s-2vcpu-4gb",
+            size_tier=None,
+            domain=None,
+            admin_email="admin@test.com",
+            admin_password="strongpassword123",
+            skip_oauth=True,
+            enable_backups=False,
+            skip_initial_sync=True,
+            monthly_cost=24,
+        )
+
+        # Create .dlt/secrets.toml
+        dlt_dir = project_root / ".dlt"
+        dlt_dir.mkdir()
+        (dlt_dir / "secrets.toml").write_text("[sources]\n")
+
+        mock_client = MagicMock()
+        mock_client.upload_ssh_key.return_value = {"ssh_key": {"id": 111}}
+        mock_ssh = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_ssh.exec_command.return_value = mock_result
+
+        droplet_dict = {
+            "id": 222,
+            "networks": {"v4": [{"type": "public", "ip_address": "1.2.3.4"}]},
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_get.return_value = mock_resp
+
+        with (
+            patch(
+                "dango.platform.cloud.digitalocean.DigitalOceanClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "dango.platform.cloud.ssh.SSHManager",
+                return_value=mock_ssh,
+            ),
+            patch(
+                "dango.platform.cloud.provisioning.provision_droplet",
+                return_value=droplet_dict,
+            ),
+            patch(
+                "dango.platform.cloud.firewall.create_default_firewall",
+                return_value={"id": "fw-333"},
+            ),
+            patch("dango.platform.cloud.server_setup.setup_server") as mock_setup,
+            patch("dango.platform.cloud.file_sync.sync_project_files"),
+            patch("dango.platform.cloud.provisioning.save_provisioning_metadata"),
+        ):
+            mock_setup.return_value = MagicMock(warnings=[])
+            mock_ssh.generate_key_pair.return_value = "ssh-ed25519 AAAA..."
+
+            result = run_provisioning(project_root, config)
+
+        assert result.droplet_ip == "1.2.3.4"
+        assert result.droplet_id == 222
+        assert result.firewall_id == "fw-333"
+
+    @patch("dango.cli.commands.deploy_provision.time.sleep")
+    def test_provision_failure_cleanup(self, mock_sleep, project_root, monkeypatch):
+        """Provisioning failure triggers resource cleanup."""
+        from dango.cli.commands.deploy_provision import run_provisioning
+        from dango.cli.commands.deploy_wizard import WizardConfig
+
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+
+        config = WizardConfig(
+            region="nyc1",
+            size_slug="s-2vcpu-4gb",
+            size_tier=None,
+            domain=None,
+            admin_email="admin@test.com",
+            admin_password="strongpassword123",
+            skip_oauth=True,
+            enable_backups=False,
+            skip_initial_sync=True,
+            monthly_cost=24,
+        )
+
+        mock_client = MagicMock()
+        mock_client.upload_ssh_key.return_value = {"ssh_key": {"id": 111}}
+        mock_ssh = MagicMock()
+        mock_ssh.generate_key_pair.return_value = "ssh-ed25519 AAAA..."
+
+        with (
+            patch(
+                "dango.platform.cloud.digitalocean.DigitalOceanClient",
+                return_value=mock_client,
+            ),
+            patch(
+                "dango.platform.cloud.ssh.SSHManager",
+                return_value=mock_ssh,
+            ),
+            patch(
+                "dango.platform.cloud.provisioning.provision_droplet",
+                side_effect=RuntimeError("API error"),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            run_provisioning(project_root, config)
+
+        # SSH key was created, so cleanup should try to delete it
+        mock_client.delete_ssh_key.assert_called_once_with(111)

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -17,6 +17,9 @@ from dango.cli.commands.deploy_provision import (
     _health_check,
     _push_secrets,
     _ResourceTracker,
+    _save_extra_metadata,
+    _setup_backups,
+    _trigger_initial_sync,
 )
 
 # ---------------------------------------------------------------------------
@@ -384,3 +387,143 @@ class TestProvisionSequence:
 
         # SSH key was created, so cleanup should try to delete it
         mock_client.delete_ssh_key.assert_called_once_with(111)
+
+
+# ---------------------------------------------------------------------------
+# 7. Backup setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSetupBackups:
+    @patch("dango.platform.cloud.spaces.SpacesClient")
+    def test_creates_bucket_and_enables_timer(self, mock_spaces_cls, project_root):
+        """Backup setup creates bucket, writes credentials, enables systemd timer."""
+        from dango.cli.commands.deploy_wizard import WizardConfig
+
+        mock_spaces = MagicMock()
+        mock_spaces_cls.return_value = mock_spaces
+
+        ssh = _make_mock_ssh()
+        config = WizardConfig(
+            region="nyc1",
+            size_slug="s-2vcpu-4gb",
+            size_tier=None,
+            domain=None,
+            admin_email="admin@test.com",
+            admin_password="pw",
+            skip_oauth=True,
+            enable_backups=True,
+            skip_initial_sync=True,
+            monthly_cost=29,
+            spaces_access_key="DO_KEY",
+            spaces_secret_key="DO_SECRET",
+        )
+        tracker = _ResourceTracker()
+
+        _setup_backups(ssh, MagicMock(), project_root, config, tracker)
+
+        # Bucket created
+        mock_spaces.create_bucket.assert_called_once()
+        # Tracker updated
+        assert tracker.spaces_bucket is not None
+        assert tracker.spaces_client is mock_spaces
+        # Credentials appended to .env
+        env_write_calls = [
+            c for c in ssh.write_remote_file.call_args_list if c[0][0] == "/srv/dango/project/.env"
+        ]
+        assert len(env_write_calls) == 1
+        written_content = env_write_calls[0][0][1]
+        assert "SPACES_ACCESS_KEY=DO_KEY" in written_content
+        assert "SPACES_SECRET_KEY=DO_SECRET" in written_content
+        # Systemd files written
+        systemd_calls = [
+            c for c in ssh.write_remote_file.call_args_list if c[0][0].startswith("/etc/systemd/")
+        ]
+        assert len(systemd_calls) == 2  # .service + .timer
+        # Timer enabled
+        enable_calls = [c for c in ssh.exec_command.call_args_list if "enable --now" in str(c)]
+        assert len(enable_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. Save extra metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSaveExtraMetadata:
+    def test_saves_firewall_and_ssh_key(self, project_root):
+        """Saves firewall_id and ssh_key_id to cloud.yml."""
+        # Create a minimal cloud.yml first (simulating save_provisioning_metadata)
+        cloud_yml = project_root / ".dango" / "cloud.yml"
+        cloud_yml.write_text(
+            "droplet_id: 123\ndroplet_ip: 1.2.3.4\nregion: nyc1\nsize: s-2vcpu-4gb\n"
+        )
+
+        _save_extra_metadata(
+            project_root,
+            firewall_id="fw-456",
+            ssh_key_id=789,
+            domain=None,
+            spaces_config=None,
+        )
+
+        content = cloud_yml.read_text()
+        assert "fw-456" in content
+        assert "789" in content
+
+    def test_saves_domain_when_provided(self, project_root):
+        """Saves domain to cloud.yml when provided."""
+        cloud_yml = project_root / ".dango" / "cloud.yml"
+        cloud_yml.write_text(
+            "droplet_id: 123\ndroplet_ip: 1.2.3.4\nregion: nyc1\nsize: s-2vcpu-4gb\n"
+        )
+
+        _save_extra_metadata(
+            project_root,
+            firewall_id="fw-456",
+            ssh_key_id=789,
+            domain="example.com",
+            spaces_config=None,
+        )
+
+        content = cloud_yml.read_text()
+        assert "example.com" in content
+
+    def test_noop_when_no_cloud_yml(self, project_root):
+        """Does nothing when cloud.yml does not exist."""
+        # No cloud.yml — should not raise
+        _save_extra_metadata(
+            project_root,
+            firewall_id="fw-456",
+            ssh_key_id=789,
+            domain=None,
+            spaces_config=None,
+        )
+        assert not (project_root / ".dango" / "cloud.yml").exists()
+
+
+# ---------------------------------------------------------------------------
+# 9. Trigger initial sync
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTriggerInitialSync:
+    @patch("httpx.post")
+    def test_posts_with_token(self, mock_post):
+        """Trigger sends POST with deploy token."""
+        _trigger_initial_sync("http://1.2.3.4", "test-token-123")
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[0][0] == "http://1.2.3.4/api/initial-sync/start"
+        headers = call_kwargs[1]["headers"]
+        assert headers["Authorization"] == "Bearer test-token-123"
+
+    @patch("httpx.post", side_effect=ConnectionError("refused"))
+    def test_swallows_errors(self, mock_post):
+        """Trigger does not raise on connection failure."""
+        # Should not raise
+        _trigger_initial_sync("http://1.2.3.4", "test-token-123")

--- a/tests/unit/test_deploy_wizard.py
+++ b/tests/unit/test_deploy_wizard.py
@@ -1,0 +1,304 @@
+"""tests/unit/test_deploy_wizard.py
+
+Unit tests for dango/cli/commands/deploy_wizard.py.
+
+Tests wizard validation, prerequisite checks, non-interactive mode,
+deployment guard, reconnect mode, and cost summary calculation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.cli.commands.deploy_wizard import (
+    _get_monthly_cost,
+    _step_prereqs,
+    run_non_interactive,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def project_root(tmp_path):
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "sources.yml").write_text("sources: []")
+    (dango_dir / "project.yml").write_text("project:\n  name: test\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisite checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPrereqCheck:
+    def test_missing_do_token(self, project_root, monkeypatch):
+        """Missing DIGITALOCEAN_TOKEN raises SystemExit."""
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+        with pytest.raises(SystemExit):
+            _step_prereqs(project_root)
+
+    def test_missing_sources_yml(self, tmp_path, monkeypatch):
+        """Missing sources.yml raises SystemExit."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        (tmp_path / ".dango").mkdir()
+        with pytest.raises(SystemExit):
+            _step_prereqs(tmp_path)
+
+    def test_valid_project(self, project_root, monkeypatch):
+        """Valid project with token passes prereqs."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        _step_prereqs(project_root)  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-interactive mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNonInteractive:
+    def test_all_required_params(self, project_root, monkeypatch):
+        """Non-interactive with all params succeeds."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        config = run_non_interactive(
+            project_root,
+            region="nyc1",
+            size="s-2vcpu-4gb",
+            admin_email="admin@example.com",
+            admin_password="strongpassword123",
+        )
+        assert config.region == "nyc1"
+        assert config.size_slug == "s-2vcpu-4gb"
+        assert config.admin_email == "admin@example.com"
+        assert config.admin_password == "strongpassword123"
+        assert config.skip_oauth is True
+
+    def test_missing_email(self, project_root, monkeypatch):
+        """Non-interactive without admin_email raises SystemExit."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        with pytest.raises(SystemExit):
+            run_non_interactive(
+                project_root,
+                admin_password="strongpassword123",
+            )
+
+    def test_weak_password(self, project_root, monkeypatch):
+        """Non-interactive with weak password raises SystemExit."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        with pytest.raises(SystemExit):
+            run_non_interactive(
+                project_root,
+                admin_email="admin@example.com",
+                admin_password="short",
+            )
+
+    def test_invalid_region(self, project_root, monkeypatch):
+        """Non-interactive with invalid region raises SystemExit."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        with pytest.raises(SystemExit):
+            run_non_interactive(
+                project_root,
+                region="invalid-region",
+                admin_email="admin@example.com",
+                admin_password="strongpassword123",
+            )
+
+    def test_invalid_size(self, project_root, monkeypatch):
+        """Non-interactive with invalid size raises SystemExit."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        with pytest.raises(SystemExit):
+            run_non_interactive(
+                project_root,
+                size="invalid-size",
+                admin_email="admin@example.com",
+                admin_password="strongpassword123",
+            )
+
+    def test_defaults_used(self, project_root, monkeypatch):
+        """Non-interactive uses defaults for region and size when not specified."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        config = run_non_interactive(
+            project_root,
+            admin_email="admin@example.com",
+            admin_password="strongpassword123",
+        )
+        # Region should be from suggest_nearest_region (varies by env)
+        assert config.region is not None
+        # Size should be standard tier default
+        assert config.size_slug == "s-2vcpu-4gb"
+
+    def test_password_from_env(self, project_root, monkeypatch):
+        """Non-interactive reads DANGO_ADMIN_PASSWORD from env."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        monkeypatch.setenv("DANGO_ADMIN_PASSWORD", "strongpassword123")
+        config = run_non_interactive(
+            project_root,
+            admin_email="admin@example.com",
+        )
+        assert config.admin_password == "strongpassword123"
+
+    def test_invalid_email_format(self, project_root, monkeypatch):
+        """Non-interactive with invalid email format raises SystemExit."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        with pytest.raises(SystemExit):
+            run_non_interactive(
+                project_root,
+                admin_email="not-an-email",
+                admin_password="strongpassword123",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Deployment guard (tested via deploy.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeploymentGuard:
+    @patch("dango.cli.utils.find_project_root")
+    def test_cloud_yml_exists_blocks(self, mock_find, project_root):
+        """Existing cloud.yml with droplet_id blocks new deployment."""
+        from click.testing import CliRunner
+
+        from dango.cli.commands.deploy import deploy
+
+        mock_find.return_value = project_root
+
+        cloud_yml = project_root / ".dango" / "cloud.yml"
+        cloud_yml.write_text("droplet_id: 12345\ndroplet_ip: 1.2.3.4\n")
+
+        runner = CliRunner()
+        result = runner.invoke(deploy, [], obj={"project_root": project_root})
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    def test_no_cloud_yml_proceeds(self, project_root, monkeypatch):
+        """Missing cloud.yml allows deployment to proceed."""
+        # Just verify the guard doesn't block — actual wizard will fail
+        # because we don't mock the wizard steps
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        cloud_yml = project_root / ".dango" / "cloud.yml"
+        assert not cloud_yml.exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. Reconnect mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReconnect:
+    @patch("dango.platform.cloud.ssh.SSHManager")
+    @patch("dango.cli.utils.find_project_root")
+    def test_valid_server(self, mock_find, mock_ssh_cls, project_root):
+        """Reconnect to a valid Dango server writes cloud.yml."""
+        from click.testing import CliRunner
+
+        from dango.cli.commands.deploy import deploy
+
+        mock_find.return_value = project_root
+
+        # Create SSH key
+        key_path = project_root / ".dango" / "cloud_key"
+        key_path.write_text("fake-key")
+
+        mock_ssh = MagicMock()
+        mock_ssh_cls.return_value = mock_ssh
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.stdout = "project:\n  name: my-project\n"
+        mock_ssh.exec_command.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy,
+            ["--reconnect", "--ip", "1.2.3.4"],
+            obj={"project_root": project_root},
+        )
+        assert result.exit_code == 0
+        cloud_yml = project_root / ".dango" / "cloud.yml"
+        assert cloud_yml.exists()
+
+    @patch("dango.platform.cloud.ssh.SSHManager")
+    @patch("dango.cli.utils.find_project_root")
+    def test_non_dango_server(self, mock_find, mock_ssh_cls, project_root):
+        """Reconnect to non-Dango server raises SystemExit."""
+        from click.testing import CliRunner
+
+        from dango.cli.commands.deploy import deploy
+
+        mock_find.return_value = project_root
+
+        key_path = project_root / ".dango" / "cloud_key"
+        key_path.write_text("fake-key")
+
+        mock_ssh = MagicMock()
+        mock_ssh_cls.return_value = mock_ssh
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.stdout = ""
+        mock_ssh.exec_command.return_value = mock_result
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy,
+            ["--reconnect", "--ip", "1.2.3.4"],
+            obj={"project_root": project_root},
+        )
+        assert result.exit_code != 0
+
+    @patch("dango.cli.utils.find_project_root")
+    def test_missing_ip(self, mock_find, project_root):
+        """Reconnect without --ip raises SystemExit."""
+        from click.testing import CliRunner
+
+        from dango.cli.commands.deploy import deploy
+
+        mock_find.return_value = project_root
+
+        key_path = project_root / ".dango" / "cloud_key"
+        key_path.write_text("fake-key")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            deploy,
+            ["--reconnect"],
+            obj={"project_root": project_root},
+        )
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Cost summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCostSummary:
+    def test_standard_no_backups(self):
+        """Standard tier without backups = $24."""
+        assert _get_monthly_cost("s-2vcpu-4gb", False) == 24
+
+    def test_budget_with_backups(self):
+        """Budget tier with backups = $17."""
+        assert _get_monthly_cost("s-1vcpu-2gb", True) == 17
+
+    def test_performance_no_backups(self):
+        """Performance tier without backups = $48."""
+        assert _get_monthly_cost("s-4vcpu-8gb", False) == 48
+
+    def test_custom_size_uses_default_estimate(self):
+        """Custom/unknown size slug uses $24 estimate."""
+        assert _get_monthly_cost("custom-slug", False) == 24
+
+    def test_standard_with_backups(self):
+        """Standard tier with backups = $29."""
+        assert _get_monthly_cost("s-2vcpu-4gb", True) == 29

--- a/tests/unit/test_initial_sync.py
+++ b/tests/unit/test_initial_sync.py
@@ -416,3 +416,75 @@ class TestPostSync:
         mock_dbt.assert_not_called()
         mock_mb.assert_not_called()
         assert mod._sync_state.phase == SyncPhase.COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# 7. Admin session re-trigger (after deploy token consumed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdminSessionRetrigger:
+    @patch("dango.config.helpers.load_config")
+    @patch("dango.web.routes.initial_sync._get_admin_user_from_session")
+    def test_admin_session_starts_sync(self, mock_get_admin, mock_config, client, tmp_path):
+        """POST /start with valid admin session starts sync (no deploy token)."""
+        mock_admin = MagicMock()
+        mock_admin.role = MagicMock()
+        mock_get_admin.return_value = mock_admin
+
+        mock_source = MagicMock()
+        mock_source.name = "stripe"
+        mock_source.type.value = "stripe"
+        mock_cfg = MagicMock()
+        mock_cfg.sources.sources = [mock_source]
+        mock_config.return_value = mock_cfg
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            resp = client.post("/api/initial-sync/start")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "started"
+
+    @patch("dango.web.routes.initial_sync._get_admin_user_from_session")
+    def test_no_token_no_session_returns_401(self, mock_get_admin, client, tmp_path):
+        """POST /start without token or session returns 401."""
+        mock_get_admin.return_value = None
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            resp = client.post("/api/initial-sync/start")
+        assert resp.status_code == 401
+
+    @patch("dango.config.helpers.load_config")
+    def test_consumed_token_then_admin_session(self, mock_config, client, tmp_path):
+        """After token is consumed, admin session can still start sync."""
+        # Create and consume token
+        token_dir = tmp_path / ".dango" / "state"
+        token_dir.mkdir(parents=True)
+        (token_dir / "deploy_token").write_text("one-time-token")
+
+        mock_source = MagicMock()
+        mock_source.name = "test"
+        mock_source.type.value = "test"
+        mock_cfg = MagicMock()
+        mock_cfg.sources.sources = [mock_source]
+        mock_config.return_value = mock_cfg
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            # First use: deploy token
+            resp1 = client.post(
+                "/api/initial-sync/start",
+                headers={"Authorization": "Bearer one-time-token"},
+            )
+            assert resp1.status_code == 200
+
+            # Reset state
+            import dango.web.routes.initial_sync as mod
+
+            mod._sync_state = InitialSyncState()
+
+            # Second use: admin session (mock _get_admin_user_from_session)
+            with patch("dango.web.routes.initial_sync._get_admin_user_from_session") as mock_admin:
+                mock_admin.return_value = MagicMock()
+                resp2 = client.post("/api/initial-sync/start")
+            assert resp2.status_code == 200
+            assert resp2.json()["status"] == "started"

--- a/tests/unit/test_initial_sync.py
+++ b/tests/unit/test_initial_sync.py
@@ -1,0 +1,418 @@
+"""tests/unit/test_initial_sync.py
+
+Unit tests for dango/web/routes/initial_sync.py.
+
+Tests sync state machine, disk checks, API endpoints, deploy token,
+and continue-on-failure behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dango.web.routes.initial_sync import (
+    InitialSyncState,
+    SyncPhase,
+    _check_disk_usage,
+    _validate_deploy_token,
+    router,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def app(tmp_path):
+    """Create a test FastAPI app with initial_sync router."""
+    test_app = FastAPI()
+    test_app.include_router(router)
+
+    # Patch get_project_root to return tmp_path
+    with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+        yield test_app
+
+
+@pytest.fixture()
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Reset module-level singleton before each test."""
+    import dango.web.routes.initial_sync as mod
+
+    mod._sync_state = InitialSyncState()
+    yield
+    mod._sync_state = InitialSyncState()
+
+
+# ---------------------------------------------------------------------------
+# 1. Sync state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSyncState:
+    def test_initial_idle(self):
+        """State starts as IDLE."""
+        state = InitialSyncState()
+        assert state.phase == SyncPhase.IDLE
+        assert state.total_sources == 0
+        assert state.completed_sources == []
+
+    def test_transitions(self):
+        """State transitions update correctly."""
+        state = InitialSyncState()
+        state.phase = SyncPhase.SYNCING
+        state.total_sources = 3
+        state.current_source_index = 1
+        state.current_source_name = "stripe"
+        assert state.to_dict()["phase"] == "syncing"
+
+    def test_json_persistence(self, tmp_path):
+        """State can be serialized and loaded from JSON."""
+        state = InitialSyncState(
+            phase=SyncPhase.SYNCING,
+            total_sources=3,
+            current_source_index=2,
+            current_source_name="stripe",
+            completed_sources=["hubspot"],
+        )
+
+        state_file = tmp_path / ".dango" / "state" / "initial_sync.json"
+        state_file.parent.mkdir(parents=True)
+        state_file.write_text(json.dumps(state.to_dict(), indent=2))
+
+        # Verify round-trip
+        data: dict = json.loads(state_file.read_text())
+        assert data["phase"] == "syncing"
+        assert data["current_source_name"] == "stripe"
+        assert data["completed_sources"] == ["hubspot"]
+
+    def test_restart_recovery(self, tmp_path):
+        """Interrupted sync (SYNCING) is marked FAILED on reload."""
+        state_file = tmp_path / ".dango" / "state" / "initial_sync.json"
+        state_file.parent.mkdir(parents=True)
+        state_file.write_text(
+            json.dumps(
+                {
+                    "phase": "syncing",
+                    "total_sources": 3,
+                    "current_source_index": 1,
+                    "current_source_name": "stripe",
+                    "completed_sources": [],
+                    "failed_sources": [],
+                    "skipped_sources": [],
+                    "cancel_requested": False,
+                    "skip_current_requested": False,
+                    "started_at": "2026-02-25T10:00:00",
+                    "completed_at": "",
+                    "error": None,
+                }
+            )
+        )
+
+        import dango.web.routes.initial_sync as mod
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            mod._load_state()
+            assert mod._sync_state.phase == SyncPhase.FAILED
+            assert "interrupted" in (mod._sync_state.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. Disk check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDiskCheck:
+    @patch("dango.web.routes.initial_sync.shutil.disk_usage")
+    def test_below_80_ok(self, mock_usage):
+        """Disk below 80% returns None."""
+        mock_usage.return_value = MagicMock(used=50, total=100)
+        assert _check_disk_usage() is None
+
+    @patch("dango.web.routes.initial_sync.shutil.disk_usage")
+    def test_80_90_warns(self, mock_usage):
+        """Disk 80-90% returns 'warn'."""
+        mock_usage.return_value = MagicMock(used=85, total=100)
+        assert _check_disk_usage() == "warn"
+
+    @patch("dango.web.routes.initial_sync.shutil.disk_usage")
+    def test_90_plus_aborts(self, mock_usage):
+        """Disk >=90% returns 'abort'."""
+        mock_usage.return_value = MagicMock(used=95, total=100)
+        assert _check_disk_usage() == "abort"
+
+
+# ---------------------------------------------------------------------------
+# 3. API endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEndpoints:
+    def test_status_returns_state(self, client, tmp_path):
+        """GET /status returns current state."""
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            resp = client.get("/api/initial-sync/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["phase"] == "idle"
+
+    def test_start_when_already_running_409(self, client, tmp_path):
+        """POST /start when syncing returns 409."""
+        import dango.web.routes.initial_sync as mod
+
+        mod._sync_state.phase = SyncPhase.SYNCING
+
+        # Create token
+        token_dir = tmp_path / ".dango" / "state"
+        token_dir.mkdir(parents=True)
+        (token_dir / "deploy_token").write_text("test-token")
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/initial-sync/start",
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 409
+
+    @patch("dango.config.helpers.load_config")
+    def test_start_with_deploy_token(self, mock_config, client, tmp_path):
+        """POST /start with valid deploy token starts sync."""
+        # Create token
+        token_dir = tmp_path / ".dango" / "state"
+        token_dir.mkdir(parents=True)
+        (token_dir / "deploy_token").write_text("test-token")
+
+        # Mock config
+        mock_source = MagicMock()
+        mock_source.name = "stripe"
+        mock_source.type.value = "stripe"
+        mock_cfg = MagicMock()
+        mock_cfg.sources.sources = [mock_source]
+        mock_config.return_value = mock_cfg
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/initial-sync/start",
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "started"
+
+    def test_start_unauthorized(self, client, tmp_path):
+        """POST /start without auth returns 401."""
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            resp = client.post("/api/initial-sync/start")
+        assert resp.status_code == 401
+
+    def test_skip_source_not_syncing(self, client):
+        """POST /skip-source when not syncing returns 409."""
+        resp = client.post("/api/initial-sync/skip-source")
+        assert resp.status_code == 409
+
+    def test_cancel_not_syncing(self, client):
+        """POST /cancel when not syncing returns 409."""
+        resp = client.post("/api/initial-sync/cancel")
+        assert resp.status_code == 409
+
+    def test_skip_source_during_sync(self, client):
+        """POST /skip-source during sync sets flag."""
+        import dango.web.routes.initial_sync as mod
+
+        mod._sync_state.phase = SyncPhase.SYNCING
+        mod._sync_state.current_source_name = "stripe"
+
+        resp = client.post("/api/initial-sync/skip-source")
+        assert resp.status_code == 200
+        assert mod._sync_state.skip_current_requested is True
+
+    def test_cancel_during_sync(self, client):
+        """POST /cancel during sync sets flag."""
+        import dango.web.routes.initial_sync as mod
+
+        mod._sync_state.phase = SyncPhase.SYNCING
+
+        resp = client.post("/api/initial-sync/cancel")
+        assert resp.status_code == 200
+        assert mod._sync_state.cancel_requested is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Deploy token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeployToken:
+    def test_valid_token(self, tmp_path):
+        """Valid token returns True and deletes the file."""
+        token_dir = tmp_path / ".dango" / "state"
+        token_dir.mkdir(parents=True)
+        (token_dir / "deploy_token").write_text("my-secret-token")
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            assert _validate_deploy_token("my-secret-token") is True
+            # Token file deleted
+            assert not (token_dir / "deploy_token").exists()
+
+    def test_invalid_token(self, tmp_path):
+        """Invalid token returns False."""
+        token_dir = tmp_path / ".dango" / "state"
+        token_dir.mkdir(parents=True)
+        (token_dir / "deploy_token").write_text("correct-token")
+
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            assert _validate_deploy_token("wrong-token") is False
+            # Token file NOT deleted
+            assert (token_dir / "deploy_token").exists()
+
+    def test_no_token_file(self, tmp_path):
+        """No token file returns False."""
+        with patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path):
+            assert _validate_deploy_token("any-token") is False
+
+    def test_token_deleted_after_use(self, client, tmp_path):
+        """Token is consumed on first successful use."""
+        token_dir = tmp_path / ".dango" / "state"
+        token_dir.mkdir(parents=True)
+        (token_dir / "deploy_token").write_text("one-time-token")
+
+        mock_source = MagicMock()
+        mock_source.name = "test"
+        mock_source.type.value = "test"
+        mock_cfg = MagicMock()
+        mock_cfg.sources.sources = [mock_source]
+
+        with (
+            patch("dango.web.routes.initial_sync.get_project_root", return_value=tmp_path),
+            patch("dango.config.helpers.load_config", return_value=mock_cfg),
+        ):
+            # First use succeeds
+            resp1 = client.post(
+                "/api/initial-sync/start",
+                headers={"Authorization": "Bearer one-time-token"},
+            )
+            assert resp1.status_code == 200
+
+            # Reset state so we can try starting again
+            import dango.web.routes.initial_sync as mod
+
+            mod._sync_state = InitialSyncState()
+
+            # Second use fails (token consumed)
+            resp2 = client.post(
+                "/api/initial-sync/start",
+                headers={"Authorization": "Bearer one-time-token"},
+            )
+            assert resp2.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 5. Continue on failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestContinueOnFailure:
+    @patch("dango.web.routes.initial_sync._save_and_broadcast", new_callable=AsyncMock)
+    @patch("dango.web.routes.initial_sync._sync_single_source", new_callable=AsyncMock)
+    @patch("dango.web.routes.initial_sync._generate_dbt_docs")
+    @patch("dango.web.routes.initial_sync._refresh_metabase")
+    @pytest.mark.anyio
+    async def test_one_fails_others_continue(
+        self, mock_mb, mock_dbt, mock_sync, mock_broadcast, tmp_path
+    ):
+        """One source failure doesn't stop subsequent sources."""
+        from dango.web.routes.initial_sync import _run_initial_sync
+
+        mock_sync.side_effect = [
+            None,  # source 1 succeeds
+            RuntimeError("API error"),  # source 2 fails
+            None,  # source 3 succeeds
+        ]
+
+        import dango.web.routes.initial_sync as mod
+
+        mod._sync_state = InitialSyncState()
+
+        with patch("dango.web.routes.initial_sync._check_disk_usage", return_value=None):
+            await _run_initial_sync(
+                tmp_path,
+                [
+                    {"name": "hubspot", "type": "hubspot"},
+                    {"name": "stripe", "type": "stripe"},
+                    {"name": "github", "type": "github"},
+                ],
+            )
+
+        assert "hubspot" in mod._sync_state.completed_sources
+        assert "github" in mod._sync_state.completed_sources
+        assert len(mod._sync_state.failed_sources) == 1
+        assert mod._sync_state.failed_sources[0]["name"] == "stripe"
+        assert mod._sync_state.phase == SyncPhase.COMPLETE
+
+
+# ---------------------------------------------------------------------------
+# 6. Post-sync phases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPostSync:
+    @patch("dango.web.routes.initial_sync._save_and_broadcast", new_callable=AsyncMock)
+    @patch("dango.web.routes.initial_sync._sync_single_source", new_callable=AsyncMock)
+    @patch("dango.web.routes.initial_sync._generate_dbt_docs")
+    @patch("dango.web.routes.initial_sync._refresh_metabase")
+    @pytest.mark.anyio
+    async def test_dbt_docs_and_metabase_after_sync(
+        self, mock_mb, mock_dbt, mock_sync, mock_broadcast, tmp_path
+    ):
+        """dbt docs + Metabase run after successful sync."""
+        import dango.web.routes.initial_sync as mod
+
+        mod._sync_state = InitialSyncState()
+
+        with patch("dango.web.routes.initial_sync._check_disk_usage", return_value=None):
+            await mod._run_initial_sync(
+                tmp_path,
+                [{"name": "hubspot", "type": "hubspot"}],
+            )
+
+        mock_dbt.assert_called_once_with(tmp_path)
+        mock_mb.assert_called_once_with(tmp_path)
+
+    @patch("dango.web.routes.initial_sync._save_and_broadcast", new_callable=AsyncMock)
+    @patch("dango.web.routes.initial_sync._sync_single_source", new_callable=AsyncMock)
+    @patch("dango.web.routes.initial_sync._generate_dbt_docs")
+    @patch("dango.web.routes.initial_sync._refresh_metabase")
+    @pytest.mark.anyio
+    async def test_post_sync_skipped_on_all_failures(
+        self, mock_mb, mock_dbt, mock_sync, mock_broadcast, tmp_path
+    ):
+        """Post-sync phases skipped if all sources failed."""
+        import dango.web.routes.initial_sync as mod
+
+        mod._sync_state = InitialSyncState()
+        mock_sync.side_effect = RuntimeError("fail")
+
+        with patch("dango.web.routes.initial_sync._check_disk_usage", return_value=None):
+            await mod._run_initial_sync(
+                tmp_path,
+                [{"name": "hubspot", "type": "hubspot"}],
+            )
+
+        mock_dbt.assert_not_called()
+        mock_mb.assert_not_called()
+        assert mod._sync_state.phase == SyncPhase.COMPLETE


### PR DESCRIPTION
## Summary

- **TASK-029 — Deployment Wizard:** `dango deploy` now runs an interactive 9-step wizard (region, size, domain, admin credentials, backups) or accepts `--non-interactive` flags for CI. Provisioning orchestrates SSH key gen, droplet creation, firewall, server setup, file sync, secrets push, admin creation, and service startup — with `_ResourceTracker` cleanup on failure (no orphaned DO resources). Also adds `--reconnect --ip X` mode and `create_bucket()` to `SpacesClient`.
- **TASK-107 — Initial Sync Workflow:** Background task syncs all configured sources sequentially after deployment, with `SyncPhase` state machine persisted to JSON (survives server restarts). Four API endpoints (`/start`, `/status`, `/skip-source`, `/cancel`) with one-time deploy token auth. Dashboard gets an Alpine.js progress banner with real-time WebSocket updates, skip/cancel controls, and disk usage checks (abort at 90%).

## Test plan

- [x] 61 new unit tests across 3 files (wizard validation, provisioning sequence, sync state machine, API endpoints, deploy token)
- [x] All 1840 tests pass
- [x] ruff check + format clean
- [x] mypy clean (0 errors)
- [x] File sizes within limits
- [ ] Manual E2E: `dango deploy` → full wizard → verify dashboard sync banner → `dango deploy destroy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)