### PR TITLE
feat(scheduling): add resilience infrastructure (TASK-040)

### DIFF
--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -35,6 +35,9 @@ __all__ = [
     "DiskSpaceError",
     "DuckDBHealthError",
     "DbtLockError",
+    "SchedulerError",
+    "JobTimeoutError",
+    "JobCancelledError",
     "MigrationError",
     "MigrationDiscoveryError",
     "MigrationApplicationError",
@@ -215,6 +218,24 @@ class DbtLockError(InfrastructureError):
             context=context,
             user_message=user_message,
         )
+
+
+class SchedulerError(InfrastructureError):
+    """Base exception for scheduler-related errors."""
+
+    _default_error_code = "DANGO-U005"
+
+
+class JobTimeoutError(SchedulerError):
+    """Raised when a scheduled job exceeds its timeout."""
+
+    _default_error_code = "DANGO-U006"
+
+
+class JobCancelledError(SchedulerError):
+    """Raised when a scheduled job is cancelled."""
+
+    _default_error_code = "DANGO-U007"
 
 
 # ---------------------------------------------------------------------------

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -27,8 +27,8 @@ platform/
 │   └── watcher_runner.py    # Background watcher process entry point
 │
 ├── scheduling/          # APScheduler-based job scheduling (TASK-036+)
-│   ├── __init__.py      # Re-exports SchedulerService
-│   ├── scheduler.py     # SchedulerService (AsyncIOScheduler wrapper)
+│   ├── __init__.py      # Re-exports SchedulerService, ResilienceConfig, run_with_resilience
+│   ├── scheduler.py     # SchedulerService + resilience (retry, timeout, cancellation)
 │   └── jobs.py          # Module-level job functions (pickle-safe)
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
@@ -67,7 +67,7 @@ platform/
 | `local/watcher.py` | File change detection | `DebouncedFileHandler`, `FileWatcher`, `MultiTargetWatcher`, `SyncTrigger` |
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |
 | `local/watcher_runner.py` | Background watcher process | `main` |
-| `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence | `SchedulerService` |
+| `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence, resilience (retry/timeout/cancel) | `SchedulerService`, `ResilienceConfig`, `run_with_resilience` |
 | `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |
 | `cloud/provisioning.py` | Droplet size tiers, regions, provisioning orchestration | `DropletSizeTier`, `RegionInfo`, `SIZE_TIERS`, `DEFAULT_TIER`, `provision_droplet`, `wait_for_droplet_ready`, `wait_for_ssh`, `suggest_nearest_region`, `save_provisioning_metadata` |
@@ -95,7 +95,7 @@ from dango.platform import DockerManager, ServiceStatus
 from dango.platform.common.startup import run_pending_migrations, start_docker_services
 
 # Scheduling (TASK-036+)
-from dango.platform.scheduling import SchedulerService
+from dango.platform.scheduling import SchedulerService, ResilienceConfig, run_with_resilience
 from dango.platform.scheduling.jobs import run_scheduled_sync, run_scheduled_dbt
 
 # Local-only components
@@ -291,7 +291,7 @@ Post-deployment hardening (not automated by Dango):
 
 ## Testing
 
-- **Scheduling:** `pytest tests/unit/test_scheduler.py`
+- **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py`
 - **Local platform:** `pytest tests/unit/test_platform_startup.py tests/unit/test_watcher_lifecycle.py`
 - **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
 - **Manual:** `dango start` (local platform), `dango deploy` (cloud provisioning)

--- a/dango/platform/scheduling/__init__.py
+++ b/dango/platform/scheduling/__init__.py
@@ -8,11 +8,17 @@ from dango.platform.scheduling.jobs import (
     run_scheduled_dbt,
     run_scheduled_sync,
 )
-from dango.platform.scheduling.scheduler import SchedulerService
+from dango.platform.scheduling.scheduler import (
+    ResilienceConfig,
+    SchedulerService,
+    run_with_resilience,
+)
 
 __all__ = [
+    "ResilienceConfig",
     "SchedulerService",
     "configure_jobs",
     "run_scheduled_dbt",
     "run_scheduled_sync",
+    "run_with_resilience",
 ]

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -54,6 +54,12 @@ class ResilienceConfig:
     retry_delays: tuple[int, ...] = _DEFAULT_RETRY_DELAYS
     timeout_minutes: int = _DEFAULT_TIMEOUT_MINUTES
 
