### PR TITLE
DOC-006, DOC-026: Phase 3 gate — platform CLAUDE.md + doc sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ dango/                          # Python package source
 │   │   ├── watcher_lifecycle.py # Watcher subprocess lifecycle
 │   │   └── watcher_runner.py   # Background watcher process
 │   ├── cloud/                  # Cloud components (TASK-022+)
-│   │   ├── __init__.py         # Re-exports 74 symbols
+│   │   ├── __init__.py         # Re-exports 63 symbols
 │   │   ├── digitalocean.py     # DO REST API v2 client (542 lines)
 │   │   ├── provisioning.py     # Size tiers, regions, provision_droplet()
 │   │   ├── firewall.py         # Firewall lifecycle, IP allowlisting
@@ -276,8 +276,8 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/source_wizard.py` | 1324 | — |
 | `visualization/metabase.py` | 1142 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/commands/platform.py` | 941 | — (extracted from main.py by TASK-005) |
 | `cli/init.py` | 965 | — |
+| `cli/commands/platform.py` | 941 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | ~854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 815 | — (renamed from auth.py by TASK-093) |
 | `oauth/providers.py` | 801 | — |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | Shared utilities | `dango/utils/` | [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md) |
 | Logging / diagnostics | `dango/logging.py` | Module docstring |
 | Database migrations | `dango/migrations/` | [`dango/migrations/CLAUDE.md`](dango/migrations/CLAUDE.md) |
-| Docker / file watcher | `dango/platform/` | [`dango/platform/CLAUDE.md`](dango/platform/CLAUDE.md) |
+| Docker / file watcher / cloud deployment | `dango/platform/` | [`dango/platform/CLAUDE.md`](dango/platform/CLAUDE.md) |
 | Jinja2 templates / Dockerfiles | `dango/templates/` | [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md) |
 | Auth / users / sessions | `dango/auth/` | [`dango/auth/CLAUDE.md`](dango/auth/CLAUDE.md) |
 | Notebooks | `dango/notebooks/` | Not yet created (Phase 6) |
@@ -51,6 +51,8 @@ When unsure which module to look at:
   - Config file format (`.dango/*.yml`) → `config/`
 - **Shared utility** (locking, logging, DB helpers) → `utils/`
 - **Docker containers / file watching** → `platform/`
+- **HOW code gets deployed to the cloud** → `platform/cloud/`
+- **CLI for cloud operations** → `cli/commands/remote*.py`, `cli/commands/deploy*.py`
 - **Still unsure** → read `ARCHITECTURE.md` §6 (Cross-Module Workflows)
 
 ## Repository Structure
