### PR TITLE
feat(config): add schedules.yml config schema and loader (TASK-037)

### DIFF
--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -24,7 +24,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | Add a new source type | `models.py` (`SourceType` enum) | `pytest tests/unit/test_config_models.py` |
 | Change config loading logic | `loader.py` | `pytest tests/unit/test_config_loader.py` |
 | Add a new config error type | `exceptions.py` | `pytest tests/unit/test_config_loader.py` |
-| Add/modify schedule config | `schedules.py` | `pytest tests/unit/test_schedules_config.py` |
+| Add/modify schedule config | `schedules.py` | `pytest tests/unit/test_schedules_config.py tests/unit/test_schedules_loading.py` |
 | Add a new credential provider | `credentials.py` | Manual: create test project with `.dlt/secrets.toml` |
 
 ## Dependencies
@@ -46,7 +46,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_config_loader.py tests/unit/test_config_models.py tests/unit/test_schedules_config.py`
+- **Unit:** `pytest tests/unit/test_config_loader.py tests/unit/test_config_models.py tests/unit/test_schedules_config.py tests/unit/test_schedules_loading.py`
 - **Integration:** `pytest tests/integration/test_config_loading.py`
 - **Manual:** `dango config show` in a dango project directory
 

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -12,6 +12,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `ShopifySourceConfig`, `CloudConfig` (incl. `firewall_id`) |
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
+| `schedules.py` | Schedule config models, validation, reload | `ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`, `CRON_PRESETS`, `load_schedules_config`, `validate_schedules`, `reload_schedules`, `log_startup_checks` |
 | `credentials.py` | Credential loading for dlt sources | `CredentialManager`, `init_dlt_directory` |
 | `exceptions.py` | Re-export shim — classes live in `dango/exceptions.py` | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError`, `ProjectNotFoundError` |
 
@@ -23,14 +24,16 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | Add a new source type | `models.py` (`SourceType` enum) | `pytest tests/unit/test_config_models.py` |
 | Change config loading logic | `loader.py` | `pytest tests/unit/test_config_loader.py` |
 | Add a new config error type | `exceptions.py` | `pytest tests/unit/test_config_loader.py` |
+| Add/modify schedule config | `schedules.py` | `pytest tests/unit/test_schedules_config.py` |
 | Add a new credential provider | `credentials.py` | Manual: create test project with `.dlt/secrets.toml` |
 
 ## Dependencies
 
 **Imports from:**
 - `pydantic` — model validation (`BaseModel`, `Field`, `validator`)
-- `yaml` — YAML parsing in `loader.py`
+- `yaml` — YAML parsing in `loader.py`, `schedules.py`
 - `toml` — TOML parsing in `credentials.py`
+- `croniter` — cron expression validation and iteration in `schedules.py`
 
 **Used by:**
 - `dango/cli/` — loads config to drive CLI commands
