### PR TITLE
feat(scheduling): add execution history tracking (TASK-039)

### DIFF
--- a/dango/migrations/CLAUDE.md
+++ b/dango/migrations/CLAUDE.md
@@ -20,9 +20,13 @@ migrations/
 ├── __init__.py     # Public API
 ├── runner.py       # Core engine
 ├── CLAUDE.md       # This file
-└── auth/           # Created by TASK-011 (Phase 2)
-    ├── 001_initial_auth.py
-    └── 002_add_sessions.py
+├── auth/           # Created by TASK-011 (Phase 2)
+│   ├── 001_initial_auth.py
+│   ├── 002_complete_auth_schema.py
+│   ├── 003_metabase_password.py
+│   └── 004_invite_tokens.py
+└── scheduler/      # Created by TASK-039 (Phase 4)
+    └── 001_execution_history.py
 ```
 
 ## Migration File Contract

--- a/dango/migrations/scheduler/001_execution_history.py
+++ b/dango/migrations/scheduler/001_execution_history.py
@@ -1,0 +1,37 @@
+"""dango/migrations/scheduler/001_execution_history.py
+
+Create the execution_history table for tracking scheduled job runs.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+VERSION = 1
+DESCRIPTION = "Create execution_history table"
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Create execution_history table and indexes.
+
+    Do not call ``conn.commit()`` — the migration runner manages the
+    transaction.
+    """
+    conn.execute(
+        """
+        CREATE TABLE execution_history (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            schedule_name    TEXT NOT NULL,
+            sources          TEXT,
+            started_at       TEXT NOT NULL,
+            ended_at         TEXT,
+            status           TEXT NOT NULL DEFAULT 'running',
+            error            TEXT,
+            duration_seconds REAL,
+            rows_processed   INTEGER
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_exec_schedule_name ON execution_history (schedule_name)")
+    conn.execute("CREATE INDEX idx_exec_started_at ON execution_history (started_at)")
+    conn.execute("CREATE INDEX idx_exec_status ON execution_history (status)")

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -27,8 +27,9 @@ platform/
 │   └── watcher_runner.py    # Background watcher process entry point
 │
 ├── scheduling/          # APScheduler-based job scheduling (TASK-036+)
-│   ├── __init__.py      # Re-exports SchedulerService, ResilienceConfig, run_with_resilience
+│   ├── __init__.py      # Re-exports SchedulerService, ResilienceConfig, run_with_resilience, history functions
 │   ├── scheduler.py     # SchedulerService + resilience (retry, timeout, cancellation)
+│   ├── history.py       # Execution history tracking (TASK-039)
 │   └── jobs.py          # Module-level job functions (pickle-safe)
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
@@ -68,6 +69,7 @@ platform/
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |
 | `local/watcher_runner.py` | Background watcher process | `main` |
 | `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence, resilience (retry/timeout/cancel) | `SchedulerService`, `ResilienceConfig`, `run_with_resilience` |
