### PR TITLE
feat(scheduling): implement scheduled sync + dbt jobs (TASK-041)

### DIFF
--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -399,7 +399,7 @@ def reload_schedules(
     """
     from apscheduler.triggers.cron import CronTrigger
 
-    from dango.platform.scheduling.jobs import dbt_run_job, sync_source_job
+    from dango.platform.scheduling.jobs import run_scheduled_dbt, run_scheduled_sync
 
     # Collect current schedule jobs
     existing_jobs: dict[str, Any] = {}
@@ -446,18 +446,18 @@ def reload_schedules(
         func: Any
         func_kwargs: dict[str, Any]
         if sched.type == ScheduleType.SYNC:
-            func = sync_source_job
-            # sync_source_job accepts a comma-separated string of source names
-            # (matches the CLI `dango sync src1,src2` convention)
+            func = run_scheduled_sync
             func_kwargs = {
-                "source_name": ",".join(sched.sources),
+                "schedule_name": sched.name,
+                "sources": list(sched.sources),
                 "project_root": str(project_root),
             }
         else:
-            func = dbt_run_job
+            func = run_scheduled_dbt
             func_kwargs = {
+                "schedule_name": sched.name,
+                "dbt_command": sched.dbt_command,
                 "project_root": str(project_root),
-                "select": sched.dbt_command,
             }
 
         if job_id in existing_ids:

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -68,7 +68,7 @@ platform/
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |
 | `local/watcher_runner.py` | Background watcher process | `main` |
 | `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence | `SchedulerService` |
-| `scheduling/jobs.py` | Module-level job function stubs (pickle-safe) | `sync_source_job`, `dbt_run_job` |
+| `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |
 | `cloud/provisioning.py` | Droplet size tiers, regions, provisioning orchestration | `DropletSizeTier`, `RegionInfo`, `SIZE_TIERS`, `DEFAULT_TIER`, `provision_droplet`, `wait_for_droplet_ready`, `wait_for_ssh`, `suggest_nearest_region`, `save_provisioning_metadata` |
 | `cloud/firewall.py` | Firewall lifecycle and IP allowlisting | `create_default_firewall`, `add_allowed_ip`, `restrict_web_to_ips`, `allow_all_web`, `validate_ip_or_cidr`, `save_firewall_metadata` |
@@ -96,7 +96,7 @@ from dango.platform.common.startup import run_pending_migrations, start_docker_s
 
 # Scheduling (TASK-036+)
 from dango.platform.scheduling import SchedulerService
-from dango.platform.scheduling.jobs import sync_source_job, dbt_run_job
+from dango.platform.scheduling.jobs import run_scheduled_sync, run_scheduled_dbt
 
 # Local-only components
 from dango.platform.local.watcher_lifecycle import start_file_watcher, get_watcher_status

--- a/dango/platform/scheduling/__init__.py
+++ b/dango/platform/scheduling/__init__.py
@@ -3,6 +3,16 @@
 APScheduler-based job scheduling for Dango data pipelines.
 """
 
+from dango.platform.scheduling.jobs import (
+    configure_jobs,
+    run_scheduled_dbt,
+    run_scheduled_sync,
+)
 from dango.platform.scheduling.scheduler import SchedulerService
 
-__all__ = ["SchedulerService"]
+__all__ = [
+    "SchedulerService",
+    "configure_jobs",
+    "run_scheduled_dbt",
+    "run_scheduled_sync",
+]

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -2,23 +2,552 @@
 
 Module-level job functions for APScheduler pickle serialization.
 
-APScheduler 3.x serializes job references by module path. Functions must be
+APScheduler 3.x serializes job references by module path.  Functions must be
 defined at module level (not as methods or lambdas) so they can be pickled
 and restored from the SQLite job store across restarts.
+
+Public API:
+    configure_jobs(loop)       -- set the event loop (called by SchedulerService.start)
+    run_scheduled_sync(...)    -- sync one or more data sources on schedule
+    run_scheduled_dbt(...)     -- run dbt models on schedule
 """
 
+from __future__ import annotations
 
-def sync_source_job(source_name: str, project_root: str) -> None:
-    """Run a scheduled sync for a data source.
+import asyncio
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-    Implementation in TASK-041.
+from dango.logging import get_logger
+
+if TYPE_CHECKING:
+    from dango.config.models import DataSource
+
+logger = get_logger(__name__)
+
+_event_loop: asyncio.AbstractEventLoop | None = None
+_BROADCAST_TIMEOUT = 5  # seconds to wait for a WebSocket broadcast
+
+
+def configure_jobs(loop: asyncio.AbstractEventLoop) -> None:
+    """Store the running event loop for async bridging.
+
+    Called once by ``SchedulerService.start()``.
     """
-    raise NotImplementedError("Job implementation pending TASK-041")
+    global _event_loop  # noqa: PLW0603
+    _event_loop = loop
+    logger.info("scheduler_jobs_configured")
 
 
-def dbt_run_job(project_root: str, select: str | None = None) -> None:
+# ---------------------------------------------------------------------------
+# Async bridge helpers
+# ---------------------------------------------------------------------------
+
+
+def _broadcast(message: dict[str, Any]) -> None:
+    """Bridge a WebSocket broadcast from the thread-pool to the event loop.
+
+    Silently returns on any error — broadcast failures must never block a job.
+    """
+    if _event_loop is None:
+        return
+    try:
+        from dango.web.routes.websocket import ws_manager
+
+        future = asyncio.run_coroutine_threadsafe(ws_manager.broadcast(message), _event_loop)
+        future.result(timeout=_BROADCAST_TIMEOUT)
+    except Exception:  # noqa: BLE001
+        logger.debug("broadcast_bridge_error", exc_info=True)
+
+
+def _notify(
+    sender: Any,
+    *,
+    event_type: Any,
+    schedule_name: str,
+    sources: list[str] | None = None,
+    error: str | None = None,
+    duration_seconds: float | None = None,
+    stale_hours: float | None = None,
+) -> None:
+    """Bridge a webhook notification (fire-and-forget).  Never raises."""
+    try:
+        if _event_loop is None or sender is None or not sender.is_configured:
+            return
+        coro = sender.send(
+            event_type=event_type,
+            schedule_name=schedule_name,
+            sources=sources,
+            error=error,
+            duration_seconds=duration_seconds,
+            stale_hours=stale_hours,
+        )
+        asyncio.run_coroutine_threadsafe(coro, _event_loop)
+    except Exception:  # noqa: BLE001
+        logger.warning("notify_bridge_error", exc_info=True)
+
+
+def _ts() -> str:
+    """UTC ISO timestamp for broadcast messages."""
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Source resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_sources(project_root: Path, names: list[str]) -> list[DataSource]:
+    """Resolve source names to ``DataSource`` objects.  Unknown names are skipped."""
+    from dango.config.helpers import load_config
+
+    config = load_config(project_root)
+    resolved: list[DataSource] = []
+    for name in names:
+        source = config.sources.get_source(name)
+        if source is None:
+            logger.warning("unknown_source_name", source=name)
+        else:
+            resolved.append(source)
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Execution history
+# ---------------------------------------------------------------------------
+
+
+def _record_execution(
+    *,
+    schedule_name: str,
+    job_type: str,
+    status: str,
+    duration_seconds: float,
+    error: str | None = None,
+    sources: list[str] | None = None,
+) -> None:
+    """Log a structured execution record (TASK-039 upgrades to SQLite)."""
+    logger.info(
+        "job_execution_recorded",
+        schedule_name=schedule_name,
+        job_type=job_type,
+        status=status,
+        duration_seconds=round(duration_seconds, 2),
+        error=error,
+        sources=sources or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data freshness check
+# ---------------------------------------------------------------------------
+
+
+def _check_freshness(
+    project_root: Path,
+    schedule_name: str,
+    source_names: list[str],
+    sender: Any,
+) -> None:
+    """Check data freshness; notify if any source is stale."""
+    try:
+        from dango.platform.notifications.webhook import EventType, load_notification_config
+        from dango.utils.sync_history import load_sync_history
+
+        notif_config = load_notification_config(project_root)
+        if notif_config is None:
+            return
+        threshold_hours = notif_config.stale_threshold_hours
+        now = datetime.now(tz=timezone.utc)
+
+        for source_name in source_names:
+            history = load_sync_history(project_root, source_name, limit=1)
+            if not history:
+                continue
+            last = history[0]
+            ts_str = last.get("completed_at") or last.get("timestamp", "")
+            if not ts_str:
+                continue
+            # Python 3.10 compat: strip timezone suffix before parsing
+            clean = ts_str.replace("+00:00", "").replace("Z", "").replace("+0000", "")
+            try:
+                completed_at = datetime.fromisoformat(clean).replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+            age_hours = (now - completed_at).total_seconds() / 3600
+            if age_hours > threshold_hours:
+                logger.warning(
+                    "source_data_stale",
+                    source=source_name,
+                    age_hours=round(age_hours, 1),
+                    threshold_hours=threshold_hours,
+                )
+                _broadcast(
+                    {
+                        "event": "sync_stale",
+                        "source": source_name,
+                        "schedule": schedule_name,
+                        "age_hours": round(age_hours, 1),
+                        "threshold_hours": threshold_hours,
+                        "timestamp": now.isoformat(),
+                    }
+                )
+                _notify(
+                    sender,
+                    event_type=EventType.SYNC_STALE,
+                    schedule_name=schedule_name,
+                    sources=[source_name],
+                    stale_hours=round(age_hours, 1),
+                )
+    except Exception:  # noqa: BLE001
+        logger.debug("freshness_check_error", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Main job functions
+# ---------------------------------------------------------------------------
+
+
+def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) -> None:
+    """Run a scheduled data sync for the given sources.
+
+    Called by APScheduler from a thread-pool executor.  Wraps ``run_sync()``
+    with DbtLock serialization, WebSocket broadcasting, webhook notifications,
+    and execution history recording.
+
+    Args:
+        schedule_name: Human-readable schedule identifier.
+        sources: List of source names to sync.
+        **kwargs: Must include ``project_root`` (str).
+    """
+    project_root = Path(kwargs.get("project_root", "."))
+    full_refresh = bool(kwargs.get("full_refresh", False))
+    t0 = time.monotonic()
+
+    from dango.exceptions import DbtLockError
+    from dango.platform.notifications.webhook import (
+        EventType,
+        WebhookSender,
+        load_notification_config,
+    )
+    from dango.utils.dbt_lock import DbtLock
+
+    sender = WebhookSender(load_notification_config(project_root))
+    source_names = list(sources)
+    lock = DbtLock(project_root, source="scheduler", operation=f"sync:{schedule_name}")
+
+    try:
+        try:
+            lock.acquire()
+        except DbtLockError:
+            elapsed = time.monotonic() - t0
+            logger.warning(
+                "scheduler_lock_contention", schedule=schedule_name, sources=source_names
+            )
+            _broadcast(
+                {
+                    "event": "job_queued",
+                    "schedule": schedule_name,
+                    "sources": source_names,
+                    "message": "Lock contention",
+                    "timestamp": _ts(),
+                }
+            )
+            _broadcast(
+                {
+                    "event": "sync_failed",
+                    "schedule": schedule_name,
+                    "sources": source_names,
+                    "error": "Could not acquire lock",
+                    "timestamp": _ts(),
+                }
+            )
+            _notify(
+                sender,
+                event_type=EventType.SYNC_FAILED,
+                schedule_name=schedule_name,
+                sources=source_names,
+                error="Could not acquire lock",
+                duration_seconds=elapsed,
+            )
+            _record_execution(
+                schedule_name=schedule_name,
+                job_type="sync",
+                status="lock_failed",
+                duration_seconds=elapsed,
+                error="Lock contention",
+                sources=source_names,
+            )
+            return
+
+        resolved = _resolve_sources(project_root, source_names)
+        if not resolved:
+            elapsed = time.monotonic() - t0
+            logger.warning("no_sources_resolved", schedule=schedule_name, names=source_names)
+            _record_execution(
+                schedule_name=schedule_name,
+                job_type="sync",
+                status="no_sources",
+                duration_seconds=elapsed,
+                sources=source_names,
+            )
+            return
+
+        _broadcast(
+            {
+                "event": "sync_started",
+                "schedule": schedule_name,
+                "sources": source_names,
+                "timestamp": _ts(),
+            }
+        )
+
+        from dango.ingestion.dlt_runner import run_sync
+
+        run_sync(project_root, resolved, full_refresh=full_refresh)
+        elapsed = time.monotonic() - t0
+
+        from dango.utils.sync_history import save_sync_history_entry
+
+        for src in resolved:
+            save_sync_history_entry(
+                project_root,
+                src.name,
+                {
+                    "trigger": "scheduler",
+                    "schedule": schedule_name,
+                    "status": "completed",
+                    "completed_at": _ts(),
+                    "duration_seconds": round(elapsed, 2),
+                },
+            )
+
+        _record_execution(
+            schedule_name=schedule_name,
+            job_type="sync",
+            status="completed",
+            duration_seconds=elapsed,
+            sources=source_names,
+        )
+        _broadcast(
+            {
+                "event": "sync_completed",
+                "schedule": schedule_name,
+                "sources": source_names,
+                "duration_seconds": round(elapsed, 2),
+                "timestamp": _ts(),
+            }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_COMPLETED,
+            schedule_name=schedule_name,
+            sources=source_names,
+            duration_seconds=round(elapsed, 2),
+        )
+        _check_freshness(project_root, schedule_name, source_names, sender)
+
+    except Exception as exc:  # noqa: BLE001
+        elapsed = time.monotonic() - t0
+        error_msg = str(exc)
+        logger.error(
+            "scheduled_sync_failed",
+            schedule=schedule_name,
+            sources=source_names,
+            error=error_msg,
+            exc_info=True,
+        )
+        _record_execution(
+            schedule_name=schedule_name,
+            job_type="sync",
+            status="failed",
+            duration_seconds=elapsed,
+            error=error_msg,
+            sources=source_names,
+        )
+        _broadcast(
+            {
+                "event": "sync_failed",
+                "schedule": schedule_name,
+                "sources": source_names,
+                "error": error_msg,
+                "timestamp": _ts(),
+            }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            sources=source_names,
+            error=error_msg,
+            duration_seconds=elapsed,
+        )
+    finally:
+        lock.release()
+
+
+def run_scheduled_dbt(
+    schedule_name: str,
+    dbt_command: str | None = None,
+    **kwargs: Any,
+) -> None:
     """Run a scheduled dbt transformation.
 
-    Implementation in TASK-041.
+    Called by APScheduler from a thread-pool executor.  Wraps
+    ``run_dbt_models()`` with DbtLock serialization, WebSocket
+    broadcasting, webhook notifications, and execution history recording.
+
+    Args:
+        schedule_name: Human-readable schedule identifier.
+        dbt_command: dbt selection criteria.  ``None`` runs all models.
+        **kwargs: Must include ``project_root`` (str).
     """
-    raise NotImplementedError("Job implementation pending TASK-041")
+    project_root = Path(kwargs.get("project_root", "."))
+    t0 = time.monotonic()
+
+    from dango.exceptions import DbtLockError
+    from dango.platform.notifications.webhook import (
+        EventType,
+        WebhookSender,
+        load_notification_config,
+    )
+    from dango.utils.dbt_lock import DbtLock
+
+    sender = WebhookSender(load_notification_config(project_root))
+    lock = DbtLock(project_root, source="scheduler", operation=f"dbt:{schedule_name}")
+
+    try:
+        try:
+            lock.acquire()
+        except DbtLockError:
+            elapsed = time.monotonic() - t0
+            logger.warning(
+                "scheduler_lock_contention", schedule=schedule_name, dbt_command=dbt_command
+            )
+            _broadcast(
+                {
+                    "event": "job_queued",
+                    "schedule": schedule_name,
+                    "message": "Lock contention",
+                    "timestamp": _ts(),
+                }
+            )
+            _broadcast(
+                {
+                    "event": "dbt_failed",
+                    "schedule": schedule_name,
+                    "error": "Could not acquire lock",
+                    "timestamp": _ts(),
+                }
+            )
+            _notify(
+                sender,
+                event_type=EventType.SYNC_FAILED,
+                schedule_name=schedule_name,
+                error="Could not acquire lock",
+                duration_seconds=elapsed,
+            )
+            _record_execution(
+                schedule_name=schedule_name,
+                job_type="dbt",
+                status="lock_failed",
+                duration_seconds=elapsed,
+                error="Lock contention",
+            )
+            return
+
+        _broadcast(
+            {
+                "event": "dbt_started",
+                "schedule": schedule_name,
+                "dbt_command": dbt_command,
+                "timestamp": _ts(),
+            }
+        )
+
+        from dango.transformation import run_dbt_models
+
+        success, output = run_dbt_models(project_root, select=dbt_command)
+        elapsed = time.monotonic() - t0
+
+        if success:
+            _record_execution(
+                schedule_name=schedule_name,
+                job_type="dbt",
+                status="completed",
+                duration_seconds=elapsed,
+            )
+            _broadcast(
+                {
+                    "event": "dbt_completed",
+                    "schedule": schedule_name,
+                    "duration_seconds": round(elapsed, 2),
+                    "timestamp": _ts(),
+                }
+            )
+            _notify(
+                sender,
+                event_type=EventType.SYNC_COMPLETED,
+                schedule_name=schedule_name,
+                duration_seconds=round(elapsed, 2),
+            )
+        else:
+            _record_execution(
+                schedule_name=schedule_name,
+                job_type="dbt",
+                status="failed",
+                duration_seconds=elapsed,
+                error=output,
+            )
+            _broadcast(
+                {
+                    "event": "dbt_failed",
+                    "schedule": schedule_name,
+                    "error": output,
+                    "timestamp": _ts(),
+                }
+            )
+            _notify(
+                sender,
+                event_type=EventType.SYNC_FAILED,
+                schedule_name=schedule_name,
+                error=output,
+                duration_seconds=elapsed,
+            )
+
+    except Exception as exc:  # noqa: BLE001
+        elapsed = time.monotonic() - t0
+        error_msg = str(exc)
+        logger.error(
+            "scheduled_dbt_failed",
+            schedule=schedule_name,
+            dbt_command=dbt_command,
+            error=error_msg,
+            exc_info=True,
+        )
+        _record_execution(
+            schedule_name=schedule_name,
+            job_type="dbt",
+            status="failed",
+            duration_seconds=elapsed,
+            error=error_msg,
+        )
+        _broadcast(
+            {
+                "event": "dbt_failed",
+                "schedule": schedule_name,
+                "error": error_msg,
+                "timestamp": _ts(),
+            }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            error=error_msg,
+            duration_seconds=elapsed,
+        )
+    finally:
+        lock.release()

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -88,6 +88,10 @@ class SchedulerService:
 
         self._loop = loop
 
+        from dango.platform.scheduling.jobs import configure_jobs
+
+        configure_jobs(loop)
+
         self._scheduler.add_listener(self._on_job_executed, EVENT_JOB_EXECUTED)
         self._scheduler.add_listener(self._on_job_error, EVENT_JOB_ERROR)
         self._scheduler.add_listener(self._on_job_missed, EVENT_JOB_MISSED)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -200,6 +200,12 @@ exemptions:
     reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"
 
+  - file: dango/platform/scheduling/jobs.py
+    lines: 553
+    category: exempt
+    reason: "TASK-041: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, and history recording. Each job path (lock failure, success, error) requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
+    review_by: "v1.1"
+
   - file: dango/platform/cloud/digitalocean.py
     lines: 542
     category: exempt

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -212,6 +212,12 @@ exemptions:
     reason: "TASK-104: Added get_action() and wait_for_action() for resize/migrate action polling. Core DO API client — splitting would fragment related HTTP methods."
     review_by: "v1.1"
 
+  - file: dango/platform/cloud/scheduled_backup.py
+    lines: 505
+    category: exempt
+    reason: "TASK-103: Server-side scheduled backup to Spaces with list/restore/enable/disable. Marginally over limit."
+    review_by: "v1.1"
+
   - file: dango/platform/cloud/ssh.py
     lines: 665
     category: exempt

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -242,6 +242,12 @@ exemptions:
     reason: "TASK-029: 9 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, and sync trigger. Each requires isolated mock setup."
     review_by: "v1.1"
 
+  - file: tests/unit/test_sync_jobs.py
+    lines: 562
+    category: exempt
+    reason: "TASK-041: 25 tests across 6 classes covering configure_jobs, _broadcast, _notify, run_scheduled_sync (8 tests incl. lock failure, no sources, exception), run_scheduled_dbt (6 tests incl. lock failure, exception), and _check_freshness. Each test requires isolated mock setup for lazy-import patching."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,7 @@ module = [
     "tests.unit.test_scheduler",
     "tests.unit.test_schedules_config",
     "tests.unit.test_schedules_loading",
+    "tests.unit.test_sync_jobs",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -374,34 +374,26 @@ class TestSchedulerStartupSummary:
 
 
 @pytest.mark.unit
-class TestJobStubs:
-    """Test module-level job function stubs."""
+class TestJobFunctions:
+    """Test module-level job functions are importable."""
 
-    def test_sync_source_job_is_module_level(self):
-        """sync_source_job should be importable at module level."""
-        from dango.platform.scheduling.jobs import sync_source_job
+    def test_run_scheduled_sync_is_module_level(self):
+        """run_scheduled_sync should be importable at module level."""
+        from dango.platform.scheduling.jobs import run_scheduled_sync
 
-        assert callable(sync_source_job)
+        assert callable(run_scheduled_sync)
 
-    def test_dbt_run_job_is_module_level(self):
-        """dbt_run_job should be importable at module level."""
-        from dango.platform.scheduling.jobs import dbt_run_job
+    def test_run_scheduled_dbt_is_module_level(self):
+        """run_scheduled_dbt should be importable at module level."""
+        from dango.platform.scheduling.jobs import run_scheduled_dbt
 
-        assert callable(dbt_run_job)
+        assert callable(run_scheduled_dbt)
 
-    def test_sync_source_job_raises_not_implemented(self):
-        """sync_source_job should raise NotImplementedError (pending TASK-041)."""
-        from dango.platform.scheduling.jobs import sync_source_job
+    def test_configure_jobs_is_module_level(self):
+        """configure_jobs should be importable at module level."""
+        from dango.platform.scheduling.jobs import configure_jobs
 
-        with pytest.raises(NotImplementedError, match="TASK-041"):
-            sync_source_job("test-source", "/tmp/project")
-
-    def test_dbt_run_job_raises_not_implemented(self):
-        """dbt_run_job should raise NotImplementedError (pending TASK-041)."""
-        from dango.platform.scheduling.jobs import dbt_run_job
-
-        with pytest.raises(NotImplementedError, match="TASK-041"):
-            dbt_run_job("/tmp/project")
+        assert callable(configure_jobs)
 
 
 _HEALTH_MOD = "dango.web.routes.health"

--- a/tests/unit/test_schedules_loading.py
+++ b/tests/unit/test_schedules_loading.py
@@ -218,5 +218,5 @@ class TestReloadSchedules:
         assert "nightly_dbt" in result.added
         scheduler.add_job.assert_called_once()
         _, call_kwargs = scheduler.add_job.call_args
-        assert call_kwargs["kwargs"]["select"] == "run --select daily_models"
+        assert call_kwargs["kwargs"]["dbt_command"] == "run --select daily_models"
         assert call_kwargs["id"] == "schedule:nightly_dbt"

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -1,0 +1,437 @@
+"""tests/unit/test_sync_jobs.py
+
+Tests for dango.platform.scheduling.jobs — scheduled sync and dbt job functions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_JOBS_MOD = "dango.platform.scheduling.jobs"
+
+# Lazy imports in job functions → patch at origin
+_LOCK_MOD = "dango.utils.dbt_lock"
+_LOCK_ERR_MOD = "dango.exceptions"
+_NOTIF_MOD = "dango.platform.notifications.webhook"
+_SYNC_MOD = "dango.ingestion.dlt_runner"
+_DBT_MOD = "dango.transformation"
+_HIST_MOD = "dango.utils.sync_history"
+_CFG_MOD = "dango.config.helpers"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_source(name="test_source", enabled=True):
+    """Create a minimal DataSource mock."""
+    src = MagicMock()
+    src.name = name
+    src.enabled = enabled
+    return src
+
+
+def _make_config_with_sources(*source_names):
+    """Create a mock load_config that returns sources by name."""
+    sources = {n: _make_source(n) for n in source_names}
+    config = MagicMock()
+    config.sources.get_source.side_effect = lambda n: sources.get(n)
+    return config
+
+
+# ---------------------------------------------------------------------------
+# configure_jobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConfigureJobs:
+    """Test configure_jobs() stores the event loop."""
+
+    def test_stores_loop(self):
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod.configure_jobs(loop)
+            assert jobs_mod._event_loop is loop
+        finally:
+            jobs_mod._event_loop = old
+
+    def test_called_from_scheduler_start(self, tmp_path):
+        """SchedulerService.start() should call configure_jobs."""
+        from tests.unit.test_scheduler import _make_service
+
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        with patch(f"{_JOBS_MOD}.configure_jobs") as mock_cfg:
+            svc.start(loop)
+
+        mock_cfg.assert_called_once_with(loop)
+
+
+# ---------------------------------------------------------------------------
+# _broadcast helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBroadcastHelper:
+    """Test _broadcast() async bridge."""
+
+    def test_delegates_to_ws_manager(self):
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        future = MagicMock()
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod._event_loop = loop
+
+            with patch(f"{_JOBS_MOD}.asyncio") as mock_asyncio:
+                mock_asyncio.run_coroutine_threadsafe.return_value = future
+                jobs_mod._broadcast({"event": "test"})
+
+            mock_asyncio.run_coroutine_threadsafe.assert_called_once()
+            future.result.assert_called_once()
+        finally:
+            jobs_mod._event_loop = old
+
+    def test_skips_without_loop(self):
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod._event_loop = None
+            jobs_mod._broadcast({"event": "test"})
+        finally:
+            jobs_mod._event_loop = old
+
+    def test_catches_exceptions(self):
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod._event_loop = loop
+            with patch(f"{_JOBS_MOD}.asyncio") as mock_asyncio:
+                mock_asyncio.run_coroutine_threadsafe.side_effect = RuntimeError("closed")
+                jobs_mod._broadcast({"event": "test"})
+        finally:
+            jobs_mod._event_loop = old
+
+
+# ---------------------------------------------------------------------------
+# run_scheduled_sync
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunScheduledSync:
+    """Test run_scheduled_sync() job function."""
+
+    def test_acquires_and_releases_lock(self, tmp_path):
+        mock_lock = MagicMock()
+        config = _make_config_with_sources("src1")
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(f"{_HIST_MOD}.save_sync_history_entry"),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._check_freshness"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        mock_lock.acquire.assert_called_once()
+        mock_lock.release.assert_called_once()
+
+    def test_lock_failure_broadcasts_and_notifies(self, tmp_path):
+        from dango.exceptions import DbtLockError
+
+        mock_lock = MagicMock()
+        mock_lock.acquire.side_effect = DbtLockError("busy")
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify") as mock_notify,
+            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "job_queued" in events
+        assert "sync_failed" in events
+        mock_notify.assert_called_once()
+        mock_record.assert_called_once()
+        assert mock_record.call_args[1]["status"] == "lock_failed"
+
+    def test_broadcasts_sync_started_and_completed(self, tmp_path):
+        mock_lock = MagicMock()
+        config = _make_config_with_sources("src1")
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(f"{_HIST_MOD}.save_sync_history_entry"),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._check_freshness"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "sync_started" in events
+        assert "sync_completed" in events
+
+    def test_exception_broadcasts_sync_failed(self, tmp_path):
+        mock_lock = MagicMock()
+        config = _make_config_with_sources("src1")
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync", side_effect=RuntimeError("boom")),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "sync_failed" in events
+        mock_lock.release.assert_called_once()
+
+    def test_records_history_per_source(self, tmp_path):
+        mock_lock = MagicMock()
+        config = _make_config_with_sources("src1", "src2")
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(f"{_HIST_MOD}.save_sync_history_entry") as mock_hist,
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._check_freshness"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1", "src2"], project_root=str(tmp_path))
+
+        assert mock_hist.call_count == 2
+
+    def test_notifies_on_success(self, tmp_path):
+        """Notification should be dispatched on successful sync."""
+        mock_lock = MagicMock()
+        config = _make_config_with_sources("src1")
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(f"{_HIST_MOD}.save_sync_history_entry"),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify") as mock_notify,
+            patch(f"{_JOBS_MOD}._check_freshness"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        mock_notify.assert_called_once()
+
+    def test_is_pickle_serializable(self):
+        """Job function must be pickle-serializable (APScheduler requirement)."""
+        import pickle
+
+        from dango.platform.scheduling.jobs import run_scheduled_sync
+
+        data = pickle.dumps(run_scheduled_sync)
+        restored = pickle.loads(data)  # noqa: S301
+        assert callable(restored)
+
+
+# ---------------------------------------------------------------------------
+# run_scheduled_dbt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunScheduledDbt:
+    """Test run_scheduled_dbt() job function."""
+
+    def test_acquires_lock_and_calls_dbt(self, tmp_path):
+        mock_lock = MagicMock()
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_DBT_MOD}.run_dbt_models", return_value=(True, "ok")),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_dbt
+
+            run_scheduled_dbt("nightly", "model_name+", project_root=str(tmp_path))
+
+        mock_lock.acquire.assert_called_once()
+        mock_lock.release.assert_called_once()
+
+    def test_broadcasts_dbt_events(self, tmp_path):
+        mock_lock = MagicMock()
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_DBT_MOD}.run_dbt_models", return_value=(True, "ok")),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_dbt
+
+            run_scheduled_dbt("nightly", None, project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "dbt_started" in events
+        assert "dbt_completed" in events
+
+    def test_dbt_failure_notifies(self, tmp_path):
+        mock_lock = MagicMock()
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_DBT_MOD}.run_dbt_models", return_value=(False, "dbt error")),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify") as mock_notify,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_dbt
+
+            run_scheduled_dbt("nightly", None, project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "dbt_failed" in events
+        mock_notify.assert_called_once()
+
+    def test_is_pickle_serializable(self):
+        """Job function must be pickle-serializable (APScheduler requirement)."""
+        import pickle
+
+        from dango.platform.scheduling.jobs import run_scheduled_dbt
+
+        data = pickle.dumps(run_scheduled_dbt)
+        restored = pickle.loads(data)  # noqa: S301
+        assert callable(restored)
+
+
+# ---------------------------------------------------------------------------
+# _check_freshness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckFreshness:
+    """Test _check_freshness() staleness detection."""
+
+    def test_stale_triggers_notification(self, tmp_path):
+        from dango.platform.scheduling.jobs import _check_freshness
+
+        old_ts = "2026-01-01T00:00:00"
+        mock_sender = MagicMock()
+        mock_sender.is_configured = True
+
+        notif_config = MagicMock()
+        notif_config.stale_threshold_hours = 24
+
+        with (
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=notif_config),
+            patch(f"{_HIST_MOD}.load_sync_history", return_value=[{"completed_at": old_ts}]),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify") as mock_notify,
+        ):
+            _check_freshness(tmp_path, "daily", ["src1"], mock_sender)
+
+        assert any(c.args[0].get("event") == "sync_stale" for c in mock_bc.call_args_list)
+        mock_notify.assert_called_once()
+
+    def test_fresh_data_no_notification(self, tmp_path):
+        from datetime import datetime, timezone
+
+        from dango.platform.scheduling.jobs import _check_freshness
+
+        recent_ts = datetime.now(tz=timezone.utc).isoformat()
+        mock_sender = MagicMock()
+        mock_sender.is_configured = True
+
+        notif_config = MagicMock()
+        notif_config.stale_threshold_hours = 24
+
+        with (
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=notif_config),
+            patch(f"{_HIST_MOD}.load_sync_history", return_value=[{"completed_at": recent_ts}]),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify") as mock_notify,
+        ):
+            _check_freshness(tmp_path, "daily", ["src1"], mock_sender)
+
+        mock_bc.assert_not_called()
+        mock_notify.assert_not_called()
+
+    def test_no_config_is_noop(self, tmp_path):
+        from dango.platform.scheduling.jobs import _check_freshness
+
+        mock_sender = MagicMock()
+
+        with patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None):
+            _check_freshness(tmp_path, "daily", ["src1"], mock_sender)
+
+    def test_missing_history_is_noop(self, tmp_path):
+        from dango.platform.scheduling.jobs import _check_freshness
+
+        mock_sender = MagicMock()
+        mock_sender.is_configured = True
+
+        notif_config = MagicMock()
+        notif_config.stale_threshold_hours = 24
+
+        with (
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=notif_config),
+            patch(f"{_HIST_MOD}.load_sync_history", return_value=[]),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+        ):
+            _check_freshness(tmp_path, "daily", ["src1"], mock_sender)
+
+        mock_bc.assert_not_called()

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -6,15 +6,22 @@ Tests for dango.platform.scheduling.jobs — scheduled sync and dbt job function
 from __future__ import annotations
 
 import asyncio
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import dango.utils.dbt_lock  # noqa: F401 — force submodule into sys.modules
+
+# dango.utils.__init__ exports a *function* named ``dbt_lock`` which shadows
+# the submodule ``dango.utils.dbt_lock``.  Both string-based patch() and
+# ``import X as Y`` resolve to the function.  Fetch the module from
+# sys.modules to get the real module object for patch.object().
+_dbt_lock_module = sys.modules["dango.utils.dbt_lock"]
+
 _JOBS_MOD = "dango.platform.scheduling.jobs"
 
 # Lazy imports in job functions → patch at origin
-_LOCK_MOD = "dango.utils.dbt_lock"
-_LOCK_ERR_MOD = "dango.exceptions"
 _NOTIF_MOD = "dango.platform.notifications.webhook"
 _SYNC_MOD = "dango.ingestion.dlt_runner"
 _DBT_MOD = "dango.transformation"
@@ -141,7 +148,7 @@ class TestRunScheduledSync:
         config = _make_config_with_sources("src1")
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
@@ -165,7 +172,7 @@ class TestRunScheduledSync:
         mock_lock.acquire.side_effect = DbtLockError("busy")
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
@@ -188,7 +195,7 @@ class TestRunScheduledSync:
         config = _make_config_with_sources("src1")
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
@@ -211,7 +218,7 @@ class TestRunScheduledSync:
         config = _make_config_with_sources("src1")
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
@@ -232,7 +239,7 @@ class TestRunScheduledSync:
         config = _make_config_with_sources("src1", "src2")
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
@@ -254,7 +261,7 @@ class TestRunScheduledSync:
         config = _make_config_with_sources("src1")
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
@@ -277,7 +284,7 @@ class TestRunScheduledSync:
         config.sources.get_source.return_value = None  # all unknown
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
@@ -318,7 +325,7 @@ class TestRunScheduledDbt:
         mock_lock = MagicMock()
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_DBT_MOD}.run_dbt_models", return_value=(True, "ok")),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
@@ -336,7 +343,7 @@ class TestRunScheduledDbt:
         mock_lock = MagicMock()
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_DBT_MOD}.run_dbt_models", return_value=(True, "ok")),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
@@ -359,7 +366,7 @@ class TestRunScheduledDbt:
         mock_lock.acquire.side_effect = DbtLockError("busy")
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
@@ -382,7 +389,7 @@ class TestRunScheduledDbt:
         mock_lock = MagicMock()
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_DBT_MOD}.run_dbt_models", side_effect=RuntimeError("crash")),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
@@ -405,7 +412,7 @@ class TestRunScheduledDbt:
         mock_lock = MagicMock()
 
         with (
-            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_DBT_MOD}.run_dbt_models", return_value=(False, "dbt error")),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -270,6 +270,30 @@ class TestRunScheduledSync:
 
         mock_notify.assert_called_once()
 
+    def test_no_sources_resolved_records_and_returns(self, tmp_path):
+        """When all source names are unknown, record no_sources and return early."""
+        mock_lock = MagicMock()
+        config = MagicMock()
+        config.sources.get_source.return_value = None  # all unknown
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync") as mock_run,
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["bogus"], project_root=str(tmp_path))
+
+        mock_run.assert_not_called()
+        mock_bc.assert_not_called()
+        mock_record.assert_called_once()
+        assert mock_record.call_args[1]["status"] == "no_sources"
+
     def test_is_pickle_serializable(self):
         """Job function must be pickle-serializable (APScheduler requirement)."""
         import pickle
@@ -327,6 +351,56 @@ class TestRunScheduledDbt:
         assert "dbt_started" in events
         assert "dbt_completed" in events
 
+    def test_lock_failure_broadcasts_and_records(self, tmp_path):
+        """DbtLockError should broadcast job_queued + dbt_failed and record lock_failed."""
+        from dango.exceptions import DbtLockError
+
+        mock_lock = MagicMock()
+        mock_lock.acquire.side_effect = DbtLockError("busy")
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify") as mock_notify,
+            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_dbt
+
+            run_scheduled_dbt("nightly", None, project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "job_queued" in events
+        assert "dbt_failed" in events
+        mock_notify.assert_called_once()
+        mock_record.assert_called_once()
+        assert mock_record.call_args[1]["status"] == "lock_failed"
+
+    def test_exception_broadcasts_dbt_failed(self, tmp_path):
+        """Unexpected exception from run_dbt_models should broadcast dbt_failed."""
+        mock_lock = MagicMock()
+
+        with (
+            patch(f"{_LOCK_MOD}.DbtLock", return_value=mock_lock),
+            patch(f"{_DBT_MOD}.run_dbt_models", side_effect=RuntimeError("crash")),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_dbt
+
+            run_scheduled_dbt("nightly", None, project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "dbt_failed" in events
+        mock_record.assert_called()
+        assert mock_record.call_args[1]["status"] == "failed"
+        assert "crash" in mock_record.call_args[1]["error"]
+        mock_lock.release.assert_called_once()
+
     def test_dbt_failure_notifies(self, tmp_path):
         mock_lock = MagicMock()
 
@@ -355,6 +429,57 @@ class TestRunScheduledDbt:
         data = pickle.dumps(run_scheduled_dbt)
         restored = pickle.loads(data)  # noqa: S301
         assert callable(restored)
+
+
+# ---------------------------------------------------------------------------
+# _notify helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNotifyHelper:
+    """Test _notify() never-raises contract."""
+
+    def test_swallows_sender_exception(self):
+        """_notify must never propagate exceptions from sender.send()."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod._event_loop = loop
+
+            sender = MagicMock()
+            sender.is_configured = True
+            sender.send.side_effect = RuntimeError("webhook exploded")
+
+            # Should not raise
+            jobs_mod._notify(
+                sender,
+                event_type="TEST",
+                schedule_name="daily",
+            )
+        finally:
+            jobs_mod._event_loop = old
+
+    def test_skips_when_sender_not_configured(self):
+        """_notify should be a no-op when sender is not configured."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod._event_loop = loop
+
+            sender = MagicMock()
+            sender.is_configured = False
+
+            with patch(f"{_JOBS_MOD}.asyncio") as mock_asyncio:
+                jobs_mod._notify(sender, event_type="TEST", schedule_name="daily")
+
+            mock_asyncio.run_coroutine_threadsafe.assert_not_called()
+        finally:
+            jobs_mod._event_loop = old
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace `NotImplementedError` stubs in `scheduling/jobs.py` with full implementations of `run_scheduled_sync()` and `run_scheduled_dbt()`
- Add `configure_jobs(loop)` for event loop bridging from APScheduler's thread-pool executor
- Implement DbtLock serialization, WebSocket broadcasting, webhook notifications, sync history recording, and data freshness checks
- Rename `sync_source_job`/`dbt_run_job` → `run_scheduled_sync`/`run_scheduled_dbt` per V1_PLAN naming

## Changes
| File | Change |
|------|--------|
| `dango/platform/scheduling/jobs.py` | Full rewrite: 6 functions (3 public + 3 internal helpers) |
| `dango/platform/scheduling/scheduler.py` | Add `configure_jobs(loop)` call in `start()` |
| `dango/platform/scheduling/__init__.py` | Export new public functions |
| `tests/unit/test_sync_jobs.py` | New: 20 tests across 5 test classes |
| `tests/unit/test_scheduler.py` | Update `TestJobStubs` → `TestJobFunctions`, remove stub tests |
| `pyproject.toml` | Add mypy exemption for new test file |
| `docs/file-exemptions.yml` | Add jobs.py (553 lines) exemption |
| `dango/platform/CLAUDE.md` | Update symbol names |

## Test plan
- [x] `pytest tests/unit/test_sync_jobs.py tests/unit/test_scheduler.py -v` — 51 passed
- [x] `pytest tests/unit/ -x` — 1966 passed
- [x] `ruff check` + `ruff format --check` + `mypy` — all clean
- [x] `grep -rn "sync_source_job\|dbt_run_job" dango/ tests/` — zero stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)