@@ -71,11 +73,21 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (1026 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (941 lines)
 │   │   ├── project.py          # init/rename/info
 │   │   ├── source.py           # source group (add/list/remove) + sync (549 lines)
 │   │   ├── transform.py        # run/docs/generate
-│   │   └── web.py              # web dev server
+│   │   ├── web.py              # web dev server
+│   │   ├── serve.py            # serve production foreground server
+│   │   ├── deploy.py           # deploy group (wizard default, destroy)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard (579 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration (543 lines)
+│   │   ├── migrate.py          # migrate group (status, run)
+│   │   ├── remote.py           # remote group + push/rollback/firewall/domain (651 lines)
+│   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
+│   │   ├── remote_ops.py       # remote upgrade/resize/migrate
+│   │   ├── remote_backup.py    # remote backup subgroup
+│   │   └── remote_mgmt.py      # remote status/logs/ssh/query
 │   ├── init.py                 # Project initialization wizard
 │   ├── wizard.py               # Interactive setup wizards
 │   ├── source_wizard.py        # Source configuration wizard
@@ -127,13 +139,17 @@ dango/                          # Python package source
 │   │   ├── upload.py           # CSV upload/list/delete (680 lines)
 │   │   ├── websocket.py        # ConnectionManager, ws_manager, /ws
 │   │   ├── ui.py               # /, /health, /logs, /login, /account, /admin/users
-│   │   └── metabase_proxy.py   # Metabase reverse proxy + SSO session
+│   │   ├── metabase_proxy.py   # Metabase reverse proxy + SSO session
+│   │   ├── secrets.py          # Secrets + OAuth credential management (admin-only)
+│   │   ├── oauth_connect.py    # Web-based OAuth connect/callback
+│   │   └── initial_sync.py     # Initial data sync after first deploy
 │   ├── templates/              # Auth page templates
 │   │   ├── login.html          # Alpine.js two-step login (credentials → totp)
 │   │   ├── change_password.html # First-login password change
 │   │   ├── admin_users.html    # Admin user management
 │   │   ├── account.html        # User account settings
-│   │   └── invite.html         # Invite acceptance page
+│   │   ├── invite.html         # Invite acceptance page
+│   │   └── secrets.html        # Secrets management page
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
@@ -152,7 +168,23 @@ dango/                          # Python package source
 │   │   ├── watcher_lifecycle.py # Watcher subprocess lifecycle
 │   │   └── watcher_runner.py   # Background watcher process
 │   ├── cloud/                  # Cloud components (TASK-022+)
-│   │   └── __init__.py         # Empty package marker
+│   │   ├── __init__.py         # Re-exports 74 symbols
+│   │   ├── digitalocean.py     # DO REST API v2 client (542 lines)
+│   │   ├── provisioning.py     # Size tiers, regions, provision_droplet()
+│   │   ├── firewall.py         # Firewall lifecycle, IP allowlisting
+│   │   ├── spaces.py           # DO Spaces (S3-compatible via boto3)
+│   │   ├── ssh.py              # SSH key mgmt, TOFU, exec/SFTP (665 lines)
+│   │   ├── server_setup.py     # Server setup orchestration (16 steps)
+│   │   ├── server_status.py    # Server metrics + service status
+│   │   ├── domain.py           # DNS check, domain set/remove
+│   │   ├── backup.py           # Backup + rollback + service lifecycle
+│   │   ├── file_sync.py        # Project file sync (SFTP + rsync)
+│   │   ├── deployer.py         # Push deploy workflow + deploy lock
+│   │   ├── scheduled_backup.py # Server-side scheduled backup (505 lines)
+│   │   ├── resize.py           # In-place droplet resize
+│   │   ├── migrate.py          # Server migration via Spaces
+│   │   ├── upgrade.py          # Remote Dango version upgrade
+│   │   └── _server_templates.py # Config file templates
 │   │   # Backwards-compatible shims (re-export from local/):
 │   ├── network.py              # → local/network.py
 │   ├── watcher.py              # → local/watcher.py
@@ -174,7 +206,9 @@ dango/                          # Python package source
 │   ├── __init__.py             # OAuthManager
 │   ├── providers.py            # Google, Facebook, Shopify providers (801 lines)
 │   ├── storage.py              # Credential CRUD in .dlt/secrets.toml
-│   └── router.py               # FastAPI OAuth callback endpoints
+│   ├── router.py               # FastAPI OAuth callback endpoints
+│   ├── validation.py           # Live token validation + refresh checking
+│   └── web_flow.py             # Browser-based OAuth for cloud deployments
 │
 ├── config/                     # Level 0 — Configuration & credentials
 │   ├── models.py               # Pydantic models (DangoConfig, DataSource, etc.)
@@ -191,7 +225,8 @@ dango/                          # Python package source
 │   ├── database.py             # Schema creation helpers
 │   ├── db_health.py            # DuckDB health checks
 │   ├── dbt_status.py           # dbt model status tracking
-│   └── data_validation.py      # Data validation utilities
+│   ├── data_validation.py      # Data validation utilities
+│   └── env_file.py             # .env file parsing and serialization
 │
 ├── migrations/                 # Level 0 — Database migration framework
 │   ├── __init__.py             # Public API: apply_all_pending(), get_all_status()
@@ -241,7 +276,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/source_wizard.py` | 1324 | — |
 | `visualization/metabase.py` | 1142 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/commands/platform.py` | 1026 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 941 | — (extracted from main.py by TASK-005) |
 | `cli/init.py` | 965 | — |
 | `web/routes/auth.py` | ~854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 815 | — (renamed from auth.py by TASK-093) |
@@ -249,11 +284,18 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/helpers.py` | 798 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 742 | — |
 | `web/routes/upload.py` | 680 | — (extracted from app.py by TASK-085) |
+| `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
+| `cli/commands/remote.py` | 651 | — (remote group + push/rollback/firewall/domain) |
 | `cli/validate.py` | 651 | — |
+| `cli/commands/deploy_wizard.py` | 579 | — (interactive deploy wizard) |
 | `transformation/generator.py` | 577 | — |
 | `cli/commands/source.py` | 549 | — (extracted from main.py by TASK-005) |
+| `cli/commands/deploy_provision.py` | 543 | — (provisioning orchestration) |
+| `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
+| `web/routes/users.py` | 527 | — (admin user CRUD) |
 | `cli/model_wizard.py` | 507 | — |
 | `platform/local/watcher.py` | 506 | — |
+| `platform/cloud/scheduled_backup.py` | 505 | — (server-side scheduled backup) |
 
 ## Module Documentation Index
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -14,7 +14,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
 | `commands/source.py` (521 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (955 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/platform.py` (941 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (500 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
 | `commands/oauth.py` (815 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
 | `commands/transform.py` (326 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
@@ -28,7 +28,11 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/serve.py` (~110 lines) | `serve` production foreground server | `serve()` |
 | `commands/deploy.py` (~410 lines) | `deploy` group (wizard default, destroy) | `deploy`, `deploy_destroy()` |
 | `commands/deploy_wizard.py` (~430 lines) | Interactive wizard steps 1-9 + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig` |
-| `commands/deploy_provision.py` (~400 lines) | Provisioning orchestration + cleanup | `run_provisioning()`, `ProvisionResult`, `_ResourceTracker` |
+| `commands/deploy_provision.py` (~543 lines) | Provisioning orchestration + cleanup | `run_provisioning()`, `ProvisionResult`, `_ResourceTracker` |
+| `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
+| `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
+| `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |
+| `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query` | `remote_status()`, `remote_logs()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
 | `init.py` (965 lines) | Project initialization wizard | `ProjectInitializer` |
@@ -79,9 +83,17 @@ dango (top-level group)
 ├── migrate (group)             ← commands/migrate.py
 │   ├── status, run
 ├── remote (group)              ← commands/remote.py
-│   ├── push
-│   └── firewall (subgroup)
-│       ├── list, allow-ip, allow-all
+│   ├── push, rollback          ← commands/remote.py
+│   ├── status, logs, ssh, query ← commands/remote_mgmt.py
+│   ├── upgrade, resize, migrate ← commands/remote_ops.py
+│   ├── env (subgroup)          ← commands/remote_env.py
+│   │   ├── set, get, list, delete
+│   ├── firewall (subgroup)     ← commands/remote.py
+│   │   ├── list, allow-ip, allow-all
+│   ├── domain (subgroup)       ← commands/remote.py
+│   │   ├── set, remove
+│   └── backup (subgroup)       ← commands/remote_backup.py
+│       ├── list, enable, disable, download, restore
 ├── deploy (group)              ← commands/deploy.py
 │   ├── (default)  interactive wizard → commands/deploy_wizard.py + deploy_provision.py
 │   └── destroy    tear down cloud infrastructure
@@ -94,6 +106,8 @@ dango (top-level group)
 - **Lazy imports:** All command functions use `from dango.xxx import ...` inside the function body, not at module level. This prevents circular imports and speeds up CLI startup.
 - **Shared console:** All command modules import `console` from `dango.cli` for Rich terminal output.
 - **Project root via context:** `ctx.obj["project_root"]` is set by the top-level `cli` group in `main.py` (via `dango.config.helpers.find_project_root`).
+- **Cross-file command registration:** `remote_mgmt.py`, `remote_ops.py`, `remote_env.py`, and `remote_backup.py` import `remote` from `remote.py` and register commands via `@remote.command()` / `@remote.group()`. Registration is triggered by bottom-of-file imports in `remote.py`.
+- **Two SSH users:** `root` for system ops (backup, rollback, domain, server setup) via `load_cloud_config_with_ssh()` in `cli/utils.py`. `dango` for project file ops (.env, .dlt/secrets.toml) via `_ssh_connect_or_fail()` in `remote.py`.
 
 ## Common Tasks
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -25,9 +25,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
 | `commands/remote.py` (~650 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
-| `commands/serve.py` (~110 lines) | `serve` production foreground server | `serve()` |
-| `commands/deploy.py` (~410 lines) | `deploy` group (wizard default, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (~430 lines) | Interactive wizard steps 1-9 + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig` |
+| `commands/serve.py` (~152 lines) | `serve` production foreground server | `serve()` |
+| `commands/deploy.py` (~460 lines) | `deploy` group (wizard default, destroy) | `deploy`, `deploy_destroy()` |
+| `commands/deploy_wizard.py` (~579 lines) | Interactive wizard steps 1-9 + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig` |
 | `commands/deploy_provision.py` (~543 lines) | Provisioning orchestration + cleanup | `run_provisioning()`, `ProvisionResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -39,6 +39,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 - `dango/oauth/` — uses `CredentialManager` for token storage
 - `dango/web/` — serves config through API endpoints
 - `dango/platform/` — reads config for Docker and watcher setup
+- `dango/platform/cloud/` — reads CloudConfig for deployment operations
 
 ## Testing
 

--- a/dango/config/credentials.py
+++ b/dango/config/credentials.py
@@ -59,6 +59,9 @@ class CredentialManager:
 # access_token = "your-long-lived-token"
 # account_id = "act_123456789"
 """
+            # Note: write_text without prior chmod — low risk since file is
+            # user-owned and gitignored, but see cloud/ssh.py os.open() pattern
+            # for sensitive files that need restricted permissions at creation.
             self.secrets_file.write_text(secrets_template)
             console.print(f"[dim]Created {self.secrets_file.relative_to(self.project_root)}[/dim]")
 

--- a/dango/oauth/CLAUDE.md
+++ b/dango/oauth/CLAUDE.md
@@ -13,6 +13,7 @@ Manages browser-based OAuth authentication flows, provider-specific token exchan
 | `router.py` | Routes OAuth requests to correct provider | `run_oauth_for_source`, `check_oauth_credentials_exist`, `OAUTH_PROVIDER_MAP` |
 | `storage.py` | Token persistence to `.dlt/secrets.toml` with metadata | `OAuthStorage`, `OAuthCredential` |
 | `validation.py` | Live token validation and refresh checking via API calls | `TokenValidationResult`, `validate_token`, `validate_all_tokens`, `validate_before_sync`, `validate_google_token`, `validate_facebook_token`, `validate_shopify_token` |
+| `web_flow.py` | Browser-based OAuth token exchange for cloud deployments | `OAuthFlowError`, `SUPPORTED_OAUTH_SOURCES`, `build_google_auth_url()`, `exchange_google_code()`, `fetch_google_user_info()`, `build_facebook_auth_url()`, `exchange_facebook_code()` |
 
 ## Common Tasks
 

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -27,7 +27,7 @@ platform/
 │   └── watcher_runner.py    # Background watcher process entry point
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
-│   ├── __init__.py      # Re-exports 74 symbols (clients, provisioning, firewall, backup, deploy, etc.)
+│   ├── __init__.py      # Re-exports 63 symbols (clients, provisioning, firewall, backup, deploy, etc.)
 │   ├── digitalocean.py  # DO REST API v2 client (Droplets, SSH Keys, Firewalls)
 │   ├── provisioning.py  # Size tiers, regions, provision_droplet() orchestration (TASK-023)
 │   ├── firewall.py      # Firewall lifecycle, IP allowlisting (TASK-025)

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -27,13 +27,14 @@ platform/
 │   └── watcher_runner.py    # Background watcher process entry point
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
-│   ├── __init__.py      # Exports CommandResult, DigitalOceanClient, SpacesClient, SSHManager, provisioning, firewall symbols
+│   ├── __init__.py      # Re-exports 74 symbols (clients, provisioning, firewall, backup, deploy, etc.)
 │   ├── digitalocean.py  # DO REST API v2 client (Droplets, SSH Keys, Firewalls)
 │   ├── provisioning.py  # Size tiers, regions, provision_droplet() orchestration (TASK-023)
 │   ├── firewall.py      # Firewall lifecycle, IP allowlisting (TASK-025)
 │   ├── spaces.py        # DO Spaces client (S3-compatible via boto3)
 │   ├── ssh.py           # SSH key management, TOFU known-hosts, exec/SFTP (TASK-024)
 │   ├── server_setup.py  # SSH-based server setup orchestration (TASK-026)
+│   ├── server_status.py # Server resource metrics + service status via SSH (TASK-104)
 │   ├── domain.py        # DNS check, set_domain(), remove_domain() (TASK-027)
 │   ├── backup.py        # SSH-based backup + rollback (TASK-035)
 │   ├── file_sync.py     # Project file sync: SFTP + rsync (TASK-028)
@@ -51,7 +52,7 @@ platform/
 └── watcher_runner.py    # → platform.local.watcher_runner
 ```
 
-## File Purpose
+## Files
 
 | File | Purpose | Key Symbols |
 |------|---------|-------------|
@@ -67,6 +68,7 @@ platform/
 | `cloud/spaces.py` | DigitalOcean Spaces (S3-compatible) client | `SpacesClient` |
 | `cloud/ssh.py` | SSH key management, TOFU known-hosts, command exec, SFTP | `SSHManager`, `CommandResult` |
 | `cloud/server_setup.py` | SSH-based server setup orchestration (16 idempotent steps) | `setup_server`, `SetupResult` |
+| `cloud/server_status.py` | Server resource metrics, service status, PyPI version check | `ServerStatus`, `ServiceInfo`, `collect_server_status`, `check_latest_pypi_version`, `get_local_resource_usage` |
 | `cloud/domain.py` | DNS check, domain set/remove for HTTPS via Caddy | `check_dns`, `set_domain`, `remove_domain` |
 | `cloud/backup.py` | SSH-based backup and rollback | `create_backup`, `rollback`, `list_local_backups`, `rotate_local_backups`, `BackupManifest`, `BackupResult`, `RestoreResult` |
 | `cloud/file_sync.py` | Project file sync (SFTP + rsync) with change detection | `sync_project_files`, `SyncResult` |
@@ -188,6 +190,7 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - **`local/` is local-only** — nginx routing and file watcher don't apply to cloud deployments (cloud uses Caddy, and `auto_sync=false`).
 - **`common/startup.py` raises, never displays** — no `console`, `click`, or `rich` imports. Callers (CLI, cloud serve) handle all user-facing output.
 - **Shims for backwards compatibility** — existing code that imports from `dango.platform.watcher_lifecycle` continues to work without changes.
+- **`cloud/backup.py` is evolving beyond pure backup** — it also provides `stop_services()`, `start_services()`, and `verify_health()`, used by resize, migrate, and deployer as service lifecycle utilities. If more lifecycle functions accumulate, consider extracting a `service_lifecycle.py` module.
 
 ## Dependencies
 
@@ -210,4 +213,77 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - `dango.cli.commands.remote` — rollback command
 - `dango.cli.commands.remote_backup` — backup subcommands
 - `dango.cli.commands.remote_ops` — resize, migrate, upgrade commands
+- `dango.cli.commands.deploy_provision` — provisioning orchestration
+- `dango.cli.commands.remote_env` — remote env var management (uses file_sync)
+- `dango.cli.commands.remote_mgmt` — remote status/logs/ssh/query
 - `dango.web.routes.health` — get_watcher_status
+
+## Cloud Deployment Flow
+
+```
+Local Machine                          DigitalOcean
+─────────────                          ────────────
+
+dango deploy
+  ├─ deploy_wizard.py (interactive)
+  ├─ deploy_provision.py
+  │  ├─ ssh.py → generate_key()
+  │  ├─ digitalocean.py → create       ──→  Droplet (Ubuntu 22.04)
+  │  ├─ provisioning.py → wait         ←──  IP address
+  │  ├─ firewall.py → create           ──→  Firewall rules
+  │  ├─ server_setup.py → setup        ──→  Docker, Caddy, systemd
+  │  ├─ file_sync.py → sync            ──→  Project files via SFTP
+  │  └─ deployer.py → push_deploy      ──→  Build + restart services
+  └─ initial_sync (web)                ──→  First data sync
+
+dango remote push
+  ├─ backup.py → create_backup         ──→  Pre-deploy backup
+  ├─ file_sync.py → sync               ──→  Changed files
+  └─ deployer.py → push_deploy         ──→  Rebuild + restart
+
+dango remote rollback
+  └─ backup.py → rollback              ──→  Restore from backup
+```
+
+## Remote Server Layout
+
+```
+/srv/dango/                            # Application root (owner: dango)
+├── project/                           # Synced project files
+│   ├── .dango/                        # Dango state
+│   │   ├── cloud.yml                  # Cloud config (IP, region, size, etc.)
+│   │   ├── state/                     # Runtime state
+│   │   └── logs/                      # Activity + audit logs
+│   ├── .dlt/                          # dlt config + secrets
+│   ├── .env                           # Environment variables
+│   ├── data/warehouse.duckdb          # DuckDB database
+│   └── docker-compose.yml             # Generated Docker Compose
+├── venv/                              # Python virtual environment
+└── backups/deploy/                    # Pre-deploy backups
+
+/etc/caddy/Caddyfile                   # Reverse proxy (HTTP or HTTPS)
+/etc/systemd/system/dango.service      # Dango systemd unit
+/etc/systemd/system/dango-backup.*     # Scheduled backup timer + service
+```
+
+## Security Recommendations
+
+Post-deployment hardening (not automated by Dango):
+
+- **Cloudflare proxy:** Route traffic through Cloudflare for DDoS protection and CDN. Set Caddy to trust Cloudflare IPs for correct client IP logging.
+- **UptimeRobot:** Monitor `/api/health` endpoint for uptime alerts. Free tier supports 5-minute check intervals.
+- **Firewall IP restriction:** Use `dango remote firewall allow-ip` to restrict web access to known IPs during development/staging.
+
+## Testing
+
+- **Local platform:** `pytest tests/unit/test_platform_startup.py tests/unit/test_watcher_lifecycle.py`
+- **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
+- **Manual:** `dango start` (local platform), `dango deploy` (cloud provisioning)
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `cloud/__init__.py` export list | Other modules depend on re-exported symbols; changes break downstream imports |
+| `cloud/_server_templates.py` systemd unit structure | Running servers depend on the exact systemd unit format |
+| `local/` watcher event format | Web UI parses watcher status responses |

--- a/dango/security/token_storage.py
+++ b/dango/security/token_storage.py
@@ -71,6 +71,9 @@ class SecureTokenStorage:
                 return key_file.read_bytes()
             else:
                 key = Fernet.generate_key()
+                # TOCTOU: file is briefly world-readable between write_bytes
+                # and chmod. For a more secure pattern, use os.open() with
+                # mode at creation time (see cloud/ssh.py generate_key()).
                 key_file.write_bytes(key)
                 key_file.chmod(0o600)  # Restrict permissions
                 return key

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -17,6 +17,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `dbt_lock.py` | Cross-process file lock for dbt operations (fcntl/msvcrt) | `DbtLock`, `dbt_lock()` context manager (imports `DbtLockError` from `dango.exceptions`) |
 | `dbt_status.py` | Persistent dbt model status from run_results.json | `update_model_status()`, `get_model_statuses()` |
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
+| `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 
 ## Common Tasks
 

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -23,6 +23,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `templates/admin_users.html` | Admin user management page — invite, edit roles, deactivate | Alpine.js with modal dialogs |
 | `templates/account.html` | User account settings — change password, sessions, API keys, 2FA | Alpine.js `accountPage()` component |
 | `templates/invite.html` | Invite acceptance page — set password for invited users | — |
+| `templates/secrets.html` | Secrets management page (env vars + OAuth credentials) | — |
 | `routes/__init__.py` | Package marker | — |
 | `routes/auth.py` | Login/logout, password change, OAuth flows, invite accept, API key CRUD (~854 lines) | `_bridge_metabase_session()`, `_set_session_cookie()` |
 | `routes/auth_2fa.py` | TOTP 2FA setup/verify/disable/recovery (~328 lines) | — |
@@ -37,6 +38,9 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/websocket.py` | `ConnectionManager`, `ws_manager` singleton, `/ws` endpoint | `ConnectionManager`, `ws_manager` |
 | `routes/ui.py` | `/`, `/health`, `/logs`, `/api`, `/api/docs`, `/api/redoc`, `/login`, `/account`, `/admin/users`, `/invite/{token}` | `templates`, `_render_template()` |
 | `routes/metabase_proxy.py` | All Metabase proxy routes + SSO session state | `proxy_to_metabase()`, `get_metabase_session()` |
+| `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
+| `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
+| `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `static/` | CSS and JS assets (`css/main.css`, `js/app.js`, `js/logs.js`) | — |
 
 ## Architecture


### PR DESCRIPTION
## Summary

- **DOC-006:** Polish `dango/platform/CLAUDE.md` — add `server_status.py`, cloud deployment flow diagram, remote server layout, security recommendations, backup lifecycle note, fix structural validation (missing `## Files`, `## Testing`, `## Don't Modify` sections)
- **DOC-026:** End-of-phase doc sweep across all 7 CLAUDE.md files — add Phase 3 files (16 cloud modules, 4 remote CLI commands, 3 web routes, `web_flow.py`, `env_file.py`, `secrets.html`), expand CLI command hierarchy, fix stale line counts, add TOCTOU audit comments

## Test plan

- [x] `python scripts/validate_claude_md.py` passes on all 7 modified CLAUDE.md files
- [x] `ruff check dango/` passes
- [x] `ruff format --check dango/` passes
- [x] `mypy dango/` passes
- [x] All pre-commit hooks pass
- [x] V1_PLAN.md superseded task notes verified (TASK-048, 050, 051, 055)
- [x] MEMORY.md cloud patterns extracted to `cloud-patterns.md`, phase status updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)