### PR TITLE
TASK-110: Remote development readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,33 @@ ruff format --check dango/
 mypy dango/
 ```
 
+### Git Workflow
+
+All v1 development happens on feature branches off `v1`. Never commit directly to `v1` or `main`.
+
+```bash
+# Start a task
+git checkout v1 && git pull && git checkout -b feat/<task-name>
+
+# Use feat/ prefix — git can't create v1/... branches when v1 exists
+# Rebase onto v1 before creating PR (surfaces conflicts, keeps linear history)
+git rebase v1
+
+# Push and create PR
+git push -u origin feat/<task-name>
+gh pr create --base v1 --title "TASK-XXX: Description" --body "..."
+
+# Merge via API (avoids local checkout conflicts)
+gh api repos/getdango/dango/pulls/NUMBER/merge -X PUT -f merge_method=merge
+
+# If merge blocked by strict branch protection:
+gh api repos/getdango/dango/pulls/NUMBER/update-branch -X PUT
+# Wait ~2-3 min for CI, then retry merge
+
+# Cleanup remote branch
+gh api repos/getdango/dango/git/refs/heads/feat/<task-name> -X DELETE
+```
+
 ### Pre-commit hooks
 
 Pre-commit hooks run automatically on `git commit`. The local hooks (`language: system`) use whatever `python3` is in your PATH.


### PR DESCRIPTION
## Summary
- Add `### Git Workflow` section to `dango/CLAUDE.md` — single-session branching, PR, and merge instructions so remote Claude Code sessions can self-serve without the private workspace
- Create `memory/remote-development.md` — private auto-memory file documenting batch session coordination (prompt templates, memory snippet format, per-session and between-batch workflows)

## Verification
- [x] No forbidden terms in CLAUDE.md (`v1-planning/`, `worktree`, `../dango` as local paths)
- [x] Git Workflow section inserted as H3 peer of Pre-commit hooks under Development Setup
- [x] `remote-development.md` has all 7 required sections
- [x] Standard template includes: plan mode, STANDARDS.md, self-verify AC, memory snippet
- [x] Memory snippet format has all 5 category tags: `[Pattern]`, `[Gotcha]`, `[File size]`, `[Bug]`, `[Scope gap]`
- [x] Pre-commit hooks pass

## Test plan
- [x] Grep CLAUDE.md for forbidden workspace paths — zero matches
- [x] Verify section ordering: Git Workflow appears between Development Setup code block and Pre-commit hooks
- [x] All pre-commit hooks pass on commit