### PR TITLE
feat(scheduling): add SchedulerService core + FastAPI lifecycle (TASK-036)

### DIFF
--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Docker service lifecycle, file watching, and platform startup helpers. Shared between local (`dango start`) and cloud (`dango serve`, TASK-026) startup flows.
+Docker service lifecycle, file watching, job scheduling, and platform startup helpers. Shared between local (`dango start`) and cloud (`dango serve`, TASK-026) startup flows.
 
 ## Directory Layout
 
@@ -25,6 +25,11 @@ platform/
 │   ├── watcher.py       # DebouncedFileHandler, FileWatcher, MultiTargetWatcher
 │   ├── watcher_lifecycle.py  # start/stop/status for watcher subprocess
 │   └── watcher_runner.py    # Background watcher process entry point
+│
+├── scheduling/          # APScheduler-based job scheduling (TASK-036+)
+│   ├── __init__.py      # Re-exports SchedulerService
+│   ├── scheduler.py     # SchedulerService (AsyncIOScheduler wrapper)
+│   └── jobs.py          # Module-level job functions (pickle-safe)
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
 │   ├── __init__.py      # Re-exports 63 symbols (clients, provisioning, firewall, backup, deploy, etc.)
@@ -62,6 +67,8 @@ platform/
 | `local/watcher.py` | File change detection | `DebouncedFileHandler`, `FileWatcher`, `MultiTargetWatcher`, `SyncTrigger` |
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |
 | `local/watcher_runner.py` | Background watcher process | `main` |
