### PR TITLE
Fix 6 integration test bugs in Phase 3 cloud modules

### DIFF
--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -108,7 +108,11 @@ def deploy(  # noqa: PLR0913
     else:
         config = run_wizard(project_root)
 
-    result = run_provisioning(project_root, config)
+    try:
+        result = run_provisioning(project_root, config)
+    except Exception:
+        # run_provisioning already prints error details and cleans up resources
+        raise SystemExit(1) from None
 
     # --- Success output ---
     console.print("\n[bold green]Deployment complete![/bold green]")

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from dango.cli import console
 from dango.cli.commands.deploy_wizard import _EMAIL_RE, WizardConfig
+from dango.exceptions import CloudProvisioningError
 
 
 @dataclass
@@ -102,7 +103,7 @@ def run_provisioning(
         ``ProvisionResult`` with deployment details.
 
     Raises:
-        SystemExit: On unrecoverable failure (after cleanup).
+        CloudProvisioningError: On unrecoverable failure (after cleanup).
     """
     from dango.platform.cloud.digitalocean import DigitalOceanClient
     from dango.platform.cloud.ssh import SSHManager
@@ -123,7 +124,7 @@ def run_provisioning(
         _status("Uploading SSH key to DigitalOcean...")
         key_name = f"dango-{project_root.name}-{int(time.time())}"
         key_data = client.upload_ssh_key(key_name, public_key)
-        ssh_key_id: int = key_data["ssh_key"]["id"]
+        ssh_key_id: int = key_data["id"]
         tracker.ssh_key_id = ssh_key_id
 
         # --- Sub-step 3: Provision droplet ---
@@ -262,8 +263,6 @@ def run_provisioning(
             warnings=warnings,
         )
 
-    except SystemExit:
-        raise
     except Exception as exc:
         console.print(f"\n[red]Provisioning failed:[/red] {exc}")
         console.print("Cleaning up resources...")
@@ -274,7 +273,7 @@ def run_provisioning(
                 console.print(f"  - {err}")
         else:
             console.print("[green]All resources cleaned up.[/green]")
-        raise SystemExit(1) from exc
+        raise CloudProvisioningError(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import platform
 import re
+import shlex
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -178,7 +179,9 @@ def _acquire_lock(ssh: SSHManager, *, force: bool = False) -> DeployLock:
     # Atomic creation: noclobber (set -C) makes > fail if the file
     # already exists, preventing a concurrent deployer from silently
     # overwriting our lock.
-    result = ssh.exec_command(f"(set -C; echo '{lock_json}' > {DEPLOY_LOCK_PATH}) 2>/dev/null")
+    result = ssh.exec_command(
+        f"(set -C; echo {shlex.quote(lock_json)} > {DEPLOY_LOCK_PATH}) 2>/dev/null"
+    )
     if not result.success:
         raise CloudProvisioningError(
             "Failed to acquire deploy lock — another deployment may have "

--- a/dango/platform/cloud/resize.py
+++ b/dango/platform/cloud/resize.py
@@ -102,28 +102,29 @@ def generate_dbt_profiles_yml(
         if getattr(dbt_overrides, "memory_limit", None) is not None:
             memory_limit = dbt_overrides.memory_limit
 
-    return f"""# dbt Profile Configuration for DuckDB
-# Auto-generated for cloud deployment — do not edit manually
-
-{project_name}:
-  target: dev
-  outputs:
-    dev:
-      type: duckdb
-      path: /srv/dango/project/data/warehouse.duckdb
-      schema: main
-      threads: {threads}
-
-      # DuckDB-specific settings
-      extensions:
-        - httpfs
-        - parquet
-
-      # Settings
-      settings:
-        memory_limit: {memory_limit}
-        threads: {threads}
-"""
+    profile: dict[str, Any] = {
+        project_name: {
+            "target": "dev",
+            "outputs": {
+                "dev": {
+                    "type": "duckdb",
+                    "path": "/srv/dango/project/data/warehouse.duckdb",
+                    "schema": "main",
+                    "threads": threads,
+                    "extensions": ["httpfs", "parquet"],
+                    "settings": {
+                        "memory_limit": memory_limit,
+                        "threads": threads,
+                    },
+                }
+            },
+        }
+    }
+    header = (
+        "# dbt Profile Configuration for DuckDB\n"
+        "# Auto-generated for cloud deployment — do not edit manually\n\n"
+    )
+    return header + yaml.dump(profile, default_flow_style=False, sort_keys=False)
 
 
 def regenerate_dbt_profiles(

--- a/dango/platform/cloud/scheduled_backup.py
+++ b/dango/platform/cloud/scheduled_backup.py
@@ -82,11 +82,18 @@ def _run_local(command: str, *, step: str, timeout: int = 120) -> str:
 
 
 def _stop_services() -> None:
-    """Stop dango-web and Metabase."""
-    _run_local("systemctl stop dango-web || true", step="stop_web", timeout=60)
-    _run_local(
+    """Stop dango-web and Metabase.
+
+    Best-effort — does not raise if services are already stopped.
+    """
+    subprocess.run(
+        "systemctl stop dango-web || true",
+        shell=True,
+        timeout=60,
+    )
+    subprocess.run(
         f"docker compose -f {PROJECT_DIR}/docker-compose.yml stop metabase 2>/dev/null || true",
-        step="stop_metabase",
+        shell=True,
         timeout=120,
     )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -295,11 +295,11 @@ def deployed_server(
     result = None
     ssh = None
 
-    # Provision — SystemExit is caught here only, not around the yield
+    # Provision — catch provisioning errors here only, not around the yield
     try:
         result = run_provisioning(project_root, config)
-    except SystemExit as exc:
-        pytest.fail(f"Provisioning failed with SystemExit({exc.code})")
+    except Exception as exc:
+        pytest.fail(f"Provisioning failed: {exc}")
 
     try:
         # Load the saved cloud config

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -21,6 +21,7 @@ from dango.cli.commands.deploy_provision import (
     _setup_backups,
     _trigger_initial_sync,
 )
+from dango.exceptions import CloudProvisioningError
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -294,7 +295,7 @@ class TestProvisionSequence:
         (dlt_dir / "secrets.toml").write_text("[sources]\n")
 
         mock_client = MagicMock()
-        mock_client.upload_ssh_key.return_value = {"ssh_key": {"id": 111}}
+        mock_client.upload_ssh_key.return_value = {"id": 111}
         mock_ssh = MagicMock()
         mock_result = MagicMock()
         mock_result.success = True
@@ -364,7 +365,7 @@ class TestProvisionSequence:
         )
 
         mock_client = MagicMock()
-        mock_client.upload_ssh_key.return_value = {"ssh_key": {"id": 111}}
+        mock_client.upload_ssh_key.return_value = {"id": 111}
         mock_ssh = MagicMock()
         mock_ssh.generate_key_pair.return_value = "ssh-ed25519 AAAA..."
 
@@ -381,7 +382,7 @@ class TestProvisionSequence:
                 "dango.platform.cloud.provisioning.provision_droplet",
                 side_effect=RuntimeError("API error"),
             ),
-            pytest.raises(SystemExit),
+            pytest.raises(CloudProvisioningError),
         ):
             run_provisioning(project_root, config)
 


### PR DESCRIPTION
## Summary
- **Fix 1:** KeyError in `deploy_provision.py` — `upload_ssh_key()` returns unwrapped dict, access `key_data["id"]` not `key_data["ssh_key"]["id"]`
- **Fix 2:** Mock return value shapes in `test_deploy_provision.py` updated to match actual API
- **Fix 3:** `SystemExit(1)` → `CloudProvisioningError` in provisioning failure handler for proper exception hierarchy
- **Fix 4:** Shell injection in `deployer.py` lock acquisition — use `shlex.quote()` for lock_json
- **Fix 5:** Dead error checking in `scheduled_backup.py` `_stop_services()` — `_run_local()` + `|| true` always exits 0, replaced with `subprocess.run()` matching `_start_services()` pattern
- **Fix 6:** f-string YAML template → `yaml.dump()` in `resize.py` `generate_dbt_profiles_yml()`

## Test plan
- [x] `pytest tests/unit/test_deploy_provision.py -v` — 26 passed
- [x] `pytest tests/unit/test_deployer.py -v` — 26 passed
- [x] `pytest tests/unit/test_scheduled_backup.py -v` — 23 passed
- [x] `pytest tests/unit/test_resize.py -v` — 17 passed
- [x] Full unit suite: 1850 passed
- [x] `ruff check` + `ruff format --check` + `mypy` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)