+| `scheduling/history.py` | Execution history tracking for scheduled jobs | `record_start`, `record_completion`, `record_failure`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
 | `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |
 | `cloud/provisioning.py` | Droplet size tiers, regions, provisioning orchestration | `DropletSizeTier`, `RegionInfo`, `SIZE_TIERS`, `DEFAULT_TIER`, `provision_droplet`, `wait_for_droplet_ready`, `wait_for_ssh`, `suggest_nearest_region`, `save_provisioning_metadata` |
@@ -96,6 +98,8 @@ from dango.platform.common.startup import run_pending_migrations, start_docker_s
 
 # Scheduling (TASK-036+)
 from dango.platform.scheduling import SchedulerService, ResilienceConfig, run_with_resilience
+from dango.platform.scheduling import record_start, record_completion, get_schedule_history
+from dango.platform.scheduling.history import get_average_duration, get_last_run
 from dango.platform.scheduling.jobs import run_scheduled_sync, run_scheduled_dbt
 
 # Local-only components
@@ -173,6 +177,7 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
 | Add/modify scheduled jobs | `scheduling/scheduler.py`, `scheduling/jobs.py` | `pytest tests/unit/test_scheduler.py` |
+| Query execution history | `scheduling/history.py` | `pytest tests/unit/test_execution_history.py` |
 | Add a startup step for both local + cloud | `common/startup.py` | `pytest tests/unit/test_platform_startup.py` |
 | Add a local-only startup step | `local/` and `cli/commands/platform.py` | `dango start` manually |
 | Add cloud infrastructure | `cloud/` | `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py` |
@@ -291,7 +296,7 @@ Post-deployment hardening (not automated by Dango):
 
 ## Testing
 
-- **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py`
+- **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py`
 - **Local platform:** `pytest tests/unit/test_platform_startup.py tests/unit/test_watcher_lifecycle.py`
 - **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
 - **Manual:** `dango start` (local platform), `dango deploy` (cloud provisioning)

--- a/dango/platform/scheduling/__init__.py
+++ b/dango/platform/scheduling/__init__.py
@@ -3,6 +3,26 @@
 APScheduler-based job scheduling for Dango data pipelines.
 """
 
+from dango.platform.scheduling.history import (
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    STATUS_SUCCESS,
+    STATUS_TIMEOUT,
+    VALID_STATUSES,
+    cleanup_history_job,
+    cleanup_old_records,
+    get_average_duration,
+    get_last_run,
+    get_recent_history,
+    get_schedule_history,
+    get_scheduler_db_path,
+    record_cancellation,
+    record_completion,
+    record_failure,
+    record_start,
+    record_timeout,
+)
 from dango.platform.scheduling.jobs import (
     configure_jobs,
     run_scheduled_dbt,
@@ -16,8 +36,26 @@ from dango.platform.scheduling.scheduler import (
 
 __all__ = [
     "ResilienceConfig",
+    "STATUS_CANCELLED",
+    "STATUS_FAILED",
+    "STATUS_RUNNING",
+    "STATUS_SUCCESS",
+    "STATUS_TIMEOUT",
+    "VALID_STATUSES",
     "SchedulerService",
+    "cleanup_history_job",
+    "cleanup_old_records",
     "configure_jobs",
+    "get_average_duration",
+    "get_last_run",
+    "get_recent_history",
+    "get_schedule_history",
+    "get_scheduler_db_path",
+    "record_cancellation",
+    "record_completion",
+    "record_failure",
+    "record_start",
+    "record_timeout",
     "run_scheduled_dbt",
     "run_scheduled_sync",
     "run_with_resilience",

--- a/dango/platform/scheduling/history.py
+++ b/dango/platform/scheduling/history.py
@@ -1,0 +1,471 @@
+"""dango/platform/scheduling/history.py
+
+Execution history tracking for scheduled jobs. Records start/completion/failure
+of each job run in the scheduler SQLite database, and provides query functions
+for the web UI, average duration warnings (TASK-037), and schedule listings.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from dango.logging import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Status constants
+# ---------------------------------------------------------------------------
+
+STATUS_RUNNING = "running"
+STATUS_SUCCESS = "success"
+STATUS_FAILED = "failed"
+STATUS_CANCELLED = "cancelled"
+STATUS_TIMEOUT = "timeout"
+
+VALID_STATUSES: frozenset[str] = frozenset(
+    {STATUS_RUNNING, STATUS_SUCCESS, STATUS_FAILED, STATUS_CANCELLED, STATUS_TIMEOUT}
+)
+
+# Stale threshold — running records older than this are marked failed on cleanup
+_STALE_RUNNING_HOURS = 24
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    """Open a SQLite connection with WAL mode enabled.
+
+    Args:
+        db_path: Path to the scheduler SQLite database.
+
+    Returns:
+        A configured sqlite3 connection.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    """Convert a Row to a plain dict, parsing ``sources`` from JSON.
+
+    Args:
+        row: A sqlite3.Row from the execution_history table.
+
+    Returns:
+        Dict with all columns, ``sources`` parsed to a list.
+    """
+    d: dict[str, Any] = dict(row)
+    if d.get("sources") is not None:
+        try:
+            d["sources"] = json.loads(d["sources"])
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return d
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse an ISO 8601 timestamp, stripping timezone suffix for 3.10 compat.
+
+    Python 3.10's ``fromisoformat()`` cannot parse ``+00:00`` or ``Z``
+    suffixes, so we strip them before parsing and assume UTC.
+
+    Args:
+        value: ISO 8601 timestamp string.
+
+    Returns:
+        A timezone-aware UTC datetime.
+    """
+    cleaned = value.replace("+00:00", "").replace("Z", "")
+    dt = datetime.fromisoformat(cleaned)
+    return dt.replace(tzinfo=timezone.utc)
+
+
+def _utcnow_iso() -> str:
+    """Return current UTC time as an ISO 8601 string."""
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Path helper
+# ---------------------------------------------------------------------------
+
+
+def get_scheduler_db_path(project_root: str | Path) -> Path:
+    """Return the path to the scheduler database.
+
+    Args:
+        project_root: Dango project root directory.
+
+    Returns:
+        Path to ``.dango/scheduler.db``.
+    """
+    return Path(project_root) / ".dango" / "scheduler.db"
+
+
+# ---------------------------------------------------------------------------
+# Record lifecycle (write)
+# ---------------------------------------------------------------------------
+
+
+def record_start(
+    db_path: Path,
+    schedule_name: str,
+    sources: list[str] | None = None,
+) -> int:
+    """Insert a new running execution record.
+
+    Args:
+        db_path: Path to the scheduler database.
+        schedule_name: Name of the schedule being executed.
+        sources: Optional list of source names involved.
+
+    Returns:
+        The ``id`` of the newly created record.
+    """
+    sources_json = json.dumps(sources) if sources is not None else None
+    now = _utcnow_iso()
+
+    conn = _connect(db_path)
+    try:
+        cursor = conn.execute(
+            """
+            INSERT INTO execution_history (schedule_name, sources, started_at, status)
+            VALUES (?, ?, ?, ?)
+            """,
+            (schedule_name, sources_json, now, STATUS_RUNNING),
+        )
+        conn.commit()
+        row_id: int = cursor.lastrowid  # type: ignore[assignment]
+        logger.debug("execution_record_started", record_id=row_id, schedule=schedule_name)
+        return row_id
+    finally:
+        conn.close()
+
+
+def _finish_record(
+    db_path: Path,
+    record_id: int,
+    status: str,
+    *,
+    error: str | None = None,
+    rows_processed: int | None = None,
+) -> None:
+    """Shared helper to finalize a running execution record.
+
+    Reads ``started_at`` from the DB, computes duration, and updates the row.
+    """
+    now = datetime.now(tz=timezone.utc)
+    now_iso = now.isoformat()
+
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT started_at FROM execution_history WHERE id = ?",
+            (record_id,),
+        ).fetchone()
+        if row is None:
+            logger.warning("execution_record_not_found", record_id=record_id)
+            return
+
+        started = _parse_iso(row["started_at"])
+        duration = (now - started).total_seconds()
+
+        conn.execute(
+            """
+            UPDATE execution_history
+            SET status = ?, ended_at = ?, duration_seconds = ?,
+                error = ?, rows_processed = ?
+            WHERE id = ?
+            """,
+            (status, now_iso, duration, error, rows_processed, record_id),
+        )
+        conn.commit()
+        logger.debug(
+            "execution_record_finished",
+            record_id=record_id,
+            status=status,
+            duration=round(duration, 2),
+        )
+    finally:
+        conn.close()
+
+
+def record_completion(db_path: Path, record_id: int, rows_processed: int | None = None) -> None:
+    """Mark an execution as successfully completed.
+
+    Args:
+        db_path: Path to the scheduler database.
+        record_id: The execution record ID.
+        rows_processed: Optional row count from the job.
+    """
+    _finish_record(db_path, record_id, STATUS_SUCCESS, rows_processed=rows_processed)
+
+
+def record_failure(db_path: Path, record_id: int, error: str) -> None:
+    """Mark an execution as failed.
+
+    Args:
+        db_path: Path to the scheduler database.
+        record_id: The execution record ID.
+        error: Human-readable error description.
+    """
+    _finish_record(db_path, record_id, STATUS_FAILED, error=error)
+
+
+def record_timeout(db_path: Path, record_id: int) -> None:
+    """Mark an execution as timed out.
+
+    Args:
+        db_path: Path to the scheduler database.
+        record_id: The execution record ID.
+    """
+    _finish_record(db_path, record_id, STATUS_TIMEOUT)
+
+
+def record_cancellation(db_path: Path, record_id: int) -> None:
+    """Mark an execution as cancelled.
+
+    Args:
+        db_path: Path to the scheduler database.
+        record_id: The execution record ID.
+    """
+    _finish_record(db_path, record_id, STATUS_CANCELLED)
+
+
+# ---------------------------------------------------------------------------
+# Queries (read)
+# ---------------------------------------------------------------------------
+
+
+def get_schedule_history(
+    db_path: Path,
+    schedule_name: str,
+    *,
+    status: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[dict[str, Any]], int]:
+    """Get paginated execution history for a schedule.
+
+    Args:
+        db_path: Path to the scheduler database.
+        schedule_name: Filter by schedule name.
+        status: Optional status filter.
+        since: Optional ISO 8601 lower bound for ``started_at``.
+        until: Optional ISO 8601 upper bound for ``started_at``.
+        limit: Maximum records to return.
+        offset: Number of records to skip.
+
+    Returns:
+        Tuple of (list of record dicts, total matching count).
+    """
+    conditions = ["schedule_name = ?"]
+    params: list[Any] = [schedule_name]
+
+    if status is not None:
+        conditions.append("status = ?")
+        params.append(status)
+    if since is not None:
+        conditions.append("started_at >= ?")
+        params.append(since)
+    if until is not None:
+        conditions.append("started_at <= ?")
+        params.append(until)
+
+    where = " AND ".join(conditions)
+
+    conn = _connect(db_path)
+    try:
+        count_row = conn.execute(
+            f"SELECT COUNT(*) as cnt FROM execution_history WHERE {where}",  # noqa: S608
+            params,
+        ).fetchone()
+        total: int = count_row["cnt"] if count_row else 0
+
+        rows = conn.execute(
+            f"SELECT * FROM execution_history WHERE {where} "  # noqa: S608
+            "ORDER BY started_at DESC LIMIT ? OFFSET ?",
+            [*params, limit, offset],
+        ).fetchall()
+
+        return [_row_to_dict(r) for r in rows], total
+    finally:
+        conn.close()
+
+
+def get_recent_history(
+    db_path: Path,
+    *,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Get the most recent execution records across all schedules.
+
+    Args:
+        db_path: Path to the scheduler database.
+        limit: Maximum records to return.
+
+    Returns:
+        List of record dicts ordered by ``started_at`` descending.
+    """
+    conn = _connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM execution_history ORDER BY started_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_average_duration(
+    db_path: Path,
+    schedule_name: str,
+    *,
+    window_days: int = 7,
+) -> float | None:
+    """Compute average duration of successful runs within a time window.
+
+    Only considers records with ``status='success'`` and a non-null
+    ``duration_seconds``.
+
+    Args:
+        db_path: Path to the scheduler database.
+        schedule_name: Schedule to compute for.
+        window_days: Number of days to look back.
+
+    Returns:
+        Average duration in seconds, or ``None`` if no qualifying records.
+    """
+    cutoff = (datetime.now(tz=timezone.utc) - timedelta(days=window_days)).isoformat()
+
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT AVG(duration_seconds) as avg_duration
+            FROM execution_history
+            WHERE schedule_name = ?
+              AND status = ?
+              AND duration_seconds IS NOT NULL
+              AND started_at >= ?
+            """,
+            (schedule_name, STATUS_SUCCESS, cutoff),
+        ).fetchone()
+        if row is None or row["avg_duration"] is None:
+            return None
+        result: float = row["avg_duration"]
+        return result
+    finally:
+        conn.close()
+
+
+def get_last_run(
+    db_path: Path,
+    schedule_name: str,
+) -> dict[str, Any] | None:
+    """Get the most recent execution record for a schedule.
+
+    Args:
+        db_path: Path to the scheduler database.
+        schedule_name: Schedule name to look up.
+
+    Returns:
+        Record dict or ``None`` if no history exists.
+    """
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT * FROM execution_history
+            WHERE schedule_name = ?
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (schedule_name,),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_dict(row)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def cleanup_old_records(
+    db_path: Path,
+    retention_days: int = 30,
+) -> int:
+    """Delete old records and mark stale running records as failed.
+
+    Args:
+        db_path: Path to the scheduler database.
+        retention_days: Delete completed records older than this many days.
+
+    Returns:
+        Number of records deleted.
+    """
+    cutoff = (datetime.now(tz=timezone.utc) - timedelta(days=retention_days)).isoformat()
+    stale_cutoff = (
+        datetime.now(tz=timezone.utc) - timedelta(hours=_STALE_RUNNING_HOURS)
+    ).isoformat()
+
+    conn = _connect(db_path)
+    try:
+        # Mark stale running records as failed
+        conn.execute(
+            """
+            UPDATE execution_history
+            SET status = ?, error = 'Marked as failed: stale running record',
+                ended_at = ?
+            WHERE status = ? AND started_at < ?
+            """,
+            (STATUS_FAILED, _utcnow_iso(), STATUS_RUNNING, stale_cutoff),
+        )
+
+        # Delete old completed records
+        cursor = conn.execute(
+            """
+            DELETE FROM execution_history
+            WHERE started_at < ? AND status != ?
+            """,
+            (cutoff, STATUS_RUNNING),
+        )
+        deleted: int = cursor.rowcount
+        conn.commit()
+
+        if deleted > 0:
+            logger.info("execution_history_cleanup", deleted=deleted)
+
+        return deleted
+    finally:
+        conn.close()
+
+
+def cleanup_history_job(project_root: str) -> None:
+    """Module-level cleanup wrapper for APScheduler pickle serialization.
+
+    APScheduler 3.x requires module-level functions for job persistence.
+
+    Args:
+        project_root: Dango project root as a string (APScheduler serializes args).
+    """
+    db_path = get_scheduler_db_path(project_root)
+    if db_path.exists():
+        cleanup_old_records(db_path)

--- a/dango/platform/scheduling/history.py
+++ b/dango/platform/scheduling/history.py
@@ -69,7 +69,7 @@ def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
         try:
             d["sources"] = json.loads(d["sources"])
         except (json.JSONDecodeError, TypeError):
-            pass
+            logger.debug("sources_json_parse_failed", raw_value=d.get("sources"))
     return d
 
 

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -98,6 +98,9 @@ class SchedulerService:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._project_root = project_root
         self._started = False
+        # Maps job_id → execution_history record_id for event listeners.
+        # Thread-safe under CPython GIL (dict ops are atomic). Revisit if
+        # targeting free-threaded Python (PEP 703).
         self._running_records: dict[str, int] = {}
 
         # Cancellation flags: job_id -> threading.Event (set = cancel requested).

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -98,6 +98,7 @@ class SchedulerService:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._project_root = project_root
         self._started = False
+        self._running_records: dict[str, int] = {}
 
         # Cancellation flags: job_id -> threading.Event (set = cancel requested).
         # Python GIL ensures dict.__setitem__ and dict.pop are atomic.
@@ -139,6 +140,7 @@ class SchedulerService:
         self._scheduler.start()
         self._started = True
 
+        self._setup_history_cleanup()
         self._log_startup_summary()
         self._check_dual_scheduler()
 
@@ -202,6 +204,19 @@ class SchedulerService:
             "job_count": len(jobs),
             "next_run_time": next_run,
         }
+
+    def register_execution(self, job_id: str, record_id: int) -> None:
+        """Register an execution history record for a running job.
+
+        Called by job functions (TASK-041) after ``record_start()`` so that
+        event listeners can look up the record ID when the job completes
+        or fails.
+
+        Args:
+            job_id: The APScheduler job ID.
+            record_id: The execution_history row ID from ``record_start()``.
+        """
+        self._running_records[job_id] = record_id
 
     # ------------------------------------------------------------------
     # Cancellation
@@ -279,6 +294,18 @@ class SchedulerService:
             job_id=event.job_id,
             scheduled_run_time=str(event.scheduled_run_time),
         )
+        record_id = self._running_records.pop(event.job_id, None)
+        if record_id is not None:
+            try:
+                from dango.platform.scheduling.history import (
+                    get_scheduler_db_path,
+                    record_completion,
+                )
+
+                db_path = get_scheduler_db_path(self._project_root)
+                record_completion(db_path, record_id)
+            except Exception:  # noqa: BLE001
+                logger.debug("execution_history_completion_failed", exc_info=True)
 
     def _on_job_error(self, event: JobExecutionEvent) -> None:
         logger.error(
@@ -288,6 +315,18 @@ class SchedulerService:
             exception=str(event.exception),
             traceback=str(event.traceback),
         )
+        record_id = self._running_records.pop(event.job_id, None)
+        if record_id is not None:
+            try:
+                from dango.platform.scheduling.history import (
+                    get_scheduler_db_path,
+                    record_failure,
+                )
+
+                db_path = get_scheduler_db_path(self._project_root)
+                record_failure(db_path, record_id, str(event.exception))
+            except Exception:  # noqa: BLE001
+                logger.debug("execution_history_failure_record_failed", exc_info=True)
 
     def _on_job_missed(self, event: JobExecutionEvent) -> None:
         logger.warning(
@@ -299,6 +338,30 @@ class SchedulerService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _setup_history_cleanup(self) -> None:
+        """Run initial cleanup and register daily cleanup job."""
+        try:
+            from dango.platform.scheduling.history import (
+                cleanup_history_job,
+                cleanup_old_records,
+                get_scheduler_db_path,
+            )
+
+            db_path = get_scheduler_db_path(self._project_root)
+            if db_path.exists():
+                cleanup_old_records(db_path)
+
+            self._scheduler.add_job(
+                cleanup_history_job,
+                "interval",
+                hours=24,
+                args=[str(self._project_root)],
+                id="dango-internal:history-cleanup",
+                replace_existing=True,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("history_cleanup_setup_failed", exc_info=True)
 
     def _log_startup_summary(self) -> None:
         """Log the number of loaded jobs and next run times."""

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -254,6 +254,7 @@ from dango.web.routes.initial_sync import router as initial_sync_router  # noqa:
 from dango.web.routes.logs import router as logs_router  # noqa: E402
 from dango.web.routes.metabase_proxy import router as metabase_proxy_router  # noqa: E402
 from dango.web.routes.oauth_connect import router as oauth_connect_router  # noqa: E402
+from dango.web.routes.schedules import router as schedules_router  # noqa: E402
 from dango.web.routes.secrets import router as secrets_router  # noqa: E402
 from dango.web.routes.sources import router as sources_router  # noqa: E402
 from dango.web.routes.sync import router as sync_router  # noqa: E402
@@ -276,6 +277,7 @@ app.include_router(upload_router)
 app.include_router(secrets_router)
 app.include_router(oauth_connect_router)
 app.include_router(dbt_router)
+app.include_router(schedules_router)
 app.include_router(websocket_router)
 app.include_router(ui_router)
 

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -8,6 +8,7 @@ Extended by TASK-038 with schedule CRUD endpoints.
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, Query
@@ -83,6 +84,19 @@ async def schedule_history(
                 "message": f"Invalid status filter. Must be one of: {', '.join(sorted(VALID_STATUSES))}",
             },
         )
+
+    for label, value in [("since", since), ("until", until)]:
+        if value is not None:
+            try:
+                datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error_code": "DANGO-S002",
+                        "message": f"Invalid '{label}' parameter. Must be an ISO 8601 timestamp.",
+                    },
+                )
 
     project_root = get_project_root()
     db_path = get_scheduler_db_path(project_root)

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -1,0 +1,119 @@
+"""dango/web/routes/schedules.py
+
+API endpoints for schedule execution history. Provides paginated history
+per schedule and a recent-executions endpoint across all schedules.
+
+Extended by TASK-038 with schedule CRUD endpoints.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+
+from dango.auth.models import User
+from dango.auth.permissions import require_permission
+from dango.logging import get_logger
+from dango.platform.scheduling.history import (
+    VALID_STATUSES,
+    get_recent_history,
+    get_schedule_history,
+    get_scheduler_db_path,
+)
+from dango.web.helpers import get_project_root
+
+router = APIRouter(tags=["schedules"])
+logger = get_logger(__name__)
+
+
+@router.get("/api/schedules/history/recent")
+async def recent_executions(
+    user: User = Depends(require_permission("scheduler.view")),
+    limit: int = Query(default=20, ge=1, le=200),
+) -> list[dict[str, Any]]:
+    """Get the most recent execution records across all schedules.
+
+    Args:
+        user: Authenticated user with ``scheduler.view`` permission.
+        limit: Maximum number of records to return.
+
+    Returns:
+        List of execution history records.
+    """
+    project_root = get_project_root()
+    db_path = get_scheduler_db_path(project_root)
+
+    if not db_path.exists():
+        return []
+
+    return get_recent_history(db_path, limit=limit)
+
+
+@router.get("/api/schedules/{name}/history")
+async def schedule_history(
+    name: str,
+    user: User = Depends(require_permission("scheduler.view")),
+    status: str | None = Query(default=None),
+    since: str | None = Query(default=None),
+    until: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> JSONResponse:
+    """Get paginated execution history for a specific schedule.
+
+    Args:
+        name: Schedule name.
+        user: Authenticated user with ``scheduler.view`` permission.
+        status: Optional status filter (running/success/failed/cancelled/timeout).
+        since: Optional ISO 8601 lower bound for started_at.
+        until: Optional ISO 8601 upper bound for started_at.
+        limit: Maximum records per page.
+        offset: Records to skip.
+
+    Returns:
+        JSON with schedule_name, items, total, limit, and offset.
+    """
+    if status is not None and status not in VALID_STATUSES:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S001",
+                "message": f"Invalid status filter. Must be one of: {', '.join(sorted(VALID_STATUSES))}",
+            },
+        )
+
+    project_root = get_project_root()
+    db_path = get_scheduler_db_path(project_root)
+
+    if not db_path.exists():
+        return JSONResponse(
+            content={
+                "schedule_name": name,
+                "items": [],
+                "total": 0,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+
+    items, total = get_schedule_history(
+        db_path,
+        name,
+        status=status,
+        since=since,
+        until=until,
+        limit=limit,
+        offset=offset,
+    )
+
+    return JSONResponse(
+        content={
+            "schedule_name": name,
+            "items": items,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+    )

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -254,6 +254,12 @@ exemptions:
     reason: "TASK-041: 25 tests across 6 classes covering configure_jobs, _broadcast, _notify, run_scheduled_sync (8 tests incl. lock failure, no sources, exception), run_scheduled_dbt (6 tests incl. lock failure, exception), and _check_freshness. Each test requires isolated mock setup for lazy-import patching."
     review_by: "v1.1"
 
+  - file: tests/unit/test_scheduler.py
+    lines: 604
+    category: exempt
+    reason: "TASK-036+039: 10 test classes covering SchedulerService init, lifecycle, jobs, status, event listeners, history integration, coroutine bridge, cloud warning, startup summary, health endpoint, and job stubs. Each class requires isolated mock setup with APScheduler dual-patch pattern."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,6 +261,8 @@ module = [
     "tests.unit.test_schedules_config",
     "tests.unit.test_schedules_loading",
     "tests.unit.test_sync_jobs",
+    "tests.unit.test_execution_history",
+    "tests.unit.test_schedule_history_api",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",

--- a/tests/unit/test_execution_history.py
+++ b/tests/unit/test_execution_history.py
@@ -1,0 +1,399 @@
+"""tests/unit/test_execution_history.py
+
+Tests for dango.platform.scheduling.history — execution history tracking
+for scheduled jobs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from dango.platform.scheduling.history import (
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    STATUS_SUCCESS,
+    STATUS_TIMEOUT,
+    cleanup_old_records,
+    get_average_duration,
+    get_last_run,
+    get_recent_history,
+    get_schedule_history,
+    record_cancellation,
+    record_completion,
+    record_failure,
+    record_start,
+    record_timeout,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_migration():
+    """Load the migration module (filename starts with digit, can't import directly)."""
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "dango"
+        / "migrations"
+        / "scheduler"
+        / "001_execution_history.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_001", migration_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _create_db(tmp_path: Path) -> Path:
+    """Create a scheduler DB with the execution_history table."""
+    migration = _load_migration()
+    db_path = tmp_path / "scheduler.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    migration.upgrade(conn)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_record(
+    db_path: Path,
+    schedule_name: str = "daily-sync",
+    status: str = STATUS_SUCCESS,
+    started_at: str | None = None,
+    duration: float | None = 10.0,
+    error: str | None = None,
+    rows_processed: int | None = None,
+) -> int:
+    """Insert a record directly for test setup."""
+    if started_at is None:
+        started_at = datetime.now(tz=timezone.utc).isoformat()
+    ended_at = datetime.now(tz=timezone.utc).isoformat() if status != STATUS_RUNNING else None
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.execute(
+        """
+        INSERT INTO execution_history
+        (schedule_name, started_at, ended_at, status, duration_seconds, error, rows_processed)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (schedule_name, started_at, ended_at, status, duration, error, rows_processed),
+    )
+    conn.commit()
+    row_id = cursor.lastrowid
+    conn.close()
+    return row_id
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMigration:
+    """Test the scheduler migration creates the correct schema."""
+
+    def test_creates_execution_history_table(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='execution_history'"
+        )
+        assert cursor.fetchone() is not None
+        conn.close()
+
+    def test_creates_indexes(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_exec_%'"
+        ).fetchall()
+        index_names = {r[0] for r in rows}
+        conn.close()
+        assert index_names == {"idx_exec_schedule_name", "idx_exec_started_at", "idx_exec_status"}
+
+
+# ---------------------------------------------------------------------------
+# Record lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRecordLifecycle:
+    """Test the write operations for execution records."""
+
+    def test_record_start_creates_running_record(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        record_id = record_start(db_path, "daily-sync", sources=["shopify", "stripe"])
+        assert isinstance(record_id, int)
+        assert record_id > 0
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM execution_history WHERE id = ?", (record_id,)).fetchone()
+        conn.close()
+
+        assert row["status"] == STATUS_RUNNING
+        assert row["schedule_name"] == "daily-sync"
+        assert '"shopify"' in row["sources"]
+
+    def test_record_completion_sets_success(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        record_id = record_start(db_path, "daily-sync")
+        record_completion(db_path, record_id, rows_processed=100)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM execution_history WHERE id = ?", (record_id,)).fetchone()
+        conn.close()
+
+        assert row["status"] == STATUS_SUCCESS
+        assert row["ended_at"] is not None
+        assert row["duration_seconds"] is not None
+        assert row["duration_seconds"] >= 0
+        assert row["rows_processed"] == 100
+
+    def test_record_failure_sets_error(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        record_id = record_start(db_path, "daily-sync")
+        record_failure(db_path, record_id, "Connection refused")
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM execution_history WHERE id = ?", (record_id,)).fetchone()
+        conn.close()
+
+        assert row["status"] == STATUS_FAILED
+        assert row["error"] == "Connection refused"
+        assert row["duration_seconds"] is not None
+
+    def test_record_timeout(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        record_id = record_start(db_path, "daily-sync")
+        record_timeout(db_path, record_id)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM execution_history WHERE id = ?", (record_id,)).fetchone()
+        conn.close()
+
+        assert row["status"] == STATUS_TIMEOUT
+
+    def test_record_cancellation(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        record_id = record_start(db_path, "daily-sync")
+        record_cancellation(db_path, record_id)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM execution_history WHERE id = ?", (record_id,)).fetchone()
+        conn.close()
+
+        assert row["status"] == STATUS_CANCELLED
+
+    def test_duration_computed_correctly(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        record_id = record_start(db_path, "daily-sync")
+        # Small sleep so duration > 0
+        time.sleep(0.05)
+        record_completion(db_path, record_id)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT duration_seconds FROM execution_history WHERE id = ?", (record_id,)
+        ).fetchone()
+        conn.close()
+
+        assert row["duration_seconds"] > 0
+
+    def test_sources_stored_as_json(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        record_id = record_start(db_path, "multi-source", sources=["src_a", "src_b"])
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT sources FROM execution_history WHERE id = ?", (record_id,)
+        ).fetchone()
+        conn.close()
+
+        import json
+
+        parsed = json.loads(row["sources"])
+        assert parsed == ["src_a", "src_b"]
+
+
+# ---------------------------------------------------------------------------
+# Query tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHistoryQueries:
+    """Test read operations for execution history."""
+
+    def test_pagination(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        for _ in range(5):
+            _insert_record(db_path, schedule_name="test-sched")
+
+        items, total = get_schedule_history(db_path, "test-sched", limit=2, offset=0)
+        assert total == 5
+        assert len(items) == 2
+
+        items2, total2 = get_schedule_history(db_path, "test-sched", limit=2, offset=2)
+        assert total2 == 5
+        assert len(items2) == 2
+
+    def test_status_filter(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        _insert_record(db_path, status=STATUS_SUCCESS)
+        _insert_record(db_path, status=STATUS_FAILED, error="err")
+        _insert_record(db_path, status=STATUS_SUCCESS)
+
+        items, total = get_schedule_history(db_path, "daily-sync", status=STATUS_FAILED)
+        assert total == 1
+        assert items[0]["status"] == STATUS_FAILED
+
+    def test_date_filter(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        old_time = (datetime.now(tz=timezone.utc) - timedelta(days=10)).isoformat()
+        recent_time = datetime.now(tz=timezone.utc).isoformat()
+
+        _insert_record(db_path, started_at=old_time)
+        _insert_record(db_path, started_at=recent_time)
+
+        since = (datetime.now(tz=timezone.utc) - timedelta(days=1)).isoformat()
+        items, total = get_schedule_history(db_path, "daily-sync", since=since)
+        assert total == 1
+
+    def test_recent_history(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        _insert_record(db_path, schedule_name="sched-a")
+        _insert_record(db_path, schedule_name="sched-b")
+        _insert_record(db_path, schedule_name="sched-a")
+
+        results = get_recent_history(db_path, limit=10)
+        assert len(results) == 3
+
+    def test_last_run(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        _insert_record(db_path, schedule_name="my-sched")
+        _insert_record(db_path, schedule_name="my-sched")
+
+        result = get_last_run(db_path, "my-sched")
+        assert result is not None
+        assert result["schedule_name"] == "my-sched"
+
+    def test_last_run_nonexistent(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        result = get_last_run(db_path, "nonexistent")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Average duration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAverageDuration:
+    """Test average duration computation."""
+
+    def test_average_of_successful_runs(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        _insert_record(db_path, duration=10.0)
+        _insert_record(db_path, duration=20.0)
+
+        avg = get_average_duration(db_path, "daily-sync")
+        assert avg == pytest.approx(15.0)
+
+    def test_no_runs_returns_none(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        avg = get_average_duration(db_path, "daily-sync")
+        assert avg is None
+
+    def test_excludes_failed_runs(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        _insert_record(db_path, duration=10.0, status=STATUS_SUCCESS)
+        _insert_record(db_path, duration=100.0, status=STATUS_FAILED, error="err")
+
+        avg = get_average_duration(db_path, "daily-sync")
+        assert avg == pytest.approx(10.0)
+
+    def test_window_days_filter(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        old_time = (datetime.now(tz=timezone.utc) - timedelta(days=30)).isoformat()
+        recent_time = datetime.now(tz=timezone.utc).isoformat()
+
+        _insert_record(db_path, started_at=old_time, duration=100.0)
+        _insert_record(db_path, started_at=recent_time, duration=10.0)
+
+        avg = get_average_duration(db_path, "daily-sync", window_days=7)
+        assert avg == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# Cleanup tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCleanup:
+    """Test execution history cleanup."""
+
+    def test_deletes_old_records(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        old_time = (datetime.now(tz=timezone.utc) - timedelta(days=60)).isoformat()
+        _insert_record(db_path, started_at=old_time)
+        _insert_record(db_path)  # recent
+
+        deleted = cleanup_old_records(db_path, retention_days=30)
+        assert deleted == 1
+
+        items = get_recent_history(db_path, limit=100)
+        assert len(items) == 1
+
+    def test_preserves_recent_records(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        _insert_record(db_path)
+        _insert_record(db_path)
+
+        deleted = cleanup_old_records(db_path, retention_days=30)
+        assert deleted == 0
+
+    def test_marks_stale_running_as_failed(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        old_time = (datetime.now(tz=timezone.utc) - timedelta(hours=48)).isoformat()
+        _insert_record(db_path, started_at=old_time, status=STATUS_RUNNING, duration=None)
+
+        cleanup_old_records(db_path, retention_days=30)
+
+        # Stale running record should be marked as failed (not deleted, since
+        # the cutoff for deletion is 30 days)
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM execution_history").fetchone()
+        conn.close()
+
+        assert row["status"] == STATUS_FAILED
+        assert "stale" in row["error"].lower()
+
+    def test_returns_count(self, tmp_path):
+        db_path = _create_db(tmp_path)
+        old_time = (datetime.now(tz=timezone.utc) - timedelta(days=60)).isoformat()
+        _insert_record(db_path, started_at=old_time)
+        _insert_record(db_path, started_at=old_time)
+
+        deleted = cleanup_old_records(db_path, retention_days=30)
+        assert deleted == 2

--- a/tests/unit/test_schedule_history_api.py
+++ b/tests/unit/test_schedule_history_api.py
@@ -1,0 +1,197 @@
+"""tests/unit/test_schedule_history_api.py
+
+Tests for the schedule execution history API endpoints in
+dango/web/routes/schedules.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers (shared with test_execution_history.py)
+# ---------------------------------------------------------------------------
+
+
+def _load_migration():
+    """Load the migration module (filename starts with digit, can't import directly)."""
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "dango"
+        / "migrations"
+        / "scheduler"
+        / "001_execution_history.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_001", migration_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _create_db(tmp_path: Path) -> Path:
+    """Create a scheduler DB with the execution_history table."""
+    migration = _load_migration()
+    db_path = tmp_path / "scheduler.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    migration.upgrade(conn)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_record(
+    db_path: Path,
+    schedule_name: str = "daily-sync",
+    status: str = "success",
+    started_at: str | None = None,
+    duration: float | None = 10.0,
+) -> int:
+    """Insert a record directly for test setup."""
+    if started_at is None:
+        started_at = datetime.now(tz=timezone.utc).isoformat()
+    ended_at = datetime.now(tz=timezone.utc).isoformat() if status != "running" else None
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.execute(
+        """
+        INSERT INTO execution_history
+        (schedule_name, started_at, ended_at, status, duration_seconds)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (schedule_name, started_at, ended_at, status, duration),
+    )
+    conn.commit()
+    row_id = cursor.lastrowid
+    conn.close()
+    return row_id
+
+
+def _make_test_user():
+    """Create a fake admin user for route tests."""
+    from dango.auth.models import Role, User
+
+    return User(
+        id="test-user-id",
+        email="admin@test.com",
+        role=Role.ADMIN,
+        is_active=True,
+    )
+
+
+def _make_schedule_app(tmp_path: Path) -> Any:
+    """Build a minimal FastAPI app with schedules routes and an injected user."""
+    from fastapi import FastAPI
+
+    from dango.web.routes.schedules import router
+
+    app = FastAPI()
+    app.state.project_root = tmp_path
+    app.include_router(router)
+
+    test_user = _make_test_user()
+
+    @app.middleware("http")
+    async def inject_user(request: Any, call_next: Any) -> Any:
+        request.state.user = test_user
+        return await call_next(request)
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScheduleHistoryAPI:
+    """Test the /api/schedules/{name}/history endpoint."""
+
+    def test_returns_history_data(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _create_db(tmp_path)
+        db_path.rename(dango_dir / "scheduler.db")
+
+        app = _make_schedule_app(tmp_path)
+
+        with patch("dango.web.routes.schedules.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/daily-sync/history")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["schedule_name"] == "daily-sync"
+        assert "items" in data
+        assert "total" in data
+
+    def test_validates_status_param(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _create_db(tmp_path)
+        db_path.rename(dango_dir / "scheduler.db")
+
+        app = _make_schedule_app(tmp_path)
+
+        with patch("dango.web.routes.schedules.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/daily-sync/history?status=invalid")
+
+        assert resp.status_code == 400
+        assert "Invalid status" in resp.json()["message"]
+
+
+@pytest.mark.unit
+class TestRecentExecutionsAPI:
+    """Test the /api/schedules/history/recent endpoint."""
+
+    def test_returns_recent_history(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _create_db(tmp_path)
+        _insert_record(db_path, schedule_name="test-sched")
+        db_path.rename(dango_dir / "scheduler.db")
+
+        app = _make_schedule_app(tmp_path)
+
+        with patch("dango.web.routes.schedules.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/history/recent")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+
+    def test_respects_limit(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _create_db(tmp_path)
+        for _ in range(5):
+            _insert_record(db_path, schedule_name="test-sched")
+        db_path.rename(dango_dir / "scheduler.db")
+
+        app = _make_schedule_app(tmp_path)
+
+        with patch("dango.web.routes.schedules.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/history/recent?limit=2")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2

--- a/tests/unit/test_schedule_history_api.py
+++ b/tests/unit/test_schedule_history_api.py
@@ -152,6 +152,56 @@ class TestScheduleHistoryAPI:
         assert resp.status_code == 400
         assert "Invalid status" in resp.json()["message"]
 
+    def test_validates_since_param(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _create_db(tmp_path)
+        db_path.rename(dango_dir / "scheduler.db")
+
+        app = _make_schedule_app(tmp_path)
+
+        with patch("dango.web.routes.schedules.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/daily-sync/history?since=banana")
+
+        assert resp.status_code == 400
+        assert "since" in resp.json()["message"]
+
+    def test_validates_until_param(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _create_db(tmp_path)
+        db_path.rename(dango_dir / "scheduler.db")
+
+        app = _make_schedule_app(tmp_path)
+
+        with patch("dango.web.routes.schedules.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/daily-sync/history?until=not-a-date")
+
+        assert resp.status_code == 400
+        assert "until" in resp.json()["message"]
+
+    def test_accepts_valid_iso_since(self, tmp_path):
+        from fastapi.testclient import TestClient
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _create_db(tmp_path)
+        db_path.rename(dango_dir / "scheduler.db")
+
+        app = _make_schedule_app(tmp_path)
+
+        with patch("dango.web.routes.schedules.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/daily-sync/history?since=2026-01-01T00:00:00Z")
+
+        assert resp.status_code == 200
+
 
 @pytest.mark.unit
 class TestRecentExecutionsAPI:

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -268,6 +268,126 @@ class TestSchedulerServiceEventListeners:
 
 
 @pytest.mark.unit
+class TestSchedulerServiceHistoryIntegration:
+    """Test execution history recording from event listeners."""
+
+    def test_register_execution_stores_record_id(self, tmp_path):
+        """register_execution() should store the mapping for later lookup."""
+        svc = _make_service(tmp_path)
+        svc.register_execution("my-job", 42)
+        assert svc._running_records["my-job"] == 42
+
+    def test_executed_event_calls_record_completion(self, tmp_path):
+        """_on_job_executed should call record_completion for registered jobs."""
+        svc = _make_service(tmp_path)
+        svc._project_root = tmp_path
+        svc.register_execution("my-job", 7)
+
+        event = MagicMock()
+        event.job_id = "my-job"
+        event.scheduled_run_time = "2026-03-01T10:00:00"
+
+        with (
+            patch(f"{_SCHEDULER_MOD}.logger"),
+            patch("dango.platform.scheduling.history.record_completion") as mock_complete,
+            patch(
+                "dango.platform.scheduling.history.get_scheduler_db_path",
+                return_value=tmp_path / ".dango" / "scheduler.db",
+            ),
+        ):
+            svc._on_job_executed(event)
+
+        mock_complete.assert_called_once_with(tmp_path / ".dango" / "scheduler.db", 7)
+        assert "my-job" not in svc._running_records
+
+    def test_error_event_calls_record_failure(self, tmp_path):
+        """_on_job_error should call record_failure for registered jobs."""
+        svc = _make_service(tmp_path)
+        svc._project_root = tmp_path
+        svc.register_execution("my-job", 9)
+
+        event = MagicMock()
+        event.job_id = "my-job"
+        event.scheduled_run_time = "2026-03-01T10:00:00"
+        event.exception = ValueError("connection lost")
+        event.traceback = "traceback text"
+
+        with (
+            patch(f"{_SCHEDULER_MOD}.logger"),
+            patch("dango.platform.scheduling.history.record_failure") as mock_failure,
+            patch(
+                "dango.platform.scheduling.history.get_scheduler_db_path",
+                return_value=tmp_path / ".dango" / "scheduler.db",
+            ),
+        ):
+            svc._on_job_error(event)
+
+        mock_failure.assert_called_once_with(
+            tmp_path / ".dango" / "scheduler.db", 9, "connection lost"
+        )
+        assert "my-job" not in svc._running_records
+
+    def test_executed_event_skips_unregistered_jobs(self, tmp_path):
+        """_on_job_executed should not call history for unregistered jobs."""
+        svc = _make_service(tmp_path)
+
+        event = MagicMock()
+        event.job_id = "unregistered-job"
+        event.scheduled_run_time = "2026-03-01T10:00:00"
+
+        with (
+            patch(f"{_SCHEDULER_MOD}.logger"),
+            patch("dango.platform.scheduling.history.record_completion") as mock_complete,
+        ):
+            svc._on_job_executed(event)
+
+        mock_complete.assert_not_called()
+
+    def test_history_error_does_not_propagate(self, tmp_path):
+        """History recording errors should be caught, not propagated."""
+        svc = _make_service(tmp_path)
+        svc._project_root = tmp_path
+        svc.register_execution("my-job", 1)
+
+        event = MagicMock()
+        event.job_id = "my-job"
+        event.scheduled_run_time = "2026-03-01T10:00:00"
+
+        with (
+            patch(f"{_SCHEDULER_MOD}.logger"),
+            patch(
+                "dango.platform.scheduling.history.record_completion",
+                side_effect=RuntimeError("db locked"),
+            ),
+            patch(
+                "dango.platform.scheduling.history.get_scheduler_db_path",
+                return_value=tmp_path / ".dango" / "scheduler.db",
+            ),
+        ):
+            # Should not raise
+            svc._on_job_executed(event)
+
+    def test_setup_history_cleanup_registers_job(self, tmp_path):
+        """_setup_history_cleanup should register a daily cleanup job."""
+        svc = _make_service(tmp_path)
+        svc._project_root = tmp_path
+
+        with (
+            patch(
+                "dango.platform.scheduling.history.get_scheduler_db_path",
+                return_value=tmp_path / ".dango" / "scheduler.db",
+            ),
+            patch("dango.platform.scheduling.history.cleanup_old_records"),
+        ):
+            svc._setup_history_cleanup()
+
+        svc._scheduler.add_job.assert_called_once()
+        call_kwargs = svc._scheduler.add_job.call_args
+        assert call_kwargs[1]["id"] == "dango-internal:history-cleanup"
+        assert call_kwargs[1]["hours"] == 24
+
+
+@pytest.mark.unit
 class TestSchedulerServiceCoroutineBridge:
     """Test run_coroutine() async bridge."""
 


### PR DESCRIPTION
## Summary

- Add execution history tracking for scheduled jobs — records start/completion/failure/timeout/cancellation with duration computation
- Provide paginated, filterable query API (`/api/schedules/{name}/history`, `/api/schedules/history/recent`) for the web UI
- Include `get_average_duration()` for TASK-037 warnings and `get_last_run()` for TASK-038 schedule listings
- Automate 30-day retention cleanup + stale running record detection via daily APScheduler job
- Wire scheduler event listeners to record completion/failure as a safety net

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `dango/migrations/scheduler/001_execution_history.py` | 37 | SQLite migration — `execution_history` table + 3 indexes |
| `dango/platform/scheduling/history.py` | 471 | Core data layer — record lifecycle, queries, cleanup |
| `dango/web/routes/schedules.py` | 113 | API endpoints with `scheduler.view` permission |
| `tests/unit/test_execution_history.py` | 410 | 23 unit tests (migration, lifecycle, queries, avg duration, cleanup) |
| `tests/unit/test_schedule_history_api.py` | 204 | 4 API route tests |

## Test plan

- [x] 27 new tests pass (`pytest tests/unit/test_execution_history.py tests/unit/test_schedule_history_api.py`)
- [x] 65 existing scheduler + migration tests still pass
- [x] ruff lint + format clean
- [x] mypy clean (159 files)
- [x] All pre-commit hooks pass
- [x] Migration auto-discovered (`['auth', 'scheduler']`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)