+| `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence | `SchedulerService` |
+| `scheduling/jobs.py` | Module-level job function stubs (pickle-safe) | `sync_source_job`, `dbt_run_job` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |
 | `cloud/provisioning.py` | Droplet size tiers, regions, provisioning orchestration | `DropletSizeTier`, `RegionInfo`, `SIZE_TIERS`, `DEFAULT_TIER`, `provision_droplet`, `wait_for_droplet_ready`, `wait_for_ssh`, `suggest_nearest_region`, `save_provisioning_metadata` |
 | `cloud/firewall.py` | Firewall lifecycle and IP allowlisting | `create_default_firewall`, `add_allowed_ip`, `restrict_web_to_ips`, `allow_all_web`, `validate_ip_or_cidr`, `save_firewall_metadata` |
@@ -86,6 +93,10 @@ platform/
 # Shared infrastructure
 from dango.platform import DockerManager, ServiceStatus
 from dango.platform.common.startup import run_pending_migrations, start_docker_services
+
+# Scheduling (TASK-036+)
+from dango.platform.scheduling import SchedulerService
+from dango.platform.scheduling.jobs import sync_source_job, dbt_run_job
 
 # Local-only components
 from dango.platform.local.watcher_lifecycle import start_file_watcher, get_watcher_status
@@ -161,6 +172,7 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
+| Add/modify scheduled jobs | `scheduling/scheduler.py`, `scheduling/jobs.py` | `pytest tests/unit/test_scheduler.py` |
 | Add a startup step for both local + cloud | `common/startup.py` | `pytest tests/unit/test_platform_startup.py` |
 | Add a local-only startup step | `local/` and `cli/commands/platform.py` | `dango start` manually |
 | Add cloud infrastructure | `cloud/` | `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py` |
@@ -206,6 +218,8 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - `paramiko` — SSH transport (cloud/ssh.py)
 - `cryptography` — Ed25519 key generation (cloud/ssh.py; core dependency)
 - `watchdog` — Observer, FileSystemEventHandler (watcher.py)
+- `apscheduler` — AsyncIOScheduler, SQLAlchemyJobStore (scheduling/)
+- `sqlalchemy` — Required by APScheduler job store (scheduling/)
 
 **Used by:**
 - `dango.cli.commands.platform` — start/stop/status commands
@@ -216,7 +230,8 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - `dango.cli.commands.deploy_provision` — provisioning orchestration
 - `dango.cli.commands.remote_env` — remote env var management (uses file_sync)
 - `dango.cli.commands.remote_mgmt` — remote status/logs/ssh/query
-- `dango.web.routes.health` — get_watcher_status
+- `dango.web.routes.health` — get_watcher_status, scheduler status
+- `dango.web.app` — SchedulerService lifecycle (startup/shutdown)
 
 ## Cloud Deployment Flow
 
@@ -276,6 +291,7 @@ Post-deployment hardening (not automated by Dango):
 
 ## Testing
 
+- **Scheduling:** `pytest tests/unit/test_scheduler.py`
 - **Local platform:** `pytest tests/unit/test_platform_startup.py tests/unit/test_watcher_lifecycle.py`
 - **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
 - **Manual:** `dango start` (local platform), `dango deploy` (cloud provisioning)

--- a/dango/platform/scheduling/__init__.py
+++ b/dango/platform/scheduling/__init__.py
@@ -1,0 +1,8 @@
+"""dango/platform/scheduling/__init__.py
+
+APScheduler-based job scheduling for Dango data pipelines.
+"""
+
+from dango.platform.scheduling.scheduler import SchedulerService
+
+__all__ = ["SchedulerService"]

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -1,0 +1,24 @@
+"""dango/platform/scheduling/jobs.py
+
+Module-level job functions for APScheduler pickle serialization.
+
+APScheduler 3.x serializes job references by module path. Functions must be
+defined at module level (not as methods or lambdas) so they can be pickled
+and restored from the SQLite job store across restarts.
+"""
+
+
+def sync_source_job(source_name: str, project_root: str) -> None:
+    """Run a scheduled sync for a data source.
+
+    Implementation in TASK-041.
+    """
+    raise NotImplementedError("Job implementation pending TASK-041")
+
+
+def dbt_run_job(project_root: str, select: str | None = None) -> None:
+    """Run a scheduled dbt transformation.
+
+    Implementation in TASK-041.
+    """
+    raise NotImplementedError("Job implementation pending TASK-041")

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -8,15 +8,16 @@ build on this foundation.
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import concurrent.futures
 
 from apscheduler.events import (
     EVENT_JOB_ERROR,
     EVENT_JOB_EXECUTED,
     EVENT_JOB_MISSED,
-    JobEvent,
     JobExecutionEvent,
 )
 from apscheduler.executors.pool import ThreadPoolExecutor
@@ -66,6 +67,7 @@ class SchedulerService:
         )
         self._loop: asyncio.AbstractEventLoop | None = None
         self._project_root = project_root
+        self._started = False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -74,9 +76,16 @@ class SchedulerService:
     def start(self, loop: asyncio.AbstractEventLoop) -> None:
         """Start the scheduler and register event listeners.
 
+        Calling ``start()`` more than once is a no-op (listeners are
+        registered exactly once).
+
         Args:
             loop: The running asyncio event loop (for coroutine bridging).
         """
+        if self._started:
+            logger.warning("scheduler_already_started")
+            return
+
         self._loop = loop
 
         self._scheduler.add_listener(self._on_job_executed, EVENT_JOB_EXECUTED)
@@ -84,6 +93,7 @@ class SchedulerService:
         self._scheduler.add_listener(self._on_job_missed, EVENT_JOB_MISSED)
 
         self._scheduler.start()
+        self._started = True
 
         self._log_startup_summary()
         self._check_dual_scheduler()
@@ -184,7 +194,7 @@ class SchedulerService:
             traceback=str(event.traceback),
         )
 
-    def _on_job_missed(self, event: JobEvent) -> None:
+    def _on_job_missed(self, event: JobExecutionEvent) -> None:
         logger.warning(
             "scheduler_job_missed",
             job_id=event.job_id,
@@ -226,5 +236,4 @@ class SchedulerService:
                     ),
                 )
         except Exception:  # noqa: BLE001
-            # Config loading failure is non-fatal for this check
-            pass
+            logger.debug("dual_scheduler_check_failed", exc_info=True)

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -1,0 +1,230 @@
+"""dango/platform/scheduling/scheduler.py
+
+SchedulerService wraps APScheduler 3.x AsyncIOScheduler for job persistence,
+event tracking, and async bridging. All subsequent Phase 4 scheduling tasks
+build on this foundation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from pathlib import Path
+from typing import Any
+
+from apscheduler.events import (
+    EVENT_JOB_ERROR,
+    EVENT_JOB_EXECUTED,
+    EVENT_JOB_MISSED,
+    JobEvent,
+    JobExecutionEvent,
+)
+from apscheduler.executors.pool import ThreadPoolExecutor
+from apscheduler.job import Job
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from dango.logging import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_THREAD_POOL_SIZE = 20
+_DEFAULT_MISFIRE_GRACE_TIME = 3600  # 1 hour
+
+
+class SchedulerService:
+    """Wrapper around APScheduler AsyncIOScheduler.
+
+    Provides job persistence via SQLite, event logging, and an async
+    coroutine bridge for thread-pool jobs that need to broadcast via
+    WebSocket.
+    """
+
+    def __init__(self, project_root: Path) -> None:
+        dango_dir = project_root / ".dango"
+        dango_dir.mkdir(parents=True, exist_ok=True)
+
+        db_path = dango_dir / "scheduler.db"
+        job_store_url = f"sqlite:///{db_path}"
+
+        jobstores: dict[str, SQLAlchemyJobStore] = {
+            "default": SQLAlchemyJobStore(url=job_store_url),
+        }
+        executors: dict[str, ThreadPoolExecutor] = {
+            "default": ThreadPoolExecutor(_DEFAULT_THREAD_POOL_SIZE),
+        }
+        job_defaults: dict[str, Any] = {
+            "coalesce": True,
+            "max_instances": 1,
+            "misfire_grace_time": _DEFAULT_MISFIRE_GRACE_TIME,
+        }
+
+        self._scheduler = AsyncIOScheduler(
+            jobstores=jobstores,
+            executors=executors,
+            job_defaults=job_defaults,
+        )
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._project_root = project_root
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Start the scheduler and register event listeners.
+
+        Args:
+            loop: The running asyncio event loop (for coroutine bridging).
+        """
+        self._loop = loop
+
+        self._scheduler.add_listener(self._on_job_executed, EVENT_JOB_EXECUTED)
+        self._scheduler.add_listener(self._on_job_error, EVENT_JOB_ERROR)
+        self._scheduler.add_listener(self._on_job_missed, EVENT_JOB_MISSED)
+
+        self._scheduler.start()
+
+        self._log_startup_summary()
+        self._check_dual_scheduler()
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Gracefully shut down the scheduler.
+
+        Args:
+            wait: If True, wait for running jobs to finish before returning.
+        """
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=wait)
+            logger.info("scheduler_shutdown", wait=wait)
+
+    # ------------------------------------------------------------------
+    # Job management
+    # ------------------------------------------------------------------
+
+    def add_job(self, func: Any, trigger: Any, **kwargs: Any) -> Job:
+        """Add a job to the scheduler.
+
+        Delegates directly to ``AsyncIOScheduler.add_job()``.
+        """
+        return self._scheduler.add_job(func, trigger, **kwargs)
+
+    def remove_job(self, job_id: str) -> None:
+        """Remove a job by ID."""
+        self._scheduler.remove_job(job_id)
+
+    def get_jobs(self) -> list[Job]:
+        """Return all scheduled jobs."""
+        result: list[Job] = self._scheduler.get_jobs()
+        return result
+
+    def get_status(self) -> dict[str, Any]:
+        """Return scheduler status for the health endpoint.
+
+        Returns:
+            Dict with ``running``, ``job_count``, and ``next_run_time`` keys.
+        """
+        jobs = self._scheduler.get_jobs() if self._scheduler.running else []
+        next_run: str | None = None
+        if jobs:
+            upcoming = sorted(
+                (j for j in jobs if j.next_run_time is not None),
+                key=lambda j: j.next_run_time,
+            )
+            if upcoming:
+                next_run = upcoming[0].next_run_time.isoformat()
+
+        return {
+            "running": self._scheduler.running,
+            "job_count": len(jobs),
+            "next_run_time": next_run,
+        }
+
+    # ------------------------------------------------------------------
+    # Async bridge
+    # ------------------------------------------------------------------
+
+    def run_coroutine(self, coro: Any) -> concurrent.futures.Future[Any]:
+        """Schedule an async coroutine from a thread-pool job.
+
+        Uses ``asyncio.run_coroutine_threadsafe`` to bridge from the
+        synchronous thread-pool executor back to the event loop. Useful
+        for WebSocket broadcasts triggered by sync/dbt jobs.
+
+        Args:
+            coro: An awaitable coroutine.
+
+        Returns:
+            A ``concurrent.futures.Future`` wrapping the coroutine result.
+
+        Raises:
+            RuntimeError: If the scheduler has not been started (no loop).
+        """
+        if self._loop is None:
+            raise RuntimeError("Scheduler not started — no event loop available")
+        return asyncio.run_coroutine_threadsafe(coro, self._loop)
+
+    # ------------------------------------------------------------------
+    # Event listeners
+    # ------------------------------------------------------------------
+
+    def _on_job_executed(self, event: JobExecutionEvent) -> None:
+        logger.info(
+            "scheduler_job_executed",
+            job_id=event.job_id,
+            scheduled_run_time=str(event.scheduled_run_time),
+        )
+
+    def _on_job_error(self, event: JobExecutionEvent) -> None:
+        logger.error(
+            "scheduler_job_error",
+            job_id=event.job_id,
+            scheduled_run_time=str(event.scheduled_run_time),
+            exception=str(event.exception),
+            traceback=str(event.traceback),
+        )
+
+    def _on_job_missed(self, event: JobEvent) -> None:
+        logger.warning(
+            "scheduler_job_missed",
+            job_id=event.job_id,
+            scheduled_run_time=str(event.scheduled_run_time),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _log_startup_summary(self) -> None:
+        """Log the number of loaded jobs and next run times."""
+        jobs = self._scheduler.get_jobs()
+        next_runs = {j.id: str(j.next_run_time) for j in jobs if j.next_run_time is not None}
+        logger.info(
+            "scheduler_started",
+            job_count=len(jobs),
+            next_run_times=next_runs,
+        )
+
+    def _check_dual_scheduler(self) -> None:
+        """Warn if a cloud deployment exists while running locally.
+
+        Prevents confusion when both local and cloud schedulers are active.
+        """
+        try:
+            from dango.config.loader import ConfigLoader
+
+            loader = ConfigLoader(self._project_root)
+            cloud_cfg = loader.load_cloud_config()
+            if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+                logger.warning(
+                    "dual_scheduler_warning",
+                    message=(
+                        "A cloud deployment is active (droplet_id="
+                        f"{cloud_cfg.droplet_id}). Running a local scheduler "
+                        "alongside the cloud scheduler may cause duplicate job "
+                        "execution."
+                    ),
+                )
+        except Exception:  # noqa: BLE001
+            # Config loading failure is non-fatal for this check
+            pass

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -329,7 +329,7 @@ async def startup_event() -> None:
         from dango.platform.scheduling import SchedulerService
 
         scheduler = SchedulerService(project_root)
-        scheduler.start(asyncio.get_event_loop())
+        scheduler.start(asyncio.get_running_loop())
         app.state.scheduler = scheduler
     except Exception:
         logger.error("scheduler_startup_failed", exc_info=True)
@@ -339,10 +339,14 @@ async def startup_event() -> None:
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
     """Run on application shutdown."""
+    import asyncio
+
     scheduler = getattr(app.state, "scheduler", None)
     if scheduler is not None:
         try:
-            scheduler.shutdown(wait=True)
+            # Run in thread to avoid blocking the event loop if a job is
+            # still executing in the ThreadPoolExecutor.
+            await asyncio.to_thread(scheduler.shutdown, True)
         except Exception:
             logger.error("scheduler_shutdown_failed", exc_info=True)
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -322,10 +322,30 @@ async def startup_event() -> None:
     except Exception:
         logger.warning("first_run_admin_check_failed", exc_info=True)
 
+    # Initialize APScheduler for job scheduling
+    try:
+        import asyncio
+
+        from dango.platform.scheduling import SchedulerService
+
+        scheduler = SchedulerService(project_root)
+        scheduler.start(asyncio.get_event_loop())
+        app.state.scheduler = scheduler
+    except Exception:
+        logger.error("scheduler_startup_failed", exc_info=True)
+        app.state.scheduler = None
+
 
 @app.on_event("shutdown")
 async def shutdown_event() -> None:
     """Run on application shutdown."""
+    scheduler = getattr(app.state, "scheduler", None)
+    if scheduler is not None:
+        try:
+            scheduler.shutdown(wait=True)
+        except Exception:
+            logger.error("scheduler_shutdown_failed", exc_info=True)
+
     logger.info("api_shutting_down")
 
 

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -157,6 +157,9 @@ async def get_platform_health() -> dict[str, Any]:
         "warnings": warnings,
     }
 
+    # Scheduler health
+    result["scheduler"] = _get_scheduler_status()
+
     # Cloud-specific: add resource metrics and backup health
     cloud_data = await _get_cloud_health_data()
     if cloud_data:
@@ -175,6 +178,20 @@ async def get_platform_health() -> dict[str, Any]:
         result["status"] = "healthy"
 
     return result
+
+
+def _get_scheduler_status() -> dict[str, Any]:
+    """Return scheduler status from app state, with a safe fallback."""
+    try:
+        from dango.web.app import app
+
+        scheduler = getattr(app.state, "scheduler", None)
+        if scheduler is not None:
+            status: dict[str, Any] = scheduler.get_status()
+            return status
+    except Exception:  # noqa: BLE001
+        pass
+    return {"running": False, "job_count": 0, "next_run_time": None}
 
 
 async def _get_cloud_health_data() -> dict[str, Any] | None:

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -158,7 +158,10 @@ async def get_platform_health() -> dict[str, Any]:
     }
 
     # Scheduler health
-    result["scheduler"] = _get_scheduler_status()
+    scheduler_status = _get_scheduler_status()
+    result["scheduler"] = scheduler_status
+    if not scheduler_status.get("running"):
+        warnings.append("Scheduler not running")
 
     # Cloud-specific: add resource metrics and backup health
     cloud_data = await _get_cloud_health_data()
@@ -180,6 +183,9 @@ async def get_platform_health() -> dict[str, Any]:
     return result
 
 
+_SCHEDULER_FALLBACK: dict[str, Any] = {"running": False, "job_count": 0, "next_run_time": None}
+
+
 def _get_scheduler_status() -> dict[str, Any]:
     """Return scheduler status from app state, with a safe fallback."""
     try:
@@ -190,8 +196,8 @@ def _get_scheduler_status() -> dict[str, Any]:
             status: dict[str, Any] = scheduler.get_status()
             return status
     except Exception:  # noqa: BLE001
-        pass
-    return {"running": False, "job_count": 0, "next_run_time": None}
+        logger.debug("scheduler_status_check_failed", exc_info=True)
+    return dict(_SCHEDULER_FALLBACK)
 
 
 async def _get_cloud_health_data() -> dict[str, Any] | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
 
     # Scheduling
     "apscheduler>=3.11,<4",   # Job scheduling (AsyncIOScheduler + SQLAlchemy job store)
-    "sqlalchemy>=2.0",        # Required by APScheduler SQLAlchemyJobStore
+    "sqlalchemy>=2.0,<3",     # Required by APScheduler SQLAlchemyJobStore
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ dependencies = [
     # Cloud deployment
     "boto3>=1.34.0",      # DigitalOcean Spaces (S3-compatible)
     "paramiko>=3.0.0",    # SSH key management and remote execution
+
+    # Scheduling
+    "apscheduler>=3.11,<4",   # Job scheduling (AsyncIOScheduler + SQLAlchemy job store)
+    "sqlalchemy>=2.0",        # Required by APScheduler SQLAlchemyJobStore
 ]
 
 [project.optional-dependencies]
@@ -111,6 +115,7 @@ packages = [
     "dango.platform.local",
     "dango.platform.common",
     "dango.platform.cloud",
+    "dango.platform.scheduling",
     "dango.templates",
     "dango.utils",
     "dango.visualization",
@@ -176,6 +181,10 @@ module = [
     "botocore.*",
     "paramiko",
     "paramiko.*",
+    "apscheduler",
+    "apscheduler.*",
+    "sqlalchemy",
+    "sqlalchemy.*",
 ]
 ignore_missing_imports = true
 
@@ -242,6 +251,7 @@ module = [
     "tests.unit.test_remote_ops_cli",
     "tests.unit.test_cli_sync",
     "tests.unit.test_webhook",
+    "tests.unit.test_scheduler",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,392 @@
+"""tests/unit/test_scheduler.py
+
+Tests for dango.platform.scheduling — SchedulerService and module-level job stubs.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Patch both SQLAlchemyJobStore AND AsyncIOScheduler to avoid real
+# APScheduler initialization (it validates isinstance on job stores).
+_SCHEDULER_MOD = "dango.platform.scheduling.scheduler"
+
+
+def _make_service(tmp_path):
+    """Create a SchedulerService with all APScheduler internals mocked."""
+    with (
+        patch(f"{_SCHEDULER_MOD}.SQLAlchemyJobStore"),
+        patch(f"{_SCHEDULER_MOD}.AsyncIOScheduler") as mock_cls,
+    ):
+        mock_scheduler = MagicMock()
+        mock_scheduler.running = False
+        mock_scheduler.get_jobs.return_value = []
+        mock_cls.return_value = mock_scheduler
+
+        from dango.platform.scheduling.scheduler import SchedulerService
+
+        svc = SchedulerService(tmp_path)
+
+    return svc
+
+
+@pytest.mark.unit
+class TestSchedulerServiceInit:
+    """Test SchedulerService construction and configuration."""
+
+    def test_init_configures_job_store_path(self, tmp_path):
+        """Job store URL should point to .dango/scheduler.db."""
+        with (
+            patch(f"{_SCHEDULER_MOD}.SQLAlchemyJobStore") as mock_store,
+            patch(f"{_SCHEDULER_MOD}.AsyncIOScheduler"),
+        ):
+            from dango.platform.scheduling.scheduler import SchedulerService
+
+            SchedulerService(tmp_path)
+
+        expected_url = f"sqlite:///{tmp_path / '.dango' / 'scheduler.db'}"
+        mock_store.assert_called_once_with(url=expected_url)
+
+    def test_ensures_dango_dir_exists(self, tmp_path):
+        """.dango/ directory should be created if it doesn't exist."""
+        project_root = tmp_path / "myproject"
+        project_root.mkdir()
+
+        with (
+            patch(f"{_SCHEDULER_MOD}.SQLAlchemyJobStore"),
+            patch(f"{_SCHEDULER_MOD}.AsyncIOScheduler"),
+        ):
+            from dango.platform.scheduling.scheduler import SchedulerService
+
+            SchedulerService(project_root)
+
+        assert (project_root / ".dango").is_dir()
+
+
+@pytest.mark.unit
+class TestSchedulerServiceLifecycle:
+    """Test start/shutdown behaviour."""
+
+    def test_start_calls_scheduler_start(self, tmp_path):
+        """start() should call the underlying scheduler.start()."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        svc.start(loop)
+
+        svc._scheduler.start.assert_called_once()
+
+    def test_start_registers_event_listeners(self, tmp_path):
+        """start() should register executed, error, and missed listeners."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        svc.start(loop)
+
+        assert svc._scheduler.add_listener.call_count == 3
+
+    def test_start_stores_loop(self, tmp_path):
+        """start() should store the event loop for coroutine bridging."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        svc.start(loop)
+
+        assert svc._loop is loop
+
+    def test_shutdown_waits_by_default(self, tmp_path):
+        """shutdown() should call scheduler.shutdown(wait=True) by default."""
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = True
+
+        svc.shutdown()
+
+        svc._scheduler.shutdown.assert_called_once_with(wait=True)
+
+    def test_shutdown_no_wait(self, tmp_path):
+        """shutdown(wait=False) should not wait for running jobs."""
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = True
+
+        svc.shutdown(wait=False)
+
+        svc._scheduler.shutdown.assert_called_once_with(wait=False)
+
+    def test_shutdown_skips_if_not_running(self, tmp_path):
+        """shutdown() should be a no-op if the scheduler isn't running."""
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = False
+
+        svc.shutdown()
+
+        svc._scheduler.shutdown.assert_not_called()
+
+
+@pytest.mark.unit
+class TestSchedulerServiceJobs:
+    """Test job management delegation."""
+
+    def test_add_job_delegates(self, tmp_path):
+        """add_job() should delegate to the underlying scheduler."""
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = True
+        func = MagicMock()
+        trigger = "interval"
+
+        svc.add_job(func, trigger, seconds=60, id="test-job")
+
+        svc._scheduler.add_job.assert_called_once_with(func, trigger, seconds=60, id="test-job")
+
+    def test_remove_job_delegates(self, tmp_path):
+        """remove_job() should delegate to the underlying scheduler."""
+        svc = _make_service(tmp_path)
+
+        svc.remove_job("test-job")
+
+        svc._scheduler.remove_job.assert_called_once_with("test-job")
+
+    def test_get_jobs_returns_list(self, tmp_path):
+        """get_jobs() should return the job list from the scheduler."""
+        svc = _make_service(tmp_path)
+        mock_jobs = [MagicMock(), MagicMock()]
+        svc._scheduler.get_jobs.return_value = mock_jobs
+
+        result = svc.get_jobs()
+
+        assert result == mock_jobs
+
+
+@pytest.mark.unit
+class TestSchedulerServiceStatus:
+    """Test get_status() output."""
+
+    def test_get_status_when_running(self, tmp_path):
+        """get_status() should report running=True with job count."""
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = True
+
+        job = MagicMock()
+        job.next_run_time = None
+        svc._scheduler.get_jobs.return_value = [job]
+
+        status = svc.get_status()
+
+        assert status["running"] is True
+        assert status["job_count"] == 1
+        assert status["next_run_time"] is None
+
+    def test_get_status_when_stopped(self, tmp_path):
+        """get_status() should report running=False when stopped."""
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = False
+
+        status = svc.get_status()
+
+        assert status["running"] is False
+        assert status["job_count"] == 0
+        assert status["next_run_time"] is None
+
+    def test_get_status_with_next_run_time(self, tmp_path):
+        """get_status() should report the earliest next_run_time."""
+        from datetime import datetime, timezone
+
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = True
+
+        job1 = MagicMock()
+        job1.next_run_time = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+        job2 = MagicMock()
+        job2.next_run_time = datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc)
+        svc._scheduler.get_jobs.return_value = [job1, job2]
+
+        status = svc.get_status()
+
+        assert status["next_run_time"] == job2.next_run_time.isoformat()
+
+
+@pytest.mark.unit
+class TestSchedulerServiceEventListeners:
+    """Test event listener logging."""
+
+    def test_event_listener_job_executed_logs(self, tmp_path):
+        """_on_job_executed should log at info level."""
+        svc = _make_service(tmp_path)
+        event = MagicMock()
+        event.job_id = "test-job"
+        event.scheduled_run_time = "2026-03-01T10:00:00"
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._on_job_executed(event)
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "scheduler_job_executed"
+        assert call_args[1]["job_id"] == "test-job"
+
+    def test_event_listener_job_error_logs(self, tmp_path):
+        """_on_job_error should log at error level."""
+        svc = _make_service(tmp_path)
+        event = MagicMock()
+        event.job_id = "test-job"
+        event.scheduled_run_time = "2026-03-01T10:00:00"
+        event.exception = ValueError("boom")
+        event.traceback = "traceback here"
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._on_job_error(event)
+
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "scheduler_job_error"
+
+    def test_event_listener_job_missed_logs(self, tmp_path):
+        """_on_job_missed should log at warning level."""
+        svc = _make_service(tmp_path)
+        event = MagicMock()
+        event.job_id = "test-job"
+        event.scheduled_run_time = "2026-03-01T10:00:00"
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._on_job_missed(event)
+
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args[0][0] == "scheduler_job_missed"
+
+
+@pytest.mark.unit
+class TestSchedulerServiceCoroutineBridge:
+    """Test run_coroutine() async bridge."""
+
+    def test_run_coroutine_bridge(self, tmp_path):
+        """run_coroutine() should call asyncio.run_coroutine_threadsafe."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        svc._loop = loop
+
+        coro = MagicMock()
+
+        with patch(f"{_SCHEDULER_MOD}.asyncio") as mock_asyncio:
+            svc.run_coroutine(coro)
+
+        mock_asyncio.run_coroutine_threadsafe.assert_called_once_with(coro, loop)
+
+    def test_run_coroutine_raises_without_loop(self, tmp_path):
+        """run_coroutine() should raise RuntimeError if not started."""
+        svc = _make_service(tmp_path)
+
+        with pytest.raises(RuntimeError, match="no event loop"):
+            svc.run_coroutine(MagicMock())
+
+
+@pytest.mark.unit
+class TestSchedulerServiceCloudWarning:
+    """Test dual-scheduler cloud detection."""
+
+    def test_cloud_warning_logged(self, tmp_path):
+        """Warning should be logged if cloud config has a droplet_id."""
+        svc = _make_service(tmp_path)
+
+        cloud_cfg = MagicMock()
+        cloud_cfg.droplet_id = 12345
+
+        mock_loader = MagicMock()
+        mock_loader.return_value.load_cloud_config.return_value = cloud_cfg
+
+        with (
+            patch("dango.config.loader.ConfigLoader", mock_loader),
+            patch(f"{_SCHEDULER_MOD}.logger") as mock_logger,
+        ):
+            svc._check_dual_scheduler()
+
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args[0][0] == "dual_scheduler_warning"
+
+    def test_no_cloud_warning_when_no_deployment(self, tmp_path):
+        """No warning when cloud config has no droplet_id."""
+        svc = _make_service(tmp_path)
+
+        cloud_cfg = MagicMock()
+        cloud_cfg.droplet_id = None
+
+        mock_loader = MagicMock()
+        mock_loader.return_value.load_cloud_config.return_value = cloud_cfg
+
+        with (
+            patch("dango.config.loader.ConfigLoader", mock_loader),
+            patch(f"{_SCHEDULER_MOD}.logger") as mock_logger,
+        ):
+            svc._check_dual_scheduler()
+
+        mock_logger.warning.assert_not_called()
+
+    def test_no_cloud_warning_when_no_config(self, tmp_path):
+        """No warning when cloud config doesn't exist."""
+        svc = _make_service(tmp_path)
+
+        mock_loader = MagicMock()
+        mock_loader.return_value.load_cloud_config.return_value = None
+
+        with (
+            patch("dango.config.loader.ConfigLoader", mock_loader),
+            patch(f"{_SCHEDULER_MOD}.logger") as mock_logger,
+        ):
+            svc._check_dual_scheduler()
+
+        mock_logger.warning.assert_not_called()
+
+
+@pytest.mark.unit
+class TestSchedulerStartupSummary:
+    """Test startup summary logging."""
+
+    def test_startup_summary_logged(self, tmp_path):
+        """Startup summary should log job count and next run times."""
+        svc = _make_service(tmp_path)
+
+        job = MagicMock()
+        job.id = "sync-google-sheets"
+        job.next_run_time = MagicMock()
+        job.next_run_time.__str__ = lambda self: "2026-03-01 10:00:00+00:00"
+        svc._scheduler.get_jobs.return_value = [job]
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._log_startup_summary()
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "scheduler_started"
+        assert call_args[1]["job_count"] == 1
+
+
+@pytest.mark.unit
+class TestJobStubs:
+    """Test module-level job function stubs."""
+
+    def test_sync_source_job_is_module_level(self):
+        """sync_source_job should be importable at module level."""
+        from dango.platform.scheduling.jobs import sync_source_job
+
+        assert callable(sync_source_job)
+
+    def test_dbt_run_job_is_module_level(self):
+        """dbt_run_job should be importable at module level."""
+        from dango.platform.scheduling.jobs import dbt_run_job
+
+        assert callable(dbt_run_job)
+
+    def test_sync_source_job_raises_not_implemented(self):
+        """sync_source_job should raise NotImplementedError (pending TASK-041)."""
+        from dango.platform.scheduling.jobs import sync_source_job
+
+        with pytest.raises(NotImplementedError, match="TASK-041"):
+            sync_source_job("test-source", "/tmp/project")
+
+    def test_dbt_run_job_raises_not_implemented(self):
+        """dbt_run_job should raise NotImplementedError (pending TASK-041)."""
+        from dango.platform.scheduling.jobs import dbt_run_job
+
+        with pytest.raises(NotImplementedError, match="TASK-041"):
+            dbt_run_job("/tmp/project")

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -122,6 +122,18 @@ class TestSchedulerServiceLifecycle:
 
         svc._scheduler.shutdown.assert_not_called()
 
+    def test_start_is_idempotent(self, tmp_path):
+        """Calling start() twice should be a no-op the second time."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        svc.start(loop)
+        svc.start(loop)
+
+        # Listeners registered exactly once (3 listeners), not 6
+        assert svc._scheduler.add_listener.call_count == 3
+        svc._scheduler.start.assert_called_once()
+
 
 @pytest.mark.unit
 class TestSchedulerServiceJobs:
@@ -390,3 +402,83 @@ class TestJobStubs:
 
         with pytest.raises(NotImplementedError, match="TASK-041"):
             dbt_run_job("/tmp/project")
+
+
+_HEALTH_MOD = "dango.web.routes.health"
+
+
+@pytest.mark.unit
+class TestGetSchedulerStatus:
+    """Test _get_scheduler_status() in health.py."""
+
+    def test_returns_status_from_scheduler(self):
+        """Should return scheduler.get_status() when scheduler is present."""
+        from dango.web.routes.health import _get_scheduler_status
+
+        mock_scheduler = MagicMock()
+        mock_scheduler.get_status.return_value = {
+            "running": True,
+            "job_count": 3,
+            "next_run_time": "2026-03-01T10:00:00+00:00",
+        }
+
+        # Patch at source — the lazy import does `from dango.web.app import app`
+        from dango.web.app import app
+
+        original_scheduler = getattr(app.state, "scheduler", None)
+        app.state.scheduler = mock_scheduler
+        try:
+            result = _get_scheduler_status()
+        finally:
+            app.state.scheduler = original_scheduler
+
+        assert result["running"] is True
+        assert result["job_count"] == 3
+
+    def test_returns_fallback_when_scheduler_is_none(self):
+        """Should return fallback dict when scheduler is None."""
+        from dango.web.app import app
+        from dango.web.routes.health import _get_scheduler_status
+
+        original_scheduler = getattr(app.state, "scheduler", None)
+        app.state.scheduler = None
+        try:
+            result = _get_scheduler_status()
+        finally:
+            app.state.scheduler = original_scheduler
+
+        assert result == {"running": False, "job_count": 0, "next_run_time": None}
+
+    def test_returns_fallback_on_exception(self):
+        """Should return fallback dict when an exception occurs."""
+        from dango.web.routes.health import _get_scheduler_status
+
+        mock_scheduler = MagicMock()
+        mock_scheduler.get_status.side_effect = RuntimeError("boom")
+
+        from dango.web.app import app
+
+        original_scheduler = getattr(app.state, "scheduler", None)
+        app.state.scheduler = mock_scheduler
+        try:
+            result = _get_scheduler_status()
+        finally:
+            app.state.scheduler = original_scheduler
+
+        assert result == {"running": False, "job_count": 0, "next_run_time": None}
+
+    def test_fallback_returns_fresh_dict_each_time(self):
+        """Each fallback call should return an independent dict (no mutation)."""
+        from dango.web.app import app
+        from dango.web.routes.health import _get_scheduler_status
+
+        original_scheduler = getattr(app.state, "scheduler", None)
+        app.state.scheduler = None
+        try:
+            result1 = _get_scheduler_status()
+            result1["running"] = True  # mutate
+            result2 = _get_scheduler_status()
+        finally:
+            app.state.scheduler = original_scheduler
+
+        assert result2["running"] is False


### PR DESCRIPTION
## Summary
- Add `dango.platform.scheduling` package with `SchedulerService` wrapping APScheduler 3.x `AsyncIOScheduler`
- SQLite persistence (`.dango/scheduler.db`), `ThreadPoolExecutor(20)`, `coalesce=True`, `max_instances=1` for DuckDB single-writer safety
- FastAPI lifecycle integration: scheduler starts on app startup (non-fatal on failure), graceful shutdown on app shutdown
- Health endpoint (`/api/health/platform`) now includes `scheduler` status key
- Module-level job stubs (`sync_source_job`, `dbt_run_job`) for pickle serialization — implementation pending TASK-041
- Async bridge (`run_coroutine`) for thread-pool → event-loop WebSocket broadcasts
- Dual-scheduler warning when cloud deployment is active locally
- 27 unit tests covering all SchedulerService methods, event listeners, and job stubs

## Test plan
- [x] `pytest tests/unit/test_scheduler.py -v` — 27/27 pass
- [x] `pytest -m unit` — 1877/1877 pass (no regressions)
- [x] `ruff check dango/` — clean
- [x] `ruff format --check dango/` — clean
- [x] `mypy dango/` — clean (0 errors in 154 files)
- [x] File size check — all new files under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)