### PR TITLE
TASK-040b: Backfill + dev sync CLI

### DIFF
--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -3,6 +3,8 @@
 Data source management commands (add, list, remove) and sync.
 """
 
+import re
+
 import click
 
 from dango.cli import console
@@ -10,6 +12,58 @@ from dango.config.helpers import (
     check_unreferenced_custom_sources,
     format_unreferenced_sources_warning,
 )
+
+_DURATION_PATTERN = re.compile(r"^(\d+)([dwmDWM])$")
+_DURATION_MULTIPLIERS = {"d": 1, "w": 7, "m": 30}
+
+
+def _parse_duration(value: str) -> int:
+    """Parse a duration string like '7d', '2w', '1m' into days.
+
+    Args:
+        value: Duration string (e.g. '7d', '30d', '2w', '1m').
+
+    Returns:
+        Number of days.
+
+    Raises:
+        click.BadParameter: If the format is invalid or value is zero/negative.
+    """
+    match = _DURATION_PATTERN.match(value)
+    if not match:
+        raise click.BadParameter(
+            f"Invalid duration '{value}'. Use format like '7d', '2w', '1m' "
+            "(d=days, w=weeks, m=months/30d)."
+        )
+    amount = int(match.group(1))
+    unit = match.group(2).lower()
+    if amount <= 0:
+        raise click.BadParameter("Duration must be a positive number.")
+    return amount * _DURATION_MULTIPLIERS[unit]
+
+
+def _source_supports_date_range(source_type: str) -> bool:
+    """Check whether a source type supports start_date/end_date filtering.
+
+    Looks up the source in the registry and checks for a 'start_date'
+    parameter in optional_params or required_params.
+
+    Args:
+        source_type: Source type key (e.g. 'facebook_ads', 'csv').
+
+    Returns:
+        True if the source has a start_date parameter.
+    """
+    from dango.ingestion.sources.registry import get_source_metadata
+
+    metadata = get_source_metadata(source_type)
+    if not metadata:
+        return False
+    for param_list_key in ("optional_params", "required_params"):
+        for param in metadata.get(param_list_key, []):
+            if param.get("name") == "start_date":
+                return True
+    return False
 
 
 @click.group()
@@ -338,16 +392,20 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 
 @click.command()
 @click.option("--source", help="Sync specific source only")
-@click.option("--start-date", help="Start date for incremental loading (YYYY-MM-DD)")
-@click.option("--end-date", help="End date for incremental loading (YYYY-MM-DD)")
+@click.option("--since", help="Start date for incremental loading (YYYY-MM-DD)")
+@click.option("--until", help="End date for incremental loading (YYYY-MM-DD)")
+@click.option("--backfill", help="Backfill duration (e.g. '7d', '2w', '1m')")
+@click.option("--limit", type=int, help="Limit rows per source (dev testing)")
 @click.option("--full-refresh", is_flag=True, help="Drop existing data and reload from scratch")
 @click.option("--dry-run", is_flag=True, help="Show what would be synced without executing")
 @click.pass_context
 def sync(
     ctx: click.Context,
     source: str | None,
-    start_date: str | None,
-    end_date: str | None,
+    since: str | None,
+    until: str | None,
+    backfill: str | None,
+    limit: int | None,
     full_refresh: bool,
     dry_run: bool,
 ) -> None:
@@ -357,7 +415,9 @@ def sync(
     Examples:
       dango sync                               Sync all enabled sources
       dango sync --source orders               Sync only 'orders' source
-      dango sync --start-date 2024-01-01       Override start date
+      dango sync --since 2024-01-01            Override start date
+      dango sync --backfill 30d                Backfill last 30 days
+      dango sync --limit 1000                  Dev mode: limit rows per source
       dango sync --full-refresh                Reset state and reload all data
       dango sync --dry-run                     Preview what would be synced
 
@@ -366,7 +426,7 @@ def sync(
       2. Runs dlt pipelines (API sources)
       3. Optionally runs dbt models (transformations)
     """
