### PR TITLE
feat: add schedule CRUD API endpoints (TASK-038)

### DIFF
--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -54,6 +54,12 @@ class AuditEvent(str, Enum):
     SECRET_DELETED     = "secret_deleted"
     OAUTH_SOURCE_CONNECTED    = "oauth_source_connected"
     OAUTH_SOURCE_DISCONNECTED = "oauth_source_disconnected"
+    SCHEDULE_CREATED          = "schedule_created"
+    SCHEDULE_UPDATED          = "schedule_updated"
+    SCHEDULE_DELETED          = "schedule_deleted"
+    SCHEDULE_TRIGGERED        = "schedule_triggered"
+    SCHEDULES_RELOADED        = "schedules_reloaded"
+    JOB_CANCELLED             = "job_cancelled"
     # fmt: on
 
 

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -36,6 +36,7 @@ __all__ = [
     "load_schedules_config",
     "log_startup_checks",
     "reload_schedules",
+    "save_schedules_config",
     "validate_schedules",
 ]
 
@@ -208,6 +209,20 @@ def load_schedules_config(project_root: Path) -> SchedulesConfig:
         return SchedulesConfig(schedules=schedules_data)
     except Exception as e:
         raise ConfigValidationError(f"Invalid schedule configuration in {path}:\n{e}") from e
+
+
+def save_schedules_config(project_root: Path, config: SchedulesConfig) -> None:
+    """Save schedule config to ``.dango/schedules.yml``.
+
+    Serialises the config with ``mode="json"`` so datetimes become ISO strings.
+    """
+    path = project_root / ".dango" / "schedules.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "schedules": [s.model_dump(exclude_none=True, mode="json") for s in config.schedules]
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
 
 # ---------------------------------------------------------------------------

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -207,3 +207,32 @@ class TwoFARegenerateRequest(BaseModel):
 
     password: str
     code: str
