### PR TITLE
Add remote resize, migrate, and upgrade commands (TASK-104, 105, 106)

### DIFF
--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -643,6 +643,7 @@ def domain_remove(ctx: click.Context) -> None:
 # ---------------------------------------------------------------------------
 
 import dango.cli.commands.remote_mgmt as _remote_mgmt  # noqa: E402, F401
+import dango.cli.commands.remote_ops as _remote_ops  # noqa: E402, F401
 from dango.cli.commands.remote_backup import backup_group  # noqa: E402
 from dango.cli.commands.remote_env import env  # noqa: E402
 

--- a/dango/cli/commands/remote_ops.py
+++ b/dango/cli/commands/remote_ops.py
@@ -1,0 +1,491 @@
+"""dango/cli/commands/remote_ops.py
+
+Remote operations: resize, migrate, and upgrade commands.
+
+These commands are registered on the ``remote`` group defined in
+``remote.py`` via ``@remote.command()`` decorators.  The parent module
+triggers registration by importing this module at the bottom of ``remote.py``.
+"""
+
+from __future__ import annotations
+
+import click
+
+from dango.cli import console
+from dango.cli.commands.remote import remote
+
+# ---------------------------------------------------------------------------
+# dango remote upgrade
+# ---------------------------------------------------------------------------
+
+
+@remote.command("upgrade")
+@click.option(
+    "--version",
+    "target_version",
+    default=None,
+    help="Specific version to install (e.g. 1.2.3). Defaults to latest on PyPI.",
+)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+@click.option("--skip-backup", is_flag=True, help="Skip the pre-upgrade backup.")
+@click.pass_context
+def remote_upgrade(
+    ctx: click.Context,
+    target_version: str | None,
+    yes: bool,
+    skip_backup: bool,
+) -> None:
+    """Upgrade Dango on the remote server."""
+    from rich.status import Status
+
+    from dango.cli.commands.remote import _load_cloud_config_with_ssh_or_fail
+    from dango.platform.cloud.upgrade import (
+        UpgradeResult,
+        check_versions,
+        upgrade_dango,
+        validate_version_string,
+    )
+
+    # Validate version early (before SSH connection)
+    if target_version is not None:
+        try:
+            validate_version_string(target_version)
+        except Exception as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise SystemExit(1) from exc
+
+    cloud_cfg, ssh = _load_cloud_config_with_ssh_or_fail(ctx)
+
+    try:
+        # Show current vs target version
+        console.print("[bold]Checking versions...[/bold]")
+        current, latest = check_versions(ssh)
+
+        display_target = target_version or latest or "unknown"
+        console.print(f"  Current version: [cyan]{current or 'unknown'}[/cyan]")
+        console.print(f"  Target version:  [cyan]{display_target}[/cyan]")
+
+        if current == display_target:
+            console.print("\n[green]Already at target version — no upgrade needed.[/green]")
+            return
+
+        if not latest and target_version is None:
+            console.print(
+                "\n[red]Error:[/red] Could not determine latest version from PyPI. "
+                "Specify a version with --version."
+            )
+            raise SystemExit(1)
+
+        # Confirm
+        if not yes:
+            console.print()
+            if skip_backup:
+                console.print("[yellow]Warning:[/yellow] Pre-upgrade backup will be skipped.")
+            if not click.confirm("Proceed with upgrade?"):
+                console.print("[yellow]Upgrade cancelled.[/yellow]")
+                return
+
+        # Execute upgrade
+        with Status("[bold blue]Upgrading...", console=console) as status:
+
+            def _on_progress(step: str, step_status: str) -> None:
+                if step_status == "running":
+                    labels: dict[str, str] = {
+                        "check_version": "Checking current version...",
+                        "check_pypi": "Checking latest PyPI version...",
+                        "backup": "Creating pre-upgrade backup...",
+                        "stop_services": "Stopping services...",
+                        "pip_install": "Installing new version...",
+                        "migrations": "Running migrations...",
+                        "docker_rebuild": "Rebuilding Docker images...",
+                        "start_services": "Starting services...",
+                        "verify_health": "Verifying health...",
+                    }
+                    status.update(f"[bold blue]{labels.get(step, step)}")
+
+            result: UpgradeResult = upgrade_dango(
+                ssh,
+                version=target_version,
+                skip_backup=skip_backup,
+                on_progress=_on_progress,
+            )
+
+        # Show results
+        console.print()
+        if result.health_check_passed:
+            console.print("[green]Upgrade complete.[/green]")
+        else:
+            console.print("[yellow]Upgrade complete with warnings.[/yellow]")
+
+        console.print(
+            f"  Version: [cyan]{result.old_version}[/cyan] → [cyan]{result.new_version}[/cyan]"
+        )
+        console.print(f"  Duration: {result.duration_seconds}s")
+        if result.backup_path:
+            console.print(f"  Backup: {result.backup_path}")
+        if result.migrations_run:
+            console.print("  Migrations: applied")
+        if result.docker_rebuilt:
+            console.print("  Docker: rebuilt")
+
+        for warning in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {warning}")
+
+        if not result.health_check_passed:
+            console.print(
+                "\n[yellow]Health check failed.[/yellow] "
+                "Run [bold]dango remote rollback[/bold] to restore the previous version."
+            )
+
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Upgrade failed: {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# dango remote resize
+# ---------------------------------------------------------------------------
+
+
+@remote.command("resize")
+@click.argument("size", required=False, default=None)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+@click.pass_context
+def remote_resize(ctx: click.Context, size: str | None, yes: bool) -> None:
+    """Resize the remote server (change CPU/RAM).
+
+    If SIZE is omitted, shows current spec and available tiers.
+    If SIZE is provided, resizes the droplet to that size slug.
+    """
+    from rich.status import Status
+    from rich.table import Table
+
+    from dango.cli.commands.remote import (
+        _load_cloud_config_with_ssh_or_fail,
+        _make_client,
+        _require_cloud_deployment,
+    )
+    from dango.platform.cloud.provisioning import (
+        SIZE_TIERS,
+        get_size_tier,
+        save_provisioning_metadata,
+    )
+    from dango.platform.cloud.resize import (
+        ResizeResult,
+        get_disk_warning,
+        resize_droplet,
+        validate_size_slug,
+    )
+
+    cloud_cfg, project_root = _require_cloud_deployment(ctx)
+
+    if size is None:
+        # Info mode: show current spec and available tiers
+        current_tier = get_size_tier(cloud_cfg.size)
+        console.print("[bold]Current server spec:[/bold]")
+        if current_tier:
+            console.print(
+                f"  {current_tier.name} ({current_tier.slug}) — "
+                f"{current_tier.vcpus} vCPU, {current_tier.ram_gb} GB RAM, "
+                f"{current_tier.disk_gb} GB disk, ${current_tier.price_monthly}/mo"
+            )
+        else:
+            console.print(f"  {cloud_cfg.size} (custom size)")
+
+        console.print("\n[bold]Available tiers:[/bold]")
+        table = Table(show_header=True)
+        table.add_column("Name")
+        table.add_column("Slug")
+        table.add_column("vCPUs")
+        table.add_column("RAM (GB)")
+        table.add_column("Disk (GB)")
+        table.add_column("Price/mo")
+        for tier in SIZE_TIERS:
+            marker = " ←" if tier.slug == cloud_cfg.size else ""
+            table.add_row(
+                f"{tier.name}{marker}",
+                tier.slug,
+                str(tier.vcpus),
+                str(tier.ram_gb),
+                str(tier.disk_gb),
+                f"${tier.price_monthly}",
+            )
+        console.print(table)
+        console.print("\nTo resize: [bold]dango remote resize <SIZE_SLUG>[/bold]")
+        return
+
+    # Resize mode: validate and execute
+    try:
+        validate_size_slug(size)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    # Show current vs new comparison
+    current_tier = get_size_tier(cloud_cfg.size)
+    new_tier = get_size_tier(size)
+
+    console.print("[bold]Resize plan:[/bold]")
+    if current_tier:
+        console.print(
+            f"  Current: {current_tier.name} ({current_tier.slug}) — "
+            f"{current_tier.vcpus} vCPU, {current_tier.ram_gb} GB RAM, "
+            f"${current_tier.price_monthly}/mo"
+        )
+    else:
+        console.print(f"  Current: {cloud_cfg.size}")
+    if new_tier:
+        console.print(
+            f"  New:     {new_tier.name} ({new_tier.slug}) — "
+            f"{new_tier.vcpus} vCPU, {new_tier.ram_gb} GB RAM, "
+            f"${new_tier.price_monthly}/mo"
+        )
+    else:
+        console.print(f"  New:     {size}")
+
+    # Disk warning
+    disk_warning = get_disk_warning(cloud_cfg.size, size)
+    if disk_warning:
+        console.print(f"\n  [yellow]Warning:[/yellow] {disk_warning}")
+
+    console.print(
+        "\n[yellow]Note:[/yellow] The server will be powered off during resize. "
+        "Expect 1-3 minutes of downtime."
+    )
+
+    if not yes:
+        if not click.confirm("\nProceed with resize?"):
+            console.print("[yellow]Resize cancelled.[/yellow]")
+            return
+
+    # Connect SSH + DO client
+    cloud_cfg_ssh, ssh = _load_cloud_config_with_ssh_or_fail(ctx)
+    client = _make_client()
+
+    try:
+        with Status("[bold blue]Resizing...", console=console) as status:
+
+            def _on_progress(step: str, step_status: str) -> None:
+                if step_status == "running":
+                    labels: dict[str, str] = {
+                        "backup": "Creating pre-resize backup...",
+                        "power_off": "Powering off droplet...",
+                        "resize": "Resizing droplet...",
+                        "power_on": "Powering on droplet...",
+                        "wait_active": "Waiting for droplet...",
+                        "wait_ssh": "Waiting for SSH...",
+                        "dbt_profiles": "Regenerating dbt profiles...",
+                        "start_services": "Starting services...",
+                        "verify_health": "Verifying health...",
+                    }
+                    status.update(f"[bold blue]{labels.get(step, step)}")
+
+            result: ResizeResult = resize_droplet(
+                client,
+                ssh,
+                cloud_cfg.droplet_id,
+                size,
+                dbt_overrides=cloud_cfg.dbt_overrides,
+                on_progress=_on_progress,
+            )
+
+        # Update cloud.yml
+        save_provisioning_metadata(
+            project_root,
+            droplet_id=cloud_cfg.droplet_id,
+            droplet_ip=cloud_cfg.droplet_ip,
+            region=cloud_cfg.region,
+            size=size,
+        )
+
+        # Show results
+        console.print()
+        console.print("[green]Resize complete.[/green]")
+        console.print(f"  Size: [cyan]{result.old_size}[/cyan] → [cyan]{result.new_size}[/cyan]")
+        console.print(f"  Duration: {result.duration_seconds}s")
+        if result.backup_path:
+            console.print(f"  Backup: {result.backup_path}")
+        if result.dbt_profiles_regenerated:
+            console.print("  dbt profiles.yml: regenerated")
+
+        for warning in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {warning}")
+
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Resize failed: {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# dango remote migrate
+# ---------------------------------------------------------------------------
+
+
+@remote.command("migrate")
+@click.option("--size", required=True, help="Size slug for the new server.")
+@click.option(
+    "--region",
+    default=None,
+    help="Region slug for the new server. Defaults to current region.",
+)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+@click.pass_context
+def remote_migrate(
+    ctx: click.Context,
+    size: str,
+    region: str | None,
+    yes: bool,
+) -> None:
+    """Migrate to a new server (new droplet for disk/region changes).
+
+    Creates a new server, transfers data via Spaces, and destroys the old
+    server after verification. Requires Spaces to be configured.
+    """
+    from rich.status import Status
+
+    from dango.cli.commands.remote import (
+        _connect_ssh,
+        _make_client,
+        _require_cloud_deployment,
+    )
+    from dango.platform.cloud.migrate import migrate_server
+    from dango.platform.cloud.provisioning import (
+        get_region_info,
+        get_size_tier,
+    )
+    from dango.platform.cloud.resize import validate_size_slug
+
+    cloud_cfg, project_root = _require_cloud_deployment(ctx)
+
+    # Validate size
+    try:
+        validate_size_slug(size)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    # Require Spaces
+    if cloud_cfg.spaces is None:
+        console.print(
+            "[red]Error:[/red] Migration requires Spaces for data transfer.\n"
+            "Configure Spaces first with: [bold]dango remote backup enable[/bold]"
+        )
+        raise SystemExit(1)
+
+    effective_region = region or cloud_cfg.region
+
+    # Show plan
+    console.print("[bold]Migration plan:[/bold]")
+    current_tier = get_size_tier(cloud_cfg.size)
+    new_tier = get_size_tier(size)
+
+    if current_tier:
+        console.print(
+            f"  Current: {current_tier.name} ({current_tier.slug}) — "
+            f"{current_tier.vcpus} vCPU, {current_tier.ram_gb} GB RAM, "
+            f"${current_tier.price_monthly}/mo"
+        )
+    else:
+        console.print(f"  Current: {cloud_cfg.size}")
+
+    if new_tier:
+        console.print(
+            f"  New:     {new_tier.name} ({new_tier.slug}) — "
+            f"{new_tier.vcpus} vCPU, {new_tier.ram_gb} GB RAM, "
+            f"${new_tier.price_monthly}/mo"
+        )
+    else:
+        console.print(f"  New:     {size}")
+
+    console.print(f"  Region:  {cloud_cfg.region} → {effective_region}")
+    region_info = get_region_info(effective_region)
+    if region_info:
+        extra = " (GDPR)" if region_info.gdpr else ""
+        console.print(f"           {region_info.city}, {region_info.country}{extra}")
+
+    console.print(
+        "\n[yellow]Warning:[/yellow] This creates a new server and destroys the old one.\n"
+        "  Downtime: ~5-15 minutes."
+    )
+
+    if cloud_cfg.domain:
+        console.print(
+            f"\n[yellow]Note:[/yellow] Domain [bold]{cloud_cfg.domain}[/bold] will be "
+            "configured on the new server. Update your DNS A record to the new IP."
+        )
+
+    if not yes:
+        if not click.confirm("\nProceed with migration?"):
+            console.print("[yellow]Migration cancelled.[/yellow]")
+            return
+
+    # Connect to old server
+    client = _make_client()
+    old_ssh = _connect_ssh(cloud_cfg, project_root)
+
+    try:
+        with Status("[bold blue]Migrating...", console=console) as status:
+
+            def _on_progress(step: str, step_status: str) -> None:
+                if step_status == "running":
+                    labels: dict[str, str] = {
+                        "backup": "Creating backup on old server...",
+                        "upload_spaces": "Uploading backup to Spaces...",
+                        "provision": "Provisioning new server...",
+                        "setup_server": "Setting up new server...",
+                        "copy_secrets": "Copying secrets...",
+                        "download_spaces": "Downloading backup on new server...",
+                        "restore": "Restoring data on new server...",
+                        "domain": "Configuring domain...",
+                        "firewall": "Updating firewall...",
+                        "verify_health": "Verifying health...",
+                        "cleanup": "Cleaning up old server...",
+                    }
+                    status.update(f"[bold blue]{labels.get(step, step)}")
+
+            result = migrate_server(
+                client,
+                old_ssh,
+                cloud_cfg,
+                size,
+                effective_region,
+                project_root=project_root,
+                on_progress=_on_progress,
+            )
+
+        # Show results
+        console.print()
+        if result.old_droplet_destroyed:
+            console.print("[green]Migration complete.[/green]")
+        else:
+            console.print("[yellow]Migration complete with warnings.[/yellow]")
+
+        console.print(f"  New droplet: {result.new_droplet_id} ({result.new_droplet_ip})")
+        console.print(f"  Region: {result.new_region}")
+        console.print(f"  Size: {result.new_size}")
+        console.print(f"  Duration: {result.duration_seconds}s")
+
+        if result.dns_updated and cloud_cfg.domain:
+            console.print(
+                f"\n[yellow]Action required:[/yellow] Update DNS A record for "
+                f"[bold]{cloud_cfg.domain}[/bold] to [bold]{result.new_droplet_ip}[/bold]"
+            )
+
+        for warning in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {warning}")
+
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Migration failed: {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        old_ssh.disconnect()

--- a/dango/cli/commands/remote_ops.py
+++ b/dango/cli/commands/remote_ops.py
@@ -172,7 +172,6 @@ def remote_resize(ctx: click.Context, size: str | None, yes: bool) -> None:
     from dango.platform.cloud.provisioning import (
         SIZE_TIERS,
         get_size_tier,
-        save_provisioning_metadata,
     )
     from dango.platform.cloud.resize import (
         ResizeResult,
@@ -263,7 +262,7 @@ def remote_resize(ctx: click.Context, size: str | None, yes: bool) -> None:
             return
 
     # Connect SSH + DO client
-    cloud_cfg_ssh, ssh = _load_cloud_config_with_ssh_or_fail(ctx)
+    _, ssh = _load_cloud_config_with_ssh_or_fail(ctx)
     client = _make_client()
 
     try:
@@ -291,16 +290,9 @@ def remote_resize(ctx: click.Context, size: str | None, yes: bool) -> None:
                 size,
                 dbt_overrides=cloud_cfg.dbt_overrides,
                 on_progress=_on_progress,
+                project_root=project_root,
+                region=cloud_cfg.region,
             )
-
-        # Update cloud.yml
-        save_provisioning_metadata(
-            project_root,
-            droplet_id=cloud_cfg.droplet_id,
-            droplet_ip=cloud_cfg.droplet_ip,
-            region=cloud_cfg.region,
-            size=size,
-        )
 
         # Show results
         console.print()

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -39,6 +39,9 @@ platform/
 │   ├── file_sync.py     # Project file sync: SFTP + rsync (TASK-028)
 │   ├── deployer.py      # Push deployment workflow + deploy lock (TASK-030)
 │   ├── scheduled_backup.py  # Server-side scheduled backup (TASK-103)
+│   ├── resize.py        # In-place resize (power off → resize → power on) (TASK-104)
+│   ├── migrate.py       # Server migration (new droplet via Spaces) (TASK-105)
+│   ├── upgrade.py       # Remote Dango version upgrade (TASK-106)
 │   └── _server_templates.py  # Config file templates (incl. build_caddyfile(), backup timer)
 │
 │   # Backwards-compatible shims (re-export from local/)
@@ -69,6 +72,9 @@ platform/
 | `cloud/file_sync.py` | Project file sync (SFTP + rsync) with change detection | `sync_project_files`, `SyncResult` |
 | `cloud/deployer.py` | Push deployment workflow with deploy lock | `push_deploy`, `DeployLock`, `DeployResult` |
 | `cloud/scheduled_backup.py` | Server-side scheduled backup to Spaces | `run_scheduled_backup`, `list_spaces_backups`, `restore_from_spaces`, `enable_scheduled_backup`, `disable_scheduled_backup` |
+| `cloud/resize.py` | In-place droplet resize (power off → resize → power on, regenerate dbt profiles) | `resize_droplet`, `ResizeResult`, `validate_size_slug`, `generate_dbt_profiles_yml`, `regenerate_dbt_profiles`, `get_disk_warning` |
+| `cloud/migrate.py` | Server migration via Spaces (new droplet, transfer data, destroy old) | `migrate_server`, `MigrateResult` |
+| `cloud/upgrade.py` | Remote Dango version upgrade (pip install, migrations, Docker rebuild) | `upgrade_dango`, `UpgradeResult`, `validate_version_string`, `check_versions` |
 | `cloud/_server_templates.py` | Config file templates (systemd, Caddy, fail2ban, backup timer, etc.) | `build_caddyfile`, `SYSTEMD_UNIT`, `CADDYFILE`, `SYSTEMD_BACKUP_SERVICE`, `SYSTEMD_BACKUP_TIMER`, etc. |
 
 ## Import Patterns
@@ -116,6 +122,17 @@ from dango.platform.cloud.deployer import DeployLock, DeployResult, push_deploy 
 
 # Scheduled backup (TASK-103, runs on server)
 from dango.platform.cloud.scheduled_backup import run_scheduled_backup, list_spaces_backups
+
+# Resize (TASK-104)
+from dango.platform.cloud import resize_droplet, ResizeResult, validate_size_slug
+from dango.platform.cloud.resize import generate_dbt_profiles_yml, regenerate_dbt_profiles
+
+# Migrate (TASK-105)
+from dango.platform.cloud import migrate_server, MigrateResult
+
+# Upgrade (TASK-106)
+from dango.platform.cloud import upgrade_dango, UpgradeResult, validate_version_string
+from dango.platform.cloud.upgrade import check_versions
 ```
 
 ### Also valid (backwards-compatible shims):
@@ -156,6 +173,10 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | Sync files to remote | `cloud/file_sync.py` → `sync_project_files()` | `pytest tests/unit/test_file_sync.py` |
 | Push deploy to remote | `cloud/deployer.py` → `push_deploy()` | `pytest tests/unit/test_deployer.py` |
 | Scheduled backup (server-side) | `cloud/scheduled_backup.py` → `run_scheduled_backup()` | `pytest tests/unit/test_scheduled_backup.py` |
+| Resize droplet | `cloud/resize.py` → `resize_droplet()` | `pytest tests/unit/test_resize.py` |
+| Migrate to new server | `cloud/migrate.py` → `migrate_server()` | `pytest tests/unit/test_migrate.py` |
+| Upgrade remote Dango | `cloud/upgrade.py` → `upgrade_dango()` | `pytest tests/unit/test_upgrade.py` |
+| CLI resize/migrate/upgrade | `cli/commands/remote_ops.py` | `pytest tests/unit/test_remote_ops_cli.py` |
 | CLI backup commands | `cli/commands/remote_backup.py` | `pytest tests/unit/test_remote_backup_cli.py` |
 | Modify watcher logic | `local/watcher.py` | `pytest tests/unit/test_watcher_lifecycle.py` |
 | Change Docker service startup | `docker.py` | `dango start` manually |
@@ -188,4 +209,5 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - `dango.cli.commands.serve` — production foreground server
 - `dango.cli.commands.remote` — rollback command
 - `dango.cli.commands.remote_backup` — backup subcommands
+- `dango.cli.commands.remote_ops` — resize, migrate, upgrade commands
 - `dango.web.routes.health` — get_watcher_status

--- a/dango/platform/cloud/__init__.py
+++ b/dango/platform/cloud/__init__.py
@@ -14,6 +14,9 @@ from .backup import (
     list_local_backups,
     rollback,
     rotate_local_backups,
+    start_services,
+    stop_services,
+    verify_health,
 )
 from .deployer import DeployLock, DeployResult, push_deploy
 from .digitalocean import DigitalOceanClient
@@ -116,6 +119,9 @@ __all__ = [
     "list_local_backups",
     "rollback",
     "rotate_local_backups",
+    "stop_services",
+    "start_services",
+    "verify_health",
     # File sync (TASK-028)
     "SyncResult",
     "sync_project_files",

--- a/dango/platform/cloud/__init__.py
+++ b/dango/platform/cloud/__init__.py
@@ -30,6 +30,7 @@ from .firewall import (
     save_firewall_metadata,
     validate_ip_or_cidr,
 )
+from .migrate import MigrateResult, migrate_server
 from .provisioning import (
     BUDGET_TIER,
     DEFAULT_TIER,
@@ -48,6 +49,7 @@ from .provisioning import (
     wait_for_droplet_ready,
     wait_for_ssh,
 )
+from .resize import ResizeResult, resize_droplet, validate_size_slug
 from .server_setup import SetupResult, setup_server
 from .server_status import (
     ServerStatus,
@@ -58,6 +60,7 @@ from .server_status import (
 )
 from .spaces import SpacesClient
 from .ssh import CommandResult, SSHManager
+from .upgrade import UpgradeResult, upgrade_dango, validate_version_string
 
 __all__ = [
     "CommandResult",
@@ -120,4 +123,15 @@ __all__ = [
     "DeployLock",
     "DeployResult",
     "push_deploy",
+    # Resize (TASK-104)
+    "ResizeResult",
+    "resize_droplet",
+    "validate_size_slug",
+    # Migrate (TASK-105)
+    "MigrateResult",
+    "migrate_server",
+    # Upgrade (TASK-106)
+    "UpgradeResult",
+    "upgrade_dango",
+    "validate_version_string",
 ]

--- a/dango/platform/cloud/backup.py
+++ b/dango/platform/cloud/backup.py
@@ -108,18 +108,19 @@ def _check_disk_space(ssh: SSHManager, required_mb: int = 500) -> None:
             )
 
 
-def _stop_services(ssh: SSHManager) -> None:
-    """Stop dango-web and Metabase to ensure no concurrent writes."""
-    _run_checked(ssh, "systemctl stop dango-web || true", step="stop_services", timeout=60)
-    _run_checked(
-        ssh,
+def stop_services(ssh: SSHManager) -> None:
+    """Stop dango-web and Metabase to ensure no concurrent writes.
+
+    Best-effort — does not raise if services are already stopped.
+    """
+    ssh.exec_command("systemctl stop dango-web || true", timeout=60)
+    ssh.exec_command(
         f"docker compose -f {PROJECT_DIR}/docker-compose.yml stop metabase 2>/dev/null || true",
-        step="stop_services",
         timeout=120,
     )
 
 
-def _start_services(ssh: SSHManager) -> None:
+def start_services(ssh: SSHManager) -> None:
     """Start Metabase then dango-web (reverse order of stop)."""
     ssh.exec_command(
         f"docker compose -f {PROJECT_DIR}/docker-compose.yml start metabase 2>/dev/null || true",
@@ -244,7 +245,7 @@ def _create_archive(
     return archive_path, manifest
 
 
-def _verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
+def verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
     """Poll the health endpoint until it responds OK or timeout."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -283,7 +284,7 @@ def create_backup(
     _notify(on_progress, "check_disk_space", "done")
 
     _notify(on_progress, "stop_services", "running")
-    _stop_services(ssh)
+    stop_services(ssh)
     _notify(on_progress, "stop_services", "done")
 
     try:
@@ -306,7 +307,7 @@ def create_backup(
     finally:
         if restart_services:
             _notify(on_progress, "start_services", "running")
-            _start_services(ssh)
+            start_services(ssh)
             _notify(on_progress, "start_services", "done")
 
     _notify(on_progress, "rotate_backups", "running")
@@ -388,7 +389,7 @@ def restore_from_archive(
         _notify(on_progress, "read_manifest", "done")
 
     _notify(on_progress, "stop_services", "running")
-    _stop_services(ssh)
+    stop_services(ssh)
     _notify(on_progress, "stop_services", "done")
 
     services_restarted = False
@@ -441,12 +442,12 @@ def restore_from_archive(
         ssh.exec_command(f"rm -rf {staging}")
     finally:
         _notify(on_progress, "start_services", "running")
-        _start_services(ssh)
+        start_services(ssh)
         services_restarted = True
         _notify(on_progress, "start_services", "done")
 
     _notify(on_progress, "verify_health", "running")
-    health_ok = _verify_health(ssh)
+    health_ok = verify_health(ssh)
     if not health_ok:
         warnings.append("Health check did not pass within 90 seconds")
     _notify(on_progress, "verify_health", "done")

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -204,7 +204,7 @@ def _start_web_service(ssh: SSHManager) -> None:
 
 
 def _start_all_services(ssh: SSHManager) -> None:
-    """Start Metabase then dango-web (same order as backup._start_services)."""
+    """Start Metabase then dango-web (same order as backup.start_services)."""
     ssh.exec_command(
         f"docker compose -f {REMOTE_PROJECT_DIR}/docker-compose.yml "
         "start metabase 2>/dev/null || true",

--- a/dango/platform/cloud/digitalocean.py
+++ b/dango/platform/cloud/digitalocean.py
@@ -310,6 +310,63 @@ class DigitalOceanClient:
         return self.droplet_action(droplet_id, "resize", size=size)
 
     # ------------------------------------------------------------------
+    # Action polling
+    # ------------------------------------------------------------------
+
+    def get_action(self, action_id: int) -> dict[str, Any]:
+        """Retrieve an action by ID.
+
+        Returns:
+            The ``action`` object from the DO API response.
+        """
+        response = self._request_with_retry("GET", f"/actions/{action_id}")
+        data: dict[str, Any] = response.json()
+        return cast(dict[str, Any], data["action"])
+
+    def wait_for_action(
+        self,
+        action_id: int,
+        *,
+        poll_interval: float = 5.0,
+        timeout: float = 300.0,
+    ) -> dict[str, Any]:
+        """Poll an action until ``status='completed'``.
+
+        Args:
+            action_id: DO action ID to poll.
+            poll_interval: Seconds between polls. Default: 5.
+            timeout: Maximum seconds to wait. Default: 300.
+
+        Returns:
+            The completed ``action`` object.
+
+        Raises:
+            CloudError: If action enters ``'errored'`` status or timeout
+                elapses before completion.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            action = self.get_action(action_id)
+            status = action.get("status", "")
+
+            if status == "completed":
+                return action
+
+            if status == "errored":
+                raise CloudError(
+                    f"Action {action_id} entered 'errored' status.",
+                    error_code="DANGO-D013",
+                )
+
+            if time.monotonic() >= deadline:
+                raise CloudError(
+                    f"Action {action_id} timed out after {timeout}s (last status: {status!r}).",
+                    error_code="DANGO-D014",
+                )
+
+            time.sleep(poll_interval)
+
+    # ------------------------------------------------------------------
     # SSH Key operations
     # ------------------------------------------------------------------
 

--- a/dango/platform/cloud/migrate.py
+++ b/dango/platform/cloud/migrate.py
@@ -61,8 +61,8 @@ def _upload_backup_to_spaces(
 ) -> str:
     """Upload a backup archive to Spaces from the remote server via SSH.
 
-    Runs a short Python script on the server that uses ``boto3`` (available
-    in the dango venv) to upload the archive.
+    Writes a Python script to the server and executes it.  Uses ``repr()``
+    for all interpolated values to prevent injection.
 
     Returns:
         The Spaces object key for the uploaded archive.
@@ -70,24 +70,28 @@ def _upload_backup_to_spaces(
     archive_name = archive_path.rsplit("/", 1)[-1]
     spaces_key = f"migration/{archive_name}"
 
-    bucket = spaces_config.bucket
     region = spaces_config.region or "nyc3"
-    access_key_env = spaces_config.access_key_env
-    secret_key_env = spaces_config.secret_key_env
+    endpoint = f"https://{region}.digitaloceanspaces.com"
 
-    upload_script = (
-        f"import boto3, os; "
-        f"s3 = boto3.client('s3', region_name='{region}', "
-        f"endpoint_url='https://{region}.digitaloceanspaces.com', "
-        f"aws_access_key_id=os.environ['{access_key_env}'], "
-        f"aws_secret_access_key=os.environ['{secret_key_env}']); "
-        f"s3.upload_file('{archive_path}', '{bucket}', '{spaces_key}')"
+    script = (
+        "import boto3, os\n"
+        f"s3 = boto3.client('s3', region_name={region!r},\n"
+        f"    endpoint_url={endpoint!r},\n"
+        f"    aws_access_key_id=os.environ[{spaces_config.access_key_env!r}],\n"
+        f"    aws_secret_access_key=os.environ[{spaces_config.secret_key_env!r}])\n"
+        f"s3.upload_file({archive_path!r}, {spaces_config.bucket!r}, {spaces_key!r})\n"
     )
 
-    result = ssh.exec_command(
-        f'source {_PROJECT_DIR}/.env 2>/dev/null; /srv/dango/venv/bin/python -c "{upload_script}"',
-        timeout=600,
-    )
+    script_path = "/tmp/_dango_upload.py"
+    ssh.write_remote_file(script_path, script, mode=0o600)
+    try:
+        result = ssh.exec_command(
+            f"source {_PROJECT_DIR}/.env 2>/dev/null && /srv/dango/venv/bin/python {script_path}",
+            timeout=600,
+        )
+    finally:
+        ssh.exec_command(f"rm -f {script_path}")
+
     if not result.success:
         raise CloudProvisioningError(
             f"Failed to upload backup to Spaces (exit {result.exit_code}): "
@@ -103,32 +107,38 @@ def _download_backup_from_spaces(
 ) -> str:
     """Download a backup archive from Spaces to the remote server via SSH.
 
+    Writes a Python script to the server and executes it.  Uses ``repr()``
+    for all interpolated values to prevent injection.
+
     Returns:
         The local path of the downloaded archive on the server.
     """
     archive_name = spaces_key.rsplit("/", 1)[-1]
     local_path = f"/srv/dango/backups/deploy/{archive_name}"
 
-    bucket = spaces_config.bucket
     region = spaces_config.region or "nyc3"
-    access_key_env = spaces_config.access_key_env
-    secret_key_env = spaces_config.secret_key_env
+    endpoint = f"https://{region}.digitaloceanspaces.com"
 
-    download_script = (
-        f"import boto3, os; "
-        f"os.makedirs('/srv/dango/backups/deploy', exist_ok=True); "
-        f"s3 = boto3.client('s3', region_name='{region}', "
-        f"endpoint_url='https://{region}.digitaloceanspaces.com', "
-        f"aws_access_key_id=os.environ['{access_key_env}'], "
-        f"aws_secret_access_key=os.environ['{secret_key_env}']); "
-        f"s3.download_file('{bucket}', '{spaces_key}', '{local_path}')"
+    script = (
+        "import boto3, os\n"
+        "os.makedirs('/srv/dango/backups/deploy', exist_ok=True)\n"
+        f"s3 = boto3.client('s3', region_name={region!r},\n"
+        f"    endpoint_url={endpoint!r},\n"
+        f"    aws_access_key_id=os.environ[{spaces_config.access_key_env!r}],\n"
+        f"    aws_secret_access_key=os.environ[{spaces_config.secret_key_env!r}])\n"
+        f"s3.download_file({spaces_config.bucket!r}, {spaces_key!r}, {local_path!r})\n"
     )
 
-    result = ssh.exec_command(
-        f"source {_PROJECT_DIR}/.env 2>/dev/null; "
-        f'/srv/dango/venv/bin/python -c "{download_script}"',
-        timeout=600,
-    )
+    script_path = "/tmp/_dango_download.py"
+    ssh.write_remote_file(script_path, script, mode=0o600)
+    try:
+        result = ssh.exec_command(
+            f"source {_PROJECT_DIR}/.env 2>/dev/null && /srv/dango/venv/bin/python {script_path}",
+            timeout=600,
+        )
+    finally:
+        ssh.exec_command(f"rm -f {script_path}")
+
     if not result.success:
         raise CloudProvisioningError(
             f"Failed to download backup from Spaces (exit {result.exit_code}): "
@@ -186,16 +196,6 @@ def _update_firewall_droplets(
     )
 
 
-def _verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
-    """Poll the health endpoint until it responds OK or timeout."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if ssh.exec_command("curl -sf http://localhost:8800/api/health", timeout=10).success:
-            return True
-        time.sleep(5)
-    return False
-
-
 def migrate_server(
     client: DigitalOceanClient,
     old_ssh: SSHManager,
@@ -238,7 +238,7 @@ def migrate_server(
         CloudError: If Spaces is not configured or validation fails.
         CloudProvisioningError: If any step fails.
     """
-    from dango.platform.cloud.backup import create_backup, restore_from_archive
+    from dango.platform.cloud.backup import create_backup, restore_from_archive, verify_health
     from dango.platform.cloud.provisioning import (
         provision_droplet,
         save_provisioning_metadata,
@@ -345,7 +345,7 @@ def migrate_server(
 
         # 12. Verify health
         _notify(on_progress, "verify_health", "running")
-        health_ok = _verify_health(new_ssh)
+        health_ok = verify_health(new_ssh)
         _notify(on_progress, "verify_health", "done")
 
         # 13. Destroy old or keep both

--- a/dango/platform/cloud/migrate.py
+++ b/dango/platform/cloud/migrate.py
@@ -1,0 +1,418 @@
+"""dango/platform/cloud/migrate.py
+
+Server migration for Dango cloud deployments.
+
+Creates a new Droplet, transfers data via DigitalOcean Spaces, and (on
+success) destroys the old Droplet.  Used when disk size or region changes
+are needed, since DigitalOcean in-place resize cannot shrink disks or
+change regions.
+
+All functions require an already-connected ``SSHManager`` (as root on the
+old server).  A new SSH connection is established to the new server during
+migration.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from dango.exceptions import CloudError, CloudProvisioningError
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.digitalocean import DigitalOceanClient
+    from dango.platform.cloud.ssh import SSHManager
+
+_PROJECT_DIR = "/srv/dango/project"
+_SECRETS_FILES = [
+    f"{_PROJECT_DIR}/.env",
+    f"{_PROJECT_DIR}/.dlt/secrets.toml",
+]
+
+
+@dataclass
+class MigrateResult:
+    """Result returned by :func:`migrate_server`."""
+
+    old_droplet_id: int
+    new_droplet_id: int
+    new_droplet_ip: str
+    new_region: str
+    new_size: str
+    duration_seconds: float
+    old_droplet_destroyed: bool
+    dns_updated: bool
+    warnings: list[str] = field(default_factory=list)
+
+
+def _notify(callback: Callable[[str, str], None] | None, step: str, status: str) -> None:
+    """Call the progress callback if provided."""
+    if callback is not None:
+        callback(step, status)
+
+
+def _upload_backup_to_spaces(
+    ssh: SSHManager,
+    archive_path: str,
+    spaces_config: Any,
+) -> str:
+    """Upload a backup archive to Spaces from the remote server via SSH.
+
+    Runs a short Python script on the server that uses ``boto3`` (available
+    in the dango venv) to upload the archive.
+
+    Returns:
+        The Spaces object key for the uploaded archive.
+    """
+    archive_name = archive_path.rsplit("/", 1)[-1]
+    spaces_key = f"migration/{archive_name}"
+
+    bucket = spaces_config.bucket
+    region = spaces_config.region or "nyc3"
+    access_key_env = spaces_config.access_key_env
+    secret_key_env = spaces_config.secret_key_env
+
+    upload_script = (
+        f"import boto3, os; "
+        f"s3 = boto3.client('s3', region_name='{region}', "
+        f"endpoint_url='https://{region}.digitaloceanspaces.com', "
+        f"aws_access_key_id=os.environ['{access_key_env}'], "
+        f"aws_secret_access_key=os.environ['{secret_key_env}']); "
+        f"s3.upload_file('{archive_path}', '{bucket}', '{spaces_key}')"
+    )
+
+    result = ssh.exec_command(
+        f'source {_PROJECT_DIR}/.env 2>/dev/null; /srv/dango/venv/bin/python -c "{upload_script}"',
+        timeout=600,
+    )
+    if not result.success:
+        raise CloudProvisioningError(
+            f"Failed to upload backup to Spaces (exit {result.exit_code}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return spaces_key
+
+
+def _download_backup_from_spaces(
+    ssh: SSHManager,
+    spaces_key: str,
+    spaces_config: Any,
+) -> str:
+    """Download a backup archive from Spaces to the remote server via SSH.
+
+    Returns:
+        The local path of the downloaded archive on the server.
+    """
+    archive_name = spaces_key.rsplit("/", 1)[-1]
+    local_path = f"/srv/dango/backups/deploy/{archive_name}"
+
+    bucket = spaces_config.bucket
+    region = spaces_config.region or "nyc3"
+    access_key_env = spaces_config.access_key_env
+    secret_key_env = spaces_config.secret_key_env
+
+    download_script = (
+        f"import boto3, os; "
+        f"os.makedirs('/srv/dango/backups/deploy', exist_ok=True); "
+        f"s3 = boto3.client('s3', region_name='{region}', "
+        f"endpoint_url='https://{region}.digitaloceanspaces.com', "
+        f"aws_access_key_id=os.environ['{access_key_env}'], "
+        f"aws_secret_access_key=os.environ['{secret_key_env}']); "
+        f"s3.download_file('{bucket}', '{spaces_key}', '{local_path}')"
+    )
+
+    result = ssh.exec_command(
+        f"source {_PROJECT_DIR}/.env 2>/dev/null; "
+        f'/srv/dango/venv/bin/python -c "{download_script}"',
+        timeout=600,
+    )
+    if not result.success:
+        raise CloudProvisioningError(
+            f"Failed to download backup from Spaces (exit {result.exit_code}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return local_path
+
+
+def _copy_secrets_between_servers(
+    old_ssh: SSHManager,
+    new_ssh: SSHManager,
+) -> list[str]:
+    """Copy secret files from old server to new server via SFTP.
+
+    Downloads ``.env`` and ``.dlt/secrets.toml`` from the old server and
+    uploads them to the new server.
+
+    Returns:
+        List of warnings for missing files.
+    """
+    warnings: list[str] = []
+    for remote_path in _SECRETS_FILES:
+        content = old_ssh.exec_command(f"cat {remote_path} 2>/dev/null")
+        if not content.success or not content.stdout:
+            warnings.append(f"Secret file not found on old server: {remote_path}")
+            continue
+        # Ensure parent directory exists on new server
+        parent_dir = remote_path.rsplit("/", 1)[0]
+        new_ssh.exec_command(f"mkdir -p {parent_dir}")
+        new_ssh.write_remote_file(remote_path, content.stdout, mode=0o600)
+    return warnings
+
+
+def _update_firewall_droplets(
+    client: DigitalOceanClient,
+    firewall_id: str,
+    old_droplet_id: int,
+    new_droplet_id: int,
+) -> None:
+    """Swap old droplet for new in the firewall's droplet list."""
+    fw = client.get_firewall(firewall_id)
+    droplet_ids: list[int] = list(fw.get("droplet_ids", []))
+
+    if old_droplet_id in droplet_ids:
+        droplet_ids.remove(old_droplet_id)
+    if new_droplet_id not in droplet_ids:
+        droplet_ids.append(new_droplet_id)
+
+    client.update_firewall(
+        firewall_id=firewall_id,
+        name=fw["name"],
+        inbound_rules=fw.get("inbound_rules", []),
+        outbound_rules=fw.get("outbound_rules", []),
+        droplet_ids=droplet_ids,
+    )
+
+
+def _verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
+    """Poll the health endpoint until it responds OK or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ssh.exec_command("curl -sf http://localhost:8800/api/health", timeout=10).success:
+            return True
+        time.sleep(5)
+    return False
+
+
+def migrate_server(
+    client: DigitalOceanClient,
+    old_ssh: SSHManager,
+    old_config: Any,
+    new_size: str,
+    new_region: str,
+    *,
+    project_root: Path,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> MigrateResult:
+    """Migrate to a new server with different size/region.
+
+    Workflow:
+        1. Validate size and Spaces config
+        2. Create backup on old server
+        3. Upload backup to Spaces
+        4. Provision new droplet
+        5. Setup new server
+        6. Copy secrets from old → new
+        7. Download backup from Spaces on new server
+        8. Restore from archive on new server
+        9. Configure domain (if set)
+        10. Update firewall (if configured)
+        11. Verify health on new server
+        12. Destroy old droplet (if healthy) or keep both
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        old_ssh: Connected ``SSHManager`` to the old server (as root).
+        old_config: ``CloudConfig`` of the current deployment.
+        new_size: Target size slug for the new droplet.
+        new_region: Target region slug for the new droplet.
+        project_root: Local project root for saving updated config.
+        on_progress: Optional ``(step, status)`` callback.
+
+    Returns:
+        ``MigrateResult`` with migration details.
+
+    Raises:
+        CloudError: If Spaces is not configured or validation fails.
+        CloudProvisioningError: If any step fails.
+    """
+    from dango.platform.cloud.backup import create_backup, restore_from_archive
+    from dango.platform.cloud.provisioning import (
+        provision_droplet,
+        save_provisioning_metadata,
+    )
+    from dango.platform.cloud.resize import validate_size_slug
+    from dango.platform.cloud.server_setup import setup_server
+    from dango.platform.cloud.ssh import SSHManager as SSHManagerCls
+
+    start_time = time.monotonic()
+    warnings: list[str] = []
+    new_droplet_id: int | None = None
+    new_ssh: SSHManager | None = None
+
+    # 1. Validate
+    validate_size_slug(new_size)
+    if old_config.spaces is None:
+        raise CloudError(
+            "Migration requires Spaces for data transfer. "
+            "Configure Spaces first with: dango remote backup enable",
+            error_code="DANGO-D040",
+        )
+
+    old_droplet_id = old_config.droplet_id
+
+    try:
+        # 2. Create backup on old server
+        _notify(on_progress, "backup", "running")
+        backup_result = create_backup(old_ssh, backup_type="pre-migrate")
+        archive_path = backup_result.archive_path
+        _notify(on_progress, "backup", "done")
+
+        # 3. Upload to Spaces
+        _notify(on_progress, "upload_spaces", "running")
+        spaces_key = _upload_backup_to_spaces(old_ssh, archive_path, old_config.spaces)
+        _notify(on_progress, "upload_spaces", "done")
+
+        # 4. Provision new droplet
+        _notify(on_progress, "provision", "running")
+        ssh_key_ids: list[int] = []
+        if old_config.ssh_key_id is not None:
+            ssh_key_ids = [old_config.ssh_key_id]
+
+        droplet_name = f"dango-{new_region}"
+        new_droplet = provision_droplet(
+            client,
+            droplet_name,
+            new_region,
+            new_size,
+            ssh_key_ids,
+        )
+        new_droplet_id = new_droplet["id"]
+        new_droplet_ip = _extract_ipv4(new_droplet)
+        _notify(on_progress, "provision", "done")
+
+        # 5. Connect SSH to new server
+        key_path = project_root / old_config.ssh_key_path
+        new_ssh = SSHManagerCls(key_path=key_path)
+        new_ssh.connect(new_droplet_ip, username="root")
+
+        # 6. Setup new server
+        _notify(on_progress, "setup_server", "running")
+        setup_server(new_ssh, domain=old_config.domain)
+        _notify(on_progress, "setup_server", "done")
+
+        # 7. Copy secrets
+        _notify(on_progress, "copy_secrets", "running")
+        secret_warnings = _copy_secrets_between_servers(old_ssh, new_ssh)
+        warnings.extend(secret_warnings)
+        _notify(on_progress, "copy_secrets", "done")
+
+        # 8. Download backup from Spaces on new server
+        _notify(on_progress, "download_spaces", "running")
+        new_archive_path = _download_backup_from_spaces(new_ssh, spaces_key, old_config.spaces)
+        _notify(on_progress, "download_spaces", "done")
+
+        # 9. Restore from archive on new server
+        _notify(on_progress, "restore", "running")
+        restore_from_archive(new_ssh, new_archive_path)
+        _notify(on_progress, "restore", "done")
+
+        # 10. Configure domain
+        dns_updated = False
+        if old_config.domain:
+            _notify(on_progress, "domain", "running")
+            try:
+                from dango.platform.cloud.domain import set_domain
+
+                set_domain(new_ssh, project_root, old_config.domain)
+                dns_updated = True
+            except Exception as exc:
+                warnings.append(f"Domain configuration failed: {exc}")
+            _notify(on_progress, "domain", "done")
+
+        # 11. Update firewall
+        if old_config.firewall_id:
+            _notify(on_progress, "firewall", "running")
+            try:
+                _update_firewall_droplets(
+                    client, old_config.firewall_id, old_droplet_id, new_droplet_id
+                )
+            except Exception as exc:
+                warnings.append(f"Firewall update failed: {exc}")
+            _notify(on_progress, "firewall", "done")
+
+        # 12. Verify health
+        _notify(on_progress, "verify_health", "running")
+        health_ok = _verify_health(new_ssh)
+        _notify(on_progress, "verify_health", "done")
+
+        # 13. Destroy old or keep both
+        old_destroyed = False
+        if health_ok:
+            _notify(on_progress, "cleanup", "running")
+            try:
+                client.delete_droplet(old_droplet_id)
+                old_destroyed = True
+            except Exception as exc:
+                warnings.append(f"Failed to destroy old droplet: {exc}")
+            _notify(on_progress, "cleanup", "done")
+
+            # Update cloud.yml
+            save_provisioning_metadata(
+                project_root,
+                droplet_id=new_droplet_id,
+                droplet_ip=new_droplet_ip,
+                region=new_region,
+                size=new_size,
+            )
+        else:
+            warnings.append(
+                f"Health check failed on new server ({new_droplet_ip}). "
+                f"Old server ({old_config.droplet_ip}) is still running. "
+                "Investigate both servers manually."
+            )
+
+    except Exception:
+        # Cleanup new droplet on failure (best effort)
+        if new_droplet_id is not None:
+            try:
+                client.delete_droplet(new_droplet_id)
+            except Exception:
+                pass
+        if new_ssh is not None:
+            try:
+                new_ssh.disconnect()
+            except Exception:
+                pass
+        raise
+
+    if new_ssh is not None:
+        try:
+            new_ssh.disconnect()
+        except Exception:
+            pass
+
+    return MigrateResult(
+        old_droplet_id=old_droplet_id,
+        new_droplet_id=new_droplet_id,
+        new_droplet_ip=new_droplet_ip,
+        new_region=new_region,
+        new_size=new_size,
+        duration_seconds=round(time.monotonic() - start_time, 1),
+        old_droplet_destroyed=old_destroyed,
+        dns_updated=dns_updated,
+        warnings=warnings,
+    )
+
+
+def _extract_ipv4(droplet: dict[str, Any]) -> str:
+    """Extract the public IPv4 address from a droplet dict."""
+    for network in droplet.get("networks", {}).get("v4", []):
+        if network.get("type") == "public":
+            return str(network["ip_address"])
+    raise CloudError(
+        "Could not find public IPv4 address for new droplet.",
+        error_code="DANGO-D041",
+    )

--- a/dango/platform/cloud/resize.py
+++ b/dango/platform/cloud/resize.py
@@ -13,7 +13,10 @@ import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+import yaml
 
 from dango.exceptions import CloudError
 
@@ -145,13 +148,14 @@ def regenerate_dbt_profiles(
     if not result.success or not result.stdout.strip():
         return False
 
-    # Parse project name (first "name:" line in YAML)
+    # Parse project name via YAML
     project_name = "dango"
-    for line in result.stdout.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("name:"):
-            project_name = stripped.split(":", 1)[1].strip().strip("'\"")
-            break
+    try:
+        data: dict[str, Any] = yaml.safe_load(result.stdout)
+        if isinstance(data, dict) and "name" in data:
+            project_name = str(data["name"])
+    except yaml.YAMLError:
+        pass  # Fall back to default name
 
     # Determine specs from tier or defaults
     tier = get_size_tier(new_size_slug)
@@ -195,6 +199,8 @@ def resize_droplet(
     create_backup: bool = True,
     dbt_overrides: Any | None = None,
     on_progress: Callable[[str, str], None] | None = None,
+    project_root: Path | None = None,
+    region: str | None = None,
 ) -> ResizeResult:
     """Resize a Droplet to a new size slug.
 
@@ -206,6 +212,7 @@ def resize_droplet(
         5. Wait for droplet active + SSH reachable
         6. Regenerate dbt profiles.yml
         7. Start services + verify health
+        8. Persist new size to cloud.yml (if *project_root* provided)
 
     Args:
         client: ``DigitalOceanClient`` instance.
@@ -215,6 +222,9 @@ def resize_droplet(
         create_backup: If ``True``, create a backup before resizing.
         dbt_overrides: Optional ``DbtOverrides`` for profiles.yml.
         on_progress: Optional ``(step, status)`` callback.
+        project_root: Local project root. When provided (along with
+            *region*), the new size is persisted to ``cloud.yml``.
+        region: Current region slug — required when *project_root* is set.
 
     Returns:
         ``ResizeResult`` with size change details.
@@ -225,6 +235,7 @@ def resize_droplet(
     """
     from dango.platform.cloud.provisioning import (
         get_size_tier,
+        save_provisioning_metadata,
         wait_for_droplet_ready,
         wait_for_ssh,
     )
@@ -259,9 +270,9 @@ def resize_droplet(
         _notify(on_progress, "backup", "done")
     else:
         # Stop services manually if no backup (backup stops them)
-        from dango.platform.cloud.backup import _stop_services
+        from dango.platform.cloud.backup import stop_services
 
-        _stop_services(ssh)
+        stop_services(ssh)
 
     try:
         # 5. Power off
@@ -310,17 +321,27 @@ def resize_droplet(
     _notify(on_progress, "dbt_profiles", "done")
 
     # 11. Start services + verify health
-    from dango.platform.cloud.backup import _start_services
+    from dango.platform.cloud.backup import start_services, verify_health
 
     _notify(on_progress, "start_services", "running")
-    _start_services(ssh)
+    start_services(ssh)
     _notify(on_progress, "start_services", "done")
 
     _notify(on_progress, "verify_health", "running")
-    health_ok = _verify_health(ssh)
+    health_ok = verify_health(ssh)
     if not health_ok:
         warnings.append("Health check did not pass within 90 seconds.")
     _notify(on_progress, "verify_health", "done")
+
+    # 12. Persist new size to cloud.yml
+    if project_root is not None and region is not None:
+        save_provisioning_metadata(
+            project_root,
+            droplet_id=droplet_id,
+            droplet_ip=droplet_ip,
+            region=region,
+            size=new_size,
+        )
 
     return ResizeResult(
         old_size=current_size,
@@ -343,13 +364,3 @@ def _extract_ipv4(droplet: dict[str, Any]) -> str:
         "Could not find public IPv4 address for droplet.",
         error_code="DANGO-D031",
     )
-
-
-def _verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
-    """Poll the health endpoint until it responds OK or timeout."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if ssh.exec_command("curl -sf http://localhost:8800/api/health", timeout=10).success:
-            return True
-        time.sleep(5)
-    return False

--- a/dango/platform/cloud/resize.py
+++ b/dango/platform/cloud/resize.py
@@ -1,0 +1,355 @@
+"""dango/platform/cloud/resize.py
+
+Remote server resize (in-place CPU/RAM change) for Dango cloud deployments.
+
+Orchestrates the DigitalOcean resize workflow: power off → resize → power on,
+then regenerates ``dbt/profiles.yml`` to match the new hardware specs.  All
+functions require an already-connected ``SSHManager`` (as root).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from dango.exceptions import CloudError
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.digitalocean import DigitalOceanClient
+    from dango.platform.cloud.ssh import SSHManager
+
+_SIZE_SLUG_PATTERN = re.compile(r"^[a-zA-Z0-9\-_.]+$")
+_PROFILES_PATH = "/srv/dango/project/dbt/profiles.yml"
+_DBT_PROJECT_PATH = "/srv/dango/project/dbt/dbt_project.yml"
+
+
+@dataclass
+class ResizeResult:
+    """Result returned by :func:`resize_droplet`."""
+
+    old_size: str
+    new_size: str
+    old_tier: str | None
+    new_tier: str | None
+    duration_seconds: float
+    backup_path: str | None
+    dbt_profiles_regenerated: bool
+    warnings: list[str] = field(default_factory=list)
+
+
+def validate_size_slug(slug: str) -> None:
+    """Validate a DigitalOcean size slug against an allowlist pattern.
+
+    Raises:
+        CloudError: If *slug* contains characters outside ``[a-zA-Z0-9\\-_.]``.
+    """
+    if not _SIZE_SLUG_PATTERN.match(slug):
+        raise CloudError(
+            f"Invalid size slug: {slug!r}. "
+            "Only alphanumeric characters, hyphens, underscores, and dots are allowed.",
+            error_code="DANGO-D030",
+        )
+
+
+def get_disk_warning(current_slug: str, new_slug: str) -> str | None:
+    """Return a warning if the new tier has less disk than the current one.
+
+    DigitalOcean disk resizes only grow — this is informational only.
+    Returns ``None`` if no warning is needed.
+    """
+    from dango.platform.cloud.provisioning import get_size_tier
+
+    current_tier = get_size_tier(current_slug)
+    new_tier = get_size_tier(new_slug)
+    if current_tier and new_tier and new_tier.disk_gb < current_tier.disk_gb:
+        return (
+            f"New tier has {new_tier.disk_gb} GB disk vs current {current_tier.disk_gb} GB. "
+            "DigitalOcean does not shrink disks — disk size will remain unchanged."
+        )
+    return None
+
+
+def generate_dbt_profiles_yml(
+    project_name: str,
+    vcpus: int,
+    ram_gb: int,
+    dbt_overrides: Any | None = None,
+) -> str:
+    """Generate ``dbt/profiles.yml`` content tuned for the given hardware.
+
+    Args:
+        project_name: The dbt project name (from ``dbt_project.yml``).
+        vcpus: Number of virtual CPUs on the server.
+        ram_gb: Total RAM in gigabytes.
+        dbt_overrides: Optional ``DbtOverrides`` with explicit ``threads``
+            and/or ``memory_limit`` overrides.
+
+    Returns:
+        The full YAML content for ``profiles.yml``.
+    """
+    threads = vcpus
+    memory_limit = f"{max(1, ram_gb // 4)}GB"
+
+    if dbt_overrides is not None:
+        if getattr(dbt_overrides, "threads", None) is not None:
+            threads = dbt_overrides.threads
+        if getattr(dbt_overrides, "memory_limit", None) is not None:
+            memory_limit = dbt_overrides.memory_limit
+
+    return f"""# dbt Profile Configuration for DuckDB
+# Auto-generated for cloud deployment — do not edit manually
+
+{project_name}:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: /srv/dango/project/data/warehouse.duckdb
+      schema: main
+      threads: {threads}
+
+      # DuckDB-specific settings
+      extensions:
+        - httpfs
+        - parquet
+
+      # Settings
+      settings:
+        memory_limit: {memory_limit}
+        threads: {threads}
+"""
+
+
+def regenerate_dbt_profiles(
+    ssh: SSHManager,
+    new_size_slug: str,
+    dbt_overrides: Any | None = None,
+) -> bool:
+    """Regenerate ``dbt/profiles.yml`` on the server for the new size.
+
+    Reads the project name from ``dbt_project.yml`` on the server, looks
+    up the tier specs (or uses defaults for custom sizes), and writes the
+    new profiles via SSH.
+
+    Returns:
+        ``True`` if profiles were written, ``False`` if ``dbt_project.yml``
+        was not found on the server.
+    """
+    from dango.platform.cloud.provisioning import get_size_tier
+
+    # Read project name from dbt_project.yml on server
+    result = ssh.exec_command(f"cat {_DBT_PROJECT_PATH} 2>/dev/null")
+    if not result.success or not result.stdout.strip():
+        return False
+
+    # Parse project name (first "name:" line in YAML)
+    project_name = "dango"
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("name:"):
+            project_name = stripped.split(":", 1)[1].strip().strip("'\"")
+            break
+
+    # Determine specs from tier or defaults
+    tier = get_size_tier(new_size_slug)
+    if tier:
+        vcpus = tier.vcpus
+        ram_gb = tier.ram_gb
+    else:
+        # Custom size: parse slug pattern s-{vcpus}vcpu-{ram}gb
+        vcpus = 2
+        ram_gb = 4
+        parts = new_size_slug.split("-")
+        for part in parts:
+            if part.endswith("vcpu"):
+                try:
+                    vcpus = int(part[:-4])
+                except ValueError:
+                    pass
+            elif part.endswith("gb"):
+                try:
+                    ram_gb = int(part[:-2])
+                except ValueError:
+                    pass
+
+    content = generate_dbt_profiles_yml(project_name, vcpus, ram_gb, dbt_overrides)
+    ssh.write_remote_file(_PROFILES_PATH, content, mode=0o644)
+    return True
+
+
+def _notify(callback: Callable[[str, str], None] | None, step: str, status: str) -> None:
+    """Call the progress callback if provided."""
+    if callback is not None:
+        callback(step, status)
+
+
+def resize_droplet(
+    client: DigitalOceanClient,
+    ssh: SSHManager,
+    droplet_id: int,
+    new_size: str,
+    *,
+    create_backup: bool = True,
+    dbt_overrides: Any | None = None,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> ResizeResult:
+    """Resize a Droplet to a new size slug.
+
+    Workflow:
+        1. Validate size slug
+        2. Get current droplet info
+        3. Create pre-resize backup (services stay stopped)
+        4. Power off → resize → power on
+        5. Wait for droplet active + SSH reachable
+        6. Regenerate dbt profiles.yml
+        7. Start services + verify health
+
+    Args:
+        client: ``DigitalOceanClient`` instance.
+        ssh: Connected ``SSHManager`` (as root).
+        droplet_id: Droplet ID to resize.
+        new_size: Target size slug (e.g. ``"s-4vcpu-8gb"``).
+        create_backup: If ``True``, create a backup before resizing.
+        dbt_overrides: Optional ``DbtOverrides`` for profiles.yml.
+        on_progress: Optional ``(step, status)`` callback.
+
+    Returns:
+        ``ResizeResult`` with size change details.
+
+    Raises:
+        CloudError: If the size slug is invalid or action fails.
+        CloudProvisioningError: If any SSH command fails.
+    """
+    from dango.platform.cloud.provisioning import (
+        get_size_tier,
+        wait_for_droplet_ready,
+        wait_for_ssh,
+    )
+
+    start_time = time.monotonic()
+    warnings: list[str] = []
+
+    # 1. Validate
+    validate_size_slug(new_size)
+
+    # 2. Get current droplet info
+    droplet = client.get_droplet(droplet_id)
+    current_size = droplet.get("size_slug", droplet.get("size", {}).get("slug", "unknown"))
+    droplet_ip = _extract_ipv4(droplet)
+
+    current_tier = get_size_tier(current_size)
+    new_tier_obj = get_size_tier(new_size)
+
+    # 3. Disk warning
+    disk_warning = get_disk_warning(current_size, new_size)
+    if disk_warning:
+        warnings.append(disk_warning)
+
+    # 4. Pre-resize backup (services stay stopped)
+    backup_path: str | None = None
+    if create_backup:
+        from dango.platform.cloud.backup import create_backup as _create_backup
+
+        _notify(on_progress, "backup", "running")
+        backup_result = _create_backup(ssh, backup_type="pre-resize", restart_services=False)
+        backup_path = backup_result.archive_path
+        _notify(on_progress, "backup", "done")
+    else:
+        # Stop services manually if no backup (backup stops them)
+        from dango.platform.cloud.backup import _stop_services
+
+        _stop_services(ssh)
+
+    try:
+        # 5. Power off
+        _notify(on_progress, "power_off", "running")
+        action = client.power_off(droplet_id)
+        client.wait_for_action(action["id"])
+        _notify(on_progress, "power_off", "done")
+
+        # 6. Resize
+        _notify(on_progress, "resize", "running")
+        action = client.resize(droplet_id, new_size)
+        client.wait_for_action(action["id"])
+        _notify(on_progress, "resize", "done")
+
+        # 7. Power on
+        _notify(on_progress, "power_on", "running")
+        action = client.power_on(droplet_id)
+        client.wait_for_action(action["id"])
+        _notify(on_progress, "power_on", "done")
+
+        # 8. Wait for droplet active + SSH
+        _notify(on_progress, "wait_active", "running")
+        wait_for_droplet_ready(client, droplet_id)
+        _notify(on_progress, "wait_active", "done")
+
+        _notify(on_progress, "wait_ssh", "running")
+        wait_for_ssh(droplet_ip)
+        _notify(on_progress, "wait_ssh", "done")
+    except Exception:
+        # Best effort: try to power on if we failed after power off
+        try:
+            client.power_on(droplet_id)
+        except Exception:
+            pass
+        raise
+
+    # 9. Reconnect SSH (connection was dropped during power cycle)
+    ssh.disconnect()
+    ssh.connect(droplet_ip, username="root")
+
+    # 10. Regenerate dbt profiles
+    _notify(on_progress, "dbt_profiles", "running")
+    dbt_regenerated = regenerate_dbt_profiles(ssh, new_size, dbt_overrides)
+    if not dbt_regenerated:
+        warnings.append("dbt_project.yml not found on server — profiles.yml not regenerated.")
+    _notify(on_progress, "dbt_profiles", "done")
+
+    # 11. Start services + verify health
+    from dango.platform.cloud.backup import _start_services
+
+    _notify(on_progress, "start_services", "running")
+    _start_services(ssh)
+    _notify(on_progress, "start_services", "done")
+
+    _notify(on_progress, "verify_health", "running")
+    health_ok = _verify_health(ssh)
+    if not health_ok:
+        warnings.append("Health check did not pass within 90 seconds.")
+    _notify(on_progress, "verify_health", "done")
+
+    return ResizeResult(
+        old_size=current_size,
+        new_size=new_size,
+        old_tier=current_tier.name if current_tier else None,
+        new_tier=new_tier_obj.name if new_tier_obj else None,
+        duration_seconds=round(time.monotonic() - start_time, 1),
+        backup_path=backup_path,
+        dbt_profiles_regenerated=dbt_regenerated,
+        warnings=warnings,
+    )
+
+
+def _extract_ipv4(droplet: dict[str, Any]) -> str:
+    """Extract the public IPv4 address from a droplet dict."""
+    for network in droplet.get("networks", {}).get("v4", []):
+        if network.get("type") == "public":
+            return str(network["ip_address"])
+    raise CloudError(
+        "Could not find public IPv4 address for droplet.",
+        error_code="DANGO-D031",
+    )
+
+
+def _verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
+    """Poll the health endpoint until it responds OK or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ssh.exec_command("curl -sf http://localhost:8800/api/health", timeout=10).success:
+            return True
+        time.sleep(5)
+    return False

--- a/dango/platform/cloud/upgrade.py
+++ b/dango/platform/cloud/upgrade.py
@@ -86,36 +86,6 @@ def _notify(callback: Callable[[str, str], None] | None, step: str, status: str)
         callback(step, status)
 
 
-def _stop_services(ssh: SSHManager) -> None:
-    """Stop dango-web and Metabase for upgrade."""
-    _run_checked(ssh, "systemctl stop dango-web || true", step="stop_services", timeout=60)
-    _run_checked(
-        ssh,
-        f"docker compose -f {_PROJECT_DIR}/docker-compose.yml stop metabase 2>/dev/null || true",
-        step="stop_services",
-        timeout=120,
-    )
-
-
-def _start_services(ssh: SSHManager) -> None:
-    """Start Metabase then dango-web (reverse order of stop)."""
-    ssh.exec_command(
-        f"docker compose -f {_PROJECT_DIR}/docker-compose.yml start metabase 2>/dev/null || true",
-        timeout=120,
-    )
-    ssh.exec_command("systemctl reload-or-restart dango-web || true", timeout=60)
-
-
-def _verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
-    """Poll the health endpoint until it responds OK or timeout."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if ssh.exec_command("curl -sf http://localhost:8800/api/health", timeout=10).success:
-            return True
-        time.sleep(5)
-    return False
-
-
 def upgrade_dango(
     ssh: SSHManager,
     *,
@@ -204,8 +174,10 @@ def upgrade_dango(
         warnings.append("Pre-upgrade backup skipped (--skip-backup).")
 
     # 5. Stop services
+    from dango.platform.cloud.backup import start_services, stop_services, verify_health
+
     _notify(on_progress, "stop_services", "running")
-    _stop_services(ssh)
+    stop_services(ssh)
     _notify(on_progress, "stop_services", "done")
 
     try:
@@ -253,12 +225,12 @@ def upgrade_dango(
     finally:
         # 10. Start services
         _notify(on_progress, "start_services", "running")
-        _start_services(ssh)
+        start_services(ssh)
         _notify(on_progress, "start_services", "done")
 
     # 11. Verify health
     _notify(on_progress, "verify_health", "running")
-    health_ok = _verify_health(ssh)
+    health_ok = verify_health(ssh)
     if not health_ok:
         warnings.append(
             "Health check did not pass within 90 seconds. "

--- a/dango/platform/cloud/upgrade.py
+++ b/dango/platform/cloud/upgrade.py
@@ -1,0 +1,278 @@
+"""dango/platform/cloud/upgrade.py
+
+Remote Dango version upgrade via SSH.
+
+Upgrades the ``getdango`` package on the remote server, runs pending
+migrations, rebuilds Docker images, and verifies health.  All functions
+require an already-connected ``SSHManager`` (as root).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from dango.exceptions import CloudError, CloudProvisioningError
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.ssh import SSHManager
+
+_VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+_VENV_PIP = "/srv/dango/venv/bin/pip"
+_VENV_PYTHON = "/srv/dango/venv/bin/python"
+_PROJECT_DIR = "/srv/dango/project"
+
+
+@dataclass
+class UpgradeResult:
+    """Result returned by :func:`upgrade_dango`."""
+
+    old_version: str | None
+    new_version: str | None
+    backup_path: str | None
+    migrations_run: bool
+    docker_rebuilt: bool
+    health_check_passed: bool
+    duration_seconds: float
+    warnings: list[str] = field(default_factory=list)
+
+
+def validate_version_string(version: str) -> None:
+    """Validate a version string against the ``X.Y.Z`` semver pattern.
+
+    Raises:
+        CloudError: If *version* does not match ``^\\d+\\.\\d+\\.\\d+$``.
+    """
+    if not _VERSION_PATTERN.match(version):
+        raise CloudError(
+            f"Invalid version string: {version!r}. Expected format: X.Y.Z (e.g. 1.2.3).",
+            error_code="DANGO-D020",
+        )
+
+
+def check_versions(ssh: SSHManager) -> tuple[str | None, str | None]:
+    """Return ``(current_remote_version, latest_pypi_version)``.
+
+    Uses ``_get_dango_version()`` from ``server_status`` for the remote
+    version and ``check_latest_pypi_version()`` for the PyPI version.
+    """
+    from dango.platform.cloud.server_status import (
+        _get_dango_version,
+        check_latest_pypi_version,
+    )
+
+    current = _get_dango_version(ssh)
+    latest = check_latest_pypi_version()
+    return current, latest
+
+
+def _run_checked(ssh: SSHManager, command: str, *, step: str, timeout: int = 120) -> str:
+    """Run *command* via SSH, raising ``CloudProvisioningError`` on failure."""
+    result = ssh.exec_command(command, timeout=timeout)
+    if not result.success:
+        raise CloudProvisioningError(
+            f"Upgrade step '{step}' failed (exit {result.exit_code}): "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout
+
+
+def _notify(callback: Callable[[str, str], None] | None, step: str, status: str) -> None:
+    """Call the progress callback if provided."""
+    if callback is not None:
+        callback(step, status)
+
+
+def _stop_services(ssh: SSHManager) -> None:
+    """Stop dango-web and Metabase for upgrade."""
+    _run_checked(ssh, "systemctl stop dango-web || true", step="stop_services", timeout=60)
+    _run_checked(
+        ssh,
+        f"docker compose -f {_PROJECT_DIR}/docker-compose.yml stop metabase 2>/dev/null || true",
+        step="stop_services",
+        timeout=120,
+    )
+
+
+def _start_services(ssh: SSHManager) -> None:
+    """Start Metabase then dango-web (reverse order of stop)."""
+    ssh.exec_command(
+        f"docker compose -f {_PROJECT_DIR}/docker-compose.yml start metabase 2>/dev/null || true",
+        timeout=120,
+    )
+    ssh.exec_command("systemctl reload-or-restart dango-web || true", timeout=60)
+
+
+def _verify_health(ssh: SSHManager, timeout: int = 90) -> bool:
+    """Poll the health endpoint until it responds OK or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ssh.exec_command("curl -sf http://localhost:8800/api/health", timeout=10).success:
+            return True
+        time.sleep(5)
+    return False
+
+
+def upgrade_dango(
+    ssh: SSHManager,
+    *,
+    version: str | None = None,
+    skip_backup: bool = False,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> UpgradeResult:
+    """Upgrade Dango on the remote server.
+
+    Workflow:
+        1. Get current version
+        2. Determine target version (specific or latest from PyPI)
+        3. Create pre-upgrade backup (unless *skip_backup*)
+        4. Stop services
+        5. pip install target version
+        6. Run migrations
+        7. Rebuild Docker images
+        8. Start services + verify health
+
+    Args:
+        ssh: Connected ``SSHManager`` (as root).
+        version: Specific version to install (e.g. ``"1.2.3"``).
+            If ``None``, upgrades to the latest PyPI version.
+        skip_backup: If ``True``, skip the pre-upgrade backup.
+        on_progress: Optional ``(step, status)`` callback.
+
+    Returns:
+        ``UpgradeResult`` with version change details and health status.
+
+    Raises:
+        CloudError: If the version string is invalid.
+        CloudProvisioningError: If any SSH command fails.
+    """
+    from dango.platform.cloud.server_status import (
+        _get_dango_version,
+        check_latest_pypi_version,
+    )
+
+    start_time = time.monotonic()
+    warnings: list[str] = []
+
+    # 1. Get current version
+    _notify(on_progress, "check_version", "running")
+    old_version = _get_dango_version(ssh)
+    _notify(on_progress, "check_version", "done")
+
+    # 2. Determine target version
+    if version is not None:
+        validate_version_string(version)
+        target_version = version
+    else:
+        _notify(on_progress, "check_pypi", "running")
+        latest = check_latest_pypi_version()
+        _notify(on_progress, "check_pypi", "done")
+        if latest is None:
+            raise CloudError(
+                "Could not determine latest version from PyPI. "
+                "Specify a version explicitly with --version.",
+                error_code="DANGO-D021",
+            )
+        target_version = latest
+
+    # 3. Already at target?
+    if old_version == target_version:
+        return UpgradeResult(
+            old_version=old_version,
+            new_version=old_version,
+            backup_path=None,
+            migrations_run=False,
+            docker_rebuilt=False,
+            health_check_passed=True,
+            duration_seconds=round(time.monotonic() - start_time, 1),
+            warnings=["Already at target version — no upgrade performed."],
+        )
+
+    # 4. Pre-upgrade backup
+    backup_path: str | None = None
+    if not skip_backup:
+        from dango.platform.cloud.backup import create_backup
+
+        _notify(on_progress, "backup", "running")
+        backup_result = create_backup(ssh, backup_type="pre-upgrade")
+        backup_path = backup_result.archive_path
+        _notify(on_progress, "backup", "done")
+    else:
+        warnings.append("Pre-upgrade backup skipped (--skip-backup).")
+
+    # 5. Stop services
+    _notify(on_progress, "stop_services", "running")
+    _stop_services(ssh)
+    _notify(on_progress, "stop_services", "done")
+
+    try:
+        # 6. pip install
+        _notify(on_progress, "pip_install", "running")
+        if version is not None:
+            pip_cmd = f"{_VENV_PIP} install getdango=={target_version}"
+        else:
+            pip_cmd = f"{_VENV_PIP} install --upgrade getdango"
+        _run_checked(ssh, pip_cmd, step="pip_install", timeout=300)
+        _notify(on_progress, "pip_install", "done")
+
+        # 7. Verify new version
+        new_version = _get_dango_version(ssh)
+
+        # 8. Run migrations
+        _notify(on_progress, "migrations", "running")
+        migrations_run = False
+        migrate_result = ssh.exec_command(
+            f"sudo -u dango {_VENV_PYTHON} -m dango.migrations run 2>&1",
+            timeout=120,
+        )
+        if migrate_result.success:
+            migrations_run = True
+        else:
+            warnings.append(
+                f"Migration command exited with code {migrate_result.exit_code}: "
+                f"{migrate_result.stderr.strip() or migrate_result.stdout.strip()}"
+            )
+        _notify(on_progress, "migrations", "done")
+
+        # 9. Docker rebuild
+        _notify(on_progress, "docker_rebuild", "running")
+        docker_rebuilt = False
+        docker_result = ssh.exec_command(
+            f"docker compose -f {_PROJECT_DIR}/docker-compose.yml pull "
+            f"&& docker compose -f {_PROJECT_DIR}/docker-compose.yml up -d --build metabase",
+            timeout=600,
+        )
+        if docker_result.success:
+            docker_rebuilt = True
+        else:
+            warnings.append("Docker rebuild did not complete successfully.")
+        _notify(on_progress, "docker_rebuild", "done")
+    finally:
+        # 10. Start services
+        _notify(on_progress, "start_services", "running")
+        _start_services(ssh)
+        _notify(on_progress, "start_services", "done")
+
+    # 11. Verify health
+    _notify(on_progress, "verify_health", "running")
+    health_ok = _verify_health(ssh)
+    if not health_ok:
+        warnings.append(
+            "Health check did not pass within 90 seconds. "
+            "Run 'dango remote rollback' to restore the previous version."
+        )
+    _notify(on_progress, "verify_health", "done")
+
+    return UpgradeResult(
+        old_version=old_version,
+        new_version=new_version,
+        backup_path=backup_path,
+        migrations_run=migrations_run,
+        docker_rebuilt=docker_rebuilt,
+        health_check_passed=health_ok,
+        duration_seconds=round(time.monotonic() - start_time, 1),
+        warnings=warnings,
+    )

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -200,6 +200,12 @@ exemptions:
     reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"
 
+  - file: dango/platform/cloud/digitalocean.py
+    lines: 542
+    category: exempt
+    reason: "TASK-104: Added get_action() and wait_for_action() for resize/migrate action polling. Core DO API client — splitting would fragment related HTTP methods."
+    review_by: "v1.1"
+
   - file: dango/platform/cloud/ssh.py
     lines: 665
     category: exempt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,10 @@ module = [
     "tests.unit.test_deploy_wizard",
     "tests.unit.test_deploy_provision",
     "tests.unit.test_initial_sync",
+    "tests.unit.test_upgrade",
+    "tests.unit.test_resize",
+    "tests.unit.test_migrate",
+    "tests.unit.test_remote_ops_cli",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -112,22 +112,22 @@ class TestBackupHelpers:
             _check_disk_space(ssh)
 
     def test_stop_services_calls_systemctl_and_docker(self):
-        """_stop_services stops dango-web and metabase."""
-        from dango.platform.cloud.backup import _stop_services
+        """stop_services stops dango-web and metabase."""
+        from dango.platform.cloud.backup import stop_services
 
         ssh = _make_ssh_mock()
-        _stop_services(ssh)
+        stop_services(ssh)
 
         cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
         assert any("systemctl stop dango-web" in cmd for cmd in cmds)
         assert any("docker compose" in cmd and "stop metabase" in cmd for cmd in cmds)
 
     def test_start_services_starts_metabase_then_web(self):
-        """_start_services starts metabase first, then dango-web."""
-        from dango.platform.cloud.backup import _start_services
+        """start_services starts metabase first, then dango-web."""
+        from dango.platform.cloud.backup import start_services
 
         ssh = _make_ssh_mock()
-        _start_services(ssh)
+        start_services(ssh)
 
         cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
         metabase_idx = next(i for i, c in enumerate(cmds) if "start metabase" in c)
@@ -191,24 +191,24 @@ class TestBackupHelpers:
         assert path is None
 
     def test_verify_health_success(self):
-        """_verify_health returns True when endpoint responds."""
-        from dango.platform.cloud.backup import _verify_health
+        """verify_health returns True when endpoint responds."""
+        from dango.platform.cloud.backup import verify_health
 
         ssh = _make_ssh_mock(exec_results={"curl": ('{"status":"ok"}', "", 0)})
-        result = _verify_health(ssh, timeout=10)
+        result = verify_health(ssh, timeout=10)
         assert result is True
 
     @patch("dango.platform.cloud.backup.time.sleep")
     @patch("dango.platform.cloud.backup.time.monotonic")
     def test_verify_health_timeout(self, mock_monotonic, mock_sleep):
-        """_verify_health returns False after timeout."""
-        from dango.platform.cloud.backup import _verify_health
+        """verify_health returns False after timeout."""
+        from dango.platform.cloud.backup import verify_health
 
         # Simulate timeout: first call returns start time, second call exceeds timeout
         mock_monotonic.side_effect = [0.0, 100.0]
 
         ssh = _make_ssh_mock(exec_results={"curl": ("", "connection refused", 1)})
-        result = _verify_health(ssh, timeout=90)
+        result = verify_health(ssh, timeout=90)
         assert result is False
 
 

--- a/tests/unit/test_migrate.py
+++ b/tests/unit/test_migrate.py
@@ -123,7 +123,9 @@ class TestUploadBackupToSpaces:
             ssh, "/srv/dango/backups/deploy/backup-test.tar.gz", spaces_cfg
         )
         assert key == "migration/backup-test.tar.gz"
-        ssh.exec_command.assert_called_once()
+        # Script written to file, then executed + cleaned up
+        ssh.write_remote_file.assert_called_once()
+        assert ssh.exec_command.call_count == 2  # exec + rm cleanup
 
     def test_raises_on_failure(self) -> None:
         from dango.platform.cloud.migrate import _upload_backup_to_spaces
@@ -321,10 +323,14 @@ class TestMigrateServer:
             patches["setup"],
             patches["download"],
             patches["restore"],
-            patch("dango.platform.cloud.migrate.time.sleep"),
+            patch("dango.platform.cloud.backup.time.sleep"),
             patch(
                 "dango.platform.cloud.migrate.time.monotonic",
-                side_effect=[0.0, 0.0, 1.0, 100.0, 100.0, 100.0],
+                side_effect=[0.0, 100.0],
+            ),
+            patch(
+                "dango.platform.cloud.backup.time.monotonic",
+                side_effect=[0.0, 1.0, 100.0, 100.0],
             ),
         ):
             result = migrate_server(

--- a/tests/unit/test_migrate.py
+++ b/tests/unit/test_migrate.py
@@ -1,0 +1,431 @@
+"""tests/unit/test_migrate.py
+
+Unit tests for dango/platform/cloud/migrate.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import CloudError, CloudProvisioningError
+from dango.platform.cloud.ssh import CommandResult
+
+# Patch paths — lazy imports, patch at source.
+_PATCH_BACKUP = "dango.platform.cloud.backup.create_backup"
+_PATCH_RESTORE = "dango.platform.cloud.backup.restore_from_archive"
+_PATCH_PROVISION = "dango.platform.cloud.provisioning.provision_droplet"
+_PATCH_SAVE_META = "dango.platform.cloud.provisioning.save_provisioning_metadata"
+_PATCH_SETUP = "dango.platform.cloud.server_setup.setup_server"
+_PATCH_SET_DOMAIN = "dango.platform.cloud.domain.set_domain"
+_PATCH_SSH_CLS = "dango.platform.cloud.ssh.SSHManager"
+
+# Private helpers in migrate.py — these are module-level, NOT lazy.
+_PATCH_UPLOAD = "dango.platform.cloud.migrate._upload_backup_to_spaces"
+_PATCH_DOWNLOAD = "dango.platform.cloud.migrate._download_backup_from_spaces"
+
+
+def _make_ssh_mock(
+    *,
+    exec_results: dict[str, tuple[str, str, int]] | None = None,
+) -> MagicMock:
+    """Return a mock SSHManager with configurable exec_command results."""
+    results = exec_results or {}
+
+    def _exec_side_effect(command: str, timeout: int | None = None) -> CommandResult:
+        for substr, (stdout, stderr, exit_code) in results.items():
+            if substr in command:
+                return CommandResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    ssh = MagicMock()
+    ssh.exec_command.side_effect = _exec_side_effect
+    ssh.write_remote_file = MagicMock()
+    ssh.connect = MagicMock()
+    ssh.disconnect = MagicMock()
+    return ssh
+
+
+def _make_cloud_config(
+    droplet_id: int = 42,
+    droplet_ip: str = "1.2.3.4",
+    region: str = "nyc1",
+    size: str = "s-2vcpu-4gb",
+    domain: str | None = None,
+    firewall_id: str | None = "fw-abc",
+    ssh_key_path: str = ".dango/cloud_key",
+    ssh_key_id: int | None = 100,
+    spaces: Any | None = None,
+) -> MagicMock:
+    """Return a mock CloudConfig."""
+    cfg = MagicMock()
+    cfg.droplet_id = droplet_id
+    cfg.droplet_ip = droplet_ip
+    cfg.region = region
+    cfg.size = size
+    cfg.domain = domain
+    cfg.firewall_id = firewall_id
+    cfg.ssh_key_path = ssh_key_path
+    cfg.ssh_key_id = ssh_key_id
+    if spaces is None:
+        spaces_cfg = MagicMock()
+        spaces_cfg.bucket = "test-bucket"
+        spaces_cfg.region = "nyc3"
+        spaces_cfg.access_key_env = "SPACES_ACCESS_KEY"
+        spaces_cfg.secret_key_env = "SPACES_SECRET_KEY"
+        cfg.spaces = spaces_cfg
+    else:
+        cfg.spaces = spaces
+    return cfg
+
+
+def _make_do_client() -> MagicMock:
+    """Return a mock DigitalOceanClient."""
+    client = MagicMock()
+    client.get_firewall.return_value = {
+        "name": "dango-fw",
+        "droplet_ids": [42],
+        "inbound_rules": [],
+        "outbound_rules": [],
+    }
+    client.delete_droplet = MagicMock()
+    return client
+
+
+def _make_new_droplet(droplet_id: int = 99, ip: str = "5.6.7.8") -> dict[str, Any]:
+    """Return a minimal droplet dict for the new server."""
+    return {
+        "id": droplet_id,
+        "networks": {
+            "v4": [{"ip_address": ip, "type": "public"}],
+        },
+    }
+
+
+@pytest.mark.unit
+class TestUploadBackupToSpaces:
+    """Tests for _upload_backup_to_spaces()."""
+
+    def test_uploads_and_returns_key(self) -> None:
+        from dango.platform.cloud.migrate import _upload_backup_to_spaces
+
+        ssh = _make_ssh_mock()
+        spaces_cfg = MagicMock()
+        spaces_cfg.bucket = "test-bucket"
+        spaces_cfg.region = "nyc3"
+        spaces_cfg.access_key_env = "SPACES_ACCESS_KEY"
+        spaces_cfg.secret_key_env = "SPACES_SECRET_KEY"
+
+        key = _upload_backup_to_spaces(
+            ssh, "/srv/dango/backups/deploy/backup-test.tar.gz", spaces_cfg
+        )
+        assert key == "migration/backup-test.tar.gz"
+        ssh.exec_command.assert_called_once()
+
+    def test_raises_on_failure(self) -> None:
+        from dango.platform.cloud.migrate import _upload_backup_to_spaces
+
+        ssh = _make_ssh_mock(exec_results={"python": ("", "error", 1)})
+        spaces_cfg = MagicMock()
+        spaces_cfg.bucket = "test-bucket"
+        spaces_cfg.region = "nyc3"
+        spaces_cfg.access_key_env = "SPACES_ACCESS_KEY"
+        spaces_cfg.secret_key_env = "SPACES_SECRET_KEY"
+
+        with pytest.raises(CloudProvisioningError, match="upload backup"):
+            _upload_backup_to_spaces(
+                ssh, "/srv/dango/backups/deploy/backup-test.tar.gz", spaces_cfg
+            )
+
+
+@pytest.mark.unit
+class TestDownloadBackupFromSpaces:
+    """Tests for _download_backup_from_spaces()."""
+
+    def test_downloads_and_returns_path(self) -> None:
+        from dango.platform.cloud.migrate import _download_backup_from_spaces
+
+        ssh = _make_ssh_mock()
+        spaces_cfg = MagicMock()
+        spaces_cfg.bucket = "test-bucket"
+        spaces_cfg.region = "nyc3"
+        spaces_cfg.access_key_env = "SPACES_ACCESS_KEY"
+        spaces_cfg.secret_key_env = "SPACES_SECRET_KEY"
+
+        path = _download_backup_from_spaces(ssh, "migration/backup-test.tar.gz", spaces_cfg)
+        assert path == "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+
+@pytest.mark.unit
+class TestCopySecretsBetweenServers:
+    """Tests for _copy_secrets_between_servers()."""
+
+    def test_copies_files(self) -> None:
+        from dango.platform.cloud.migrate import _copy_secrets_between_servers
+
+        old_ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/.env": ("DB_URL=test", "", 0),
+                "cat /srv/dango/project/.dlt/secrets.toml": ("[sources]", "", 0),
+            }
+        )
+        new_ssh = _make_ssh_mock()
+
+        warnings = _copy_secrets_between_servers(old_ssh, new_ssh)
+        assert len(warnings) == 0
+        assert new_ssh.write_remote_file.call_count == 2
+
+    def test_warns_on_missing_file(self) -> None:
+        from dango.platform.cloud.migrate import _copy_secrets_between_servers
+
+        old_ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/.env": ("", "", 1),
+                "cat /srv/dango/project/.dlt/secrets.toml": ("", "", 1),
+            }
+        )
+        new_ssh = _make_ssh_mock()
+
+        warnings = _copy_secrets_between_servers(old_ssh, new_ssh)
+        assert len(warnings) == 2
+        assert new_ssh.write_remote_file.call_count == 0
+
+
+@pytest.mark.unit
+class TestUpdateFirewallDroplets:
+    """Tests for _update_firewall_droplets()."""
+
+    def test_swaps_droplet_ids(self) -> None:
+        from dango.platform.cloud.migrate import _update_firewall_droplets
+
+        client = _make_do_client()
+
+        _update_firewall_droplets(client, "fw-abc", old_droplet_id=42, new_droplet_id=99)
+
+        client.update_firewall.assert_called_once()
+        call_kwargs = client.update_firewall.call_args[1]
+        assert 42 not in call_kwargs["droplet_ids"]
+        assert 99 in call_kwargs["droplet_ids"]
+
+
+def _setup_migrate_patches(
+    tmp_path: Path,
+    *,
+    new_ssh: MagicMock | None = None,
+    health_ok: bool = True,
+    setup_error: Exception | None = None,
+) -> dict[str, Any]:
+    """Return a dict of common patch context managers for migrate_server tests."""
+    backup_result = MagicMock()
+    backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+    key_dir = tmp_path / ".dango"
+    key_dir.mkdir(parents=True, exist_ok=True)
+    (key_dir / "cloud_key").write_text("dummy-key")
+
+    if new_ssh is None:
+        health_result = ("ok", "", 0) if health_ok else ("", "", 1)
+        new_ssh = _make_ssh_mock(exec_results={"curl -sf": health_result})
+
+    patches: dict[str, Any] = {
+        "backup": patch(_PATCH_BACKUP, return_value=backup_result),
+        "upload": patch(_PATCH_UPLOAD, return_value="migration/backup-test.tar.gz"),
+        "provision": patch(_PATCH_PROVISION, return_value=_make_new_droplet()),
+        "ssh_cls": patch(_PATCH_SSH_CLS, return_value=new_ssh),
+        "download": patch(
+            _PATCH_DOWNLOAD, return_value="/srv/dango/backups/deploy/backup-test.tar.gz"
+        ),
+        "restore": patch(_PATCH_RESTORE),
+        "save_meta": patch(_PATCH_SAVE_META),
+    }
+
+    if setup_error:
+        patches["setup"] = patch(_PATCH_SETUP, side_effect=setup_error)
+    else:
+        patches["setup"] = patch(_PATCH_SETUP)
+
+    return patches
+
+
+@pytest.mark.unit
+class TestMigrateServer:
+    """Tests for migrate_server()."""
+
+    def test_requires_spaces_configured(self, tmp_path: Path) -> None:
+        from dango.platform.cloud.migrate import migrate_server
+
+        client = _make_do_client()
+        ssh = _make_ssh_mock()
+        config = _make_cloud_config()
+        config.spaces = None
+
+        with pytest.raises(CloudError, match="requires Spaces"):
+            migrate_server(client, ssh, config, "s-4vcpu-8gb", "nyc1", project_root=tmp_path)
+
+    def test_full_migration_happy_path(self, tmp_path: Path) -> None:
+        from dango.platform.cloud.migrate import migrate_server
+
+        old_ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/.env": ("KEY=val", "", 0),
+                "cat /srv/dango/project/.dlt/secrets.toml": ("[src]", "", 0),
+            }
+        )
+        config = _make_cloud_config(domain=None, firewall_id=None)
+        client = _make_do_client()
+        patches = _setup_migrate_patches(tmp_path)
+
+        with (
+            patches["backup"],
+            patches["upload"],
+            patches["provision"],
+            patches["ssh_cls"],
+            patches["setup"],
+            patches["download"],
+            patches["restore"],
+            patches["save_meta"],
+        ):
+            result = migrate_server(
+                client,
+                old_ssh,
+                config,
+                "s-4vcpu-8gb",
+                "sfo3",
+                project_root=tmp_path,
+            )
+
+        assert result.new_droplet_id == 99
+        assert result.new_droplet_ip == "5.6.7.8"
+        assert result.new_region == "sfo3"
+        assert result.new_size == "s-4vcpu-8gb"
+        assert result.old_droplet_destroyed is True
+
+    def test_keeps_both_on_health_failure(self, tmp_path: Path) -> None:
+        from dango.platform.cloud.migrate import migrate_server
+
+        old_ssh = _make_ssh_mock()
+        config = _make_cloud_config(domain=None, firewall_id=None)
+        client = _make_do_client()
+
+        new_ssh = _make_ssh_mock(exec_results={"curl -sf": ("", "", 1)})
+        patches = _setup_migrate_patches(tmp_path, new_ssh=new_ssh, health_ok=False)
+
+        with (
+            patches["backup"],
+            patches["upload"],
+            patches["provision"],
+            patches["ssh_cls"],
+            patches["setup"],
+            patches["download"],
+            patches["restore"],
+            patch("dango.platform.cloud.migrate.time.sleep"),
+            patch(
+                "dango.platform.cloud.migrate.time.monotonic",
+                side_effect=[0.0, 0.0, 1.0, 100.0, 100.0, 100.0],
+            ),
+        ):
+            result = migrate_server(
+                client,
+                old_ssh,
+                config,
+                "s-4vcpu-8gb",
+                "sfo3",
+                project_root=tmp_path,
+            )
+
+        assert result.old_droplet_destroyed is False
+        client.delete_droplet.assert_not_called()
+        assert any("Health check failed" in w for w in result.warnings)
+
+    def test_cleans_up_new_droplet_on_failure(self, tmp_path: Path) -> None:
+        from dango.platform.cloud.migrate import migrate_server
+
+        old_ssh = _make_ssh_mock()
+        config = _make_cloud_config()
+        client = _make_do_client()
+
+        patches = _setup_migrate_patches(
+            tmp_path, setup_error=CloudProvisioningError("Setup failed")
+        )
+
+        with (
+            patches["backup"],
+            patches["upload"],
+            patches["provision"],
+            patches["ssh_cls"],
+            patches["setup"],
+            pytest.raises(CloudProvisioningError, match="Setup failed"),
+        ):
+            migrate_server(
+                client,
+                old_ssh,
+                config,
+                "s-4vcpu-8gb",
+                "sfo3",
+                project_root=tmp_path,
+            )
+
+        client.delete_droplet.assert_called_once_with(99)
+
+    def test_domain_update_on_migration(self, tmp_path: Path) -> None:
+        from dango.platform.cloud.migrate import migrate_server
+
+        old_ssh = _make_ssh_mock()
+        config = _make_cloud_config(domain="example.com", firewall_id=None)
+        client = _make_do_client()
+        patches = _setup_migrate_patches(tmp_path)
+
+        with (
+            patches["backup"],
+            patches["upload"],
+            patches["provision"],
+            patches["ssh_cls"],
+            patches["setup"],
+            patches["download"],
+            patches["restore"],
+            patch(_PATCH_SET_DOMAIN) as mock_domain,
+            patches["save_meta"],
+        ):
+            result = migrate_server(
+                client,
+                old_ssh,
+                config,
+                "s-4vcpu-8gb",
+                "sfo3",
+                project_root=tmp_path,
+            )
+
+        assert result.dns_updated is True
+        mock_domain.assert_called_once()
+
+    def test_firewall_update_on_migration(self, tmp_path: Path) -> None:
+        from dango.platform.cloud.migrate import migrate_server
+
+        old_ssh = _make_ssh_mock()
+        config = _make_cloud_config(domain=None, firewall_id="fw-abc")
+        client = _make_do_client()
+        patches = _setup_migrate_patches(tmp_path)
+
+        with (
+            patches["backup"],
+            patches["upload"],
+            patches["provision"],
+            patches["ssh_cls"],
+            patches["setup"],
+            patches["download"],
+            patches["restore"],
+            patches["save_meta"],
+        ):
+            migrate_server(
+                client,
+                old_ssh,
+                config,
+                "s-4vcpu-8gb",
+                "sfo3",
+                project_root=tmp_path,
+            )
+
+        client.update_firewall.assert_called_once()

--- a/tests/unit/test_remote_ops_cli.py
+++ b/tests/unit/test_remote_ops_cli.py
@@ -267,6 +267,45 @@ class TestRemoteResizeCommand:
         assert "Resize plan" in result.output
         assert "s-4vcpu-8gb" in result.output
 
+    def test_yes_flag_runs_resize(self, tmp_path: Path) -> None:
+        """--yes skips the confirmation prompt."""
+        from dango.platform.cloud.resize import ResizeResult
+
+        cloud_cfg = _make_cloud_config(size="s-2vcpu-4gb")
+        loader = _make_loader(cloud_cfg)
+        ssh = _make_ssh_mock()
+
+        resize_result = ResizeResult(
+            old_size="s-2vcpu-4gb",
+            new_size="s-4vcpu-8gb",
+            old_tier="Standard",
+            new_tier="Performance",
+            duration_seconds=120.0,
+            backup_path="/srv/dango/backups/deploy/backup.tar.gz",
+            dbt_profiles_regenerated=True,
+        )
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+            patch(_PATCH_SSH_CLS, return_value=ssh),
+            patch(
+                "dango.platform.cloud.resize.resize_droplet",
+                return_value=resize_result,
+            ),
+            patch(
+                "dango.platform.cloud.digitalocean.DigitalOceanClient",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = _run(
+                ["resize", "s-4vcpu-8gb", "--yes"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert "Resize complete" in result.output
+
 
 # ---------------------------------------------------------------------------
 # dango remote migrate
@@ -356,3 +395,20 @@ class TestRemoteMigrateCommand:
             )
 
         assert "Migration complete" in result.output
+
+    def test_region_shows_in_plan(self, tmp_path: Path) -> None:
+        """--region shows target region in migration plan."""
+        cloud_cfg = _make_cloud_config(size="s-2vcpu-4gb")
+        loader = _make_loader(cloud_cfg)
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+        ):
+            result = _run(
+                ["migrate", "--size", "s-4vcpu-8gb", "--region", "sfo3"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert "sfo3" in result.output

--- a/tests/unit/test_remote_ops_cli.py
+++ b/tests/unit/test_remote_ops_cli.py
@@ -1,0 +1,358 @@
+"""tests/unit/test_remote_ops_cli.py
+
+Unit tests for dango/cli/commands/remote_ops.py.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.remote import remote
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
+    return re.sub(r"\x1b\[[^m]*m", "", text)
+
+
+_PATCH_REQUIRE_CTX = "dango.cli.utils.require_project_context"
+_PATCH_LOADER = "dango.config.loader.ConfigLoader"
+_PATCH_SSH_CLS = "dango.platform.cloud.ssh.SSHManager"
+
+
+def _make_cloud_config(
+    droplet_id: int = 42,
+    droplet_ip: str = "1.2.3.4",
+    size: str = "s-2vcpu-4gb",
+    region: str = "nyc1",
+    domain: str | None = None,
+    firewall_id: str | None = "fw-abc",
+    spaces: Any | None = "default",
+    dbt_overrides: Any | None = None,
+    ssh_key_path: str = ".dango/cloud_key",
+    ssh_key_id: int | None = 100,
+) -> MagicMock:
+    """Return a mock CloudConfig."""
+    cfg = MagicMock()
+    cfg.droplet_id = droplet_id
+    cfg.droplet_ip = droplet_ip
+    cfg.size = size
+    cfg.region = region
+    cfg.domain = domain
+    cfg.firewall_id = firewall_id
+    cfg.ssh_key_path = ssh_key_path
+    cfg.ssh_key_id = ssh_key_id
+    cfg.dbt_overrides = dbt_overrides
+    if spaces == "default":
+        s = MagicMock()
+        s.bucket = "test-bucket"
+        s.region = "nyc3"
+        cfg.spaces = s
+    else:
+        cfg.spaces = spaces
+    return cfg
+
+
+def _make_loader(cloud_cfg: Any | None = None) -> MagicMock:
+    """Return a mock ConfigLoader."""
+    loader = MagicMock()
+    loader.load_cloud_config.return_value = cloud_cfg or _make_cloud_config()
+    return loader
+
+
+def _make_ssh_mock() -> MagicMock:
+    """Return a mock SSHManager."""
+    ssh = MagicMock()
+    ssh.connect = MagicMock()
+    ssh.disconnect = MagicMock()
+    return ssh
+
+
+def _run(
+    args: list[str],
+    tmp_path: Path,
+    *,
+    catch_exceptions: bool = False,
+) -> Any:
+    """Invoke ``remote`` CLI group with the given args."""
+    runner = CliRunner()
+    return runner.invoke(
+        remote,
+        args,
+        obj={"project_root": tmp_path},
+        catch_exceptions=catch_exceptions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# dango remote upgrade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteUpgradeCommand:
+    """Tests for the ``dango remote upgrade`` command."""
+
+    def test_shows_version_comparison(self, tmp_path: Path) -> None:
+        """Upgrade shows current vs latest before confirming."""
+        cloud_cfg = _make_cloud_config()
+        loader = _make_loader(cloud_cfg)
+        ssh = _make_ssh_mock()
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+            patch(_PATCH_SSH_CLS, return_value=ssh),
+            patch(
+                "dango.platform.cloud.server_status.check_latest_pypi_version",
+                return_value="1.1.0",
+            ),
+            patch(
+                "dango.platform.cloud.server_status._get_dango_version",
+                return_value="1.0.0",
+            ),
+        ):
+            result = _run(["upgrade"], tmp_path, catch_exceptions=True)
+
+        plain = _strip_ansi(result.output)
+        assert "1.0.0" in plain
+        assert "1.1.0" in plain
+
+    def test_already_at_latest_skips(self, tmp_path: Path) -> None:
+        """Upgrade exits early when already at target."""
+        cloud_cfg = _make_cloud_config()
+        loader = _make_loader(cloud_cfg)
+        ssh = _make_ssh_mock()
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+            patch(_PATCH_SSH_CLS, return_value=ssh),
+            patch(
+                "dango.platform.cloud.server_status.check_latest_pypi_version",
+                return_value="1.1.0",
+            ),
+            patch(
+                "dango.platform.cloud.server_status._get_dango_version",
+                return_value="1.1.0",
+            ),
+        ):
+            result = _run(["upgrade"], tmp_path, catch_exceptions=True)
+
+        assert "no upgrade needed" in result.output.lower()
+
+    def test_invalid_version_rejected(self, tmp_path: Path) -> None:
+        """Invalid --version is caught before SSH."""
+        cloud_cfg = _make_cloud_config()
+        loader = _make_loader(cloud_cfg)
+        ssh = _make_ssh_mock()
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+            patch(_PATCH_SSH_CLS, return_value=ssh),
+        ):
+            result = _run(
+                ["upgrade", "--version", "bad-version"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code != 0
+
+    def test_yes_flag_skips_confirmation(self, tmp_path: Path) -> None:
+        """--yes skips the confirmation prompt."""
+        from dango.platform.cloud.upgrade import UpgradeResult
+
+        cloud_cfg = _make_cloud_config()
+        loader = _make_loader(cloud_cfg)
+        ssh = _make_ssh_mock()
+
+        upgrade_result = UpgradeResult(
+            old_version="1.0.0",
+            new_version="1.1.0",
+            backup_path="/srv/dango/backups/deploy/backup.tar.gz",
+            migrations_run=True,
+            docker_rebuilt=True,
+            health_check_passed=True,
+            duration_seconds=45.0,
+        )
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+            patch(_PATCH_SSH_CLS, return_value=ssh),
+            patch(
+                "dango.platform.cloud.server_status.check_latest_pypi_version",
+                return_value="1.1.0",
+            ),
+            patch(
+                "dango.platform.cloud.server_status._get_dango_version",
+                return_value="1.0.0",
+            ),
+            patch(
+                "dango.platform.cloud.upgrade.upgrade_dango",
+                return_value=upgrade_result,
+            ),
+        ):
+            result = _run(["upgrade", "--yes"], tmp_path, catch_exceptions=True)
+
+        assert "Upgrade complete" in result.output
+
+
+# ---------------------------------------------------------------------------
+# dango remote resize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteResizeCommand:
+    """Tests for the ``dango remote resize`` command."""
+
+    def test_no_arg_shows_size_list(self, tmp_path: Path) -> None:
+        """resize with no arg shows current spec and tier table."""
+        cloud_cfg = _make_cloud_config(size="s-2vcpu-4gb")
+        loader = _make_loader(cloud_cfg)
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+        ):
+            result = _run(["resize"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code == 0
+        assert "Standard" in result.output
+        assert "s-2vcpu-4gb" in result.output
+        assert "Budget" in result.output
+        assert "Performance" in result.output
+
+    def test_invalid_slug_rejected(self, tmp_path: Path) -> None:
+        """Invalid size slug is caught."""
+        cloud_cfg = _make_cloud_config()
+        loader = _make_loader(cloud_cfg)
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+        ):
+            result = _run(
+                ["resize", "bad slug"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code != 0
+
+    def test_resize_with_arg_shows_plan(self, tmp_path: Path) -> None:
+        """resize with arg shows comparison and asks for confirmation."""
+        cloud_cfg = _make_cloud_config(size="s-2vcpu-4gb")
+        loader = _make_loader(cloud_cfg)
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+        ):
+            result = _run(
+                ["resize", "s-4vcpu-8gb"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert "Resize plan" in result.output
+        assert "s-4vcpu-8gb" in result.output
+
+
+# ---------------------------------------------------------------------------
+# dango remote migrate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteMigrateCommand:
+    """Tests for the ``dango remote migrate`` command."""
+
+    def test_requires_size_option(self, tmp_path: Path) -> None:
+        """migrate requires --size."""
+        result = _run(["migrate"], tmp_path, catch_exceptions=True)
+        assert result.exit_code != 0
+
+    def test_no_spaces_shows_error(self, tmp_path: Path) -> None:
+        """migrate without Spaces configured shows error."""
+        cloud_cfg = _make_cloud_config(spaces=None)
+        loader = _make_loader(cloud_cfg)
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+        ):
+            result = _run(
+                ["migrate", "--size", "s-4vcpu-8gb"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code != 0
+        assert "requires Spaces" in result.output
+
+    def test_shows_migration_plan(self, tmp_path: Path) -> None:
+        """migrate shows current → new comparison."""
+        cloud_cfg = _make_cloud_config(size="s-2vcpu-4gb")
+        loader = _make_loader(cloud_cfg)
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+        ):
+            result = _run(
+                ["migrate", "--size", "s-4vcpu-8gb"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert "Migration plan" in result.output
+
+    def test_yes_flag_runs_migration(self, tmp_path: Path) -> None:
+        """--yes skips confirmation."""
+        from dango.platform.cloud.migrate import MigrateResult
+
+        cloud_cfg = _make_cloud_config()
+        loader = _make_loader(cloud_cfg)
+        ssh = _make_ssh_mock()
+
+        migrate_result = MigrateResult(
+            old_droplet_id=42,
+            new_droplet_id=99,
+            new_droplet_ip="5.6.7.8",
+            new_region="nyc1",
+            new_size="s-4vcpu-8gb",
+            duration_seconds=300.0,
+            old_droplet_destroyed=True,
+            dns_updated=False,
+        )
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=loader),
+            patch(
+                "dango.platform.cloud.digitalocean.DigitalOceanClient",
+                return_value=MagicMock(),
+            ),
+            patch(_PATCH_SSH_CLS, return_value=ssh),
+            patch(
+                "dango.platform.cloud.migrate.migrate_server",
+                return_value=migrate_result,
+            ),
+        ):
+            result = _run(
+                ["migrate", "--size", "s-4vcpu-8gb", "--yes"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert "Migration complete" in result.output

--- a/tests/unit/test_resize.py
+++ b/tests/unit/test_resize.py
@@ -1,0 +1,323 @@
+"""tests/unit/test_resize.py
+
+Unit tests for dango/platform/cloud/resize.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import CloudError
+from dango.platform.cloud.ssh import CommandResult
+
+# Patch paths — lazy imports, patch at source.
+_PATCH_BACKUP = "dango.platform.cloud.backup.create_backup"
+_PATCH_STOP = "dango.platform.cloud.backup._stop_services"
+_PATCH_START = "dango.platform.cloud.backup._start_services"
+_PATCH_WAIT_DROPLET = "dango.platform.cloud.provisioning.wait_for_droplet_ready"
+_PATCH_WAIT_SSH = "dango.platform.cloud.provisioning.wait_for_ssh"
+
+
+def _make_ssh_mock(
+    *,
+    exec_results: dict[str, tuple[str, str, int]] | None = None,
+) -> MagicMock:
+    """Return a mock SSHManager with configurable exec_command results."""
+    results = exec_results or {}
+
+    def _exec_side_effect(command: str, timeout: int | None = None) -> CommandResult:
+        for substr, (stdout, stderr, exit_code) in results.items():
+            if substr in command:
+                return CommandResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    ssh = MagicMock()
+    ssh.exec_command.side_effect = _exec_side_effect
+    ssh.write_remote_file = MagicMock()
+    ssh.connect = MagicMock()
+    ssh.disconnect = MagicMock()
+    return ssh
+
+
+def _make_droplet(
+    size_slug: str = "s-2vcpu-4gb",
+    ip: str = "1.2.3.4",
+) -> dict[str, Any]:
+    """Return a minimal droplet dict."""
+    return {
+        "id": 42,
+        "size_slug": size_slug,
+        "networks": {
+            "v4": [
+                {"ip_address": ip, "type": "public"},
+            ]
+        },
+    }
+
+
+def _make_do_client(droplet: dict[str, Any] | None = None) -> MagicMock:
+    """Return a mock DigitalOceanClient."""
+    client = MagicMock()
+    client.get_droplet.return_value = droplet or _make_droplet()
+    client.power_off.return_value = {"id": 100}
+    client.resize.return_value = {"id": 101}
+    client.power_on.return_value = {"id": 102}
+    client.wait_for_action.return_value = {"id": 100, "status": "completed"}
+    return client
+
+
+@pytest.mark.unit
+class TestValidateSizeSlug:
+    """Tests for validate_size_slug()."""
+
+    def test_valid_slugs(self) -> None:
+        from dango.platform.cloud.resize import validate_size_slug
+
+        validate_size_slug("s-2vcpu-4gb")
+        validate_size_slug("s-1vcpu-2gb")
+        validate_size_slug("g-4vcpu-16gb")
+        validate_size_slug("so1_5-2vcpu-16gb")
+
+    def test_invalid_slugs(self) -> None:
+        from dango.platform.cloud.resize import validate_size_slug
+
+        with pytest.raises(CloudError, match="Invalid size slug"):
+            validate_size_slug("")
+
+        with pytest.raises(CloudError, match="Invalid size slug"):
+            validate_size_slug("s-2vcpu-4gb; rm -rf /")
+
+        with pytest.raises(CloudError, match="Invalid size slug"):
+            validate_size_slug("$(whoami)")
+
+        with pytest.raises(CloudError, match="Invalid size slug"):
+            validate_size_slug("size with spaces")
+
+
+@pytest.mark.unit
+class TestGetDiskWarning:
+    """Tests for get_disk_warning()."""
+
+    def test_downgrade_warns(self) -> None:
+        from dango.platform.cloud.resize import get_disk_warning
+
+        warning = get_disk_warning("s-4vcpu-8gb", "s-1vcpu-2gb")
+        assert warning is not None
+        assert "does not shrink" in warning
+
+    def test_upgrade_no_warning(self) -> None:
+        from dango.platform.cloud.resize import get_disk_warning
+
+        warning = get_disk_warning("s-1vcpu-2gb", "s-4vcpu-8gb")
+        assert warning is None
+
+    def test_same_size_no_warning(self) -> None:
+        from dango.platform.cloud.resize import get_disk_warning
+
+        warning = get_disk_warning("s-2vcpu-4gb", "s-2vcpu-4gb")
+        assert warning is None
+
+    def test_custom_slug_returns_none(self) -> None:
+        from dango.platform.cloud.resize import get_disk_warning
+
+        warning = get_disk_warning("custom-slug", "s-2vcpu-4gb")
+        assert warning is None
+
+
+@pytest.mark.unit
+class TestGenerateDbtProfilesYml:
+    """Tests for generate_dbt_profiles_yml()."""
+
+    def test_default_generation(self) -> None:
+        from dango.platform.cloud.resize import generate_dbt_profiles_yml
+
+        content = generate_dbt_profiles_yml("my_project", 4, 8)
+        assert "my_project:" in content
+        assert "threads: 4" in content
+        assert "memory_limit: 2GB" in content
+        assert "/srv/dango/project/data/warehouse.duckdb" in content
+
+    def test_with_overrides(self) -> None:
+        from dango.platform.cloud.resize import generate_dbt_profiles_yml
+
+        overrides = MagicMock()
+        overrides.threads = 8
+        overrides.memory_limit = "6GB"
+
+        content = generate_dbt_profiles_yml("my_project", 4, 16, overrides)
+        assert "threads: 8" in content
+        assert "memory_limit: 6GB" in content
+
+    def test_minimum_memory(self) -> None:
+        from dango.platform.cloud.resize import generate_dbt_profiles_yml
+
+        content = generate_dbt_profiles_yml("proj", 1, 2)
+        assert "memory_limit: 1GB" in content
+
+
+@pytest.mark.unit
+class TestRegenerateDbtProfiles:
+    """Tests for regenerate_dbt_profiles()."""
+
+    def test_writes_profiles(self) -> None:
+        from dango.platform.cloud.resize import regenerate_dbt_profiles
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/dbt/dbt_project.yml": (
+                    "name: my_project\nversion: 1.0.0",
+                    "",
+                    0,
+                ),
+            }
+        )
+
+        result = regenerate_dbt_profiles(ssh, "s-4vcpu-8gb")
+        assert result is True
+        ssh.write_remote_file.assert_called_once()
+        content = ssh.write_remote_file.call_args[0][1]
+        assert "my_project:" in content
+
+    def test_returns_false_when_no_dbt_project(self) -> None:
+        from dango.platform.cloud.resize import regenerate_dbt_profiles
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/dbt/dbt_project.yml": ("", "", 1),
+            }
+        )
+
+        result = regenerate_dbt_profiles(ssh, "s-2vcpu-4gb")
+        assert result is False
+
+    def test_custom_slug_uses_defaults(self) -> None:
+        from dango.platform.cloud.resize import regenerate_dbt_profiles
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/dbt/dbt_project.yml": (
+                    "name: proj\nversion: 1.0.0",
+                    "",
+                    0,
+                ),
+            }
+        )
+
+        regenerate_dbt_profiles(ssh, "custom-unknown-slug")
+        content = ssh.write_remote_file.call_args[0][1]
+        assert "threads: 2" in content
+
+
+@pytest.mark.unit
+class TestResizeDroplet:
+    """Tests for resize_droplet()."""
+
+    def test_full_resize_workflow(self) -> None:
+        from dango.platform.cloud.resize import resize_droplet
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/dbt/dbt_project.yml": (
+                    "name: proj\nversion: 1.0.0",
+                    "",
+                    0,
+                ),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+                "docker compose": ("", "", 0),
+            }
+        )
+        client = _make_do_client()
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        with (
+            patch(_PATCH_BACKUP, return_value=backup_result) as mock_backup,
+            patch(_PATCH_WAIT_DROPLET),
+            patch(_PATCH_WAIT_SSH),
+            patch(_PATCH_START),
+        ):
+            result = resize_droplet(client, ssh, 42, "s-4vcpu-8gb")
+
+        assert result.old_size == "s-2vcpu-4gb"
+        assert result.new_size == "s-4vcpu-8gb"
+        assert result.backup_path is not None
+        assert result.dbt_profiles_regenerated is True
+
+        client.power_off.assert_called_once_with(42)
+        client.resize.assert_called_once_with(42, "s-4vcpu-8gb")
+        client.power_on.assert_called_once_with(42)
+        assert client.wait_for_action.call_count == 3
+
+        mock_backup.assert_called_once()
+        _, kwargs = mock_backup.call_args
+        assert kwargs["restart_services"] is False
+
+    def test_progress_callback(self) -> None:
+        from dango.platform.cloud.resize import resize_droplet
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/dbt/dbt_project.yml": (
+                    "name: proj",
+                    "",
+                    0,
+                ),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+                "docker compose": ("", "", 0),
+            }
+        )
+        client = _make_do_client()
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        progress_calls: list[tuple[str, str]] = []
+
+        with (
+            patch(_PATCH_BACKUP, return_value=backup_result),
+            patch(_PATCH_WAIT_DROPLET),
+            patch(_PATCH_WAIT_SSH),
+            patch(_PATCH_START),
+        ):
+            resize_droplet(
+                client,
+                ssh,
+                42,
+                "s-4vcpu-8gb",
+                on_progress=lambda s, st: progress_calls.append((s, st)),
+            )
+
+        steps = [s for s, _ in progress_calls]
+        assert "backup" in steps
+        assert "power_off" in steps
+        assert "resize" in steps
+        assert "power_on" in steps
+        assert "verify_health" in steps
+
+    def test_action_error_attempts_power_on(self) -> None:
+        from dango.platform.cloud.resize import resize_droplet
+
+        ssh = _make_ssh_mock()
+        client = _make_do_client()
+        client.wait_for_action.side_effect = [
+            {"id": 100, "status": "completed"},  # power_off OK
+            CloudError("Action errored"),  # resize fails
+        ]
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        with (
+            patch(_PATCH_BACKUP, return_value=backup_result),
+            pytest.raises(CloudError, match="Action errored"),
+        ):
+            resize_droplet(client, ssh, 42, "s-4vcpu-8gb")
+
+        # Should attempt to power on after failure
+        assert client.power_on.call_count >= 1

--- a/tests/unit/test_resize.py
+++ b/tests/unit/test_resize.py
@@ -15,8 +15,10 @@ from dango.platform.cloud.ssh import CommandResult
 
 # Patch paths — lazy imports, patch at source.
 _PATCH_BACKUP = "dango.platform.cloud.backup.create_backup"
-_PATCH_STOP = "dango.platform.cloud.backup._stop_services"
-_PATCH_START = "dango.platform.cloud.backup._start_services"
+_PATCH_STOP = "dango.platform.cloud.backup.stop_services"
+_PATCH_START = "dango.platform.cloud.backup.start_services"
+_PATCH_VERIFY = "dango.platform.cloud.backup.verify_health"
+_PATCH_SAVE_META = "dango.platform.cloud.provisioning.save_provisioning_metadata"
 _PATCH_WAIT_DROPLET = "dango.platform.cloud.provisioning.wait_for_droplet_ready"
 _PATCH_WAIT_SSH = "dango.platform.cloud.provisioning.wait_for_ssh"
 
@@ -321,3 +323,74 @@ class TestResizeDroplet:
 
         # Should attempt to power on after failure
         assert client.power_on.call_count >= 1
+
+    def test_resize_without_backup(self) -> None:
+        from dango.platform.cloud.resize import resize_droplet
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/dbt/dbt_project.yml": (
+                    "name: proj\nversion: 1.0.0",
+                    "",
+                    0,
+                ),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+                "docker compose": ("", "", 0),
+            }
+        )
+        client = _make_do_client()
+
+        with (
+            patch(_PATCH_STOP) as mock_stop,
+            patch(_PATCH_WAIT_DROPLET),
+            patch(_PATCH_WAIT_SSH),
+            patch(_PATCH_START),
+            patch(_PATCH_VERIFY, return_value=True),
+        ):
+            result = resize_droplet(client, ssh, 42, "s-4vcpu-8gb", create_backup=False)
+
+        assert result.backup_path is None
+        mock_stop.assert_called_once()
+
+    def test_resize_persists_metadata(self, tmp_path: Any) -> None:
+        from dango.platform.cloud.resize import resize_droplet
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "cat /srv/dango/project/dbt/dbt_project.yml": (
+                    "name: proj\nversion: 1.0.0",
+                    "",
+                    0,
+                ),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+                "docker compose": ("", "", 0),
+            }
+        )
+        client = _make_do_client()
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        with (
+            patch(_PATCH_BACKUP, return_value=backup_result),
+            patch(_PATCH_WAIT_DROPLET),
+            patch(_PATCH_WAIT_SSH),
+            patch(_PATCH_START),
+            patch(_PATCH_VERIFY, return_value=True),
+            patch(_PATCH_SAVE_META) as mock_save,
+        ):
+            resize_droplet(
+                client,
+                ssh,
+                42,
+                "s-4vcpu-8gb",
+                project_root=tmp_path,
+                region="nyc1",
+            )
+
+        mock_save.assert_called_once()
+        kwargs = mock_save.call_args[1]
+        assert kwargs["size"] == "s-4vcpu-8gb"
+        assert kwargs["region"] == "nyc1"

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -207,16 +207,21 @@ class TestUpgradeDango:
         with (
             patch(_PATCH_PYPI, return_value="1.1.0"),
             patch(_PATCH_BACKUP, return_value=backup_result),
-            patch("dango.platform.cloud.upgrade.time.sleep"),
+            patch("dango.platform.cloud.backup.time.sleep"),
             patch(
                 "dango.platform.cloud.upgrade.time.monotonic",
                 side_effect=[
                     0.0,  # start_time
+                    100.0,  # final duration
+                ],
+            ),
+            patch(
+                "dango.platform.cloud.backup.time.monotonic",
+                side_effect=[
                     0.0,
-                    1.0,  # _verify_health loop iterations
+                    1.0,  # verify_health loop iterations
                     100.0,
                     100.0,  # timeout exceeded
-                    100.0,  # final duration
                 ],
             ),
         ):

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -1,0 +1,269 @@
+"""tests/unit/test_upgrade.py
+
+Unit tests for dango/platform/cloud/upgrade.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import CloudError
+from dango.platform.cloud.ssh import CommandResult
+
+# Patch paths — lazy imports mean we patch at the SOURCE module.
+_PATCH_PYPI = "dango.platform.cloud.server_status.check_latest_pypi_version"
+_PATCH_BACKUP = "dango.platform.cloud.backup.create_backup"
+
+
+def _make_ssh_mock(
+    *,
+    exec_results: dict[str, tuple[str, str, int]] | None = None,
+) -> MagicMock:
+    """Return a mock SSHManager with configurable exec_command results."""
+    results = exec_results or {}
+
+    def _exec_side_effect(command: str, timeout: int | None = None) -> CommandResult:
+        for substr, (stdout, stderr, exit_code) in results.items():
+            if substr in command:
+                return CommandResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    ssh = MagicMock()
+    ssh.exec_command.side_effect = _exec_side_effect
+    ssh.write_remote_file = MagicMock()
+    ssh.connect = MagicMock()
+    ssh.disconnect = MagicMock()
+    return ssh
+
+
+@pytest.mark.unit
+class TestValidateVersionString:
+    """Tests for validate_version_string()."""
+
+    def test_valid_versions(self) -> None:
+        from dango.platform.cloud.upgrade import validate_version_string
+
+        validate_version_string("1.0.0")
+        validate_version_string("0.1.1")
+        validate_version_string("99.88.77")
+
+    def test_invalid_versions(self) -> None:
+        from dango.platform.cloud.upgrade import validate_version_string
+
+        with pytest.raises(CloudError, match="Invalid version string"):
+            validate_version_string("1.0")
+
+        with pytest.raises(CloudError, match="Invalid version string"):
+            validate_version_string("v1.0.0")
+
+        with pytest.raises(CloudError, match="Invalid version string"):
+            validate_version_string("1.0.0-beta")
+
+    def test_injection_attempts(self) -> None:
+        from dango.platform.cloud.upgrade import validate_version_string
+
+        with pytest.raises(CloudError):
+            validate_version_string("1.0.0; rm -rf /")
+
+        with pytest.raises(CloudError):
+            validate_version_string("1.0.0 && echo pwned")
+
+        with pytest.raises(CloudError):
+            validate_version_string("$(whoami)")
+
+
+@pytest.mark.unit
+class TestCheckVersions:
+    """Tests for check_versions()."""
+
+    def test_returns_both_versions(self) -> None:
+        from dango.platform.cloud.upgrade import check_versions
+
+        ssh = _make_ssh_mock(exec_results={"import dango": ("1.0.0", "", 0)})
+        with patch(_PATCH_PYPI, return_value="1.1.0"):
+            current, latest = check_versions(ssh)
+
+        assert current == "1.0.0"
+        assert latest == "1.1.0"
+
+    def test_handles_missing_version(self) -> None:
+        from dango.platform.cloud.upgrade import check_versions
+
+        ssh = _make_ssh_mock(exec_results={"import dango": ("", "", 1)})
+        with patch(_PATCH_PYPI, return_value=None):
+            current, latest = check_versions(ssh)
+
+        assert current is None
+        assert latest is None
+
+
+@pytest.mark.unit
+class TestUpgradeDango:
+    """Tests for upgrade_dango()."""
+
+    def test_upgrade_to_latest(self) -> None:
+        from dango.platform.cloud.upgrade import upgrade_dango
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "import dango": ("1.0.0", "", 0),
+                "pip install": ("", "", 0),
+                "migrations run": ("No pending migrations", "", 0),
+                "docker compose": ("", "", 0),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+            }
+        )
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        with (
+            patch(_PATCH_PYPI, return_value="1.1.0"),
+            patch(_PATCH_BACKUP, return_value=backup_result),
+        ):
+            result = upgrade_dango(ssh)
+
+        assert result.old_version == "1.0.0"
+        assert result.backup_path is not None
+        assert result.health_check_passed is True
+
+    def test_upgrade_to_specific_version(self) -> None:
+        from dango.platform.cloud.upgrade import upgrade_dango
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "import dango": ("1.0.0", "", 0),
+                "pip install getdango==1.2.0": ("", "", 0),
+                "migrations run": ("", "", 0),
+                "docker compose": ("", "", 0),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+            }
+        )
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        with patch(_PATCH_BACKUP, return_value=backup_result):
+            result = upgrade_dango(ssh, version="1.2.0")
+
+        assert result.old_version == "1.0.0"
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        assert any("getdango==1.2.0" in cmd for cmd in cmds)
+
+    def test_already_at_target_version(self) -> None:
+        from dango.platform.cloud.upgrade import upgrade_dango
+
+        ssh = _make_ssh_mock(exec_results={"import dango": ("1.1.0", "", 0)})
+
+        with patch(_PATCH_PYPI, return_value="1.1.0"):
+            result = upgrade_dango(ssh)
+
+        assert result.old_version == "1.1.0"
+        assert result.new_version == "1.1.0"
+        assert result.backup_path is None
+        assert any("Already at target" in w for w in result.warnings)
+
+    def test_skip_backup_flag(self) -> None:
+        from dango.platform.cloud.upgrade import upgrade_dango
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "import dango": ("1.0.0", "", 0),
+                "pip install": ("", "", 0),
+                "migrations run": ("", "", 0),
+                "docker compose": ("", "", 0),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+            }
+        )
+
+        with patch(_PATCH_PYPI, return_value="1.1.0"):
+            result = upgrade_dango(ssh, skip_backup=True)
+
+        assert result.backup_path is None
+        assert any("backup skipped" in w for w in result.warnings)
+
+    def test_health_check_failure_suggests_rollback(self) -> None:
+        from dango.platform.cloud.upgrade import upgrade_dango
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "import dango": ("1.0.0", "", 0),
+                "pip install": ("", "", 0),
+                "migrations run": ("", "", 0),
+                "docker compose": ("", "", 0),
+                "curl -sf": ("", "", 1),  # Health check fails
+                "systemctl": ("", "", 0),
+            }
+        )
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        with (
+            patch(_PATCH_PYPI, return_value="1.1.0"),
+            patch(_PATCH_BACKUP, return_value=backup_result),
+            patch("dango.platform.cloud.upgrade.time.sleep"),
+            patch(
+                "dango.platform.cloud.upgrade.time.monotonic",
+                side_effect=[
+                    0.0,  # start_time
+                    0.0,
+                    1.0,  # _verify_health loop iterations
+                    100.0,
+                    100.0,  # timeout exceeded
+                    100.0,  # final duration
+                ],
+            ),
+        ):
+            result = upgrade_dango(ssh)
+
+        assert result.health_check_passed is False
+        assert any("rollback" in w.lower() for w in result.warnings)
+
+    def test_pypi_unavailable_raises(self) -> None:
+        from dango.platform.cloud.upgrade import upgrade_dango
+
+        ssh = _make_ssh_mock(exec_results={"import dango": ("1.0.0", "", 0)})
+
+        with (
+            patch(_PATCH_PYPI, return_value=None),
+            pytest.raises(CloudError, match="Could not determine latest"),
+        ):
+            upgrade_dango(ssh)
+
+    def test_progress_callback_called(self) -> None:
+        from dango.platform.cloud.upgrade import upgrade_dango
+
+        ssh = _make_ssh_mock(
+            exec_results={
+                "import dango": ("1.0.0", "", 0),
+                "pip install": ("", "", 0),
+                "migrations run": ("", "", 0),
+                "docker compose": ("", "", 0),
+                "curl -sf": ("ok", "", 0),
+                "systemctl": ("", "", 0),
+            }
+        )
+        progress_calls: list[tuple[str, str]] = []
+
+        backup_result = MagicMock()
+        backup_result.archive_path = "/srv/dango/backups/deploy/backup-test.tar.gz"
+
+        with (
+            patch(_PATCH_PYPI, return_value="1.1.0"),
+            patch(_PATCH_BACKUP, return_value=backup_result),
+        ):
+            upgrade_dango(
+                ssh,
+                on_progress=lambda step, status: progress_calls.append((step, status)),
+            )
+
+        steps = [s for s, _ in progress_calls]
+        assert "check_version" in steps
+        assert "pip_install" in steps
+        assert "verify_health" in steps


### PR DESCRIPTION
## Summary

- **TASK-104 (Resize):** In-place droplet resize via power off → resize → power on, with automatic dbt `profiles.yml` regeneration for new CPU/RAM specs. Adds `get_action()`/`wait_for_action()` to `DigitalOceanClient` for polling async actions.
- **TASK-105 (Migrate):** Full server migration via Spaces for disk/region changes — backup → upload to Spaces → provision new droplet → setup → copy secrets → download → restore → verify health → destroy old. Keeps both servers on health failure.
- **TASK-106 (Upgrade):** Remote Dango version upgrade with pre-upgrade backup, pip install, database migrations, Docker rebuild, and health verification. Suggests rollback on failure.
- All user-supplied inputs (size slugs, version strings) validated via strict regex at the platform layer to prevent shell injection
- 50 new unit tests across 4 test files, all 1846 existing tests pass with no regressions

### New files (8)
| File | Purpose |
|------|---------|
| `dango/platform/cloud/upgrade.py` | Upgrade business logic |
| `dango/platform/cloud/resize.py` | Resize business logic + dbt profiles generation |
| `dango/platform/cloud/migrate.py` | Migration business logic via Spaces |
| `dango/cli/commands/remote_ops.py` | CLI commands: `resize`, `migrate`, `upgrade` |
| `tests/unit/test_upgrade.py` | 12 tests |
| `tests/unit/test_resize.py` | 16 tests |
| `tests/unit/test_migrate.py` | 12 tests |
| `tests/unit/test_remote_ops_cli.py` | 10 tests |

### Modified files (6)
| File | Change |
|------|--------|
| `dango/platform/cloud/digitalocean.py` | `get_action()` + `wait_for_action()` (+57 lines) |
| `dango/platform/cloud/__init__.py` | New exports |
| `dango/cli/commands/remote.py` | Bottom-of-file import for `remote_ops` |
| `pyproject.toml` | 4 mypy exemptions for new test files |
| `dango/platform/CLAUDE.md` | Documented new modules |
| `docs/file-exemptions.yml` | `digitalocean.py` exemption (542 lines) |

## Test plan

- [x] `ruff check dango/` — all checks passed
- [x] `ruff format --check dango/` — 151 files formatted
- [x] `mypy dango/platform/cloud/{upgrade,resize,migrate}.py dango/cli/commands/remote_ops.py dango/platform/cloud/digitalocean.py` — no issues
- [x] `python scripts/check_file_sizes.py --all` — 187 checked, 36 exempt
- [x] `pytest tests/unit/test_upgrade.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_remote_ops_cli.py -v` — 50 passed
- [x] `pytest tests/unit/test_digitalocean_client.py -v` — 37 passed (no regressions)
- [x] `pytest tests/unit/ -x` — 1846 passed (full suite, no regressions)
- [x] `dango remote resize --help` / `migrate --help` / `upgrade --help` — all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)