@@ -43,7 +46,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_config_loader.py tests/unit/test_config_models.py`
+- **Unit:** `pytest tests/unit/test_config_loader.py tests/unit/test_config_models.py tests/unit/test_schedules_config.py`
 - **Integration:** `pytest tests/integration/test_config_loading.py`
 - **Manual:** `dango config show` in a dango project directory
 

--- a/dango/config/__init__.py
+++ b/dango/config/__init__.py
@@ -34,6 +34,7 @@ from .schedules import (
     ScheduleConfig,
     SchedulesConfig,
     ScheduleType,
+    get_schedule_job_id,
 )
 
 __all__ = [
@@ -59,6 +60,7 @@ __all__ = [
     "ScheduleType",
     "ReloadResult",
     "CRON_PRESETS",
+    "get_schedule_job_id",
     # Loader
     "ConfigLoader",
     # Helpers

--- a/dango/config/__init__.py
+++ b/dango/config/__init__.py
@@ -28,6 +28,13 @@ from .models import (
     Stakeholder,
     StripeSourceConfig,
 )
+from .schedules import (
+    CRON_PRESETS,
+    ReloadResult,
+    ScheduleConfig,
+    SchedulesConfig,
+    ScheduleType,
+)
 
 __all__ = [
     # Models
@@ -46,6 +53,12 @@ __all__ = [
     "CloudConfig",
     "SpacesConfig",
     "DbtOverrides",
+    # Schedule config models
+    "ScheduleConfig",
+    "SchedulesConfig",
+    "ScheduleType",
+    "ReloadResult",
+    "CRON_PRESETS",
     # Loader
     "ConfigLoader",
     # Helpers

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -188,8 +188,10 @@ class ConfigLoader:
         return sources
 
     def load_schedules_config(self) -> SchedulesConfig:
-        """
-        Load schedule configuration from schedules.yml.
+        """Load schedule configuration from schedules.yml.
+
+        Delegates to the standalone ``load_schedules_config()`` function which
+        handles missing-file detection internally (returns empty config).
 
         Returns:
             SchedulesConfig model (empty if file is missing)
@@ -197,10 +199,7 @@ class ConfigLoader:
         Raises:
             ConfigValidationError: If the file exists but fails validation
         """
-        from dango.config.schedules import SchedulesConfig, load_schedules_config
-
-        if not self.schedules_file.exists():
-            return SchedulesConfig()
+        from dango.config.schedules import load_schedules_config
 
         return load_schedules_config(self.project_root)
 

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -3,14 +3,19 @@
 Handles loading and validation of YAML configuration files.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 from pydantic import ValidationError
 
 from .exceptions import ConfigError, ConfigNotFoundError, ConfigValidationError
 from .models import CloudConfig, DangoConfig, ProjectContext, SourcesConfig
+
+if TYPE_CHECKING:
+    from .schedules import SchedulesConfig
 
 
 class ConfigLoader:
@@ -20,6 +25,7 @@ class ConfigLoader:
     PROJECT_FILE = "project.yml"
     SOURCES_FILE = "sources.yml"
     CLOUD_FILE = "cloud.yml"
+    SCHEDULES_FILE = "schedules.yml"
 
     def __init__(self, project_root: Path | None = None):
         """
@@ -33,6 +39,7 @@ class ConfigLoader:
         self.project_file = self.dango_dir / self.PROJECT_FILE
         self.sources_file = self.dango_dir / self.SOURCES_FILE
         self.cloud_file = self.dango_dir / self.CLOUD_FILE
+        self.schedules_file = self.dango_dir / self.SCHEDULES_FILE
 
     def is_dango_project(self) -> bool:
         """Check if current directory is a Dango project"""
@@ -179,6 +186,23 @@ class ConfigLoader:
             )
 
         return sources
+
+    def load_schedules_config(self) -> SchedulesConfig:
+        """
+        Load schedule configuration from schedules.yml.
+
+        Returns:
+            SchedulesConfig model (empty if file is missing)
+
+        Raises:
+            ConfigValidationError: If the file exists but fails validation
+        """
+        from dango.config.schedules import SchedulesConfig, load_schedules_config
+
+        if not self.schedules_file.exists():
+            return SchedulesConfig()
+
+        return load_schedules_config(self.project_root)
 
     def load_config(self) -> DangoConfig:
         """

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -32,6 +32,7 @@ __all__ = [
     "ScheduleConfig",
     "ScheduleType",
     "SchedulesConfig",
+    "get_schedule_job_id",
     "load_schedules_config",
     "log_startup_checks",
     "reload_schedules",
@@ -55,6 +56,16 @@ _SCHEDULE_JOB_PREFIX = "schedule:"
 _SLUG_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 _VALID_NOTIFY_ON = frozenset({"failure", "success", "stale"})
+
+
+def get_schedule_job_id(schedule_name: str) -> str:
+    """Return the APScheduler job ID for a schedule name.
+
+    Downstream consumers (TASK-038 CRUD API, TASK-041 sync wiring) should use
+    this instead of hard-coding the ``schedule:`` prefix.
+    """
+    return f"{_SCHEDULE_JOB_PREFIX}{schedule_name}"
+
 
 # ---------------------------------------------------------------------------
 # Models
@@ -151,7 +162,12 @@ class SchedulesConfig(BaseModel):
 
 
 class ReloadResult(BaseModel):
-    """Result of a schedule reload operation."""
+    """Result of a schedule reload operation.
+
+    Note: ``unchanged`` is always empty in the current implementation because
+    APScheduler 3.x has no cheap way to diff trigger parameters. All existing
+    jobs that remain in config are treated as ``updated`` (remove + re-add).
+    """
 
     model_config = ConfigDict(frozen=True)
 
@@ -250,14 +266,25 @@ def validate_schedules(
     return issues
 
 
-def _get_cron_interval_seconds(cron_expr: str) -> float:
-    """Estimate the average interval between cron runs in seconds."""
+def _get_cron_interval_seconds(cron_expr: str, sample_count: int = 5) -> float:
+    """Return the minimum interval between consecutive cron runs in seconds.
+
+    Samples ``sample_count`` consecutive intervals and returns the smallest one.
+    This handles non-uniform crons like ``0 6,18 * * *`` (12h and 12h gap) or
+    ``0 9-17 * * 1-5`` where sampling only two ticks might see a long weekend gap.
+    """
     from croniter import croniter
 
     it = croniter(cron_expr)
-    t1: float = it.get_next(float)
-    t2: float = it.get_next(float)
-    return t2 - t1
+    prev: float = it.get_next(float)
+    min_interval = float("inf")
+    for _ in range(sample_count):
+        nxt: float = it.get_next(float)
+        gap = nxt - prev
+        if gap < min_interval:
+            min_interval = gap
+        prev = nxt
+    return min_interval
 
 
 def _detect_overlaps(
@@ -410,7 +437,6 @@ def reload_schedules(
         job_kwargs: dict[str, Any] = {
             "id": job_id,
             "name": sched.name,
-            "replace_existing": True,
         }
         if sched.misfire_grace_time is not None:
             job_kwargs["misfire_grace_time"] = sched.misfire_grace_time
@@ -421,6 +447,8 @@ def reload_schedules(
         func_kwargs: dict[str, Any]
         if sched.type == ScheduleType.SYNC:
             func = sync_source_job
+            # sync_source_job accepts a comma-separated string of source names
+            # (matches the CLI `dango sync src1,src2` convention)
             func_kwargs = {
                 "source_name": ",".join(sched.sources),
                 "project_root": str(project_root),
@@ -440,12 +468,6 @@ def reload_schedules(
             added.append(sched.name)
 
         scheduler.add_job(func, trigger, kwargs=func_kwargs, **job_kwargs)
-
-    # Unchanged = desired jobs that already existed and weren't updated
-    # (We always remove+re-add for existing jobs, so unchanged only applies
-    # if we detect no config change. For simplicity, we treat all existing
-    # jobs as updated since we can't cheaply diff trigger params.)
-    # unchanged stays empty — the caller can infer from the result.
 
     return ReloadResult(
         added=added,

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -1,0 +1,455 @@
+"""dango/config/schedules.py
+
+Schedule configuration models, validation, and reload logic.
+
+Defines the ``schedules:`` section of ``.dango/schedules.yml`` as Pydantic
+models, validates cron expressions and source references, and provides a
+reload function that diffs YAML configs against running APScheduler jobs.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from dango.config.exceptions import ConfigValidationError
+from dango.logging import get_logger
+
+if TYPE_CHECKING:
+    from dango.platform.scheduling.scheduler import SchedulerService
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "CRON_PRESETS",
+    "ReloadResult",
+    "ScheduleConfig",
+    "ScheduleType",
+    "SchedulesConfig",
+    "load_schedules_config",
+    "log_startup_checks",
+    "reload_schedules",
+    "validate_schedules",
+]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CRON_PRESETS: dict[str, str] = {
+    "every_15m": "*/15 * * * *",
+    "every_hour": "0 * * * *",
+    "every_6h": "0 */6 * * *",
+    "daily": "0 6 * * *",
+    "weekly": "0 6 * * 1",
+}
+
+_SCHEDULE_JOB_PREFIX = "schedule:"
+
+_SLUG_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+_VALID_NOTIFY_ON = frozenset({"failure", "success", "stale"})
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class ScheduleType(str, Enum):
+    """Type of scheduled job."""
+
+    SYNC = "sync"
+    DBT = "dbt"
+
+
+class ScheduleConfig(BaseModel):
+    """Configuration for a single scheduled job."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    type: ScheduleType = ScheduleType.SYNC
+    cron: str
+    sources: list[str] = []
+    enabled: bool = True
+    timezone: str | None = None
+    start_date: datetime | None = None
+    misfire_grace_time: int | None = None
+    timeout_minutes: int | None = None
+    notify_on: list[str] = []
+    dbt_command: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str) -> str:
+        if not _SLUG_RE.match(v):
+            msg = (
+                f"Schedule name must be lowercase alphanumeric + underscore, "
+                f"starting with a letter. Got: {v!r}"
+            )
+            raise ValueError(msg)
+        return v
+
+    @field_validator("cron")
+    @classmethod
+    def _validate_cron(cls, v: str) -> str:
+        resolved = CRON_PRESETS.get(v, v)
+        from croniter import croniter
+
+        if not croniter.is_valid(resolved):
+            msg = f"Invalid cron expression: {v!r}"
+            if v in CRON_PRESETS:
+                msg += f" (resolved from preset to {resolved!r})"
+            raise ValueError(msg)
+        return resolved
+
+    @field_validator("notify_on")
+    @classmethod
+    def _validate_notify_on(cls, v: list[str]) -> list[str]:
+        invalid = set(v) - _VALID_NOTIFY_ON
+        if invalid:
+            msg = f"Invalid notify_on values: {sorted(invalid)}. Valid: {sorted(_VALID_NOTIFY_ON)}"
+            raise ValueError(msg)
+        return v
+
+    @model_validator(mode="after")
+    def _validate_type_fields(self) -> ScheduleConfig:
+        if self.type == ScheduleType.SYNC and not self.sources:
+            msg = "Sync schedules must specify at least one source"
+            raise ValueError(msg)
+        if self.type == ScheduleType.DBT and not self.dbt_command:
+            msg = "dbt schedules must specify a dbt_command"
+            raise ValueError(msg)
+        return self
+
+    def get_notify_on_dict(self) -> dict[str, bool] | None:
+        """Convert ``notify_on`` list to dict for ``webhook.should_notify()`` interop.
+
+        Returns ``None`` if ``notify_on`` is empty (use global defaults).
+        """
+        if not self.notify_on:
+            return None
+        return {
+            "on_failure": "failure" in self.notify_on,
+            "on_success": "success" in self.notify_on,
+            "on_stale": "stale" in self.notify_on,
+        }
+
+
+class SchedulesConfig(BaseModel):
+    """Top-level container for schedule definitions."""
+
+    model_config = ConfigDict(frozen=True)
+
+    schedules: list[ScheduleConfig] = []
+
+
+class ReloadResult(BaseModel):
+    """Result of a schedule reload operation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    added: list[str] = []
+    updated: list[str] = []
+    removed: list[str] = []
+    unchanged: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_schedules_config(project_root: Path) -> SchedulesConfig:
+    """Load schedule config from ``.dango/schedules.yml``.
+
+    Returns an empty ``SchedulesConfig`` if the file is missing.
+
+    Raises:
+        ConfigValidationError: If the file exists but contains invalid data.
+    """
+    path = project_root / ".dango" / "schedules.yml"
+    if not path.exists():
+        return SchedulesConfig()
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data: dict[str, Any] = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        raise ConfigValidationError(f"Invalid YAML in {path}:\n{e}") from e
+
+    schedules_data = data.get("schedules")
+    if schedules_data is None:
+        return SchedulesConfig()
+
+    try:
+        return SchedulesConfig(schedules=schedules_data)
+    except Exception as e:
+        raise ConfigValidationError(f"Invalid schedule configuration in {path}:\n{e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation
+# ---------------------------------------------------------------------------
+
+
+def validate_schedules(
+    schedules: list[ScheduleConfig],
+    source_names: set[str],
+    average_durations: dict[str, float] | None = None,
+) -> list[str]:
+    """Cross-validate schedules against known sources.
+
+    Returns a list of error/warning strings (empty = all good).
+
+    Checks:
+    1. Duplicate schedule names (error)
+    2. Unknown source references (error)
+    3. Cron interval < avg duration * 0.8 (warning, when durations provided)
+    4. Overlapping crons for shared sources (warning)
+    """
+    issues: list[str] = []
+
+    # 1. Duplicate names
+    seen_names: dict[str, int] = {}
+    for sched in schedules:
+        seen_names[sched.name] = seen_names.get(sched.name, 0) + 1
+    for name, count in seen_names.items():
+        if count > 1:
+            issues.append(f"Duplicate schedule name: {name!r} (appears {count} times)")
+
+    # 2. Unknown sources
+    for sched in schedules:
+        for src in sched.sources:
+            if src not in source_names:
+                issues.append(f"Schedule {sched.name!r} references unknown source: {src!r}")
+
+    # 3. Interval vs duration check
+    if average_durations:
+        for sched in schedules:
+            if sched.type != ScheduleType.SYNC:
+                continue
+            interval = _get_cron_interval_seconds(sched.cron)
+            for src in sched.sources:
+                avg = average_durations.get(src)
+                if avg is not None and interval < avg * 0.8:
+                    issues.append(
+                        f"Schedule {sched.name!r}: cron interval ({interval:.0f}s) "
+                        f"is less than 80% of avg duration for {src!r} ({avg:.0f}s)"
+                    )
+
+    # 4. Overlapping crons for shared sources
+    issues.extend(_detect_overlaps(schedules))
+
+    return issues
+
+
+def _get_cron_interval_seconds(cron_expr: str) -> float:
+    """Estimate the average interval between cron runs in seconds."""
+    from croniter import croniter
+
+    it = croniter(cron_expr)
+    t1: float = it.get_next(float)
+    t2: float = it.get_next(float)
+    return t2 - t1
+
+
+def _detect_overlaps(
+    schedules: list[ScheduleConfig],
+    check_count: int = 10,
+    proximity_seconds: int = 60,
+) -> list[str]:
+    """Detect schedules with overlapping cron times for shared sources."""
+    from croniter import croniter
+
+    # Build source→schedule mapping (only enabled sync schedules)
+    source_schedules: dict[str, list[ScheduleConfig]] = {}
+    for sched in schedules:
+        if not sched.enabled or sched.type != ScheduleType.SYNC:
+            continue
+        for src in sched.sources:
+            source_schedules.setdefault(src, []).append(sched)
+
+    warnings: list[str] = []
+    checked_pairs: set[tuple[str, ...]] = set()
+
+    for src, scheds in source_schedules.items():
+        if len(scheds) < 2:
+            continue
+        for i, s1 in enumerate(scheds):
+            for s2 in scheds[i + 1 :]:
+                pair_key = tuple(sorted([s1.name, s2.name]))
+                if pair_key in checked_pairs:
+                    continue
+                checked_pairs.add(pair_key)
+
+                it1 = croniter(s1.cron)
+                it2 = croniter(s2.cron)
+                times1 = [it1.get_next(float) for _ in range(check_count)]
+                times2 = [it2.get_next(float) for _ in range(check_count)]
+
+                for t1 in times1:
+                    for t2 in times2:
+                        if abs(t1 - t2) < proximity_seconds:
+                            warnings.append(
+                                f"Schedules {s1.name!r} and {s2.name!r} have "
+                                f"overlapping cron times for shared source {src!r}"
+                            )
+                            break
+                    else:
+                        continue
+                    break
+
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Startup logging
+# ---------------------------------------------------------------------------
+
+
+def log_startup_checks(
+    schedules: list[ScheduleConfig],
+    source_names: set[str],
+    project_root: Path,
+) -> None:
+    """Log INFO for unscheduled sources and WARNING for cloud conflicts."""
+    if not schedules:
+        logger.info("no_schedules_configured")
+        return
+
+    # Unscheduled sources
+    scheduled_sources: set[str] = set()
+    for sched in schedules:
+        scheduled_sources.update(sched.sources)
+
+    unscheduled = source_names - scheduled_sources
+    if unscheduled:
+        logger.info(
+            "unscheduled_sources",
+            sources=sorted(unscheduled),
+        )
+
+    # Cloud conflict check
+    try:
+        from dango.config.loader import ConfigLoader
+
+        loader = ConfigLoader(project_root)
+        cloud_cfg = loader.load_cloud_config()
+        if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+            logger.warning(
+                "cloud_schedule_conflict",
+                message=(
+                    "A cloud deployment is active. Local schedules may conflict "
+                    "with cloud-side scheduling."
+                ),
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug("cloud_config_check_failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Reload
+# ---------------------------------------------------------------------------
+
+
+def reload_schedules(
+    scheduler: SchedulerService,
+    new_schedules: list[ScheduleConfig],
+    project_root: Path,
+) -> ReloadResult:
+    """Diff running jobs against config and apply changes.
+
+    Only touches jobs with the ``schedule:`` ID prefix.
+
+    Returns a ``ReloadResult`` summarizing what changed.
+    """
+    from apscheduler.triggers.cron import CronTrigger
+
+    from dango.platform.scheduling.jobs import dbt_run_job, sync_source_job
+
+    # Collect current schedule jobs
+    existing_jobs: dict[str, Any] = {}
+    for job in scheduler.get_jobs():
+        if job.id.startswith(_SCHEDULE_JOB_PREFIX):
+            existing_jobs[job.id] = job
+
+    # Build desired state from enabled schedules
+    desired: dict[str, ScheduleConfig] = {}
+    for sched in new_schedules:
+        if sched.enabled:
+            desired[f"{_SCHEDULE_JOB_PREFIX}{sched.name}"] = sched
+
+    existing_ids = set(existing_jobs.keys())
+    desired_ids = set(desired.keys())
+
+    added: list[str] = []
+    removed: list[str] = []
+    updated: list[str] = []
+    unchanged: list[str] = []
+
+    # Remove jobs no longer in config
+    for job_id in existing_ids - desired_ids:
+        scheduler.remove_job(job_id)
+        name = job_id.removeprefix(_SCHEDULE_JOB_PREFIX)
+        removed.append(name)
+
+    # Add or update
+    for job_id, sched in desired.items():
+        trigger_kwargs: dict[str, Any] = {}
+        if sched.timezone:
+            trigger_kwargs["timezone"] = sched.timezone
+        trigger = CronTrigger.from_crontab(sched.cron, **trigger_kwargs)
+
+        job_kwargs: dict[str, Any] = {
+            "id": job_id,
+            "name": sched.name,
+            "replace_existing": True,
+        }
+        if sched.misfire_grace_time is not None:
+            job_kwargs["misfire_grace_time"] = sched.misfire_grace_time
+        if sched.start_date is not None:
+            job_kwargs["next_run_time"] = sched.start_date
+
+        func: Any
+        func_kwargs: dict[str, Any]
+        if sched.type == ScheduleType.SYNC:
+            func = sync_source_job
+            func_kwargs = {
+                "source_name": ",".join(sched.sources),
+                "project_root": str(project_root),
+            }
+        else:
+            func = dbt_run_job
+            func_kwargs = {
+                "project_root": str(project_root),
+                "select": sched.dbt_command,
+            }
+
+        if job_id in existing_ids:
+            # Update: remove then re-add (APScheduler 3.x has no atomic trigger update)
+            scheduler.remove_job(job_id)
+            updated.append(sched.name)
+        else:
+            added.append(sched.name)
+
+        scheduler.add_job(func, trigger, kwargs=func_kwargs, **job_kwargs)
+
+    # Unchanged = desired jobs that already existed and weren't updated
+    # (We always remove+re-add for existing jobs, so unchanged only applies
+    # if we detect no config change. For simplicity, we treat all existing
+    # jobs as updated since we can't cheaply diff trigger params.)
+    # unchanged stays empty — the caller can infer from the result.
+
+    return ReloadResult(
+        added=added,
+        updated=updated,
+        removed=removed,
+        unchanged=unchanged,
+    )

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -411,7 +411,7 @@ def reload_schedules(
     desired: dict[str, ScheduleConfig] = {}
     for sched in new_schedules:
         if sched.enabled:
-            desired[f"{_SCHEDULE_JOB_PREFIX}{sched.name}"] = sched
+            desired[get_schedule_job_id(sched.name)] = sched
 
     existing_ids = set(existing_jobs.keys())
     desired_ids = set(desired.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ module = [
     "tests.unit.test_slack_formatter",
     "tests.unit.test_scheduler",
     "tests.unit.test_schedules_config",
+    "tests.unit.test_schedules_loading",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
     # Scheduling
     "apscheduler>=3.11,<4",   # Job scheduling (AsyncIOScheduler + SQLAlchemy job store)
     "sqlalchemy>=2.0,<3",     # Required by APScheduler SQLAlchemyJobStore
+    "croniter>=2.0,<4",       # Cron expression validation and iteration
 ]
 
 [project.optional-dependencies]
@@ -185,6 +186,8 @@ module = [
     "apscheduler.*",
     "sqlalchemy",
     "sqlalchemy.*",
+    "croniter",
+    "croniter.*",
 ]
 ignore_missing_imports = true
 
@@ -251,7 +254,9 @@ module = [
     "tests.unit.test_remote_ops_cli",
     "tests.unit.test_cli_sync",
     "tests.unit.test_webhook",
+    "tests.unit.test_slack_formatter",
     "tests.unit.test_scheduler",
+    "tests.unit.test_schedules_config",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -1,0 +1,389 @@
+"""tests/unit/test_schedules_config.py
+
+Tests for dango.config.schedules — schedule config models, validation, and reload.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+_MOD = "dango.config.schedules"
+
+
+@pytest.mark.unit
+class TestScheduleType:
+    """Test ScheduleType enum."""
+
+    def test_enum_members(self):
+        from dango.config.schedules import ScheduleType
+
+        assert ScheduleType.SYNC.value == "sync"
+        assert ScheduleType.DBT.value == "dbt"
+
+    def test_enum_count(self):
+        from dango.config.schedules import ScheduleType
+
+        assert len(ScheduleType) == 2
+
+
+@pytest.mark.unit
+class TestCronPresets:
+    """Test CRON_PRESETS dictionary."""
+
+    def test_preset_count(self):
+        from dango.config.schedules import CRON_PRESETS
+
+        assert len(CRON_PRESETS) == 5
+
+    def test_all_presets_are_valid_cron(self):
+        from croniter import croniter
+
+        from dango.config.schedules import CRON_PRESETS
+
+        for name, expr in CRON_PRESETS.items():
+            assert croniter.is_valid(expr), f"Preset {name!r} has invalid cron: {expr!r}"
+
+
+@pytest.mark.unit
+class TestScheduleConfig:
+    """Test ScheduleConfig model and validators."""
+
+    def test_valid_sync_config(self):
+        from dango.config.schedules import ScheduleConfig
+
+        cfg = ScheduleConfig(name="daily_sync", cron="daily", sources=["google_sheets"])
+        assert cfg.name == "daily_sync"
+        assert cfg.cron == "0 6 * * *"  # preset resolved
+        assert cfg.sources == ["google_sheets"]
+        assert cfg.enabled is True
+
+    def test_valid_dbt_config(self):
+        from dango.config.schedules import ScheduleConfig, ScheduleType
+
+        cfg = ScheduleConfig(
+            name="nightly_dbt",
+            type=ScheduleType.DBT,
+            cron="0 2 * * *",
+            dbt_command="run --select daily_models",
+        )
+        assert cfg.type == ScheduleType.DBT
+        assert cfg.dbt_command == "run --select daily_models"
+
+    def test_preset_resolved(self):
+        from dango.config.schedules import ScheduleConfig
+
+        cfg = ScheduleConfig(name="hourly_sync", cron="every_hour", sources=["csv"])
+        assert cfg.cron == "0 * * * *"
+
+    def test_invalid_name_rejected(self):
+        from dango.config.schedules import ScheduleConfig
+
+        with pytest.raises(Exception, match="lowercase alphanumeric"):
+            ScheduleConfig(name="Bad-Name!", cron="daily", sources=["s"])
+
+    def test_name_must_start_with_letter(self):
+        from dango.config.schedules import ScheduleConfig
+
+        with pytest.raises(Exception, match="lowercase alphanumeric"):
+            ScheduleConfig(name="123bad", cron="daily", sources=["s"])
+
+    def test_invalid_cron_rejected(self):
+        from dango.config.schedules import ScheduleConfig
+
+        with pytest.raises(Exception, match="Invalid cron"):
+            ScheduleConfig(name="bad_cron", cron="not a cron", sources=["s"])
+
+    def test_invalid_notify_on_rejected(self):
+        from dango.config.schedules import ScheduleConfig
+
+        with pytest.raises(Exception, match="Invalid notify_on"):
+            ScheduleConfig(name="bad_notify", cron="daily", sources=["s"], notify_on=["invalid"])
+
+    def test_sync_requires_sources(self):
+        from dango.config.schedules import ScheduleConfig
+
+        with pytest.raises(Exception, match="at least one source"):
+            ScheduleConfig(name="no_sources", cron="daily", sources=[])
+
+    def test_dbt_requires_command(self):
+        from dango.config.schedules import ScheduleConfig, ScheduleType
+
+        with pytest.raises(Exception, match="dbt_command"):
+            ScheduleConfig(name="no_cmd", type=ScheduleType.DBT, cron="daily")
+
+    def test_defaults(self):
+        from dango.config.schedules import ScheduleConfig, ScheduleType
+
+        cfg = ScheduleConfig(name="test_sched", cron="daily", sources=["s"])
+        assert cfg.type == ScheduleType.SYNC
+        assert cfg.enabled is True
+        assert cfg.timezone is None
+        assert cfg.start_date is None
+        assert cfg.misfire_grace_time is None
+        assert cfg.timeout_minutes is None
+        assert cfg.notify_on == []
+        assert cfg.dbt_command is None
+
+    def test_get_notify_on_dict_empty(self):
+        from dango.config.schedules import ScheduleConfig
+
+        cfg = ScheduleConfig(name="test_sched", cron="daily", sources=["s"])
+        assert cfg.get_notify_on_dict() is None
+
+    def test_get_notify_on_dict_with_values(self):
+        from dango.config.schedules import ScheduleConfig
+
+        cfg = ScheduleConfig(name="test_sched", cron="daily", sources=["s"], notify_on=["failure"])
+        result = cfg.get_notify_on_dict()
+        assert result == {"on_failure": True, "on_success": False, "on_stale": False}
+
+
+@pytest.mark.unit
+class TestSchedulesConfig:
+    """Test SchedulesConfig container."""
+
+    def test_empty_default(self):
+        from dango.config.schedules import SchedulesConfig
+
+        cfg = SchedulesConfig()
+        assert cfg.schedules == []
+
+    def test_from_list(self):
+        from dango.config.schedules import ScheduleConfig, SchedulesConfig
+
+        s = ScheduleConfig(name="my_sync", cron="daily", sources=["csv"])
+        cfg = SchedulesConfig(schedules=[s])
+        assert len(cfg.schedules) == 1
+        assert cfg.schedules[0].name == "my_sync"
+
+
+@pytest.mark.unit
+class TestValidateSchedules:
+    """Test validate_schedules() cross-validation."""
+
+    def test_clean_pass(self):
+        from dango.config.schedules import ScheduleConfig, validate_schedules
+
+        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
+        issues = validate_schedules(scheds, {"csv"})
+        assert issues == []
+
+    def test_duplicate_names(self):
+        from dango.config.schedules import ScheduleConfig, validate_schedules
+
+        scheds = [
+            ScheduleConfig(name="s1", cron="daily", sources=["csv"]),
+            ScheduleConfig(name="s1", cron="every_hour", sources=["csv"]),
+        ]
+        issues = validate_schedules(scheds, {"csv"})
+        assert any("Duplicate" in i for i in issues)
+
+    def test_unknown_source(self):
+        from dango.config.schedules import ScheduleConfig, validate_schedules
+
+        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["nonexistent"])]
+        issues = validate_schedules(scheds, {"csv"})
+        assert any("unknown source" in i for i in issues)
+
+    def test_interval_vs_duration_warning(self):
+        from dango.config.schedules import ScheduleConfig, validate_schedules
+
+        # every_15m = 900s, avg duration = 2000s → 900 < 2000*0.8 = 1600
+        scheds = [ScheduleConfig(name="s1", cron="every_15m", sources=["slow_src"])]
+        issues = validate_schedules(scheds, {"slow_src"}, average_durations={"slow_src": 2000.0})
+        assert any("less than 80%" in i for i in issues)
+
+    def test_interval_vs_duration_skipped_when_none(self):
+        from dango.config.schedules import ScheduleConfig, validate_schedules
+
+        scheds = [ScheduleConfig(name="s1", cron="every_15m", sources=["csv"])]
+        issues = validate_schedules(scheds, {"csv"}, average_durations=None)
+        # No duration warning when average_durations is None
+        assert not any("less than 80%" in i for i in issues)
+
+    def test_overlap_warning(self):
+        from dango.config.schedules import ScheduleConfig, validate_schedules
+
+        # Two schedules with identical crons sharing a source
+        scheds = [
+            ScheduleConfig(name="s1", cron="0 6 * * *", sources=["csv"]),
+            ScheduleConfig(name="s2", cron="0 6 * * *", sources=["csv"]),
+        ]
+        issues = validate_schedules(scheds, {"csv"})
+        assert any("overlapping" in i.lower() for i in issues)
+
+
+@pytest.mark.unit
+class TestLogStartupChecks:
+    """Test log_startup_checks() logging."""
+
+    def test_empty_schedules_logs_info(self):
+        from dango.config.schedules import log_startup_checks
+
+        with patch(f"{_MOD}.logger") as mock_logger:
+            log_startup_checks([], {"csv"}, "/tmp/project")
+
+        mock_logger.info.assert_called_once_with("no_schedules_configured")
+
+    def test_unscheduled_sources_logged(self):
+        from dango.config.schedules import ScheduleConfig, log_startup_checks
+
+        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
+        with (
+            patch(f"{_MOD}.logger") as mock_logger,
+            patch("dango.config.loader.ConfigLoader") as mock_loader_cls,
+        ):
+            mock_loader_cls.return_value.load_cloud_config.return_value = None
+            log_startup_checks(scheds, {"csv", "stripe"}, "/tmp/project")
+
+        info_calls = mock_logger.info.call_args_list
+        assert any(call[0][0] == "unscheduled_sources" for call in info_calls)
+
+    def test_cloud_conflict_logged(self):
+        from dango.config.schedules import ScheduleConfig, log_startup_checks
+
+        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
+        cloud_cfg = MagicMock()
+        cloud_cfg.droplet_id = 12345
+
+        with (
+            patch(f"{_MOD}.logger") as mock_logger,
+            patch("dango.config.loader.ConfigLoader") as mock_loader_cls,
+        ):
+            mock_loader_cls.return_value.load_cloud_config.return_value = cloud_cfg
+            log_startup_checks(scheds, {"csv"}, "/tmp/project")
+
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][0] == "cloud_schedule_conflict"
+
+    def test_all_sources_covered(self):
+        from dango.config.schedules import ScheduleConfig, log_startup_checks
+
+        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
+        with (
+            patch(f"{_MOD}.logger") as mock_logger,
+            patch("dango.config.loader.ConfigLoader") as mock_loader_cls,
+        ):
+            mock_loader_cls.return_value.load_cloud_config.return_value = None
+            log_startup_checks(scheds, {"csv"}, "/tmp/project")
+
+        info_calls = mock_logger.info.call_args_list
+        # No "unscheduled_sources" log when all are covered
+        assert not any(call[0][0] == "unscheduled_sources" for call in info_calls)
+
+
+@pytest.mark.unit
+class TestLoadSchedulesConfig:
+    """Test load_schedules_config() file loading."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from dango.config.schedules import load_schedules_config
+
+        cfg = load_schedules_config(tmp_path)
+        assert cfg.schedules == []
+
+    def test_valid_yaml(self, tmp_path):
+        from dango.config.schedules import load_schedules_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        data = {
+            "schedules": [
+                {"name": "daily_sync", "cron": "0 6 * * *", "sources": ["csv"]},
+            ]
+        }
+        (dango_dir / "schedules.yml").write_text(yaml.safe_dump(data))
+
+        cfg = load_schedules_config(tmp_path)
+        assert len(cfg.schedules) == 1
+        assert cfg.schedules[0].name == "daily_sync"
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        from dango.config.exceptions import ConfigValidationError
+        from dango.config.schedules import load_schedules_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "schedules.yml").write_text("schedules: [unclosed bracket\n")
+
+        with pytest.raises(ConfigValidationError, match="Invalid YAML"):
+            load_schedules_config(tmp_path)
+
+
+@pytest.mark.unit
+class TestReloadSchedules:
+    """Test reload_schedules() diff and apply logic."""
+
+    def _make_scheduler(self, existing_jobs=None):
+        """Create a mock SchedulerService with optional existing jobs."""
+        scheduler = MagicMock()
+        jobs = []
+        if existing_jobs:
+            for job_id in existing_jobs:
+                job = MagicMock()
+                job.id = job_id
+                jobs.append(job)
+        scheduler.get_jobs.return_value = jobs
+        return scheduler
+
+    def test_add_new_job(self):
+        from dango.config.schedules import ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler()
+        scheds = [ScheduleConfig(name="daily_sync", cron="0 6 * * *", sources=["csv"])]
+
+        result = reload_schedules(scheduler, scheds, "/tmp/project")
+
+        assert "daily_sync" in result.added
+        scheduler.add_job.assert_called_once()
+
+    def test_remove_old_job(self):
+        from dango.config.schedules import reload_schedules
+
+        scheduler = self._make_scheduler(existing_jobs=["schedule:old_job"])
+
+        result = reload_schedules(scheduler, [], "/tmp/project")
+
+        assert "old_job" in result.removed
+        scheduler.remove_job.assert_called_once_with("schedule:old_job")
+
+    def test_update_existing_job(self):
+        from dango.config.schedules import ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler(existing_jobs=["schedule:my_sync"])
+        scheds = [ScheduleConfig(name="my_sync", cron="0 6 * * *", sources=["csv"])]
+
+        result = reload_schedules(scheduler, scheds, "/tmp/project")
+
+        assert "my_sync" in result.updated
+        # remove + re-add for update
+        scheduler.remove_job.assert_called_with("schedule:my_sync")
+        scheduler.add_job.assert_called_once()
+
+    def test_disabled_schedule_not_added(self):
+        from dango.config.schedules import ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler()
+        scheds = [
+            ScheduleConfig(name="disabled_sync", cron="daily", sources=["csv"], enabled=False)
+        ]
+
+        result = reload_schedules(scheduler, scheds, "/tmp/project")
+
+        assert result.added == []
+        scheduler.add_job.assert_not_called()
+
+    def test_result_shape(self):
+        from dango.config.schedules import ReloadResult, ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler()
+        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
+
+        result = reload_schedules(scheduler, scheds, "/tmp/project")
+
+        assert isinstance(result, ReloadResult)
+        assert isinstance(result.added, list)
+        assert isinstance(result.updated, list)
+        assert isinstance(result.removed, list)
+        assert isinstance(result.unchanged, list)

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -1,12 +1,12 @@
 """tests/unit/test_schedules_config.py
 
-Tests for dango.config.schedules — schedule config models, validation, and reload.
+Tests for dango.config.schedules — models, validators, and cross-validation.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-import yaml
 
 _MOD = "dango.config.schedules"
 
@@ -222,7 +222,7 @@ class TestLogStartupChecks:
         from dango.config.schedules import log_startup_checks
 
         with patch(f"{_MOD}.logger") as mock_logger:
-            log_startup_checks([], {"csv"}, "/tmp/project")
+            log_startup_checks([], {"csv"}, Path("/tmp/project"))
 
         mock_logger.info.assert_called_once_with("no_schedules_configured")
 
@@ -235,7 +235,7 @@ class TestLogStartupChecks:
             patch("dango.config.loader.ConfigLoader") as mock_loader_cls,
         ):
             mock_loader_cls.return_value.load_cloud_config.return_value = None
-            log_startup_checks(scheds, {"csv", "stripe"}, "/tmp/project")
+            log_startup_checks(scheds, {"csv", "stripe"}, Path("/tmp/project"))
 
         info_calls = mock_logger.info.call_args_list
         assert any(call[0][0] == "unscheduled_sources" for call in info_calls)
@@ -252,7 +252,7 @@ class TestLogStartupChecks:
             patch("dango.config.loader.ConfigLoader") as mock_loader_cls,
         ):
             mock_loader_cls.return_value.load_cloud_config.return_value = cloud_cfg
-            log_startup_checks(scheds, {"csv"}, "/tmp/project")
+            log_startup_checks(scheds, {"csv"}, Path("/tmp/project"))
 
         mock_logger.warning.assert_called_once()
         assert mock_logger.warning.call_args[0][0] == "cloud_schedule_conflict"
@@ -266,7 +266,7 @@ class TestLogStartupChecks:
             patch("dango.config.loader.ConfigLoader") as mock_loader_cls,
         ):
             mock_loader_cls.return_value.load_cloud_config.return_value = None
-            log_startup_checks(scheds, {"csv"}, "/tmp/project")
+            log_startup_checks(scheds, {"csv"}, Path("/tmp/project"))
 
         info_calls = mock_logger.info.call_args_list
         # No "unscheduled_sources" log when all are covered
@@ -274,116 +274,69 @@ class TestLogStartupChecks:
 
 
 @pytest.mark.unit
-class TestLoadSchedulesConfig:
-    """Test load_schedules_config() file loading."""
+class TestGetScheduleJobId:
+    """Test get_schedule_job_id() helper."""
 
-    def test_missing_file_returns_empty(self, tmp_path):
-        from dango.config.schedules import load_schedules_config
+    def test_returns_prefixed_id(self):
+        from dango.config.schedules import get_schedule_job_id
 
-        cfg = load_schedules_config(tmp_path)
-        assert cfg.schedules == []
+        assert get_schedule_job_id("daily_sync") == "schedule:daily_sync"
 
-    def test_valid_yaml(self, tmp_path):
-        from dango.config.schedules import load_schedules_config
+    def test_round_trips_with_removeprefix(self):
+        from dango.config.schedules import get_schedule_job_id
 
-        dango_dir = tmp_path / ".dango"
-        dango_dir.mkdir()
-        data = {
-            "schedules": [
-                {"name": "daily_sync", "cron": "0 6 * * *", "sources": ["csv"]},
-            ]
-        }
-        (dango_dir / "schedules.yml").write_text(yaml.safe_dump(data))
-
-        cfg = load_schedules_config(tmp_path)
-        assert len(cfg.schedules) == 1
-        assert cfg.schedules[0].name == "daily_sync"
-
-    def test_invalid_yaml_raises(self, tmp_path):
-        from dango.config.exceptions import ConfigValidationError
-        from dango.config.schedules import load_schedules_config
-
-        dango_dir = tmp_path / ".dango"
-        dango_dir.mkdir()
-        (dango_dir / "schedules.yml").write_text("schedules: [unclosed bracket\n")
-
-        with pytest.raises(ConfigValidationError, match="Invalid YAML"):
-            load_schedules_config(tmp_path)
+        job_id = get_schedule_job_id("my_job")
+        assert job_id.removeprefix("schedule:") == "my_job"
 
 
 @pytest.mark.unit
-class TestReloadSchedules:
-    """Test reload_schedules() diff and apply logic."""
+class TestHelpers:
+    """Test private helper functions."""
 
-    def _make_scheduler(self, existing_jobs=None):
-        """Create a mock SchedulerService with optional existing jobs."""
-        scheduler = MagicMock()
-        jobs = []
-        if existing_jobs:
-            for job_id in existing_jobs:
-                job = MagicMock()
-                job.id = job_id
-                jobs.append(job)
-        scheduler.get_jobs.return_value = jobs
-        return scheduler
+    def test_get_cron_interval_uniform(self):
+        """Uniform cron (every hour) returns 3600s."""
+        from dango.config.schedules import _get_cron_interval_seconds
 
-    def test_add_new_job(self):
-        from dango.config.schedules import ScheduleConfig, reload_schedules
+        interval = _get_cron_interval_seconds("0 * * * *")
+        assert interval == 3600.0
 
-        scheduler = self._make_scheduler()
-        scheds = [ScheduleConfig(name="daily_sync", cron="0 6 * * *", sources=["csv"])]
+    def test_get_cron_interval_non_uniform(self):
+        """Non-uniform cron (6am and 6pm) returns the min gap (12h)."""
+        from dango.config.schedules import _get_cron_interval_seconds
 
-        result = reload_schedules(scheduler, scheds, "/tmp/project")
+        interval = _get_cron_interval_seconds("0 6,18 * * *")
+        assert interval == 12 * 3600.0
 
-        assert "daily_sync" in result.added
-        scheduler.add_job.assert_called_once()
+    def test_detect_overlaps_identical_crons(self):
+        """Two schedules with identical crons and shared source produce a warning."""
+        from dango.config.schedules import ScheduleConfig, _detect_overlaps
 
-    def test_remove_old_job(self):
-        from dango.config.schedules import reload_schedules
-
-        scheduler = self._make_scheduler(existing_jobs=["schedule:old_job"])
-
-        result = reload_schedules(scheduler, [], "/tmp/project")
-
-        assert "old_job" in result.removed
-        scheduler.remove_job.assert_called_once_with("schedule:old_job")
-
-    def test_update_existing_job(self):
-        from dango.config.schedules import ScheduleConfig, reload_schedules
-
-        scheduler = self._make_scheduler(existing_jobs=["schedule:my_sync"])
-        scheds = [ScheduleConfig(name="my_sync", cron="0 6 * * *", sources=["csv"])]
-
-        result = reload_schedules(scheduler, scheds, "/tmp/project")
-
-        assert "my_sync" in result.updated
-        # remove + re-add for update
-        scheduler.remove_job.assert_called_with("schedule:my_sync")
-        scheduler.add_job.assert_called_once()
-
-    def test_disabled_schedule_not_added(self):
-        from dango.config.schedules import ScheduleConfig, reload_schedules
-
-        scheduler = self._make_scheduler()
         scheds = [
-            ScheduleConfig(name="disabled_sync", cron="daily", sources=["csv"], enabled=False)
+            ScheduleConfig(name="s1", cron="0 6 * * *", sources=["csv"]),
+            ScheduleConfig(name="s2", cron="0 6 * * *", sources=["csv"]),
         ]
+        warnings = _detect_overlaps(scheds)
+        assert len(warnings) == 1
+        assert "overlapping" in warnings[0].lower()
 
-        result = reload_schedules(scheduler, scheds, "/tmp/project")
+    def test_detect_overlaps_no_shared_source(self):
+        """Same cron but different sources -> no overlap warning."""
+        from dango.config.schedules import ScheduleConfig, _detect_overlaps
 
-        assert result.added == []
-        scheduler.add_job.assert_not_called()
+        scheds = [
+            ScheduleConfig(name="s1", cron="0 6 * * *", sources=["csv"]),
+            ScheduleConfig(name="s2", cron="0 6 * * *", sources=["stripe"]),
+        ]
+        warnings = _detect_overlaps(scheds)
+        assert warnings == []
 
-    def test_result_shape(self):
-        from dango.config.schedules import ReloadResult, ScheduleConfig, reload_schedules
+    def test_detect_overlaps_disabled_ignored(self):
+        """Disabled schedules are not checked for overlaps."""
+        from dango.config.schedules import ScheduleConfig, _detect_overlaps
 
-        scheduler = self._make_scheduler()
-        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
-
-        result = reload_schedules(scheduler, scheds, "/tmp/project")
-
-        assert isinstance(result, ReloadResult)
-        assert isinstance(result.added, list)
-        assert isinstance(result.updated, list)
-        assert isinstance(result.removed, list)
-        assert isinstance(result.unchanged, list)
+        scheds = [
+            ScheduleConfig(name="s1", cron="0 6 * * *", sources=["csv"]),
+            ScheduleConfig(name="s2", cron="0 6 * * *", sources=["csv"], enabled=False),
+        ]
+        warnings = _detect_overlaps(scheds)
+        assert warnings == []

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -202,6 +202,14 @@ class TestValidateSchedules:
         # No duration warning when average_durations is None
         assert not any("less than 80%" in i for i in issues)
 
+    def test_interval_vs_duration_skipped_when_empty_dict(self):
+        from dango.config.schedules import ScheduleConfig, validate_schedules
+
+        scheds = [ScheduleConfig(name="s1", cron="every_15m", sources=["csv"])]
+        issues = validate_schedules(scheds, {"csv"}, average_durations={})
+        # Empty dict is truthy but has no entries — no duration warning
+        assert not any("less than 80%" in i for i in issues)
+
     def test_overlap_warning(self):
         from dango.config.schedules import ScheduleConfig, validate_schedules
 

--- a/tests/unit/test_schedules_loading.py
+++ b/tests/unit/test_schedules_loading.py
@@ -217,5 +217,6 @@ class TestReloadSchedules:
 
         assert "nightly_dbt" in result.added
         scheduler.add_job.assert_called_once()
-        call_kwargs = scheduler.add_job.call_args
-        assert call_kwargs[1]["kwargs"]["select"] == "run --select daily_models"
+        _, call_kwargs = scheduler.add_job.call_args
+        assert call_kwargs["kwargs"]["select"] == "run --select daily_models"
+        assert call_kwargs["id"] == "schedule:nightly_dbt"

--- a/tests/unit/test_schedules_loading.py
+++ b/tests/unit/test_schedules_loading.py
@@ -1,0 +1,221 @@
+"""tests/unit/test_schedules_loading.py
+
+Tests for schedule config loading, reload logic, and ConfigLoader integration.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+
+@pytest.mark.unit
+class TestLoadSchedulesConfig:
+    """Test load_schedules_config() file loading."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from dango.config.schedules import load_schedules_config
+
+        cfg = load_schedules_config(tmp_path)
+        assert cfg.schedules == []
+
+    def test_valid_yaml(self, tmp_path):
+        from dango.config.schedules import load_schedules_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        data = {
+            "schedules": [
+                {"name": "daily_sync", "cron": "0 6 * * *", "sources": ["csv"]},
+            ]
+        }
+        (dango_dir / "schedules.yml").write_text(yaml.safe_dump(data))
+
+        cfg = load_schedules_config(tmp_path)
+        assert len(cfg.schedules) == 1
+        assert cfg.schedules[0].name == "daily_sync"
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        from dango.config.exceptions import ConfigValidationError
+        from dango.config.schedules import load_schedules_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "schedules.yml").write_text("schedules: [unclosed bracket\n")
+
+        with pytest.raises(ConfigValidationError, match="Invalid YAML"):
+            load_schedules_config(tmp_path)
+
+    def test_schedules_key_null(self, tmp_path):
+        """YAML with 'schedules: null' returns empty config."""
+        from dango.config.schedules import load_schedules_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "schedules.yml").write_text("schedules: null\n")
+
+        cfg = load_schedules_config(tmp_path)
+        assert cfg.schedules == []
+
+    def test_no_schedules_key(self, tmp_path):
+        """YAML without a 'schedules' key returns empty config."""
+        from dango.config.schedules import load_schedules_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "schedules.yml").write_text("notifications:\n  webhook_url: http://x\n")
+
+        cfg = load_schedules_config(tmp_path)
+        assert cfg.schedules == []
+
+    def test_empty_file(self, tmp_path):
+        """Empty YAML file returns empty config."""
+        from dango.config.schedules import load_schedules_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "schedules.yml").write_text("")
+
+        cfg = load_schedules_config(tmp_path)
+        assert cfg.schedules == []
+
+
+@pytest.mark.unit
+class TestConfigLoaderSchedules:
+    """Test ConfigLoader.load_schedules_config() integration."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from dango.config.loader import ConfigLoader
+
+        loader = ConfigLoader(project_root=tmp_path)
+        cfg = loader.load_schedules_config()
+        assert cfg.schedules == []
+
+    def test_valid_file(self, tmp_path):
+        from dango.config.loader import ConfigLoader
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        data = {
+            "schedules": [
+                {"name": "daily_sync", "cron": "0 6 * * *", "sources": ["csv"]},
+            ]
+        }
+        (dango_dir / "schedules.yml").write_text(yaml.safe_dump(data))
+
+        loader = ConfigLoader(project_root=tmp_path)
+        cfg = loader.load_schedules_config()
+        assert len(cfg.schedules) == 1
+        assert cfg.schedules[0].name == "daily_sync"
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        from dango.config.exceptions import ConfigValidationError
+        from dango.config.loader import ConfigLoader
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "schedules.yml").write_text("schedules: [unclosed\n")
+
+        loader = ConfigLoader(project_root=tmp_path)
+        with pytest.raises(ConfigValidationError, match="Invalid YAML"):
+            loader.load_schedules_config()
+
+
+@pytest.mark.unit
+class TestReloadSchedules:
+    """Test reload_schedules() diff and apply logic."""
+
+    def _make_scheduler(self, existing_jobs=None):
+        """Create a mock SchedulerService with optional existing jobs."""
+        scheduler = MagicMock()
+        jobs = []
+        if existing_jobs:
+            for job_id in existing_jobs:
+                job = MagicMock()
+                job.id = job_id
+                jobs.append(job)
+        scheduler.get_jobs.return_value = jobs
+        return scheduler
+
+    def test_add_new_job(self):
+        from dango.config.schedules import ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler()
+        scheds = [ScheduleConfig(name="daily_sync", cron="0 6 * * *", sources=["csv"])]
+
+        result = reload_schedules(scheduler, scheds, Path("/tmp/project"))
+
+        assert "daily_sync" in result.added
+        scheduler.add_job.assert_called_once()
+
+    def test_remove_old_job(self):
+        from dango.config.schedules import reload_schedules
+
+        scheduler = self._make_scheduler(existing_jobs=["schedule:old_job"])
+
+        result = reload_schedules(scheduler, [], Path("/tmp/project"))
+
+        assert "old_job" in result.removed
+        scheduler.remove_job.assert_called_once_with("schedule:old_job")
+
+    def test_update_existing_job(self):
+        from dango.config.schedules import ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler(existing_jobs=["schedule:my_sync"])
+        scheds = [ScheduleConfig(name="my_sync", cron="0 6 * * *", sources=["csv"])]
+
+        result = reload_schedules(scheduler, scheds, Path("/tmp/project"))
+
+        assert "my_sync" in result.updated
+        # remove + re-add for update
+        scheduler.remove_job.assert_called_with("schedule:my_sync")
+        scheduler.add_job.assert_called_once()
+
+    def test_disabled_schedule_not_added(self):
+        from dango.config.schedules import ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler()
+        scheds = [
+            ScheduleConfig(name="disabled_sync", cron="daily", sources=["csv"], enabled=False)
+        ]
+
+        result = reload_schedules(scheduler, scheds, Path("/tmp/project"))
+
+        assert result.added == []
+        scheduler.add_job.assert_not_called()
+
+    def test_result_shape(self):
+        from dango.config.schedules import ReloadResult, ScheduleConfig, reload_schedules
+
+        scheduler = self._make_scheduler()
+        scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
+
+        result = reload_schedules(scheduler, scheds, Path("/tmp/project"))
+
+        assert isinstance(result, ReloadResult)
+        assert isinstance(result.added, list)
+        assert isinstance(result.updated, list)
+        assert isinstance(result.removed, list)
+        assert isinstance(result.unchanged, list)
+
+    def test_dbt_schedule_reload(self):
+        """Test reload with a dbt-type schedule."""
+        from dango.config.schedules import ScheduleConfig, ScheduleType, reload_schedules
+
+        scheduler = self._make_scheduler()
+        scheds = [
+            ScheduleConfig(
+                name="nightly_dbt",
+                type=ScheduleType.DBT,
+                cron="0 2 * * *",
+                dbt_command="run --select daily_models",
+            )
+        ]
+
+        result = reload_schedules(scheduler, scheds, Path("/tmp/project"))
+
+        assert "nightly_dbt" in result.added
+        scheduler.add_job.assert_called_once()
+        call_kwargs = scheduler.add_job.call_args
+        assert call_kwargs[1]["kwargs"]["select"] == "run --select daily_models"


### PR DESCRIPTION
## Summary

- **New `dango/config/schedules.py`** (~455 lines) — Pydantic models (`ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`), cron validation via croniter (with preset resolution), cross-validation (duplicate names, unknown sources, interval-vs-duration, overlapping crons), startup logging, and a `reload_schedules()` function that diffs YAML configs against running APScheduler jobs
- **`ConfigLoader.load_schedules_config()`** — optional file loading following the `load_sources_config()` pattern
- **`croniter>=2.0,<4`** added to project dependencies
- **36 unit tests** across 8 test classes in `test_schedules_config.py`
- Updated `config/__init__.py` exports, `config/CLAUDE.md`, and `pyproject.toml` mypy overrides

## Test plan

- [x] `ruff check` — pass
- [x] `ruff format --check` — pass
- [x] `mypy dango/config/schedules.py dango/config/loader.py` — 0 errors
- [x] `pytest tests/unit/test_schedules_config.py -v` — 36/36 pass
- [x] `pytest tests/unit/test_config_loader.py -v` — 41/41 pass (no regressions)
- [x] `pytest tests/unit/test_scheduler.py -v` — 32/32 pass (no regressions)
- [x] `scripts/check_file_sizes.py` — both new files under 500 lines
- [x] All 11 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)