-    from datetime import datetime
+    from datetime import datetime, timedelta
 
     from dango.config import get_config
     from dango.ingestion import run_sync
@@ -407,23 +467,44 @@ def sync(
         if unreferenced:
             console.print(format_unreferenced_sources_warning(unreferenced))
 
-        # Parse dates if provided
+        # --- Validate option conflicts ---
+        if backfill and (since or until):
+            console.print(
+                "[red]Error:[/red] --backfill conflicts with --since/--until. Use one or the other."
+            )
+            raise click.Abort()
+
+        if limit is not None and limit <= 0:
+            console.print("[red]Error:[/red] --limit must be a positive integer.")
+            raise click.Abort()
+
+        # --- Resolve dates ---
         start_date_obj = None
         end_date_obj = None
 
-        if start_date:
+        if backfill:
+            days = _parse_duration(backfill)
+            today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            start_date_obj = today - timedelta(days=days)
+            end_date_obj = today
+
+        if since:
             try:
-                start_date_obj = datetime.strptime(start_date, "%Y-%m-%d")
+                start_date_obj = datetime.strptime(since, "%Y-%m-%d")
             except ValueError:
-                console.print("[red]Error:[/red] Invalid start date format. Use YYYY-MM-DD")
+                console.print("[red]Error:[/red] Invalid --since date format. Use YYYY-MM-DD")
                 raise click.Abort() from None
 
-        if end_date:
+        if until:
             try:
-                end_date_obj = datetime.strptime(end_date, "%Y-%m-%d")
+                end_date_obj = datetime.strptime(until, "%Y-%m-%d")
             except ValueError:
-                console.print("[red]Error:[/red] Invalid end date format. Use YYYY-MM-DD")
+                console.print("[red]Error:[/red] Invalid --until date format. Use YYYY-MM-DD")
                 raise click.Abort() from None
+
+        if start_date_obj and end_date_obj and start_date_obj >= end_date_obj:
+            console.print("[red]Error:[/red] --since must be before --until.")
+            raise click.Abort()
 
         # Get sources to sync
         if source:
@@ -452,6 +533,19 @@ def sync(
         if full_refresh:
             console.print("[yellow]⚠️  Full refresh mode: existing data will be dropped[/yellow]")
 
+        if limit:
+            console.print(f"[yellow]⚠️  Dev mode: limiting to {limit} rows per source[/yellow]")
+
+        # Warn if date range specified for sources that don't support it
+        has_date_range = start_date_obj is not None or end_date_obj is not None
+        if has_date_range:
+            for src in sources_to_sync:
+                if not _source_supports_date_range(src.type.value):
+                    console.print(
+                        f"[yellow]⚠️  '{src.name}' ({src.type.value}) does not support "
+                        f"date range filtering — dates will be ignored[/yellow]"
+                    )
+
         console.print()
 
         # Dry run mode - show what would be synced without executing
@@ -472,8 +566,12 @@ def sync(
             console.print()
             console.print("[dim]Options:[/dim]")
             console.print(f"  • Full refresh: {'Yes' if full_refresh else 'No'}")
-            console.print(f"  • Start date: {start_date or 'Default'}")
-            console.print(f"  • End date: {end_date or 'Default'}")
+            since_display = start_date_obj.strftime("%Y-%m-%d") if start_date_obj else "Default"
+            until_display = end_date_obj.strftime("%Y-%m-%d") if end_date_obj else "Default"
+            console.print(f"  • Since: {since_display}")
+            console.print(f"  • Until: {until_display}")
+            if limit:
+                console.print(f"  • Limit: {limit} rows")
             console.print()
             console.print("[dim]Run without --dry-run to execute sync[/dim]")
             return
@@ -496,6 +594,7 @@ def sync(
             start_date=start_date_obj,
             end_date=end_date_obj,
             full_refresh=full_refresh,
+            limit=limit,
         )
 
         # Trigger Metabase schema sync (if Metabase is running)

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -27,7 +27,7 @@ def _parse_duration(value: str) -> int:
         Number of days.
 
     Raises:
-        click.BadParameter: If the format is invalid or value is zero/negative.
+        click.BadParameter: If the format is invalid or value is zero.
     """
     match = _DURATION_PATTERN.match(value)
     if not match:
@@ -536,15 +536,20 @@ def sync(
         if limit:
             console.print(f"[yellow]⚠️  Dev mode: limiting to {limit} rows per source[/yellow]")
 
-        # Warn if date range specified for sources that don't support it
-        has_date_range = start_date_obj is not None or end_date_obj is not None
-        if has_date_range:
-            for src in sources_to_sync:
-                if not _source_supports_date_range(src.type.value):
-                    console.print(
-                        f"[yellow]⚠️  '{src.name}' ({src.type.value}) does not support "
-                        f"date range filtering — dates will be ignored[/yellow]"
-                    )
+        # Warn about source-specific option limitations
+        for src in sources_to_sync:
+            src_type = src.type.value
+            has_date_range = start_date_obj is not None or end_date_obj is not None
+            if has_date_range and not _source_supports_date_range(src_type):
+                console.print(
+                    f"[yellow]⚠️  '{src.name}' ({src_type}) does not support "
+                    f"date range filtering — dates will be ignored[/yellow]"
+                )
+            if limit and src_type == "csv":
+                console.print(
+                    f"[yellow]⚠️  '{src.name}' (csv) does not support "
+                    f"--limit — CSV loads all rows[/yellow]"
+                )
 
         console.print()
 

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -152,6 +152,7 @@ class DltPipelineRunner:
         end_date: datetime | None = None,
         full_refresh: bool = False,
         timeout_minutes: int = 60,
+        limit: int | None = None,
     ) -> dict[str, Any]:
         """
         Run data pipeline for any source type
@@ -162,6 +163,7 @@ class DltPipelineRunner:
             end_date: Override end date for incremental loading
             full_refresh: Drop existing data and reload from scratch
             timeout_minutes: Timeout in minutes (default: 60)
+            limit: Max rows to load (dev testing, applies to dlt sources only)
 
         Returns:
             Dictionary with load statistics and status
@@ -284,7 +286,11 @@ class DltPipelineRunner:
             elif source_type == SourceType.DLT_NATIVE:
                 try:
                     result = self._run_with_timeout(
-                        self._run_dlt_native_source, timeout_minutes, source_config, full_refresh
+                        self._run_dlt_native_source,
+                        timeout_minutes,
+                        source_config,
+                        full_refresh,
+                        limit=limit,
                     )
                 except SyncTimeoutError as e:
                     error_message = str(e)
@@ -328,6 +334,7 @@ class DltPipelineRunner:
                         start_date,
                         end_date,
                         full_refresh,
+                        limit=limit,
                     )
                 except SyncTimeoutError as e:
                     error_message = str(e)
@@ -493,7 +500,10 @@ class DltPipelineRunner:
         }
 
     def _run_dlt_native_source(
-        self, source_config: DataSource, full_refresh: bool = False
+        self,
+        source_config: DataSource,
+        full_refresh: bool = False,
+        limit: int | None = None,
     ) -> dict[str, Any]:
         """
         Run dlt native source (registry bypass for advanced users)
@@ -506,6 +516,7 @@ class DltPipelineRunner:
         Args:
             source_config: Source configuration with dlt_native config
             full_refresh: Drop pipeline state and reload
+            limit: Max rows to load (dev testing)
 
         Returns:
             Load statistics
@@ -567,6 +578,11 @@ class DltPipelineRunner:
                     f"  [dim]Calling {config.source_function}(**{config.function_kwargs})[/dim]"
                 )
                 source = source_function(**config.function_kwargs)
+
+                # Apply row limit if specified (dev testing)
+                if limit is not None:
+                    source.add_limit(limit)
+                    console.print(f"  [dim]Row limit: {limit}[/dim]")
 
             finally:
                 # Remove custom_sources from path
@@ -692,6 +708,7 @@ class DltPipelineRunner:
         start_date: datetime | None = None,
         end_date: datetime | None = None,
         full_refresh: bool = False,
+        limit: int | None = None,
     ) -> dict[str, Any]:
         """
         Run dlt pipeline for any verified source (generic implementation)
@@ -706,6 +723,7 @@ class DltPipelineRunner:
             start_date: Override start date
             end_date: Override end date
             full_refresh: Drop pipeline state and reload
+            limit: Max rows to load (dev testing)
 
         Returns:
             Load statistics
@@ -790,6 +808,11 @@ class DltPipelineRunner:
             # Dynamic import of dlt source
             # dlt resolves dlt.secrets.value parameters at this point
             source = self._load_dlt_source(dlt_package, dlt_function, source_kwargs)
+
+            # Apply row limit if specified (dev testing)
+            if limit is not None:
+                source.add_limit(limit)
+                console.print(f"  [dim]Row limit: {limit}[/dim]")
 
             # Detect actual load type from dlt source configuration
             # Check if source uses replace write_disposition (full refresh by design)
@@ -1575,6 +1598,7 @@ def run_sync(
     start_date: datetime | None = None,
     end_date: datetime | None = None,
     full_refresh: bool = False,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     """
     Sync multiple sources and return summary
@@ -1585,6 +1609,7 @@ def run_sync(
         start_date: Override start date
         end_date: Override end date
         full_refresh: Full refresh mode
+        limit: Max rows per source (dev testing)
 
     Returns:
         Summary dictionary with success/failed counts
@@ -1602,7 +1627,7 @@ def run_sync(
             skipped_sources.append(source_config.name)
             continue
 
-        result = runner.run_source(source_config, start_date, end_date, full_refresh)
+        result = runner.run_source(source_config, start_date, end_date, full_refresh, limit=limit)
         results.append(result)
 
         if result.get("status") == "success":

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -75,7 +75,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 649
+    lines: 653
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -75,9 +75,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 549
+    lines: 649
     category: exempt
-    reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. Sync command alone is ~200 lines of orchestration logic."
+    reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"
 
   - file: dango/cli/commands/remote.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ module = [
     "tests.unit.test_resize",
     "tests.unit.test_migrate",
     "tests.unit.test_remote_ops_cli",
+    "tests.unit.test_cli_sync",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -3,6 +3,8 @@
 Unit tests for dango sync CLI backfill and dev-sync options.
 """
 
+import re
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +17,8 @@ from dango.cli.commands.source import (
     _source_supports_date_range,
     sync,
 )
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 @pytest.mark.unit
@@ -70,12 +74,28 @@ class TestSourceSupportsDateRange:
         assert _source_supports_date_range("nonexistent_source_xyz") is False
 
 
-def _patch_sync_prereqs():
+def _make_mock_source(name: str = "test_src", source_type: str = "stripe"):
+    """Create a mock DataSource with the given name and type."""
+    mock_src = MagicMock()
+    mock_src.name = name
+    mock_src.type.value = source_type
+    mock_src.enabled = True
+    mock_src.csv = None
+    mock_src.dlt_native = None
+    mock_src.dlt_config = None
+    return mock_src
+
+
+def _patch_sync_prereqs(sources=None):
     """Stack patches for all sync prerequisites (lazy imports)."""
-    mock_sources = MagicMock()
-    mock_sources.sources = []
+    if sources is None:
+        sources = [_make_mock_source()]
+
+    mock_sources_cfg = MagicMock()
+    mock_sources_cfg.sources = sources
+    mock_sources_cfg.get_enabled_sources.return_value = sources
     mock_config = MagicMock()
-    mock_config.sources = mock_sources
+    mock_config.sources = mock_sources_cfg
 
     return [
         patch("dango.cli.utils.require_project_context", return_value=Path("/tmp/fake")),
@@ -91,12 +111,14 @@ def _patch_sync_prereqs():
 
 @pytest.mark.unit
 class TestSyncBackfillValidation:
-    """Tests for backfill/limit validation via CliRunner."""
+    """Tests for backfill/limit validation and happy paths via CliRunner."""
 
-    def _invoke(self, args: list[str]) -> object:
+    def _invoke(self, args: list[str], sources=None, extra_patches=None):
         """Invoke sync command with all prerequisites mocked."""
         runner = CliRunner()
-        patches = _patch_sync_prereqs()
+        patches = _patch_sync_prereqs(sources)
+        if extra_patches:
+            patches.extend(extra_patches)
         for p in patches:
             p.start()
         try:
@@ -134,3 +156,35 @@ class TestSyncBackfillValidation:
         result = self._invoke(["--limit", "0"])
         assert result.exit_code != 0
         assert "positive" in result.output.lower()
+
+    def test_backfill_computes_dates_in_dry_run(self) -> None:
+        """--backfill 30d shows correct date range in dry-run output."""
+        result = self._invoke(["--backfill", "30d", "--dry-run"])
+        assert result.exit_code == 0
+        plain = _ANSI_RE.sub("", result.output)
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        expected_since = (today - timedelta(days=30)).strftime("%Y-%m-%d")
+        expected_until = today.strftime("%Y-%m-%d")
+        assert expected_since in plain
+        assert expected_until in plain
+
+    def test_limit_passed_to_run_sync(self) -> None:
+        """--limit value is forwarded to run_sync()."""
+        mock_run_sync = MagicMock(
+            return_value={"failed_count": 0, "success_count": 1, "oauth_warnings": []}
+        )
+        mock_metabase = patch(
+            "dango.visualization.metabase.sync_metabase_schema", return_value=False
+        )
+        mock_validate = patch("dango.oauth.validation.validate_before_sync")
+        result = self._invoke(
+            ["--limit", "500"],
+            extra_patches=[
+                patch("dango.ingestion.run_sync", mock_run_sync),
+                mock_metabase,
+                mock_validate,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        mock_run_sync.assert_called_once()
+        assert mock_run_sync.call_args.kwargs["limit"] == 500

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -1,0 +1,136 @@
+"""tests/unit/test_cli_sync.py
+
+Unit tests for dango sync CLI backfill and dev-sync options.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.source import (
+    _parse_duration,
+    _source_supports_date_range,
+    sync,
+)
+
+
+@pytest.mark.unit
+class TestParseDuration:
+    """Tests for _parse_duration() helper."""
+
+    def test_days(self) -> None:
+        assert _parse_duration("7d") == 7
+
+    def test_days_large(self) -> None:
+        assert _parse_duration("30d") == 30
+
+    def test_weeks(self) -> None:
+        assert _parse_duration("2w") == 14
+
+    def test_months(self) -> None:
+        assert _parse_duration("1m") == 30
+
+    def test_months_multiple(self) -> None:
+        assert _parse_duration("3m") == 90
+
+    def test_case_insensitive(self) -> None:
+        assert _parse_duration("7D") == 7
+        assert _parse_duration("2W") == 14
+        assert _parse_duration("1M") == 30
+
+    def test_invalid_format_raises(self) -> None:
+        with pytest.raises(click.BadParameter, match="Invalid duration"):
+            _parse_duration("abc")
+
+    def test_zero_raises(self) -> None:
+        with pytest.raises(click.BadParameter, match="positive"):
+            _parse_duration("0d")
+
+
+@pytest.mark.unit
+class TestSourceSupportsDateRange:
+    """Tests for _source_supports_date_range() helper."""
+
+    def test_facebook_ads_supports(self) -> None:
+        assert _source_supports_date_range("facebook_ads") is True
+
+    def test_stripe_supports(self) -> None:
+        assert _source_supports_date_range("stripe") is True
+
+    def test_google_analytics_supports(self) -> None:
+        assert _source_supports_date_range("google_analytics") is True
+
+    def test_csv_not_supported(self) -> None:
+        assert _source_supports_date_range("csv") is False
+
+    def test_unknown_source_not_supported(self) -> None:
+        assert _source_supports_date_range("nonexistent_source_xyz") is False
+
+
+def _patch_sync_prereqs():
+    """Stack patches for all sync prerequisites (lazy imports)."""
+    mock_sources = MagicMock()
+    mock_sources.sources = []
+    mock_config = MagicMock()
+    mock_config.sources = mock_sources
+
+    return [
+        patch("dango.cli.utils.require_project_context", return_value=Path("/tmp/fake")),
+        patch("dango.utils.DbtLock"),
+        patch("dango.cli.utils.check_git_branch_warning"),
+        patch("dango.config.get_config", return_value=mock_config),
+        patch(
+            "dango.cli.commands.source.check_unreferenced_custom_sources",
+            return_value=[],
+        ),
+    ]
+
+
+@pytest.mark.unit
+class TestSyncBackfillValidation:
+    """Tests for backfill/limit validation via CliRunner."""
+
+    def _invoke(self, args: list[str]) -> object:
+        """Invoke sync command with all prerequisites mocked."""
+        runner = CliRunner()
+        patches = _patch_sync_prereqs()
+        for p in patches:
+            p.start()
+        try:
+            return runner.invoke(sync, args, obj={"project_root": "/tmp"})
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_backfill_conflicts_with_since(self) -> None:
+        """--backfill and --since cannot be used together."""
+        result = self._invoke(["--backfill", "30d", "--since", "2024-01-01"])
+        assert result.exit_code != 0
+        assert "conflicts" in result.output.lower()
+
+    def test_backfill_conflicts_with_until(self) -> None:
+        """--backfill and --until cannot be used together."""
+        result = self._invoke(["--backfill", "7d", "--until", "2024-12-31"])
+        assert result.exit_code != 0
+        assert "conflicts" in result.output.lower()
+
+    def test_since_must_be_before_until(self) -> None:
+        """--since must be chronologically before --until."""
+        result = self._invoke(["--since", "2024-12-31", "--until", "2024-01-01"])
+        assert result.exit_code != 0
+        assert "before" in result.output.lower()
+
+    def test_negative_limit_rejected(self) -> None:
+        """Click's type=int rejects non-numeric --limit."""
+        runner = CliRunner()
+        result = runner.invoke(sync, ["--limit", "abc"], obj={"project_root": "/tmp"})
+        assert result.exit_code != 0
+
+    def test_zero_limit_rejected(self) -> None:
+        """--limit 0 is rejected as non-positive."""
+        result = self._invoke(["--limit", "0"])
+        assert result.exit_code != 0
+        assert "positive" in result.output.lower()


### PR DESCRIPTION
## Summary
- Add `--backfill` option (duration strings: `7d`, `2w`, `1m`) to `dango sync` for relative date backfilling
- Rename `--start-date`/`--end-date` to `--since`/`--until` (pre-v1, no backward compat needed)
- Add `--limit` option (int) for dev-mode row limiting via dlt `add_limit()`
- Thread `limit` param through `run_sync()` → `run_source()` → `_run_dlt_source()`/`_run_dlt_native_source()`
- Add source-type-aware warnings when date range specified for sources without `start_date` support
- Add conflict validation (`--backfill` vs `--since`/`--until`, `--since` before `--until`, positive `--limit`)

## Test plan
- [x] 18 unit tests in `tests/unit/test_cli_sync.py` (all pass)
- [x] `TestParseDuration`: 8 tests covering `d`/`w`/`m` units, case insensitivity, invalid/zero input
- [x] `TestSourceSupportsDateRange`: 5 tests against real registry data
- [x] `TestSyncBackfillValidation`: 5 tests via CliRunner for option conflicts and validation
- [x] Full unit suite: 1868 passed, 0 regressions
- [x] ruff lint + format + mypy + file size checks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)