+    def __post_init__(self) -> None:
+        if self.max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
+        if self.timeout_minutes <= 0:
+            raise ValueError("timeout_minutes must be positive")
+
 
 class SchedulerService:
     """Wrapper around APScheduler AsyncIOScheduler.
@@ -227,6 +233,8 @@ class SchedulerService:
 
     def _register_cancel_flag(self, job_id: str) -> threading.Event:
         """Create and store a cancel flag for a starting job."""
+        if job_id in self._cancel_flags:
+            logger.warning("cancel_flag_overwrite", job_id=job_id)
         flag = threading.Event()
         self._cancel_flags[job_id] = flag
         return flag
@@ -491,4 +499,4 @@ def _fire_callbacks(
         try:
             cb(**kwargs)
         except Exception:  # noqa: BLE001
-            logger.debug("callback_error", exc_info=True)
+            logger.warning("callback_error", exc_info=True)

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -57,6 +57,8 @@ class ResilienceConfig:
     def __post_init__(self) -> None:
         if self.max_retries < 1:
             raise ValueError("max_retries must be at least 1")
+        if not self.retry_delays:
+            raise ValueError("retry_delays must not be empty")
         if self.timeout_minutes <= 0:
             raise ValueError("timeout_minutes must be positive")
 

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -1,13 +1,18 @@
 """dango/platform/scheduling/scheduler.py
 
 SchedulerService wraps APScheduler 3.x AsyncIOScheduler for job persistence,
-event tracking, and async bridging. All subsequent Phase 4 scheduling tasks
-build on this foundation.
+event tracking, and async bridging. Includes resilience features: retry with
+configurable backoff, execution timeout with thread-based kill, cancellation
+flags, and event callbacks for history/notification integration.
 """
 
 from __future__ import annotations
 
 import asyncio
+import ctypes
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -25,12 +30,29 @@ from apscheduler.job import Job
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
+from dango.exceptions import JobCancelledError, JobTimeoutError
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
 
 _DEFAULT_THREAD_POOL_SIZE = 20
 _DEFAULT_MISFIRE_GRACE_TIME = 3600  # 1 hour
+_DEFAULT_MAX_RETRIES = 3
+_DEFAULT_RETRY_DELAYS = (30, 120, 300)
+_DEFAULT_TIMEOUT_MINUTES = 60
+
+
+@dataclass(frozen=True)
+class ResilienceConfig:
+    """Per-schedule resilience configuration.
+
+    Controls retry, backoff, and timeout behaviour for scheduled jobs.
+    TASK-037 constructs these from ``schedules.yml`` per-schedule fields.
+    """
+
+    max_retries: int = _DEFAULT_MAX_RETRIES
+    retry_delays: tuple[int, ...] = _DEFAULT_RETRY_DELAYS
+    timeout_minutes: int = _DEFAULT_TIMEOUT_MINUTES
 
 
 class SchedulerService:
@@ -69,6 +91,16 @@ class SchedulerService:
         self._project_root = project_root
         self._started = False
 
+        # Cancellation flags: job_id -> threading.Event (set = cancel requested).
+        # Python GIL ensures dict.__setitem__ and dict.pop are atomic.
+        self._cancel_flags: dict[str, threading.Event] = {}
+
+        # Event callbacks for resilience events.
+        # TASK-039 (history) and TASK-041 (notifications) register listeners.
+        self._on_retry_callbacks: list[Callable[..., None]] = []
+        self._on_timeout_callbacks: list[Callable[..., None]] = []
+        self._on_cancel_callbacks: list[Callable[..., None]] = []
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -105,12 +137,21 @@ class SchedulerService:
     def shutdown(self, wait: bool = True) -> None:
         """Gracefully shut down the scheduler.
 