+
+
+# ---------------------------------------------------------------------------
+# Schedule DTOs (used by web/routes/schedules.py)
+# ---------------------------------------------------------------------------
+
+
+class ScheduleCreateRequest(BaseModel):
+    """Schedule creation/update payload."""
+
+    name: str
+    type: str = "sync"
+    cron: str
+    sources: list[str] = []
+    enabled: bool = True
+    timezone: str | None = None
+    start_date: str | None = None
+    misfire_grace_time: int | None = None
+    timeout_minutes: int | None = None
+    notify_on: list[str] = []
+    dbt_command: str | None = None
+
+
+class TriggerRequest(BaseModel):
+    """Manual trigger payload (optional overrides)."""
+
+    full_refresh: bool = False
+    start_date: str | None = None
+    end_date: str | None = None

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -1,32 +1,88 @@
 """dango/web/routes/schedules.py
 
-API endpoints for schedule execution history. Provides paginated history
-per schedule and a recent-executions endpoint across all schedules.
-
-Extended by TASK-038 with schedule CRUD endpoints.
+API endpoints for schedule management and execution history. Provides CRUD
+for schedule definitions, manual triggering, reload from YAML, cancellation,
+unscheduled-source discovery, and paginated execution history.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 
+from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
 from dango.auth.permissions import require_permission
+from dango.config.schedules import (
+    ScheduleConfig,
+    SchedulesConfig,
+    get_schedule_job_id,
+    load_schedules_config,
+    reload_schedules,
+    save_schedules_config,
+    validate_schedules,
+)
 from dango.logging import get_logger
 from dango.platform.scheduling.history import (
     VALID_STATUSES,
+    get_last_run,
     get_recent_history,
     get_schedule_history,
     get_scheduler_db_path,
 )
-from dango.web.helpers import get_project_root
+from dango.web.helpers import get_project_root, load_sources_config
+from dango.web.models import ScheduleCreateRequest, TriggerRequest
+
+if TYPE_CHECKING:
+    from dango.platform.scheduling.scheduler import SchedulerService
 
 router = APIRouter(tags=["schedules"])
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_scheduler(request: Request) -> SchedulerService | None:
+    """Get scheduler from app state (may be ``None`` if startup failed)."""
+    return getattr(request.app.state, "scheduler", None)
+
+
+def _find_schedule(config: SchedulesConfig, name: str) -> ScheduleConfig | None:
+    """Find a schedule by name in the config."""
+    for sched in config.schedules:
+        if sched.name == name:
+            return sched
+    return None
+
+
+def _audit(
+    event: AuditEvent,
+    user: User,
+    request: Request,
+    project_root: Any,
+    **extra: Any,
+) -> None:
+    """Log an audit event with standard fields."""
+    log_auth_event(
+        event,
+        user_id=user.id,
+        email=user.email,
+        ip=request.client.host if request.client else None,
+        details=extra,
+        log_dir=project_root / ".dango" / "logs",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Literal routes (must be registered BEFORE parameterized {name} routes)
+# ---------------------------------------------------------------------------
 
 
 @router.get("/api/schedules/history/recent")
@@ -34,15 +90,7 @@ async def recent_executions(
     user: User = Depends(require_permission("scheduler.view")),
     limit: int = Query(default=20, ge=1, le=200),
 ) -> list[dict[str, Any]]:
-    """Get the most recent execution records across all schedules.
-
-    Args:
-        user: Authenticated user with ``scheduler.view`` permission.
-        limit: Maximum number of records to return.
-
-    Returns:
-        List of execution history records.
-    """
+    """Get the most recent execution records across all schedules."""
     project_root = get_project_root()
     db_path = get_scheduler_db_path(project_root)
 
@@ -50,6 +98,454 @@ async def recent_executions(
         return []
 
     return get_recent_history(db_path, limit=limit)
+
+
+@router.get("/api/schedules")
+async def list_schedules(
+    request: Request,
+    user: User = Depends(require_permission("scheduler.view")),
+) -> JSONResponse:
+    """List all configured schedules with runtime status."""
+    project_root = get_project_root()
+    config = load_schedules_config(project_root)
+    scheduler = _get_scheduler(request)
+
+    # Build next_run_time lookup from APScheduler jobs
+    next_runs: dict[str, str] = {}
+    if scheduler is not None:
+        for job in scheduler.get_jobs():
+            if job.next_run_time is not None:
+                next_runs[job.id] = job.next_run_time.isoformat()
+
+    # Build last_run lookup from history DB
+    db_path = get_scheduler_db_path(project_root)
+    last_runs: dict[str, dict[str, Any]] = {}
+    if db_path.exists():
+        for sched in config.schedules:
+            last = get_last_run(db_path, sched.name)
+            if last is not None:
+                last_runs[sched.name] = last
+
+    result: list[dict[str, Any]] = []
+    for sched in config.schedules:
+        job_id = get_schedule_job_id(sched.name)
+        entry: dict[str, Any] = {
+            "name": sched.name,
+            "type": sched.type.value,
+            "cron": sched.cron,
+            "sources": list(sched.sources),
+            "enabled": sched.enabled,
+            "next_run_time": next_runs.get(job_id),
+            "last_run": last_runs.get(sched.name),
+        }
+        result.append(entry)
+
+    return JSONResponse(content=result)
+
+
+@router.post("/api/schedules")
+async def create_schedule(
+    request: Request,
+    body: ScheduleCreateRequest,
+    user: User = Depends(require_permission("scheduler.manage")),
+) -> JSONResponse:
+    """Create a new schedule definition."""
+    project_root = get_project_root()
+    config = load_schedules_config(project_root)
+
+    # Check for duplicate name
+    if _find_schedule(config, body.name) is not None:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error_code": "DANGO-S005",
+                "message": f"Schedule {body.name!r} already exists.",
+            },
+        )
+
+    # Validate through ScheduleConfig (handles cron, name, type validation)
+    try:
+        new_sched = ScheduleConfig(**body.model_dump())
+    except ValidationError as e:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S004",
+                "message": str(e),
+            },
+        )
+
+    # Cross-validate against sources
+    sources = load_sources_config()
+    source_names = {s["name"] for s in sources if "name" in s}
+    issues = validate_schedules([*config.schedules, new_sched], source_names)
+    errors = [i for i in issues if not i.startswith("Schedule") or "warning" not in i.lower()]
+    if errors:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S004",
+                "message": "; ".join(errors),
+            },
+        )
+
+    # Persist
+    updated_config = SchedulesConfig(schedules=[*config.schedules, new_sched])
+    save_schedules_config(project_root, updated_config)
+
+    # Reload scheduler
+    scheduler = _get_scheduler(request)
+    if scheduler is not None:
+        reload_schedules(scheduler, updated_config.schedules, project_root)
+
+    _audit(
+        AuditEvent.SCHEDULE_CREATED,
+        user,
+        request,
+        project_root,
+        schedule_name=body.name,
+    )
+
+    return JSONResponse(
+        status_code=201,
+        content=new_sched.model_dump(exclude_none=True, mode="json"),
+    )
+
+
+@router.post("/api/schedules/reload")
+async def reload_schedules_endpoint(
+    request: Request,
+    user: User = Depends(require_permission("scheduler.manage")),
+) -> JSONResponse:
+    """Reload schedules from YAML config."""
+    project_root = get_project_root()
+    scheduler = _get_scheduler(request)
+
+    if scheduler is None:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error_code": "DANGO-S006",
+                "message": "Scheduler is not available.",
+            },
+        )
+
+    config = load_schedules_config(project_root)
+    result = reload_schedules(scheduler, config.schedules, project_root)
+
+    _audit(
+        AuditEvent.SCHEDULES_RELOADED,
+        user,
+        request,
+        project_root,
+        added=result.added,
+        removed=result.removed,
+        updated=result.updated,
+    )
+
+    return JSONResponse(
+        content=result.model_dump(mode="json"),
+    )
+
+
+@router.post("/api/schedules/jobs/{job_id}/cancel")
+async def cancel_job(
+    job_id: str,
+    request: Request,
+    user: User = Depends(require_permission("scheduler.manage")),
+) -> JSONResponse:
+    """Cancel a currently running job."""
+    project_root = get_project_root()
+    scheduler = _get_scheduler(request)
+
+    if scheduler is None:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error_code": "DANGO-S006",
+                "message": "Scheduler is not available.",
+            },
+        )
+
+    cancelled = scheduler.cancel_job(job_id)
+    if not cancelled:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-S007",
+                "message": f"Job {job_id!r} is not currently running.",
+            },
+        )
+
+    _audit(
+        AuditEvent.JOB_CANCELLED,
+        user,
+        request,
+        project_root,
+        job_id=job_id,
+    )
+
+    return JSONResponse(content={"status": "cancelled", "job_id": job_id})
+
+
+@router.get("/api/sources/unscheduled")
+async def unscheduled_sources(
+    user: User = Depends(require_permission("scheduler.view")),
+) -> JSONResponse:
+    """List sources that are not referenced by any schedule."""
+    project_root = get_project_root()
+    sources = load_sources_config()
+    source_names = {s["name"] for s in sources if "name" in s}
+
+    config = load_schedules_config(project_root)
+    scheduled_sources: set[str] = set()
+    for sched in config.schedules:
+        scheduled_sources.update(sched.sources)
+
+    unscheduled = sorted(source_names - scheduled_sources)
+    return JSONResponse(content={"sources": unscheduled})
+
+
+# ---------------------------------------------------------------------------
+# Parameterized {name} routes (MUST come after literal routes)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/schedules/{name}")
+async def get_schedule(
+    name: str,
+    request: Request,
+    user: User = Depends(require_permission("scheduler.view")),
+) -> JSONResponse:
+    """Get details for a single schedule."""
+    project_root = get_project_root()
+    config = load_schedules_config(project_root)
+    sched = _find_schedule(config, name)
+
+    if sched is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-S003",
+                "message": f"Schedule {name!r} not found.",
+            },
+        )
+
+    # Get next_run_time from APScheduler
+    scheduler = _get_scheduler(request)
+    next_run_time: str | None = None
+    if scheduler is not None:
+        job_id = get_schedule_job_id(name)
+        for job in scheduler.get_jobs():
+            if job.id == job_id and job.next_run_time is not None:
+                next_run_time = job.next_run_time.isoformat()
+                break
+
+    # Get last 10 history records
+    db_path = get_scheduler_db_path(project_root)
+    history: list[dict[str, Any]] = []
+    if db_path.exists():
+        history, _ = get_schedule_history(db_path, name, limit=10)
+
+    result = sched.model_dump(exclude_none=True, mode="json")
+    result["next_run_time"] = next_run_time
+    result["recent_history"] = history
+
+    return JSONResponse(content=result)
+
+
+@router.put("/api/schedules/{name}")
+async def update_schedule(
+    name: str,
+    request: Request,
+    body: ScheduleCreateRequest,
+    user: User = Depends(require_permission("scheduler.manage")),
+) -> JSONResponse:
+    """Update an existing schedule definition."""
+    project_root = get_project_root()
+    config = load_schedules_config(project_root)
+    existing = _find_schedule(config, name)
+
+    if existing is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-S003",
+                "message": f"Schedule {name!r} not found.",
+            },
+        )
+
+    # Validate the updated schedule through ScheduleConfig
+    try:
+        updated_sched = ScheduleConfig(**body.model_dump())
+    except ValidationError as e:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S004",
+                "message": str(e),
+            },
+        )
+
+    # Replace in list
+    new_schedules = [updated_sched if s.name == name else s for s in config.schedules]
+
+    # Cross-validate
+    sources = load_sources_config()
+    source_names = {s["name"] for s in sources if "name" in s}
+    issues = validate_schedules(new_schedules, source_names)
+    errors = [i for i in issues if "Duplicate" in i or "unknown source" in i]
+    if errors:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S004",
+                "message": "; ".join(errors),
+            },
+        )
+
+    # Persist
+    updated_config = SchedulesConfig(schedules=new_schedules)
+    save_schedules_config(project_root, updated_config)
+
+    # Reload scheduler
+    scheduler = _get_scheduler(request)
+    if scheduler is not None:
+        reload_schedules(scheduler, updated_config.schedules, project_root)
+
+    _audit(
+        AuditEvent.SCHEDULE_UPDATED,
+        user,
+        request,
+        project_root,
+        schedule_name=name,
+    )
+
+    return JSONResponse(
+        content=updated_sched.model_dump(exclude_none=True, mode="json"),
+    )
+
+
+@router.delete("/api/schedules/{name}")
+async def delete_schedule(
+    name: str,
+    request: Request,
+    user: User = Depends(require_permission("scheduler.manage")),
+) -> JSONResponse:
+    """Delete a schedule definition."""
+    project_root = get_project_root()
+    config = load_schedules_config(project_root)
+    existing = _find_schedule(config, name)
+
+    if existing is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-S003",
+                "message": f"Schedule {name!r} not found.",
+            },
+        )
+
+    # Remove from config
+    new_schedules = [s for s in config.schedules if s.name != name]
+    updated_config = SchedulesConfig(schedules=new_schedules)
+    save_schedules_config(project_root, updated_config)
+
+    # Remove from scheduler
+    scheduler = _get_scheduler(request)
+    if scheduler is not None:
+        job_id = get_schedule_job_id(name)
+        try:
+            scheduler.remove_job(job_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("schedule_job_remove_failed", name=name)
+
+    _audit(
+        AuditEvent.SCHEDULE_DELETED,
+        user,
+        request,
+        project_root,
+        schedule_name=name,
+    )
+
+    return JSONResponse(content={"status": "deleted", "name": name})
+
+
+@router.post("/api/schedules/{name}/trigger")
+async def trigger_schedule(
+    name: str,
+    request: Request,
+    body: TriggerRequest | None = None,
+    user: User = Depends(require_permission("source.sync")),
+) -> JSONResponse:
+    """Manually trigger a schedule for immediate execution."""
+    project_root = get_project_root()
+    config = load_schedules_config(project_root)
+    sched = _find_schedule(config, name)
+
+    if sched is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-S003",
+                "message": f"Schedule {name!r} not found.",
+            },
+        )
+
+    scheduler = _get_scheduler(request)
+    if scheduler is None:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error_code": "DANGO-S006",
+                "message": "Scheduler is not available.",
+            },
+        )
+
+    # Add a one-off job using the same function + kwargs as the scheduled version
+    from apscheduler.triggers.date import DateTrigger
+
+    from dango.config.schedules import ScheduleType
+    from dango.platform.scheduling.jobs import (
+        run_scheduled_dbt,
+        run_scheduled_sync,
+    )
+
+    func: Any
+    if sched.type == ScheduleType.SYNC:
+        func = run_scheduled_sync
+        func_kwargs: dict[str, Any] = {
+            "schedule_name": sched.name,
+            "sources": list(sched.sources),
+            "project_root": str(project_root),
+        }
+    else:
+        func = run_scheduled_dbt
+        func_kwargs = {
+            "schedule_name": sched.name,
+            "dbt_command": sched.dbt_command,
+            "project_root": str(project_root),
+        }
+
+    job = scheduler.add_job(
+        func,
+        DateTrigger(),
+        kwargs=func_kwargs,
+        id=f"manual:{name}:{datetime.now().isoformat()}",
+        name=f"manual-{name}",
+    )
+
+    _audit(
+        AuditEvent.SCHEDULE_TRIGGERED,
+        user,
+        request,
+        project_root,
+        schedule_name=name,
+    )
+
+    return JSONResponse(
+        content={"status": "triggered", "name": name, "job_id": job.id},
+    )
 
 
 @router.get("/api/schedules/{name}/history")
@@ -62,26 +558,15 @@ async def schedule_history(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> JSONResponse:
-    """Get paginated execution history for a specific schedule.
-
-    Args:
-        name: Schedule name.
-        user: Authenticated user with ``scheduler.view`` permission.
-        status: Optional status filter (running/success/failed/cancelled/timeout).
-        since: Optional ISO 8601 lower bound for started_at.
-        until: Optional ISO 8601 upper bound for started_at.
-        limit: Maximum records per page.
-        offset: Records to skip.
-
-    Returns:
-        JSON with schedule_name, items, total, limit, and offset.
-    """
+    """Get paginated execution history for a specific schedule."""
     if status is not None and status not in VALID_STATUSES:
         return JSONResponse(
             status_code=400,
             content={
                 "error_code": "DANGO-S001",
-                "message": f"Invalid status filter. Must be one of: {', '.join(sorted(VALID_STATUSES))}",
+                "message": (
+                    f"Invalid status filter. Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+                ),
             },
         )
 
@@ -94,7 +579,7 @@ async def schedule_history(
                     status_code=400,
                     content={
                         "error_code": "DANGO-S002",
-                        "message": f"Invalid '{label}' parameter. Must be an ISO 8601 timestamp.",
+                        "message": (f"Invalid '{label}' parameter. Must be an ISO 8601 timestamp."),
                     },
                 )
 

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -8,6 +8,7 @@ unscheduled-source discovery, and paginated execution history.
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -66,7 +67,7 @@ def _audit(
     event: AuditEvent,
     user: User,
     request: Request,
-    project_root: Any,
+    project_root: Path,
     **extra: Any,
 ) -> None:
     """Log an audit event with standard fields."""
@@ -175,11 +176,11 @@ async def create_schedule(
             },
         )
 
-    # Cross-validate against sources
+    # Cross-validate against sources (only block on errors, not overlap/interval warnings)
     sources = load_sources_config()
     source_names = {s["name"] for s in sources if "name" in s}
     issues = validate_schedules([*config.schedules, new_sched], source_names)
-    errors = [i for i in issues if not i.startswith("Schedule") or "warning" not in i.lower()]
+    errors = [i for i in issues if "Duplicate" in i or "unknown source" in i]
     if errors:
         return JSONResponse(
             status_code=400,
@@ -372,6 +373,20 @@ async def update_schedule(
             content={
                 "error_code": "DANGO-S003",
                 "message": f"Schedule {name!r} not found.",
+            },
+        )
+
+    # Block renames — body name must match URL name to avoid orphaned history
+    if body.name != name:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S004",
+                "message": (
+                    f"Schedule name in body ({body.name!r}) does not match "
+                    f"URL name ({name!r}). Renaming is not supported — "
+                    "delete and re-create instead."
+                ),
             },
         )
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -260,6 +260,25 @@ exemptions:
     reason: "TASK-036+039: 10 test classes covering SchedulerService init, lifecycle, jobs, status, event listeners, history integration, coroutine bridge, cloud warning, startup summary, health endpoint, and job stubs. Each class requires isolated mock setup with APScheduler dual-patch pattern."
     review_by: "v1.1"
 
+  # --- Phase 4 scheduling ---
+  - file: dango/platform/scheduling/scheduler.py
+    lines: 570
+    category: exempt
+    reason: "SchedulerService + resilience (retry/timeout/cancel). Extraction of resilience functions into scheduling/resilience.py planned for TEST-008."
+    review_by: "v1.1"
+
+  - file: dango/web/routes/schedules.py
+    lines: 630
+    category: exempt
+    reason: "TASK-037+038: 11 endpoints (history×2, CRUD×5, trigger, reload, cancel, unscheduled). Single router file — split would scatter schedule logic across files."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_schedule_crud_api.py
+    lines: 518
+    category: exempt
+    reason: "TASK-038: 9 test classes covering all schedule CRUD endpoints (list, get, create, update, delete, trigger, reload, cancel, unscheduled). Each class needs isolated app setup."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -274,9 +274,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_schedule_crud_api.py
-    lines: 518
+    lines: 751
     category: exempt
-    reason: "TASK-038: 9 test classes covering all schedule CRUD endpoints (list, get, create, update, delete, trigger, reload, cancel, unscheduled). Each class needs isolated app setup."
+    reason: "TASK-038: 13 test classes covering all schedule CRUD endpoints (list, get, create, update, delete, trigger, reload, cancel, unscheduled) plus audit logging, reload verification, rename guard, and RBAC enforcement. Each class needs isolated app setup."
     review_by: "v1.1"
 
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ module = [
     "tests.unit.test_sync_jobs",
     "tests.unit.test_execution_history",
     "tests.unit.test_schedule_history_api",
+    "tests.unit.test_schedule_crud_api",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",

--- a/tests/unit/test_schedule_crud_api.py
+++ b/tests/unit/test_schedule_crud_api.py
@@ -26,21 +26,11 @@ def _make_admin_user() -> User:
 
 
 def _make_editor_user() -> User:
-    return User(
-        id="editor-id",
-        email="editor@test.com",
-        role=Role.EDITOR,
-        is_active=True,
-    )
+    return User(id="editor-id", email="editor@test.com", role=Role.EDITOR, is_active=True)
 
 
 def _make_viewer_user() -> User:
-    return User(
-        id="viewer-id",
-        email="viewer@test.com",
-        role=Role.VIEWER,
-        is_active=True,
-    )
+    return User(id="viewer-id", email="viewer@test.com", role=Role.VIEWER, is_active=True)
 
 
 def _make_crud_app(
@@ -50,7 +40,9 @@ def _make_crud_app(
 ) -> Any:
     """Build a minimal FastAPI app with schedules router and injected user."""
     from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
 
+    from dango.exceptions import AuthorizationError
     from dango.web.routes.schedules import router
 
     app = FastAPI()
@@ -65,6 +57,10 @@ def _make_crud_app(
     async def inject_user(request: Any, call_next: Any) -> Any:
         request.state.user = test_user
         return await call_next(request)
+
+    @app.exception_handler(AuthorizationError)
+    async def auth_error_handler(request: Any, exc: AuthorizationError) -> Any:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
 
     return app
 
@@ -97,6 +93,9 @@ def _mock_scheduler() -> MagicMock:
     scheduler = MagicMock()
     scheduler.get_jobs.return_value = []
     scheduler.cancel_job.return_value = True
+    mock_job = MagicMock()
+    mock_job.id = "mock-job-id"
+    scheduler.add_job.return_value = mock_job
     return scheduler
 
 
@@ -525,3 +524,228 @@ class TestUnscheduledSources:
         data = resp.json()
         assert "hubspot" in data["sources"]
         assert "stripe" not in data["sources"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — Audit logging verification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAuditLogging:
+    """Verify audit events are logged on write endpoints."""
+
+    def test_create_logs_audit_event(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(
+                f"{_PATCH_ROOT}.load_sources_config",
+                return_value=[{"name": "stripe", "type": "stripe"}],
+            ),
+            patch(f"{_PATCH_ROOT}.log_auth_event") as mock_audit,
+        ):
+            client = TestClient(app)
+            client.post(
+                "/api/schedules",
+                json=_sample_schedule(),
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        mock_audit.assert_called_once()
+        call_args = mock_audit.call_args
+        from dango.auth.audit import AuditEvent
+
+        assert call_args[0][0] == AuditEvent.SCHEDULE_CREATED
+
+    def test_delete_logs_audit_event(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(f"{_PATCH_ROOT}.log_auth_event") as mock_audit,
+        ):
+            client = TestClient(app)
+            client.request(
+                "DELETE",
+                "/api/schedules/daily_sync",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        mock_audit.assert_called_once()
+        from dango.auth.audit import AuditEvent
+
+        assert mock_audit.call_args[0][0] == AuditEvent.SCHEDULE_DELETED
+
+
+# ---------------------------------------------------------------------------
+# Tests — Scheduler reload verification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSchedulerReloadIntegration:
+    """Verify scheduler is reloaded after config changes."""
+
+    def test_create_calls_reload(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(
+                f"{_PATCH_ROOT}.load_sources_config",
+                return_value=[{"name": "stripe", "type": "stripe"}],
+            ),
+            patch(f"{_PATCH_ROOT}.reload_schedules") as mock_reload,
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules",
+                json=_sample_schedule(),
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 201
+        mock_reload.assert_called_once()
+
+    def test_update_calls_reload(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        updated = _sample_schedule()
+        updated["cron"] = "0 12 * * *"
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(
+                f"{_PATCH_ROOT}.load_sources_config",
+                return_value=[{"name": "stripe", "type": "stripe"}],
+            ),
+            patch(f"{_PATCH_ROOT}.reload_schedules") as mock_reload,
+        ):
+            client = TestClient(app)
+            resp = client.put(
+                "/api/schedules/daily_sync",
+                json=updated,
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        mock_reload.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests — Rename guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRenameGuard:
+    """Verify update rejects name changes."""
+
+    def test_rename_rejected(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        app = _make_crud_app(tmp_path, scheduler=_mock_scheduler())
+
+        renamed = _sample_schedule()
+        renamed["name"] = "different_name"
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.put(
+                "/api/schedules/daily_sync",
+                json=renamed,
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 400
+        assert "does not match" in resp.json()["message"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — RBAC enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRBACEnforcement:
+    """Verify permission checks on schedule endpoints."""
+
+    def test_viewer_can_list_schedules(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        app = _make_crud_app(tmp_path, user=_make_viewer_user(), scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules")
+
+        assert resp.status_code == 200
+
+    def test_viewer_cannot_create_schedule(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
+        app = _make_crud_app(tmp_path, user=_make_viewer_user(), scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules",
+                json=_sample_schedule(),
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 403
+
+    def test_editor_cannot_create_schedule(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
+        app = _make_crud_app(tmp_path, user=_make_editor_user(), scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules",
+                json=_sample_schedule(),
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 403
+
+    def test_editor_can_trigger_schedule(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, user=_make_editor_user(), scheduler=scheduler)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/daily_sync/trigger",
+                json={},
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200

--- a/tests/unit/test_schedule_crud_api.py
+++ b/tests/unit/test_schedule_crud_api.py
@@ -1,0 +1,527 @@
+"""tests/unit/test_schedule_crud_api.py
+
+Tests for the schedule CRUD API endpoints in dango/web/routes/schedules.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from dango.auth.models import Role, User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PATCH_ROOT = "dango.web.routes.schedules"
+
+
+def _make_admin_user() -> User:
+    return User(id="admin-id", email="admin@test.com", role=Role.ADMIN, is_active=True)
+
+
+def _make_editor_user() -> User:
+    return User(
+        id="editor-id",
+        email="editor@test.com",
+        role=Role.EDITOR,
+        is_active=True,
+    )
+
+
+def _make_viewer_user() -> User:
+    return User(
+        id="viewer-id",
+        email="viewer@test.com",
+        role=Role.VIEWER,
+        is_active=True,
+    )
+
+
+def _make_crud_app(
+    tmp_path: Path,
+    user: User | None = None,
+    scheduler: Any = None,
+) -> Any:
+    """Build a minimal FastAPI app with schedules router and injected user."""
+    from fastapi import FastAPI
+
+    from dango.web.routes.schedules import router
+
+    app = FastAPI()
+    app.state.project_root = tmp_path
+    if scheduler is not None:
+        app.state.scheduler = scheduler
+    app.include_router(router)
+
+    test_user = user or _make_admin_user()
+
+    @app.middleware("http")
+    async def inject_user(request: Any, call_next: Any) -> Any:
+        request.state.user = test_user
+        return await call_next(request)
+
+    return app
+
+
+def _write_schedules_yml(tmp_path: Path, schedules: list[dict[str, Any]]) -> None:
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir(parents=True, exist_ok=True)
+    with open(dango_dir / "schedules.yml", "w") as f:
+        yaml.dump({"schedules": schedules}, f)
+
+
+def _write_sources_yml(tmp_path: Path, sources: list[dict[str, Any]]) -> None:
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir(parents=True, exist_ok=True)
+    with open(dango_dir / "sources.yml", "w") as f:
+        yaml.dump({"sources": sources}, f)
+
+
+def _sample_schedule() -> dict[str, Any]:
+    return {
+        "name": "daily_sync",
+        "type": "sync",
+        "cron": "0 6 * * *",
+        "sources": ["stripe"],
+        "enabled": True,
+    }
+
+
+def _mock_scheduler() -> MagicMock:
+    scheduler = MagicMock()
+    scheduler.get_jobs.return_value = []
+    scheduler.cancel_job.return_value = True
+    return scheduler
+
+
+# ---------------------------------------------------------------------------
+# Tests — List schedules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestListSchedules:
+    """GET /api/schedules."""
+
+    def test_list_with_data(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        app = _make_crud_app(tmp_path, scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "daily_sync"
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        app = _make_crud_app(tmp_path)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — Get schedule detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetSchedule:
+    """GET /api/schedules/{name}."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        app = _make_crud_app(tmp_path, scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/daily_sync")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "daily_sync"
+        assert "recent_history" in data
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        app = _make_crud_app(tmp_path)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.get("/api/schedules/nonexistent")
+
+        assert resp.status_code == 404
+        assert resp.json()["error_code"] == "DANGO-S003"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Create schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCreateSchedule:
+    """POST /api/schedules."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
+        _write_sources_yml(tmp_path, [{"name": "stripe", "type": "stripe"}])
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(
+                f"{_PATCH_ROOT}.load_sources_config",
+                return_value=[{"name": "stripe", "type": "stripe"}],
+            ),
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules",
+                json=_sample_schedule(),
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "daily_sync"
+
+        # Verify YAML was written
+        yml_path = tmp_path / ".dango" / "schedules.yml"
+        assert yml_path.exists()
+
+    def test_validation_error(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
+        app = _make_crud_app(tmp_path, scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules",
+                json={"name": "INVALID NAME", "cron": "bad", "sources": ["x"]},
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["error_code"] == "DANGO-S004"
+
+    def test_duplicate_name(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        _write_sources_yml(tmp_path, [{"name": "stripe", "type": "stripe"}])
+        app = _make_crud_app(tmp_path, scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules",
+                json=_sample_schedule(),
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 409
+        assert resp.json()["error_code"] == "DANGO-S005"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Update schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUpdateSchedule:
+    """PUT /api/schedules/{name}."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        _write_sources_yml(tmp_path, [{"name": "stripe", "type": "stripe"}])
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        updated = _sample_schedule()
+        updated["cron"] = "0 12 * * *"
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(
+                f"{_PATCH_ROOT}.load_sources_config",
+                return_value=[{"name": "stripe", "type": "stripe"}],
+            ),
+        ):
+            client = TestClient(app)
+            resp = client.put(
+                "/api/schedules/daily_sync",
+                json=updated,
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["cron"] == "0 12 * * *"
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        app = _make_crud_app(tmp_path, scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.put(
+                "/api/schedules/nonexistent",
+                json=_sample_schedule(),
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 404
+        assert resp.json()["error_code"] == "DANGO-S003"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Delete schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeleteSchedule:
+    """DELETE /api/schedules/{name}."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.request(
+                "DELETE",
+                "/api/schedules/daily_sync",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        # Verify YAML was updated
+        with open(tmp_path / ".dango" / "schedules.yml") as f:
+            data: dict[str, Any] = yaml.safe_load(f)
+        assert len(data["schedules"]) == 0
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        app = _make_crud_app(tmp_path, scheduler=_mock_scheduler())
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.request(
+                "DELETE",
+                "/api/schedules/nonexistent",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests — Trigger schedule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTriggerSchedule:
+    """POST /api/schedules/{name}/trigger."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        scheduler = _mock_scheduler()
+        mock_job = MagicMock()
+        mock_job.id = "manual:daily_sync:2026-01-01"
+        scheduler.add_job.return_value = mock_job
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/daily_sync/trigger",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "triggered"
+        scheduler.add_job.assert_called_once()
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/nonexistent/trigger",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_scheduler_unavailable(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        # No scheduler on app.state
+        app = _make_crud_app(tmp_path)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/daily_sync/trigger",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 503
+        assert resp.json()["error_code"] == "DANGO-S006"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Reload schedules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReloadSchedules:
+    """POST /api/schedules/reload."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        from dango.config.schedules import ReloadResult
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        scheduler = _mock_scheduler()
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        mock_result = ReloadResult(added=["daily_sync"], removed=[], updated=[])
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(f"{_PATCH_ROOT}.reload_schedules", return_value=mock_result),
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/reload",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "daily_sync" in data["added"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — Cancel job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCancelJob:
+    """POST /api/schedules/jobs/{job_id}/cancel."""
+
+    def test_success(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        scheduler = _mock_scheduler()
+        scheduler.cancel_job.return_value = True
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/jobs/schedule:daily_sync/cancel",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cancelled"
+
+    def test_not_found(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        scheduler = _mock_scheduler()
+        scheduler.cancel_job.return_value = False
+        app = _make_crud_app(tmp_path, scheduler=scheduler)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/jobs/nonexistent/cancel",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 404
+        assert resp.json()["error_code"] == "DANGO-S007"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Unscheduled sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUnscheduledSources:
+    """GET /api/sources/unscheduled."""
+
+    def test_returns_unscheduled(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _write_schedules_yml(tmp_path, [_sample_schedule()])
+        app = _make_crud_app(tmp_path)
+
+        with (
+            patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path),
+            patch(
+                f"{_PATCH_ROOT}.load_sources_config",
+                return_value=[
+                    {"name": "stripe", "type": "stripe"},
+                    {"name": "hubspot", "type": "hubspot"},
+                ],
+            ),
+        ):
+            client = TestClient(app)
+            resp = client.get("/api/sources/unscheduled")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "hubspot" in data["sources"]
+        assert "stripe" not in data["sources"]


### PR DESCRIPTION
## Summary

- Add 9 API endpoints for schedule management: list, detail, create, update, delete, trigger, reload, cancel, and unscheduled sources
- Add 6 `AuditEvent` members for schedule operations with audit logging on all write endpoints
- Add `save_schedules_config()` to persist schedule changes back to `.dango/schedules.yml`
- Add `ScheduleCreateRequest` and `TriggerRequest` Pydantic DTOs
- RBAC enforced: `scheduler.view` (viewer+), `scheduler.manage` (admin), `source.sync` (editor+)
- Route ordering preserved: literal routes before parameterized `{name}` routes
- File-size exemptions added for `scheduler.py` (570 lines, CI blocker), `routes/schedules.py` (630 lines), and test file

## Test plan

- [x] 18 unit tests across 9 test classes (all endpoints covered)
- [x] All 2110 existing unit tests pass (0 regressions)
- [x] ruff lint + format clean
- [x] mypy clean
- [x] File size check passes (43 exempt)
- [x] All 11 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)