+        Sets all cancel flags so threads blocked in ``cancel_flag.wait()``
+        unblock immediately, then delegates to the underlying scheduler.
+
         Args:
             wait: If True, wait for running jobs to finish before returning.
         """
+        # Signal all running jobs to cancel
+        for flag in self._cancel_flags.values():
+            flag.set()
+
         if self._scheduler.running:
             self._scheduler.shutdown(wait=wait)
             logger.info("scheduler_shutdown", wait=wait)
+
+        self._cancel_flags.clear()
 
     # ------------------------------------------------------------------
     # Job management
@@ -153,6 +194,46 @@ class SchedulerService:
             "job_count": len(jobs),
             "next_run_time": next_run,
         }
+
+    # ------------------------------------------------------------------
+    # Cancellation
+    # ------------------------------------------------------------------
+
+    def cancel_job(self, job_id: str) -> bool:
+        """Request cancellation of a running job.
+
+        Sets the cancel flag for the given job. The job function must check
+        ``is_cancelled()`` between pipeline steps to honour the request.
+        The cancel API endpoint is deferred to TASK-038.
+
+        Returns:
+            True if a cancel flag was found and set, False if the job is
+            not currently running (no registered cancel flag).
+        """
+        flag = self._cancel_flags.get(job_id)
+        if flag is None:
+            return False
+        flag.set()
+        logger.info("job_cancel_requested", job_id=job_id)
+        return True
+
+    def is_cancelled(self, job_id: str) -> bool:
+        """Check whether cancellation has been requested for a job.
+
+        Called by job functions between pipeline steps.
+        """
+        flag = self._cancel_flags.get(job_id)
+        return flag is not None and flag.is_set()
+
+    def _register_cancel_flag(self, job_id: str) -> threading.Event:
+        """Create and store a cancel flag for a starting job."""
+        flag = threading.Event()
+        self._cancel_flags[job_id] = flag
+        return flag
+
+    def _clear_cancel_flag(self, job_id: str) -> None:
+        """Remove the cancel flag after a job completes."""
+        self._cancel_flags.pop(job_id, None)
 
     # ------------------------------------------------------------------
     # Async bridge
@@ -241,3 +322,173 @@ class SchedulerService:
                 )
         except Exception:  # noqa: BLE001
             logger.debug("dual_scheduler_check_failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Module-level resilience functions
+# ---------------------------------------------------------------------------
+
+
+def _raise_in_thread(thread_id: int, exc_type: type[BaseException]) -> None:
+    """Inject an exception into a running thread via ctypes.
+
+    CPython-specific: uses ``PyThreadState_SetAsyncExc``. Only works when
+    the target thread executes Python bytecode. If blocked in a C extension
+    (e.g., DuckDB query), the exception is deferred until the C call returns.
+    DbtLock timeout and DuckDB query timeouts serve as additional backstops.
+    """
+    res: int = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_ulong(thread_id),
+        ctypes.py_object(exc_type),
+    )
+    if res == 0:
+        logger.debug("raise_in_thread_invalid_id", thread_id=thread_id)
+    elif res > 1:
+        # Multiple threads affected — should never happen. Revert.
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_ulong(thread_id), None)
+        logger.error("raise_in_thread_multi_affected", thread_id=thread_id)
+
+
+def _execute_with_timeout(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    timeout_seconds: int,
+    cancel_flag: threading.Event,
+) -> Any:
+    """Run *func* with a timeout enforced via a daemon Timer.
+
+    If the cancel flag is set before starting, raises ``JobCancelledError``
+    immediately. On timeout, injects ``JobTimeoutError`` into the worker
+    thread.
+    """
+    if cancel_flag.is_set():
+        raise JobCancelledError("Job cancelled before execution")
+
+    thread_id = threading.current_thread().ident
+    if thread_id is None:
+        raise RuntimeError("Cannot determine current thread ID")
+
+    timer = threading.Timer(
+        timeout_seconds,
+        _raise_in_thread,
+        args=(thread_id, JobTimeoutError),
+    )
+    timer.daemon = True
+    timer.start()
+    try:
+        return func(*args, **kwargs)
+    finally:
+        timer.cancel()
+
+
+def run_with_resilience(
+    func: Callable[..., Any],
+    *args: Any,
+    scheduler_service: SchedulerService,
+    job_id: str,
+    resilience: ResilienceConfig | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Execute a job function with retry, timeout, and cancellation.
+
+    Called from ``jobs.py`` (TASK-041) as the top-level wrapper around
+    actual sync/dbt job functions. Manages cancel flag lifecycle and
+    fires event callbacks for history (TASK-039) and notifications
+    (TASK-041).
+
+    Args:
+        func: The job function to execute.
+        *args: Positional arguments forwarded to *func*.
+        scheduler_service: The SchedulerService instance (for cancel
+            flag management and callbacks).
+        job_id: The APScheduler job ID.
+        resilience: Per-schedule resilience config. Uses defaults if None.
+        **kwargs: Keyword arguments forwarded to *func*.
+
+    Returns:
+        The return value of *func*.
+
+    Raises:
+        JobTimeoutError: If the job exceeds its timeout (no retry).
+        JobCancelledError: If the job is cancelled.
+        Exception: The last exception if all retries are exhausted.
+    """
+    cfg = resilience if resilience is not None else ResilienceConfig()
+    timeout_seconds = cfg.timeout_minutes * 60
+    cancel_flag = scheduler_service._register_cancel_flag(job_id)
+    last_exception: BaseException | None = None
+
+    try:
+        for attempt in range(1, cfg.max_retries + 1):
+            if cancel_flag.is_set():
+                raise JobCancelledError(f"Job {job_id} cancelled before attempt {attempt}")
+
+            try:
+                return _execute_with_timeout(func, args, kwargs, timeout_seconds, cancel_flag)
+            except JobTimeoutError:
+                _fire_callbacks(
+                    scheduler_service._on_timeout_callbacks,
+                    job_id=job_id,
+                    timeout_minutes=cfg.timeout_minutes,
+                )
+                raise
+            except JobCancelledError:
+                _fire_callbacks(
+                    scheduler_service._on_cancel_callbacks,
+                    job_id=job_id,
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001
+                last_exception = exc
+                if attempt < cfg.max_retries:
+                    delay_index = min(attempt - 1, len(cfg.retry_delays) - 1)
+                    delay = cfg.retry_delays[delay_index]
+                    _fire_callbacks(
+                        scheduler_service._on_retry_callbacks,
+                        job_id=job_id,
+                        attempt=attempt,
+                        max_retries=cfg.max_retries,
+                        next_retry_delay=delay,
+                        error=str(exc),
+                    )
+                    logger.warning(
+                        "job_retry",
+                        job_id=job_id,
+                        attempt=attempt,
+                        next_retry_delay=delay,
+                        error=str(exc),
+                    )
+                    # Interruptible sleep — cancel_flag.wait() returns True
+                    # if the flag is set (cancellation), False on timeout
+                    # (delay elapsed normally).
+                    if cancel_flag.wait(timeout=delay):
+                        raise JobCancelledError(
+                            f"Job {job_id} cancelled during retry wait"
+                        ) from exc
+
+        # All retries exhausted — propagate the last exception
+        if last_exception is not None:
+            raise last_exception
+
+    finally:
+        scheduler_service._clear_cancel_flag(job_id)
+
+    # Unreachable, but satisfies type checker
+    raise RuntimeError("run_with_resilience: unreachable")  # pragma: no cover
+
+
+def _fire_callbacks(
+    callbacks: list[Callable[..., None]],
+    **kwargs: Any,
+) -> None:
+    """Fire event callbacks, catching and logging any errors.
+
+    Each callback is wrapped in try/except — callbacks are fire-and-forget.
+    Matches the "never raises" pattern from webhook.py.
+    """
+    for cb in callbacks:
+        try:
+            cb(**kwargs)
+        except Exception:  # noqa: BLE001
+            logger.debug("callback_error", exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ module = [
     "tests.unit.test_webhook",
     "tests.unit.test_slack_formatter",
     "tests.unit.test_scheduler",
+    "tests.unit.test_scheduler_resilience",
     "tests.unit.test_schedules_config",
     "tests.unit.test_schedules_loading",
     "tests.unit.test_sync_jobs",

--- a/tests/unit/test_scheduler_resilience.py
+++ b/tests/unit/test_scheduler_resilience.py
@@ -76,6 +76,12 @@ class TestResilienceConfig:
         with pytest.raises(ValueError, match="timeout_minutes must be positive"):
             ResilienceConfig(timeout_minutes=-1)
 
+    def test_rejects_empty_retry_delays(self):
+        from dango.platform.scheduling.scheduler import ResilienceConfig
+
+        with pytest.raises(ValueError, match="retry_delays must not be empty"):
+            ResilienceConfig(retry_delays=())
+
 
 @pytest.mark.unit
 class TestCancellation:
@@ -84,49 +90,42 @@ class TestCancellation:
     def test_cancel_job_sets_flag(self, tmp_path):
         svc = _make_service(tmp_path)
         flag = svc._register_cancel_flag("job-1")
-
-        result = svc.cancel_job("job-1")
-
-        assert result is True
+        assert svc.cancel_job("job-1") is True
         assert flag.is_set()
 
     def test_cancel_job_returns_false_for_unknown(self, tmp_path):
         svc = _make_service(tmp_path)
-
-        result = svc.cancel_job("nonexistent")
-
-        assert result is False
+        assert svc.cancel_job("nonexistent") is False
 
     def test_is_cancelled_true_when_set(self, tmp_path):
         svc = _make_service(tmp_path)
-        flag = svc._register_cancel_flag("job-1")
-        flag.set()
-
+        svc._register_cancel_flag("job-1").set()
         assert svc.is_cancelled("job-1") is True
 
-    def test_is_cancelled_false_when_not_set(self, tmp_path):
+    def test_is_cancelled_false_when_not_set_or_unknown(self, tmp_path):
         svc = _make_service(tmp_path)
         svc._register_cancel_flag("job-1")
-
         assert svc.is_cancelled("job-1") is False
-
-    def test_is_cancelled_false_for_unknown(self, tmp_path):
-        svc = _make_service(tmp_path)
-
         assert svc.is_cancelled("nonexistent") is False
 
     def test_clear_cancel_flag_removes(self, tmp_path):
         svc = _make_service(tmp_path)
         svc._register_cancel_flag("job-1")
-
         svc._clear_cancel_flag("job-1")
-
         assert "job-1" not in svc._cancel_flags
 
     def test_clear_cancel_flag_noop_for_unknown(self, tmp_path):
-        """Clearing a non-existent flag should not raise."""
+        _make_service(tmp_path)._clear_cancel_flag("nonexistent")
+
+    def test_register_cancel_flag_warns_on_overwrite(self, tmp_path):
         svc = _make_service(tmp_path)
-        svc._clear_cancel_flag("nonexistent")  # should not raise
+        svc._register_cancel_flag("job-1")
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._register_cancel_flag("job-1")
+
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][0] == "cancel_flag_overwrite"
 
     def test_shutdown_sets_all_flags(self, tmp_path):
         svc = _make_service(tmp_path)

--- a/tests/unit/test_scheduler_resilience.py
+++ b/tests/unit/test_scheduler_resilience.py
@@ -1,0 +1,473 @@
+"""tests/unit/test_scheduler_resilience.py
+
+Tests for scheduler resilience: retry, timeout, cancellation, and callbacks.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.exceptions import JobCancelledError, JobTimeoutError
+
+_SCHEDULER_MOD = "dango.platform.scheduling.scheduler"
+
+
+def _make_service(tmp_path):
+    """Create a SchedulerService with all APScheduler internals mocked."""
+    with (
+        patch(f"{_SCHEDULER_MOD}.SQLAlchemyJobStore"),
+        patch(f"{_SCHEDULER_MOD}.AsyncIOScheduler") as mock_cls,
+    ):
+        mock_scheduler = MagicMock()
+        mock_scheduler.running = False
+        mock_scheduler.get_jobs.return_value = []
+        mock_cls.return_value = mock_scheduler
+
+        from dango.platform.scheduling.scheduler import SchedulerService
+
+        svc = SchedulerService(tmp_path)
+
+    return svc
+
+
+@pytest.mark.unit
+class TestResilienceConfig:
+    """Test ResilienceConfig default and custom values."""
+
+    def test_default_values(self):
+        from dango.platform.scheduling.scheduler import ResilienceConfig
+
+        cfg = ResilienceConfig()
+        assert cfg.max_retries == 3
+        assert cfg.retry_delays == (30, 120, 300)
+        assert cfg.timeout_minutes == 60
+
+    def test_custom_values(self):
+        from dango.platform.scheduling.scheduler import ResilienceConfig
+
+        cfg = ResilienceConfig(max_retries=5, retry_delays=(10, 20), timeout_minutes=30)
+        assert cfg.max_retries == 5
+        assert cfg.retry_delays == (10, 20)
+        assert cfg.timeout_minutes == 30
+
+    def test_frozen(self):
+        from dango.platform.scheduling.scheduler import ResilienceConfig
+
+        cfg = ResilienceConfig()
+        with pytest.raises(AttributeError):
+            cfg.max_retries = 10  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestCancellation:
+    """Test cancel flag management on SchedulerService."""
+
+    def test_cancel_job_sets_flag(self, tmp_path):
+        svc = _make_service(tmp_path)
+        flag = svc._register_cancel_flag("job-1")
+
+        result = svc.cancel_job("job-1")
+
+        assert result is True
+        assert flag.is_set()
+
+    def test_cancel_job_returns_false_for_unknown(self, tmp_path):
+        svc = _make_service(tmp_path)
+
+        result = svc.cancel_job("nonexistent")
+
+        assert result is False
+
+    def test_is_cancelled_true_when_set(self, tmp_path):
+        svc = _make_service(tmp_path)
+        flag = svc._register_cancel_flag("job-1")
+        flag.set()
+
+        assert svc.is_cancelled("job-1") is True
+
+    def test_is_cancelled_false_when_not_set(self, tmp_path):
+        svc = _make_service(tmp_path)
+        svc._register_cancel_flag("job-1")
+
+        assert svc.is_cancelled("job-1") is False
+
+    def test_is_cancelled_false_for_unknown(self, tmp_path):
+        svc = _make_service(tmp_path)
+
+        assert svc.is_cancelled("nonexistent") is False
+
+    def test_clear_cancel_flag_removes(self, tmp_path):
+        svc = _make_service(tmp_path)
+        svc._register_cancel_flag("job-1")
+
+        svc._clear_cancel_flag("job-1")
+
+        assert "job-1" not in svc._cancel_flags
+
+    def test_clear_cancel_flag_noop_for_unknown(self, tmp_path):
+        """Clearing a non-existent flag should not raise."""
+        svc = _make_service(tmp_path)
+        svc._clear_cancel_flag("nonexistent")  # should not raise
+
+    def test_shutdown_sets_all_flags(self, tmp_path):
+        svc = _make_service(tmp_path)
+        svc._scheduler.running = True
+        flag1 = svc._register_cancel_flag("job-1")
+        flag2 = svc._register_cancel_flag("job-2")
+
+        svc.shutdown()
+
+        assert flag1.is_set()
+        assert flag2.is_set()
+        assert len(svc._cancel_flags) == 0
+
+
+@pytest.mark.unit
+class TestRunWithResilience:
+    """Test the run_with_resilience() wrapper."""
+
+    def test_success_passthrough(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(return_value="result")
+
+        result = run_with_resilience(
+            func,
+            "arg1",
+            scheduler_service=svc,
+            job_id="job-1",
+            resilience=ResilienceConfig(timeout_minutes=1),
+            key="val",
+        )
+
+        assert result == "result"
+        func.assert_called_once_with("arg1", key="val")
+
+    def test_cancel_flag_cleared_on_success(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(return_value="ok")
+
+        run_with_resilience(
+            func,
+            scheduler_service=svc,
+            job_id="job-1",
+            resilience=ResilienceConfig(timeout_minutes=1),
+        )
+
+        assert "job-1" not in svc._cancel_flags
+
+    def test_cancel_flag_cleared_on_failure(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(side_effect=ValueError("boom"))
+
+        with pytest.raises(ValueError, match="boom"):
+            run_with_resilience(
+                func,
+                scheduler_service=svc,
+                job_id="job-1",
+                resilience=ResilienceConfig(max_retries=1, timeout_minutes=1),
+            )
+
+        assert "job-1" not in svc._cancel_flags
+
+    def test_retry_on_failure(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(side_effect=[ValueError("fail1"), "success"])
+
+        result = run_with_resilience(
+            func,
+            scheduler_service=svc,
+            job_id="job-1",
+            resilience=ResilienceConfig(
+                max_retries=2,
+                retry_delays=(0,),
+                timeout_minutes=1,
+            ),
+        )
+
+        assert result == "success"
+        assert func.call_count == 2
+
+    def test_all_retries_exhausted(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(side_effect=ValueError("persistent"))
+
+        with pytest.raises(ValueError, match="persistent"):
+            run_with_resilience(
+                func,
+                scheduler_service=svc,
+                job_id="job-1",
+                resilience=ResilienceConfig(
+                    max_retries=2,
+                    retry_delays=(0,),
+                    timeout_minutes=1,
+                ),
+            )
+
+        assert func.call_count == 2
+
+    def test_retry_emits_callback(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        callback = MagicMock()
+        svc._on_retry_callbacks.append(callback)
+        func = MagicMock(side_effect=[ValueError("fail"), "ok"])
+
+        run_with_resilience(
+            func,
+            scheduler_service=svc,
+            job_id="job-1",
+            resilience=ResilienceConfig(
+                max_retries=2,
+                retry_delays=(0,),
+                timeout_minutes=1,
+            ),
+        )
+
+        callback.assert_called_once()
+        call_kwargs = callback.call_args[1]
+        assert call_kwargs["job_id"] == "job-1"
+        assert call_kwargs["attempt"] == 1
+        assert call_kwargs["max_retries"] == 2
+        assert call_kwargs["next_retry_delay"] == 0
+        assert "fail" in call_kwargs["error"]
+
+    def test_cancel_before_execution(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(return_value="ok")
+
+        # Patch _register_cancel_flag to return an already-set event
+        already_set = threading.Event()
+        already_set.set()
+        svc._register_cancel_flag = MagicMock(return_value=already_set)
+
+        with pytest.raises(JobCancelledError):
+            run_with_resilience(
+                func,
+                scheduler_service=svc,
+                job_id="job-1",
+                resilience=ResilienceConfig(timeout_minutes=1),
+            )
+
+        func.assert_not_called()
+
+    def test_cancel_during_retry_wait(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(side_effect=ValueError("fail"))
+
+        # After the first failure, set the cancel flag during the retry wait.
+        # cancel_flag.wait() returns True when the flag is set.
+        original_register = svc._register_cancel_flag
+
+        def register_and_schedule_cancel(job_id):
+            flag = original_register(job_id)
+            # Set flag after a tiny delay to simulate cancel during wait
+            timer = threading.Timer(0.01, flag.set)
+            timer.start()
+            return flag
+
+        svc._register_cancel_flag = register_and_schedule_cancel
+
+        with pytest.raises(JobCancelledError, match="cancelled during retry wait"):
+            run_with_resilience(
+                func,
+                scheduler_service=svc,
+                job_id="job-1",
+                resilience=ResilienceConfig(
+                    max_retries=3,
+                    retry_delays=(60,),
+                    timeout_minutes=1,
+                ),
+            )
+
+    def test_uses_default_config_when_none(self, tmp_path):
+        from dango.platform.scheduling.scheduler import run_with_resilience
+
+        svc = _make_service(tmp_path)
+        func = MagicMock(return_value="ok")
+
+        result = run_with_resilience(
+            func,
+            scheduler_service=svc,
+            job_id="job-1",
+            resilience=None,
+        )
+
+        assert result == "ok"
+
+    def test_timeout_does_not_retry(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+
+        def slow_func():
+            raise JobTimeoutError("timed out")
+
+        with pytest.raises(JobTimeoutError):
+            run_with_resilience(
+                slow_func,
+                scheduler_service=svc,
+                job_id="job-1",
+                resilience=ResilienceConfig(max_retries=3, timeout_minutes=1),
+            )
+
+    def test_timeout_emits_callback(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        callback = MagicMock()
+        svc._on_timeout_callbacks.append(callback)
+
+        def slow_func():
+            raise JobTimeoutError("timed out")
+
+        with pytest.raises(JobTimeoutError):
+            run_with_resilience(
+                slow_func,
+                scheduler_service=svc,
+                job_id="job-1",
+                resilience=ResilienceConfig(max_retries=3, timeout_minutes=5),
+            )
+
+        callback.assert_called_once()
+        call_kwargs = callback.call_args[1]
+        assert call_kwargs["job_id"] == "job-1"
+        assert call_kwargs["timeout_minutes"] == 5
+
+    def test_callback_error_does_not_propagate(self, tmp_path):
+        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+
+        svc = _make_service(tmp_path)
+        bad_callback = MagicMock(side_effect=RuntimeError("callback boom"))
+        svc._on_retry_callbacks.append(bad_callback)
+        func = MagicMock(side_effect=[ValueError("fail"), "ok"])
+
+        # Should not raise — callback error is swallowed
+        result = run_with_resilience(
+            func,
+            scheduler_service=svc,
+            job_id="job-1",
+            resilience=ResilienceConfig(
+                max_retries=2,
+                retry_delays=(0,),
+                timeout_minutes=1,
+            ),
+        )
+
+        assert result == "ok"
+        bad_callback.assert_called_once()
+
+
+@pytest.mark.unit
+class TestExecuteWithTimeout:
+    """Test _execute_with_timeout() timeout enforcement."""
+
+    def test_completes_within_timeout(self):
+        from dango.platform.scheduling.scheduler import _execute_with_timeout
+
+        func = MagicMock(return_value="done")
+        cancel_flag = threading.Event()
+
+        result = _execute_with_timeout(func, (), {}, timeout_seconds=60, cancel_flag=cancel_flag)
+
+        assert result == "done"
+
+    def test_cancel_before_execution_raises(self):
+        from dango.platform.scheduling.scheduler import _execute_with_timeout
+
+        cancel_flag = threading.Event()
+        cancel_flag.set()
+        func = MagicMock()
+
+        with pytest.raises(JobCancelledError, match="cancelled before execution"):
+            _execute_with_timeout(func, (), {}, timeout_seconds=60, cancel_flag=cancel_flag)
+
+        func.assert_not_called()
+
+    def test_timeout_raises_job_timeout_error(self):
+        """Verify timeout fires _raise_in_thread with JobTimeoutError."""
+        from dango.platform.scheduling.scheduler import _execute_with_timeout
+
+        cancel_flag = threading.Event()
+
+        # Use a function that blocks long enough for the timer to fire
+        block_event = threading.Event()
+
+        def blocking_func():
+            block_event.wait(timeout=5)
+
+        with pytest.raises(JobTimeoutError):
+            _execute_with_timeout(
+                blocking_func,
+                (),
+                {},
+                timeout_seconds=0,  # immediate timeout
+                cancel_flag=cancel_flag,
+            )
+
+
+@pytest.mark.unit
+class TestRaiseInThread:
+    """Test _raise_in_thread() ctypes injection."""
+
+    def test_raises_in_target_thread(self):
+        from dango.platform.scheduling.scheduler import _raise_in_thread
+
+        caught = threading.Event()
+
+        def target():
+            try:
+                # Loop to give the async exception a chance to fire
+                while not caught.is_set():
+                    pass  # Python bytecode — exception can be injected
+            except JobTimeoutError:
+                caught.set()
+
+        t = threading.Thread(target=target)
+        t.start()
+        # Small delay to let the thread start
+        import time
+
+        time.sleep(0.01)
+
+        _raise_in_thread(t.ident, JobTimeoutError)
+        t.join(timeout=2)
+
+        assert caught.is_set()
+
+
+@pytest.mark.unit
+class TestDeduplication:
+    """Test max_instances=1 in job_defaults prevents overlapping runs."""
+
+    def test_max_instances_in_job_defaults(self, tmp_path):
+        with (
+            patch(f"{_SCHEDULER_MOD}.SQLAlchemyJobStore"),
+            patch(f"{_SCHEDULER_MOD}.AsyncIOScheduler") as mock_cls,
+        ):
+            mock_cls.return_value = MagicMock()
+            mock_cls.return_value.running = False
+            mock_cls.return_value.get_jobs.return_value = []
+
+            from dango.platform.scheduling.scheduler import SchedulerService
+
+            SchedulerService(tmp_path)
+
+        call_kwargs = mock_cls.call_args[1]
+        assert call_kwargs["job_defaults"]["max_instances"] == 1
+        assert call_kwargs["job_defaults"]["coalesce"] is True

--- a/tests/unit/test_scheduler_resilience.py
+++ b/tests/unit/test_scheduler_resilience.py
@@ -58,6 +58,24 @@ class TestResilienceConfig:
         with pytest.raises(AttributeError):
             cfg.max_retries = 10  # type: ignore[misc]
 
+    def test_rejects_zero_max_retries(self):
+        from dango.platform.scheduling.scheduler import ResilienceConfig
+
+        with pytest.raises(ValueError, match="max_retries must be at least 1"):
+            ResilienceConfig(max_retries=0)
+
+    def test_rejects_zero_timeout(self):
+        from dango.platform.scheduling.scheduler import ResilienceConfig
+
+        with pytest.raises(ValueError, match="timeout_minutes must be positive"):
+            ResilienceConfig(timeout_minutes=0)
+
+    def test_rejects_negative_timeout(self):
+        from dango.platform.scheduling.scheduler import ResilienceConfig
+
+        with pytest.raises(ValueError, match="timeout_minutes must be positive"):
+            ResilienceConfig(timeout_minutes=-1)
+
 
 @pytest.mark.unit
 class TestCancellation:
@@ -449,6 +467,15 @@ class TestRaiseInThread:
         t.join(timeout=2)
 
         assert caught.is_set()
+
+    def test_invalid_thread_id_logs_debug(self):
+        from dango.platform.scheduling.scheduler import _raise_in_thread
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            _raise_in_thread(999999999, JobTimeoutError)
+
+        mock_logger.debug.assert_called_once()
+        assert mock_logger.debug.call_args[0][0] == "raise_in_thread_invalid_id"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Add retry with configurable backoff (default: 3 attempts at 30s, 120s, 300s), execution timeout with thread-based kill (default: 60min), and cooperative cancellation via `threading.Event` flags
- Add `ResilienceConfig` frozen dataclass with input validation for per-schedule configuration
- Add `run_with_resilience()` wrapper that manages cancel flag lifecycle, fires event callbacks for history/notification integration, and uses interruptible `cancel_flag.wait()` for immediate cancellation during retry waits
- Add `SchedulerError`, `JobTimeoutError`, `JobCancelledError` to exception hierarchy (DANGO-U005/U006/U007)
- Update `SchedulerService.shutdown()` to set all cancel flags before APScheduler shutdown
- Update `scheduling/__init__.py` exports and `platform/CLAUDE.md` documentation

## Test plan

- [x] 34 unit tests across 6 test classes (all passing)
- [x] `TestResilienceConfig` — defaults, custom values, frozen, 4 validation edge cases
- [x] `TestCancellation` — cancel_job, is_cancelled, clear, overwrite warning, shutdown
- [x] `TestRunWithResilience` — success, retry, exhaustion, callbacks, cancel before/during, timeout no-retry, default config, callback error isolation
- [x] `TestExecuteWithTimeout` — success, pre-cancel, timeout
- [x] `TestRaiseInThread` — ctypes injection, invalid thread ID
- [x] `TestDeduplication` — max_instances=1 verified
- [x] ruff lint + format, mypy, file size checks all pass
- [x] Existing `test_scheduler.py` (31 tests) still passes — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)