### PR TITLE
feat: scheduler test audit + gap-fill (TEST-008)

### DIFF
--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -28,7 +28,8 @@ platform/
 │
 ├── scheduling/          # APScheduler-based job scheduling (TASK-036+)
 │   ├── __init__.py      # Re-exports SchedulerService, ResilienceConfig, run_with_resilience, history functions
-│   ├── scheduler.py     # SchedulerService + resilience (retry, timeout, cancellation)
+│   ├── scheduler.py     # SchedulerService (lifecycle, events, cancellation, async bridge)
+│   ├── resilience.py    # Resilience: retry, timeout, cancellation (extracted from scheduler.py)
 │   ├── history.py       # Execution history tracking (TASK-039)
 │   └── jobs.py          # Module-level job functions (pickle-safe)
 │
@@ -68,7 +69,8 @@ platform/
 | `local/watcher.py` | File change detection | `DebouncedFileHandler`, `FileWatcher`, `MultiTargetWatcher`, `SyncTrigger` |
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |
 | `local/watcher_runner.py` | Background watcher process | `main` |
-| `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence, resilience (retry/timeout/cancel) | `SchedulerService`, `ResilienceConfig`, `run_with_resilience` |
+| `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence, event listeners, retry callback | `SchedulerService` |
+| `scheduling/resilience.py` | Resilience: retry with backoff, timeout via thread kill, cancellation | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `scheduling/history.py` | Execution history tracking for scheduled jobs | `record_start`, `record_completion`, `record_failure`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
 | `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |

--- a/dango/platform/scheduling/__init__.py
+++ b/dango/platform/scheduling/__init__.py
@@ -28,11 +28,11 @@ from dango.platform.scheduling.jobs import (
     run_scheduled_dbt,
     run_scheduled_sync,
 )
-from dango.platform.scheduling.scheduler import (
+from dango.platform.scheduling.resilience import (
     ResilienceConfig,
-    SchedulerService,
     run_with_resilience,
 )
+from dango.platform.scheduling.scheduler import SchedulerService
 
 __all__ = [
     "ResilienceConfig",

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -7,9 +7,9 @@ defined at module level (not as methods or lambdas) so they can be pickled
 and restored from the SQLite job store across restarts.
 
 Public API:
-    configure_jobs(loop)       -- set the event loop (called by SchedulerService.start)
-    run_scheduled_sync(...)    -- sync one or more data sources on schedule
-    run_scheduled_dbt(...)     -- run dbt models on schedule
+    configure_jobs(loop, scheduler)  -- set event loop + scheduler service
+    run_scheduled_sync(...)          -- sync one or more data sources on schedule
+    run_scheduled_dbt(...)           -- run dbt models on schedule
 """
 
 from __future__ import annotations
@@ -24,20 +24,26 @@ from dango.logging import get_logger
 
 if TYPE_CHECKING:
     from dango.config.models import DataSource
+    from dango.platform.scheduling.scheduler import SchedulerService
 
 logger = get_logger(__name__)
 
 _event_loop: asyncio.AbstractEventLoop | None = None
+_scheduler_service: SchedulerService | None = None
 _BROADCAST_TIMEOUT = 5  # seconds to wait for a WebSocket broadcast
 
 
-def configure_jobs(loop: asyncio.AbstractEventLoop) -> None:
-    """Store the running event loop for async bridging.
+def configure_jobs(
+    loop: asyncio.AbstractEventLoop,
+    scheduler: SchedulerService | None = None,
+) -> None:
+    """Store the running event loop and scheduler service for async bridging.
 
     Called once by ``SchedulerService.start()``.
     """
-    global _event_loop  # noqa: PLW0603
+    global _event_loop, _scheduler_service  # noqa: PLW0603
     _event_loop = loop
+    _scheduler_service = scheduler
     logger.info("scheduler_jobs_configured")
 
 
@@ -115,11 +121,11 @@ def _resolve_sources(project_root: Path, names: list[str]) -> list[DataSource]:
 
 
 # ---------------------------------------------------------------------------
-# Execution history
+# Execution history (structlog)
 # ---------------------------------------------------------------------------
 
 
-def _record_execution(
+def _log_execution_event(
     *,
     schedule_name: str,
     job_type: str,
@@ -128,7 +134,7 @@ def _record_execution(
     error: str | None = None,
     sources: list[str] | None = None,
 ) -> None:
-    """Log a structured execution record (TASK-039 upgrades to SQLite)."""
+    """Log a structured execution record (complements SQLite history)."""
     logger.info(
         "job_execution_recorded",
         schedule_name=schedule_name,
@@ -138,6 +144,52 @@ def _record_execution(
         error=error,
         sources=sources or [],
     )
+
+
+# ---------------------------------------------------------------------------
+# SQLite history helpers
+# ---------------------------------------------------------------------------
+
+
+def _try_record_start(
+    project_root: Path,
+    schedule_name: str,
+    source_names: list[str] | None = None,
+) -> int | None:
+    """Attempt to record job start in SQLite history. Returns record_id or None."""
+    if _scheduler_service is None:
+        return None
+    try:
+        from dango.platform.scheduling.history import get_scheduler_db_path, record_start
+
+        db_path = get_scheduler_db_path(project_root)
+        record_id = record_start(db_path, schedule_name, sources=source_names)
+        _scheduler_service.register_execution(f"schedule:{schedule_name}", record_id)
+        return record_id
+    except Exception:  # noqa: BLE001
+        logger.debug("record_start_failed", exc_info=True)
+        return None
+
+
+def _try_finish_record(
+    project_root: Path,
+    schedule_name: str,
+    record_id: int | None,
+    finish_func_name: str,
+    **kwargs: Any,
+) -> None:
+    """Attempt to finalize a history record (completion/failure/timeout/cancel)."""
+    if record_id is None or _scheduler_service is None:
+        return
+    try:
+        from dango.platform.scheduling import history as hist_mod
+
+        db_path = hist_mod.get_scheduler_db_path(project_root)
+        func = getattr(hist_mod, finish_func_name)
+        func(db_path, record_id, **kwargs)
+        _scheduler_service._running_records.pop(f"schedule:{schedule_name}", None)
+    except Exception:  # noqa: BLE001
+        logger.debug("record_finish_failed", func=finish_func_name, exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +269,8 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
     with DbtLock serialization, WebSocket broadcasting, webhook notifications,
     and execution history recording.
 
+    Sources are synced individually with cancellation checks between each source.
+
     Args:
         schedule_name: Human-readable schedule identifier.
         sources: List of source names to sync.
@@ -226,7 +280,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
     full_refresh = bool(kwargs.get("full_refresh", False))
     t0 = time.monotonic()
 
-    from dango.exceptions import DbtLockError
+    from dango.exceptions import DbtLockError, JobCancelledError, JobTimeoutError
     from dango.platform.notifications.webhook import (
         EventType,
         WebhookSender,
@@ -237,6 +291,8 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
     sender = WebhookSender(load_notification_config(project_root))
     source_names = list(sources)
     lock = DbtLock(project_root, source="scheduler", operation=f"sync:{schedule_name}")
+
+    record_id: int | None = None
 
     try:
         try:
@@ -272,7 +328,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 error="Could not acquire lock",
                 duration_seconds=elapsed,
             )
-            _record_execution(
+            _log_execution_event(
                 schedule_name=schedule_name,
                 job_type="sync",
                 status="lock_failed",
@@ -286,7 +342,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         if not resolved:
             elapsed = time.monotonic() - t0
             logger.warning("no_sources_resolved", schedule=schedule_name, names=source_names)
-            _record_execution(
+            _log_execution_event(
                 schedule_name=schedule_name,
                 job_type="sync",
                 status="no_sources",
@@ -294,6 +350,8 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 sources=source_names,
             )
             return
+
+        record_id = _try_record_start(project_root, schedule_name, source_names)
 
         _broadcast(
             {
@@ -305,13 +363,13 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         )
 
         from dango.ingestion.dlt_runner import run_sync
-
-        run_sync(project_root, resolved, full_refresh=full_refresh)
-        elapsed = time.monotonic() - t0
-
         from dango.utils.sync_history import save_sync_history_entry
 
+        job_id = f"schedule:{schedule_name}"
         for src in resolved:
+            if _scheduler_service is not None and _scheduler_service.is_cancelled(job_id):
+                raise JobCancelledError(f"Sync cancelled between sources for {schedule_name}")
+            run_sync(project_root, [src], full_refresh=full_refresh)
             save_sync_history_entry(
                 project_root,
                 src.name,
@@ -320,11 +378,15 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                     "schedule": schedule_name,
                     "status": "completed",
                     "completed_at": _ts(),
-                    "duration_seconds": round(elapsed, 2),
+                    "duration_seconds": round(time.monotonic() - t0, 2),
                 },
             )
 
-        _record_execution(
+        elapsed = time.monotonic() - t0
+
+        _try_finish_record(project_root, schedule_name, record_id, "record_completion")
+
+        _log_execution_event(
             schedule_name=schedule_name,
             job_type="sync",
             status="completed",
@@ -349,6 +411,56 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         )
         _check_freshness(project_root, schedule_name, source_names, sender)
 
+    except JobTimeoutError:
+        elapsed = time.monotonic() - t0
+        _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
+        _log_execution_event(
+            schedule_name=schedule_name,
+            job_type="sync",
+            status="timeout",
+            duration_seconds=elapsed,
+            error="Job timed out",
+            sources=source_names,
+        )
+        _broadcast(
+            {
+                "event": "sync_failed",
+                "schedule": schedule_name,
+                "sources": source_names,
+                "error": "Job timed out",
+                "timestamp": _ts(),
+            }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            sources=source_names,
+            error="Job timed out",
+            duration_seconds=elapsed,
+        )
+
+    except JobCancelledError:
+        elapsed = time.monotonic() - t0
+        _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")
+        _log_execution_event(
+            schedule_name=schedule_name,
+            job_type="sync",
+            status="cancelled",
+            duration_seconds=elapsed,
+            error="Job cancelled",
+            sources=source_names,
+        )
+        _broadcast(
+            {
+                "event": "sync_failed",
+                "schedule": schedule_name,
+                "sources": source_names,
+                "error": "Job cancelled",
+                "timestamp": _ts(),
+            }
+        )
+
     except Exception as exc:  # noqa: BLE001
         elapsed = time.monotonic() - t0
         error_msg = str(exc)
@@ -359,7 +471,10 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             error=error_msg,
             exc_info=True,
         )
-        _record_execution(
+        _try_finish_record(
+            project_root, schedule_name, record_id, "record_failure", error=error_msg
+        )
+        _log_execution_event(
             schedule_name=schedule_name,
             job_type="sync",
             status="failed",
@@ -407,7 +522,7 @@ def run_scheduled_dbt(
     project_root = Path(kwargs.get("project_root", "."))
     t0 = time.monotonic()
 
-    from dango.exceptions import DbtLockError
+    from dango.exceptions import DbtLockError, JobCancelledError, JobTimeoutError
     from dango.platform.notifications.webhook import (
         EventType,
         WebhookSender,
@@ -417,6 +532,8 @@ def run_scheduled_dbt(
 
     sender = WebhookSender(load_notification_config(project_root))
     lock = DbtLock(project_root, source="scheduler", operation=f"dbt:{schedule_name}")
+
+    record_id: int | None = None
 
     try:
         try:
@@ -449,7 +566,7 @@ def run_scheduled_dbt(
                 error="Could not acquire lock",
                 duration_seconds=elapsed,
             )
-            _record_execution(
+            _log_execution_event(
                 schedule_name=schedule_name,
                 job_type="dbt",
                 status="lock_failed",
@@ -457,6 +574,8 @@ def run_scheduled_dbt(
                 error="Lock contention",
             )
             return
+
+        record_id = _try_record_start(project_root, schedule_name, source_names=None)
 
         _broadcast(
             {
@@ -473,7 +592,8 @@ def run_scheduled_dbt(
         elapsed = time.monotonic() - t0
 
         if success:
-            _record_execution(
+            _try_finish_record(project_root, schedule_name, record_id, "record_completion")
+            _log_execution_event(
                 schedule_name=schedule_name,
                 job_type="dbt",
                 status="completed",
@@ -494,7 +614,10 @@ def run_scheduled_dbt(
                 duration_seconds=round(elapsed, 2),
             )
         else:
-            _record_execution(
+            _try_finish_record(
+                project_root, schedule_name, record_id, "record_failure", error=output
+            )
+            _log_execution_event(
                 schedule_name=schedule_name,
                 job_type="dbt",
                 status="failed",
@@ -517,6 +640,36 @@ def run_scheduled_dbt(
                 duration_seconds=elapsed,
             )
 
+    except JobTimeoutError:
+        elapsed = time.monotonic() - t0
+        _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
+        _log_execution_event(
+            schedule_name=schedule_name,
+            job_type="dbt",
+            status="timeout",
+            duration_seconds=elapsed,
+            error="Job timed out",
+        )
+        _broadcast(
+            {
+                "event": "dbt_failed",
+                "schedule": schedule_name,
+                "error": "Job timed out",
+                "timestamp": _ts(),
+            }
+        )
+
+    except JobCancelledError:
+        elapsed = time.monotonic() - t0
+        _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")
+        _log_execution_event(
+            schedule_name=schedule_name,
+            job_type="dbt",
+            status="cancelled",
+            duration_seconds=elapsed,
+            error="Job cancelled",
+        )
+
     except Exception as exc:  # noqa: BLE001
         elapsed = time.monotonic() - t0
         error_msg = str(exc)
@@ -527,7 +680,10 @@ def run_scheduled_dbt(
             error=error_msg,
             exc_info=True,
         )
-        _record_execution(
+        _try_finish_record(
+            project_root, schedule_name, record_id, "record_failure", error=error_msg
+        )
+        _log_execution_event(
             schedule_name=schedule_name,
             job_type="dbt",
             status="failed",

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -369,6 +369,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         for src in resolved:
             if _scheduler_service is not None and _scheduler_service.is_cancelled(job_id):
                 raise JobCancelledError(f"Sync cancelled between sources for {schedule_name}")
+            src_t0 = time.monotonic()
             run_sync(project_root, [src], full_refresh=full_refresh)
             save_sync_history_entry(
                 project_root,
@@ -378,7 +379,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                     "schedule": schedule_name,
                     "status": "completed",
                     "completed_at": _ts(),
-                    "duration_seconds": round(time.monotonic() - t0, 2),
+                    "duration_seconds": round(time.monotonic() - src_t0, 2),
                 },
             )
 
@@ -459,6 +460,14 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 "error": "Job cancelled",
                 "timestamp": _ts(),
             }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            sources=source_names,
+            error="Job cancelled",
+            duration_seconds=elapsed,
         )
 
     except Exception as exc:  # noqa: BLE001
@@ -658,6 +667,13 @@ def run_scheduled_dbt(
                 "timestamp": _ts(),
             }
         )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            error="Job timed out",
+            duration_seconds=elapsed,
+        )
 
     except JobCancelledError:
         elapsed = time.monotonic() - t0
@@ -668,6 +684,13 @@ def run_scheduled_dbt(
             status="cancelled",
             duration_seconds=elapsed,
             error="Job cancelled",
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            error="Job cancelled",
+            duration_seconds=elapsed,
         )
 
     except Exception as exc:  # noqa: BLE001

--- a/dango/platform/scheduling/resilience.py
+++ b/dango/platform/scheduling/resilience.py
@@ -1,0 +1,211 @@
+"""dango/platform/scheduling/resilience.py
+
+Resilience features for scheduled jobs: retry with configurable backoff,
+execution timeout with thread-based kill, and cancellation flags.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from dango.exceptions import JobCancelledError, JobTimeoutError
+from dango.logging import get_logger
+
+if TYPE_CHECKING:
+    from dango.platform.scheduling.scheduler import SchedulerService
+
+logger = get_logger(__name__)
+
+_DEFAULT_MAX_RETRIES = 3
+_DEFAULT_RETRY_DELAYS = (30, 120, 300)
+_DEFAULT_TIMEOUT_MINUTES = 60
+
+
+@dataclass(frozen=True)
+class ResilienceConfig:
+    """Per-schedule resilience configuration.
+
+    Controls retry, backoff, and timeout behaviour for scheduled jobs.
+    TASK-037 constructs these from ``schedules.yml`` per-schedule fields.
+    """
+
+    max_retries: int = _DEFAULT_MAX_RETRIES
+    retry_delays: tuple[int, ...] = _DEFAULT_RETRY_DELAYS
+    timeout_minutes: int = _DEFAULT_TIMEOUT_MINUTES
+
+    def __post_init__(self) -> None:
+        if self.max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
+        if not self.retry_delays:
+            raise ValueError("retry_delays must not be empty")
+        if self.timeout_minutes <= 0:
+            raise ValueError("timeout_minutes must be positive")
+
+
+def _raise_in_thread(thread_id: int, exc_type: type[BaseException]) -> None:
+    """Inject an exception into a running thread via ctypes.
+
+    CPython-specific: uses ``PyThreadState_SetAsyncExc``. Only works when
+    the target thread executes Python bytecode. If blocked in a C extension
+    (e.g., DuckDB query), the exception is deferred until the C call returns.
+    DbtLock timeout and DuckDB query timeouts serve as additional backstops.
+    """
+    res: int = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_ulong(thread_id),
+        ctypes.py_object(exc_type),
+    )
+    if res == 0:
+        logger.debug("raise_in_thread_invalid_id", thread_id=thread_id)
+    elif res > 1:
+        # Multiple threads affected — should never happen. Revert.
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_ulong(thread_id), None)
+        logger.error("raise_in_thread_multi_affected", thread_id=thread_id)
+
+
+def _execute_with_timeout(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    timeout_seconds: int,
+    cancel_flag: threading.Event,
+) -> Any:
+    """Run *func* with a timeout enforced via a daemon Timer.
+
+    If the cancel flag is set before starting, raises ``JobCancelledError``
+    immediately. On timeout, injects ``JobTimeoutError`` into the worker
+    thread.
+    """
+    if cancel_flag.is_set():
+        raise JobCancelledError("Job cancelled before execution")
+
+    thread_id = threading.current_thread().ident
+    if thread_id is None:
+        raise RuntimeError("Cannot determine current thread ID")
+
+    timer = threading.Timer(
+        timeout_seconds,
+        _raise_in_thread,
+        args=(thread_id, JobTimeoutError),
+    )
+    timer.daemon = True
+    timer.start()
+    try:
+        return func(*args, **kwargs)
+    finally:
+        timer.cancel()
+
+
+def run_with_resilience(
+    func: Callable[..., Any],
+    *args: Any,
+    scheduler_service: SchedulerService,
+    job_id: str,
+    resilience: ResilienceConfig | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Execute a job function with retry, timeout, and cancellation.
+
+    Called from ``jobs.py`` (TASK-041) as the top-level wrapper around
+    actual sync/dbt job functions. Manages cancel flag lifecycle and
+    fires event callbacks for history (TASK-039) and notifications
+    (TASK-041).
+
+    Args:
+        func: The job function to execute.
+        *args: Positional arguments forwarded to *func*.
+        scheduler_service: The SchedulerService instance (for cancel
+            flag management and callbacks).
+        job_id: The APScheduler job ID.
+        resilience: Per-schedule resilience config. Uses defaults if None.
+        **kwargs: Keyword arguments forwarded to *func*.
+
+    Returns:
+        The return value of *func*.
+
+    Raises:
+        JobTimeoutError: If the job exceeds its timeout (no retry).
+        JobCancelledError: If the job is cancelled.
+        Exception: The last exception if all retries are exhausted.
+    """
+    cfg = resilience if resilience is not None else ResilienceConfig()
+    timeout_seconds = cfg.timeout_minutes * 60
+    cancel_flag = scheduler_service._register_cancel_flag(job_id)
+    last_exception: BaseException | None = None
+
+    try:
+        for attempt in range(1, cfg.max_retries + 1):
+            if cancel_flag.is_set():
+                raise JobCancelledError(f"Job {job_id} cancelled before attempt {attempt}")
+
+            try:
+                return _execute_with_timeout(func, args, kwargs, timeout_seconds, cancel_flag)
+            except JobTimeoutError:
+                _fire_callbacks(
+                    scheduler_service._on_timeout_callbacks,
+                    job_id=job_id,
+                    timeout_minutes=cfg.timeout_minutes,
+                )
+                raise
+            except JobCancelledError:
+                _fire_callbacks(
+                    scheduler_service._on_cancel_callbacks,
+                    job_id=job_id,
+                )
+                raise
+            except Exception as exc:  # noqa: BLE001
+                last_exception = exc
+                if attempt < cfg.max_retries:
+                    delay_index = min(attempt - 1, len(cfg.retry_delays) - 1)
+                    delay = cfg.retry_delays[delay_index]
+                    _fire_callbacks(
+                        scheduler_service._on_retry_callbacks,
+                        job_id=job_id,
+                        attempt=attempt,
+                        max_retries=cfg.max_retries,
+                        next_retry_delay=delay,
+                        error=str(exc),
+                    )
+                    logger.warning(
+                        "job_retry",
+                        job_id=job_id,
+                        attempt=attempt,
+                        next_retry_delay=delay,
+                        error=str(exc),
+                    )
+                    # Interruptible sleep — cancel_flag.wait() returns True
+                    # if the flag is set (cancellation), False on timeout
+                    # (delay elapsed normally).
+                    if cancel_flag.wait(timeout=delay):
+                        raise JobCancelledError(
+                            f"Job {job_id} cancelled during retry wait"
+                        ) from exc
+
+        # All retries exhausted — propagate the last exception
+        if last_exception is not None:
+            raise last_exception
+
+    finally:
+        scheduler_service._clear_cancel_flag(job_id)
+
+    # Unreachable, but satisfies type checker
+    raise RuntimeError("run_with_resilience: unreachable")  # pragma: no cover
+
+
+def _fire_callbacks(
+    callbacks: list[Callable[..., None]],
+    **kwargs: Any,
+) -> None:
+    """Fire event callbacks, catching and logging any errors.
+
+    Each callback is wrapped in try/except — callbacks are fire-and-forget.
+    Matches the "never raises" pattern from webhook.py.
+    """
+    for cb in callbacks:
+        try:
+            cb(**kwargs)
+        except Exception:  # noqa: BLE001
+            logger.warning("callback_error", exc_info=True)

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -1,23 +1,21 @@
 """dango/platform/scheduling/scheduler.py
 
 SchedulerService wraps APScheduler 3.x AsyncIOScheduler for job persistence,
-event tracking, and async bridging. Includes resilience features: retry with
-configurable backoff, execution timeout with thread-based kill, cancellation
-flags, and event callbacks for history/notification integration.
+event tracking, and async bridging. Resilience features (retry, timeout,
+cancellation) are in scheduling/resilience.py.
 """
 
 from __future__ import annotations
 
 import asyncio
-import ctypes
 import threading
-from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import concurrent.futures
+
+from collections.abc import Callable
 
 from apscheduler.events import (
     EVENT_JOB_ERROR,
@@ -30,37 +28,12 @@ from apscheduler.job import Job
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-from dango.exceptions import JobCancelledError, JobTimeoutError
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
 
 _DEFAULT_THREAD_POOL_SIZE = 20
 _DEFAULT_MISFIRE_GRACE_TIME = 3600  # 1 hour
-_DEFAULT_MAX_RETRIES = 3
-_DEFAULT_RETRY_DELAYS = (30, 120, 300)
-_DEFAULT_TIMEOUT_MINUTES = 60
-
-
-@dataclass(frozen=True)
-class ResilienceConfig:
-    """Per-schedule resilience configuration.
-
-    Controls retry, backoff, and timeout behaviour for scheduled jobs.
-    TASK-037 constructs these from ``schedules.yml`` per-schedule fields.
-    """
-
-    max_retries: int = _DEFAULT_MAX_RETRIES
-    retry_delays: tuple[int, ...] = _DEFAULT_RETRY_DELAYS
-    timeout_minutes: int = _DEFAULT_TIMEOUT_MINUTES
-
-    def __post_init__(self) -> None:
-        if self.max_retries < 1:
-            raise ValueError("max_retries must be at least 1")
-        if not self.retry_delays:
-            raise ValueError("retry_delays must not be empty")
-        if self.timeout_minutes <= 0:
-            raise ValueError("timeout_minutes must be positive")
 
 
 class SchedulerService:
@@ -134,7 +107,7 @@ class SchedulerService:
 
         from dango.platform.scheduling.jobs import configure_jobs
 
-        configure_jobs(loop)
+        configure_jobs(loop, self)
 
         self._scheduler.add_listener(self._on_job_executed, EVENT_JOB_EXECUTED)
         self._scheduler.add_listener(self._on_job_error, EVENT_JOB_ERROR)
@@ -142,6 +115,8 @@ class SchedulerService:
 
         self._scheduler.start()
         self._started = True
+
+        self._on_retry_callbacks.append(self._on_retry_event)
 
         self._setup_history_cleanup()
         self._log_startup_summary()
@@ -339,6 +314,57 @@ class SchedulerService:
         )
 
     # ------------------------------------------------------------------
+    # Retry callback
+    # ------------------------------------------------------------------
+
+    def _on_retry_event(self, **kwargs: Any) -> None:
+        """Broadcast a sync_retrying WebSocket event and send webhook.
+
+        Registered as a retry callback by ``start()``. Never raises.
+        """
+        try:
+            job_id: str = kwargs.get("job_id", "")
+            attempt: int = kwargs.get("attempt", 0)
+            max_retries: int = kwargs.get("max_retries", 0)
+            error: str = kwargs.get("error", "")
+
+            schedule_name = job_id.removeprefix("schedule:")
+
+            from dango.platform.scheduling.jobs import _broadcast
+
+            _broadcast(
+                {
+                    "event": "sync_retrying",
+                    "schedule": schedule_name,
+                    "attempt": attempt,
+                    "max_retries": max_retries,
+                    "error": error,
+                    "timestamp": _ts(),
+                }
+            )
+
+            from dango.platform.notifications.webhook import (
+                EventType,
+                WebhookSender,
+                load_notification_config,
+            )
+
+            notif_config = load_notification_config(self._project_root)
+            sender = WebhookSender(notif_config)
+            if sender.is_configured:
+                from dango.platform.scheduling.jobs import _event_loop
+
+                if _event_loop is not None:
+                    coro = sender.send(
+                        event_type=EventType.SYNC_FAILED,
+                        schedule_name=schedule_name,
+                        error=f"Retrying (attempt {attempt}/{max_retries}): {error}",
+                    )
+                    asyncio.run_coroutine_threadsafe(coro, _event_loop)
+        except Exception:  # noqa: BLE001
+            logger.warning("retry_event_callback_error", exc_info=True)
+
+    # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
@@ -400,171 +426,8 @@ class SchedulerService:
             logger.debug("dual_scheduler_check_failed", exc_info=True)
 
 
-# ---------------------------------------------------------------------------
-# Module-level resilience functions
-# ---------------------------------------------------------------------------
+def _ts() -> str:
+    """UTC ISO timestamp for broadcast messages."""
+    from datetime import datetime, timezone
 
-
-def _raise_in_thread(thread_id: int, exc_type: type[BaseException]) -> None:
-    """Inject an exception into a running thread via ctypes.
-
-    CPython-specific: uses ``PyThreadState_SetAsyncExc``. Only works when
-    the target thread executes Python bytecode. If blocked in a C extension
-    (e.g., DuckDB query), the exception is deferred until the C call returns.
-    DbtLock timeout and DuckDB query timeouts serve as additional backstops.
-    """
-    res: int = ctypes.pythonapi.PyThreadState_SetAsyncExc(
-        ctypes.c_ulong(thread_id),
-        ctypes.py_object(exc_type),
-    )
-    if res == 0:
-        logger.debug("raise_in_thread_invalid_id", thread_id=thread_id)
-    elif res > 1:
-        # Multiple threads affected — should never happen. Revert.
-        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_ulong(thread_id), None)
-        logger.error("raise_in_thread_multi_affected", thread_id=thread_id)
-
-
-def _execute_with_timeout(
-    func: Callable[..., Any],
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    timeout_seconds: int,
-    cancel_flag: threading.Event,
-) -> Any:
-    """Run *func* with a timeout enforced via a daemon Timer.
-
-    If the cancel flag is set before starting, raises ``JobCancelledError``
-    immediately. On timeout, injects ``JobTimeoutError`` into the worker
-    thread.
-    """
-    if cancel_flag.is_set():
-        raise JobCancelledError("Job cancelled before execution")
-
-    thread_id = threading.current_thread().ident
-    if thread_id is None:
-        raise RuntimeError("Cannot determine current thread ID")
-
-    timer = threading.Timer(
-        timeout_seconds,
-        _raise_in_thread,
-        args=(thread_id, JobTimeoutError),
-    )
-    timer.daemon = True
-    timer.start()
-    try:
-        return func(*args, **kwargs)
-    finally:
-        timer.cancel()
-
-
-def run_with_resilience(
-    func: Callable[..., Any],
-    *args: Any,
-    scheduler_service: SchedulerService,
-    job_id: str,
-    resilience: ResilienceConfig | None = None,
-    **kwargs: Any,
-) -> Any:
-    """Execute a job function with retry, timeout, and cancellation.
-
-    Called from ``jobs.py`` (TASK-041) as the top-level wrapper around
-    actual sync/dbt job functions. Manages cancel flag lifecycle and
-    fires event callbacks for history (TASK-039) and notifications
-    (TASK-041).
-
-    Args:
-        func: The job function to execute.
-        *args: Positional arguments forwarded to *func*.
-        scheduler_service: The SchedulerService instance (for cancel
-            flag management and callbacks).
-        job_id: The APScheduler job ID.
-        resilience: Per-schedule resilience config. Uses defaults if None.
-        **kwargs: Keyword arguments forwarded to *func*.
-
-    Returns:
-        The return value of *func*.
-
-    Raises:
-        JobTimeoutError: If the job exceeds its timeout (no retry).
-        JobCancelledError: If the job is cancelled.
-        Exception: The last exception if all retries are exhausted.
-    """
-    cfg = resilience if resilience is not None else ResilienceConfig()
-    timeout_seconds = cfg.timeout_minutes * 60
-    cancel_flag = scheduler_service._register_cancel_flag(job_id)
-    last_exception: BaseException | None = None
-
-    try:
-        for attempt in range(1, cfg.max_retries + 1):
-            if cancel_flag.is_set():
-                raise JobCancelledError(f"Job {job_id} cancelled before attempt {attempt}")
-
-            try:
-                return _execute_with_timeout(func, args, kwargs, timeout_seconds, cancel_flag)
-            except JobTimeoutError:
-                _fire_callbacks(
-                    scheduler_service._on_timeout_callbacks,
-                    job_id=job_id,
-                    timeout_minutes=cfg.timeout_minutes,
-                )
-                raise
-            except JobCancelledError:
-                _fire_callbacks(
-                    scheduler_service._on_cancel_callbacks,
-                    job_id=job_id,
-                )
-                raise
-            except Exception as exc:  # noqa: BLE001
-                last_exception = exc
-                if attempt < cfg.max_retries:
-                    delay_index = min(attempt - 1, len(cfg.retry_delays) - 1)
-                    delay = cfg.retry_delays[delay_index]
-                    _fire_callbacks(
-                        scheduler_service._on_retry_callbacks,
-                        job_id=job_id,
-                        attempt=attempt,
-                        max_retries=cfg.max_retries,
-                        next_retry_delay=delay,
-                        error=str(exc),
-                    )
-                    logger.warning(
-                        "job_retry",
-                        job_id=job_id,
-                        attempt=attempt,
-                        next_retry_delay=delay,
-                        error=str(exc),
-                    )
-                    # Interruptible sleep — cancel_flag.wait() returns True
-                    # if the flag is set (cancellation), False on timeout
-                    # (delay elapsed normally).
-                    if cancel_flag.wait(timeout=delay):
-                        raise JobCancelledError(
-                            f"Job {job_id} cancelled during retry wait"
-                        ) from exc
-
-        # All retries exhausted — propagate the last exception
-        if last_exception is not None:
-            raise last_exception
-
-    finally:
-        scheduler_service._clear_cancel_flag(job_id)
-
-    # Unreachable, but satisfies type checker
-    raise RuntimeError("run_with_resilience: unreachable")  # pragma: no cover
-
-
-def _fire_callbacks(
-    callbacks: list[Callable[..., None]],
-    **kwargs: Any,
-) -> None:
-    """Fire event callbacks, catching and logging any errors.
-
-    Each callback is wrapped in try/except — callbacks are fire-and-forget.
-    Matches the "never raises" pattern from webhook.py.
-    """
-    for cb in callbacks:
-        try:
-            cb(**kwargs)
-        except Exception:  # noqa: BLE001
-            logger.warning("callback_error", exc_info=True)
+    return datetime.now(tz=timezone.utc).isoformat()

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -351,16 +351,13 @@ class SchedulerService:
 
             notif_config = load_notification_config(self._project_root)
             sender = WebhookSender(notif_config)
-            if sender.is_configured:
-                from dango.platform.scheduling.jobs import _event_loop
-
-                if _event_loop is not None:
-                    coro = sender.send(
-                        event_type=EventType.SYNC_FAILED,
-                        schedule_name=schedule_name,
-                        error=f"Retrying (attempt {attempt}/{max_retries}): {error}",
-                    )
-                    asyncio.run_coroutine_threadsafe(coro, _event_loop)
+            if sender.is_configured and self._loop is not None:
+                coro = sender.send(
+                    event_type=EventType.SYNC_FAILED,
+                    schedule_name=schedule_name,
+                    error=f"Retrying (attempt {attempt}/{max_retries}): {error}",
+                )
+                asyncio.run_coroutine_threadsafe(coro, self._loop)
         except Exception:  # noqa: BLE001
             logger.warning("retry_event_callback_error", exc_info=True)
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -201,9 +201,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py
-    lines: 553
+    lines: 709
     category: exempt
-    reason: "TASK-041: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, and history recording. Each job path (lock failure, success, error) requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
+    reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/digitalocean.py
@@ -261,11 +261,6 @@ exemptions:
     review_by: "v1.1"
 
   # --- Phase 4 scheduling ---
-  - file: dango/platform/scheduling/scheduler.py
-    lines: 570
-    category: exempt
-    reason: "SchedulerService + resilience (retry/timeout/cancel). Extraction of resilience functions into scheduling/resilience.py planned for TEST-008."
-    review_by: "v1.1"
 
   - file: dango/web/routes/schedules.py
     lines: 630

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -201,7 +201,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py
-    lines: 709
+    lines: 732
     category: exempt
     reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
     review_by: "v1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,10 +267,12 @@ module = [
     "tests.unit.test_cli_schedule",
     "tests.unit.test_cli_schedule_webhook",
     "tests.unit.test_notifications_audit",
+    "tests.unit.test_scheduler_gaps",
     "tests.integration.test_sync_notification",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",
     "tests.integration.test_remote",
+    "tests.integration.test_scheduler_integration",
 ]
 ignore_errors = true
 

--- a/tests/integration/test_scheduler_integration.py
+++ b/tests/integration/test_scheduler_integration.py
@@ -1,0 +1,124 @@
+"""tests/integration/test_scheduler_integration.py
+
+Integration test: schedule registration -> job fire -> history recorded.
+Uses real SQLite via migration loading (importlib.util), not mocks.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+def _apply_migration(db_path: Path) -> None:
+    """Apply the 001_execution_history migration to create the table."""
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "dango"
+        / "migrations"
+        / "scheduler"
+        / "001_execution_history.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_001", str(migration_path))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        mod.upgrade(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.integration
+class TestScheduleToHistoryIntegration:
+    """Full path: record_start → record_completion/timeout/cancellation."""
+
+    def test_record_start_then_completion(self, tmp_path):
+        """record_start creates a row, record_completion finalizes it."""
+        from dango.platform.scheduling.history import (
+            get_scheduler_db_path,
+            record_completion,
+            record_start,
+        )
+
+        db_path = get_scheduler_db_path(tmp_path)
+        _apply_migration(db_path)
+
+        record_id = record_start(db_path, "daily_sync", sources=["google_sheets", "stripe"])
+        assert isinstance(record_id, int)
+
+        record_completion(db_path, record_id, rows_processed=1500)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT * FROM execution_history WHERE id = ?", (record_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None
+        assert row["status"] == "success"
+        assert row["rows_processed"] == 1500
+        assert row["duration_seconds"] is not None
+        assert row["ended_at"] is not None
+
+    def test_record_start_then_timeout(self, tmp_path):
+        """record_timeout marks the execution with 'timeout' status."""
+        from dango.platform.scheduling.history import (
+            get_scheduler_db_path,
+            record_start,
+            record_timeout,
+        )
+
+        db_path = get_scheduler_db_path(tmp_path)
+        _apply_migration(db_path)
+
+        record_id = record_start(db_path, "hourly_sync", sources=["src1"])
+        record_timeout(db_path, record_id)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT * FROM execution_history WHERE id = ?", (record_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row["status"] == "timeout"
+        assert row["ended_at"] is not None
+
+    def test_record_start_then_cancellation(self, tmp_path):
+        """record_cancellation marks the execution with 'cancelled' status."""
+        from dango.platform.scheduling.history import (
+            get_scheduler_db_path,
+            record_cancellation,
+            record_start,
+        )
+
+        db_path = get_scheduler_db_path(tmp_path)
+        _apply_migration(db_path)
+
+        record_id = record_start(db_path, "weekly_sync", sources=["hubspot"])
+        record_cancellation(db_path, record_id)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT * FROM execution_history WHERE id = ?", (record_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row["status"] == "cancelled"
+        assert row["ended_at"] is not None

--- a/tests/unit/test_scheduler_gaps.py
+++ b/tests/unit/test_scheduler_gaps.py
@@ -9,10 +9,8 @@ timeout distinct status.
 from __future__ import annotations
 
 import asyncio
-import sqlite3
 import sys
 import threading
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -62,31 +60,6 @@ def _make_config_with_sources(*source_names):
     config = MagicMock()
     config.sources.get_source.side_effect = lambda n: sources.get(n)
     return config
-
-
-def _create_history_db(db_path: Path) -> None:
-    """Create a scheduler DB with the execution_history table."""
-    import importlib.util
-
-    migration_path = (
-        Path(__file__).resolve().parents[2]
-        / "dango"
-        / "migrations"
-        / "scheduler"
-        / "001_execution_history.py"
-    )
-    spec = importlib.util.spec_from_file_location("migration_001", str(migration_path))
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(db_path))
-    try:
-        mod.upgrade(conn)
-        conn.commit()
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scheduler_gaps.py
+++ b/tests/unit/test_scheduler_gaps.py
@@ -1,0 +1,481 @@
+"""tests/unit/test_scheduler_gaps.py
+
+Gap-fill tests for scheduler: DST transitions, concurrent reload,
+job store recovery, multi-source DbtLock serialization, cancellation
+between sources, retry callback wiring, record_start wiring, and
+timeout distinct status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import dango.utils.dbt_lock  # noqa: F401 — force submodule into sys.modules
+from dango.exceptions import JobCancelledError, JobTimeoutError
+
+_dbt_lock_module = sys.modules["dango.utils.dbt_lock"]
+
+_SCHEDULER_MOD = "dango.platform.scheduling.scheduler"
+_JOBS_MOD = "dango.platform.scheduling.jobs"
+_NOTIF_MOD = "dango.platform.notifications.webhook"
+_SYNC_MOD = "dango.ingestion.dlt_runner"
+_CFG_MOD = "dango.config.helpers"
+_HIST_MOD = "dango.utils.sync_history"
+
+
+def _make_service(tmp_path):
+    """Create a SchedulerService with all APScheduler internals mocked."""
+    with (
+        patch(f"{_SCHEDULER_MOD}.SQLAlchemyJobStore"),
+        patch(f"{_SCHEDULER_MOD}.AsyncIOScheduler") as mock_cls,
+    ):
+        mock_scheduler = MagicMock()
+        mock_scheduler.running = False
+        mock_scheduler.get_jobs.return_value = []
+        mock_cls.return_value = mock_scheduler
+
+        from dango.platform.scheduling.scheduler import SchedulerService
+
+        svc = SchedulerService(tmp_path)
+
+    return svc
+
+
+def _make_source(name="test_source"):
+    """Create a minimal DataSource mock."""
+    src = MagicMock()
+    src.name = name
+    src.enabled = True
+    return src
+
+
+def _make_config_with_sources(*source_names):
+    """Create a mock load_config that returns sources by name."""
+    sources = {n: _make_source(n) for n in source_names}
+    config = MagicMock()
+    config.sources.get_source.side_effect = lambda n: sources.get(n)
+    return config
+
+
+def _create_history_db(db_path: Path) -> None:
+    """Create a scheduler DB with the execution_history table."""
+    import importlib.util
+
+    migration_path = (
+        Path(__file__).resolve().parents[2]
+        / "dango"
+        / "migrations"
+        / "scheduler"
+        / "001_execution_history.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_001", str(migration_path))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        mod.upgrade(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# DST transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDSTTransition:
+    """CronTrigger with timezone across spring-forward and fall-back."""
+
+    def test_spring_forward_does_not_skip_run(self):
+        """A daily-at-2am cron should produce a run time near DST spring-forward."""
+        from zoneinfo import ZoneInfo
+
+        from apscheduler.triggers.cron import CronTrigger
+
+        tz = ZoneInfo("America/New_York")
+        # Daily at 2:30 AM — on 2026-03-08 (spring-forward), 2:30 AM doesn't exist.
+        trigger = CronTrigger(hour=2, minute=30, timezone=tz)
+
+        from datetime import datetime
+
+        # Get next fire time starting before spring-forward
+        base = datetime(2026, 3, 7, 3, 0, tzinfo=tz)
+        fire = trigger.get_next_fire_time(None, base)
+        assert fire is not None
+        # APScheduler should still schedule something on or around March 8
+        assert fire.month == 3
+        assert fire.day == 8
+
+    def test_fall_back_max_instances_prevents_overlap(self, tmp_path):
+        """max_instances=1 prevents duplicate runs during fall-back ambiguous hour.
+
+        APScheduler's CronTrigger may fire twice during DST fall-back (two
+        1:00 AM's). The ``max_instances=1`` setting in job_defaults ensures
+        only one concurrent execution even if two fire times match.
+        """
+        _make_service(tmp_path)
+
+        # Verify the safeguard is configured via the constructor call on AsyncIOScheduler mock
+        with (
+            patch(f"{_SCHEDULER_MOD}.SQLAlchemyJobStore"),
+            patch(f"{_SCHEDULER_MOD}.AsyncIOScheduler") as mock_cls,
+        ):
+            mock_cls.return_value = MagicMock()
+            mock_cls.return_value.running = False
+            mock_cls.return_value.get_jobs.return_value = []
+
+            from dango.platform.scheduling.scheduler import SchedulerService
+
+            SchedulerService(tmp_path)
+
+        init_kwargs = mock_cls.call_args[1]
+        assert init_kwargs["job_defaults"]["max_instances"] == 1
+        assert init_kwargs["job_defaults"]["coalesce"] is True
+
+
+# ---------------------------------------------------------------------------
+# Concurrent reload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConcurrentReload:
+    """Two threads calling reload_schedules() — no corruption."""
+
+    def test_concurrent_reload_no_corruption(self, tmp_path):
+        """Concurrent reloads should not raise or leave inconsistent state."""
+        from dango.config.schedules import ScheduleConfig, reload_schedules
+
+        svc = _make_service(tmp_path)
+        # Start the scheduler's internal state
+        svc._scheduler.get_jobs.return_value = []
+
+        schedules = [
+            ScheduleConfig(
+                name="daily_sync",
+                type="sync",
+                cron="0 6 * * *",
+                sources=["src1"],
+            ),
+        ]
+
+        barrier = threading.Barrier(2, timeout=5)
+        errors: list[Exception] = []
+
+        def do_reload():
+            try:
+                barrier.wait()
+                reload_schedules(svc, schedules, tmp_path)
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=do_reload)
+        t2 = threading.Thread(target=do_reload)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert not errors, f"Concurrent reload raised: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Job store recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestJobStoreRecovery:
+    """Job store SQLite directory creation and error handling."""
+
+    def test_missing_dir_created(self, tmp_path):
+        """SchedulerService.__init__ creates .dango/ if missing."""
+        project = tmp_path / "newproject"
+        project.mkdir()
+        assert not (project / ".dango").exists()
+
+        svc = _make_service(project)
+        assert (project / ".dango").is_dir()
+        assert svc is not None
+
+    def test_corrupt_db_handled_by_apscheduler(self, tmp_path):
+        """A corrupt scheduler.db should be handled at the APScheduler level."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = dango_dir / "scheduler.db"
+        db_path.write_text("not a sqlite database")
+
+        # APScheduler's SQLAlchemyJobStore handles the corruption when
+        # instantiated with a real connection. With our mock, we just
+        # verify the service still constructs.
+        svc = _make_service(tmp_path)
+        assert svc is not None
+
+    def test_empty_db_starts_with_no_jobs(self, tmp_path):
+        """An empty scheduler.db results in zero scheduled jobs."""
+        svc = _make_service(tmp_path)
+        svc._scheduler.get_jobs.return_value = []
+
+        assert svc.get_jobs() == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-source DbtLock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMultiSourceDbtLock:
+    """Second schedule gets lock contention on shared sources."""
+
+    def test_lock_contention_reported(self, tmp_path):
+        """When DbtLock.acquire raises, the job broadcasts lock_failed."""
+        from dango.exceptions import DbtLockError
+
+        mock_lock = MagicMock()
+        mock_lock.acquire.side_effect = DbtLockError("held by another schedule")
+
+        with (
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._log_execution_event") as mock_log,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("hourly", ["src1"], project_root=str(tmp_path))
+
+        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
+        assert "job_queued" in events
+        assert mock_log.call_args[1]["status"] == "lock_failed"
+
+
+# ---------------------------------------------------------------------------
+# Cancellation between sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCancellationBetweenSources:
+    """Cancellation stops remaining sources mid-iteration."""
+
+    def test_cancel_stops_remaining_sources(self, tmp_path):
+        """When cancelled between sources, remaining sources are not synced."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        config = _make_config_with_sources("src1", "src2", "src3")
+        mock_lock = MagicMock()
+        synced_sources: list[str] = []
+
+        mock_svc = MagicMock()
+        cancel_count = 0
+
+        def track_cancel(job_id):
+            nonlocal cancel_count
+            cancel_count += 1
+            # Cancel after first source synced
+            return cancel_count > 1
+
+        mock_svc.is_cancelled = track_cancel
+        mock_svc._running_records = {}
+        mock_svc.register_execution = MagicMock()
+
+        def mock_run_sync(root, sources, **kw):
+            synced_sources.append(sources[0].name)
+
+        old_svc = jobs_mod._scheduler_service
+        try:
+            jobs_mod._scheduler_service = mock_svc
+
+            with (
+                patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
+                patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+                patch(f"{_NOTIF_MOD}.WebhookSender"),
+                patch(f"{_CFG_MOD}.load_config", return_value=config),
+                patch(f"{_SYNC_MOD}.run_sync", side_effect=mock_run_sync),
+                patch(f"{_HIST_MOD}.save_sync_history_entry"),
+                patch(f"{_JOBS_MOD}._broadcast"),
+                patch(f"{_JOBS_MOD}._notify"),
+                patch(f"{_JOBS_MOD}._log_execution_event"),
+                patch(f"{_JOBS_MOD}._try_record_start", return_value=None),
+                patch(f"{_JOBS_MOD}._try_finish_record"),
+            ):
+                from dango.platform.scheduling.jobs import run_scheduled_sync
+
+                run_scheduled_sync("daily", ["src1", "src2", "src3"], project_root=str(tmp_path))
+        finally:
+            jobs_mod._scheduler_service = old_svc
+
+        # src1 synced, then cancelled before src2
+        assert synced_sources == ["src1"]
+
+
+# ---------------------------------------------------------------------------
+# Retry callback wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRetryCallbackWiring:
+    """start() registers callback, callback broadcasts event."""
+
+    def test_start_registers_retry_callback(self, tmp_path):
+        """SchedulerService.start() should register _on_retry_event callback."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        assert len(svc._on_retry_callbacks) == 0
+        svc.start(loop)
+        assert len(svc._on_retry_callbacks) == 1
+
+    def test_retry_callback_broadcasts_event(self, tmp_path):
+        """_on_retry_event should broadcast a sync_retrying WebSocket event."""
+        svc = _make_service(tmp_path)
+
+        with (
+            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender") as mock_sender_cls,
+        ):
+            mock_sender_cls.return_value.is_configured = False
+            svc._on_retry_event(
+                job_id="schedule:daily_sync",
+                attempt=1,
+                max_retries=3,
+                next_retry_delay=30,
+                error="connection reset",
+            )
+
+        mock_bc.assert_called_once()
+        msg = mock_bc.call_args[0][0]
+        assert msg["event"] == "sync_retrying"
+        assert msg["schedule"] == "daily_sync"
+        assert msg["attempt"] == 1
+        assert msg["error"] == "connection reset"
+
+
+# ---------------------------------------------------------------------------
+# record_start wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRecordStartWiring:
+    """record_start called at entry, register_execution called."""
+
+    def test_record_start_called_on_sync(self, tmp_path):
+        """run_scheduled_sync should call _try_record_start when scheduler is available."""
+        config = _make_config_with_sources("src1")
+        mock_lock = MagicMock()
+
+        with (
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync"),
+            patch(f"{_HIST_MOD}.save_sync_history_entry"),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._check_freshness"),
+            patch(f"{_JOBS_MOD}._try_record_start", return_value=42) as mock_start,
+            patch(f"{_JOBS_MOD}._try_finish_record") as mock_finish,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        mock_start.assert_called_once()
+        mock_finish.assert_called_once()
+        assert mock_finish.call_args[0][3] == "record_completion"
+
+    def test_record_start_called_on_dbt(self, tmp_path):
+        """run_scheduled_dbt should call _try_record_start."""
+        mock_lock = MagicMock()
+
+        with (
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch("dango.transformation.run_dbt_models", return_value=(True, "ok")),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._try_record_start", return_value=7) as mock_start,
+            patch(f"{_JOBS_MOD}._try_finish_record") as mock_finish,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_dbt
+
+            run_scheduled_dbt("nightly", "model+", project_root=str(tmp_path))
+
+        mock_start.assert_called_once()
+        mock_finish.assert_called_once()
+        assert mock_finish.call_args[0][3] == "record_completion"
+
+
+# ---------------------------------------------------------------------------
+# Timeout distinct status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTimeoutDistinctStatus:
+    """JobTimeoutError recorded as 'timeout' not 'failed'."""
+
+    def test_timeout_records_timeout_status(self, tmp_path):
+        """When JobTimeoutError is raised, execution log should show 'timeout'."""
+        config = _make_config_with_sources("src1")
+        mock_lock = MagicMock()
+
+        with (
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync", side_effect=JobTimeoutError("timed out")),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._log_execution_event") as mock_log,
+            patch(f"{_JOBS_MOD}._try_record_start", return_value=None),
+            patch(f"{_JOBS_MOD}._try_finish_record"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        assert mock_log.call_args[1]["status"] == "timeout"
+
+    def test_cancellation_records_cancelled_status(self, tmp_path):
+        """When JobCancelledError is raised, execution log should show 'cancelled'."""
+        config = _make_config_with_sources("src1")
+        mock_lock = MagicMock()
+
+        with (
+            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(f"{_SYNC_MOD}.run_sync", side_effect=JobCancelledError("cancelled")),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._log_execution_event") as mock_log,
+            patch(f"{_JOBS_MOD}._try_record_start", return_value=None),
+            patch(f"{_JOBS_MOD}._try_finish_record"),
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
+
+        assert mock_log.call_args[1]["status"] == "cancelled"

--- a/tests/unit/test_scheduler_resilience.py
+++ b/tests/unit/test_scheduler_resilience.py
@@ -11,6 +11,7 @@ import pytest
 from dango.exceptions import JobCancelledError, JobTimeoutError
 
 _SCHEDULER_MOD = "dango.platform.scheduling.scheduler"
+_RESILIENCE_MOD = "dango.platform.scheduling.resilience"
 
 
 def _make_service(tmp_path):
@@ -36,7 +37,7 @@ class TestResilienceConfig:
     """Test ResilienceConfig default and custom values."""
 
     def test_default_values(self):
-        from dango.platform.scheduling.scheduler import ResilienceConfig
+        from dango.platform.scheduling.resilience import ResilienceConfig
 
         cfg = ResilienceConfig()
         assert cfg.max_retries == 3
@@ -44,7 +45,7 @@ class TestResilienceConfig:
         assert cfg.timeout_minutes == 60
 
     def test_custom_values(self):
-        from dango.platform.scheduling.scheduler import ResilienceConfig
+        from dango.platform.scheduling.resilience import ResilienceConfig
 
         cfg = ResilienceConfig(max_retries=5, retry_delays=(10, 20), timeout_minutes=30)
         assert cfg.max_retries == 5
@@ -52,32 +53,32 @@ class TestResilienceConfig:
         assert cfg.timeout_minutes == 30
 
     def test_frozen(self):
-        from dango.platform.scheduling.scheduler import ResilienceConfig
+        from dango.platform.scheduling.resilience import ResilienceConfig
 
         cfg = ResilienceConfig()
         with pytest.raises(AttributeError):
             cfg.max_retries = 10  # type: ignore[misc]
 
     def test_rejects_zero_max_retries(self):
-        from dango.platform.scheduling.scheduler import ResilienceConfig
+        from dango.platform.scheduling.resilience import ResilienceConfig
 
         with pytest.raises(ValueError, match="max_retries must be at least 1"):
             ResilienceConfig(max_retries=0)
 
     def test_rejects_zero_timeout(self):
-        from dango.platform.scheduling.scheduler import ResilienceConfig
+        from dango.platform.scheduling.resilience import ResilienceConfig
 
         with pytest.raises(ValueError, match="timeout_minutes must be positive"):
             ResilienceConfig(timeout_minutes=0)
 
     def test_rejects_negative_timeout(self):
-        from dango.platform.scheduling.scheduler import ResilienceConfig
+        from dango.platform.scheduling.resilience import ResilienceConfig
 
         with pytest.raises(ValueError, match="timeout_minutes must be positive"):
             ResilienceConfig(timeout_minutes=-1)
 
     def test_rejects_empty_retry_delays(self):
-        from dango.platform.scheduling.scheduler import ResilienceConfig
+        from dango.platform.scheduling.resilience import ResilienceConfig
 
         with pytest.raises(ValueError, match="retry_delays must not be empty"):
             ResilienceConfig(retry_delays=())
@@ -145,7 +146,7 @@ class TestRunWithResilience:
     """Test the run_with_resilience() wrapper."""
 
     def test_success_passthrough(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(return_value="result")
@@ -163,7 +164,7 @@ class TestRunWithResilience:
         func.assert_called_once_with("arg1", key="val")
 
     def test_cancel_flag_cleared_on_success(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(return_value="ok")
@@ -178,7 +179,7 @@ class TestRunWithResilience:
         assert "job-1" not in svc._cancel_flags
 
     def test_cancel_flag_cleared_on_failure(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(side_effect=ValueError("boom"))
@@ -194,7 +195,7 @@ class TestRunWithResilience:
         assert "job-1" not in svc._cancel_flags
 
     def test_retry_on_failure(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(side_effect=[ValueError("fail1"), "success"])
@@ -214,7 +215,7 @@ class TestRunWithResilience:
         assert func.call_count == 2
 
     def test_all_retries_exhausted(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(side_effect=ValueError("persistent"))
@@ -234,7 +235,7 @@ class TestRunWithResilience:
         assert func.call_count == 2
 
     def test_retry_emits_callback(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         callback = MagicMock()
@@ -261,7 +262,7 @@ class TestRunWithResilience:
         assert "fail" in call_kwargs["error"]
 
     def test_cancel_before_execution(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(return_value="ok")
@@ -282,7 +283,7 @@ class TestRunWithResilience:
         func.assert_not_called()
 
     def test_cancel_during_retry_wait(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(side_effect=ValueError("fail"))
@@ -313,7 +314,7 @@ class TestRunWithResilience:
             )
 
     def test_uses_default_config_when_none(self, tmp_path):
-        from dango.platform.scheduling.scheduler import run_with_resilience
+        from dango.platform.scheduling.resilience import run_with_resilience
 
         svc = _make_service(tmp_path)
         func = MagicMock(return_value="ok")
@@ -328,7 +329,7 @@ class TestRunWithResilience:
         assert result == "ok"
 
     def test_timeout_does_not_retry(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
 
@@ -344,7 +345,7 @@ class TestRunWithResilience:
             )
 
     def test_timeout_emits_callback(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         callback = MagicMock()
@@ -367,7 +368,7 @@ class TestRunWithResilience:
         assert call_kwargs["timeout_minutes"] == 5
 
     def test_callback_error_does_not_propagate(self, tmp_path):
-        from dango.platform.scheduling.scheduler import ResilienceConfig, run_with_resilience
+        from dango.platform.scheduling.resilience import ResilienceConfig, run_with_resilience
 
         svc = _make_service(tmp_path)
         bad_callback = MagicMock(side_effect=RuntimeError("callback boom"))
@@ -395,7 +396,7 @@ class TestExecuteWithTimeout:
     """Test _execute_with_timeout() timeout enforcement."""
 
     def test_completes_within_timeout(self):
-        from dango.platform.scheduling.scheduler import _execute_with_timeout
+        from dango.platform.scheduling.resilience import _execute_with_timeout
 
         func = MagicMock(return_value="done")
         cancel_flag = threading.Event()
@@ -405,7 +406,7 @@ class TestExecuteWithTimeout:
         assert result == "done"
 
     def test_cancel_before_execution_raises(self):
-        from dango.platform.scheduling.scheduler import _execute_with_timeout
+        from dango.platform.scheduling.resilience import _execute_with_timeout
 
         cancel_flag = threading.Event()
         cancel_flag.set()
@@ -418,7 +419,7 @@ class TestExecuteWithTimeout:
 
     def test_timeout_raises_job_timeout_error(self):
         """Verify timeout fires _raise_in_thread with JobTimeoutError."""
-        from dango.platform.scheduling.scheduler import _execute_with_timeout
+        from dango.platform.scheduling.resilience import _execute_with_timeout
 
         cancel_flag = threading.Event()
 
@@ -443,7 +444,7 @@ class TestRaiseInThread:
     """Test _raise_in_thread() ctypes injection."""
 
     def test_raises_in_target_thread(self):
-        from dango.platform.scheduling.scheduler import _raise_in_thread
+        from dango.platform.scheduling.resilience import _raise_in_thread
 
         caught = threading.Event()
 
@@ -468,9 +469,9 @@ class TestRaiseInThread:
         assert caught.is_set()
 
     def test_invalid_thread_id_logs_debug(self):
-        from dango.platform.scheduling.scheduler import _raise_in_thread
+        from dango.platform.scheduling.resilience import _raise_in_thread
 
-        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+        with patch(f"{_RESILIENCE_MOD}.logger") as mock_logger:
             _raise_in_thread(999999999, JobTimeoutError)
 
         mock_logger.debug.assert_called_once()

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -80,7 +80,7 @@ class TestConfigureJobs:
         with patch(f"{_JOBS_MOD}.configure_jobs") as mock_cfg:
             svc.start(loop)
 
-        mock_cfg.assert_called_once_with(loop)
+        mock_cfg.assert_called_once_with(loop, svc)
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +177,7 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify") as mock_notify,
-            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+            patch(f"{_JOBS_MOD}._log_execution_event") as mock_record,
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -290,7 +290,7 @@ class TestRunScheduledSync:
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(f"{_SYNC_MOD}.run_sync") as mock_run,
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
-            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+            patch(f"{_JOBS_MOD}._log_execution_event") as mock_record,
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -371,7 +371,7 @@ class TestRunScheduledDbt:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify") as mock_notify,
-            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+            patch(f"{_JOBS_MOD}._log_execution_event") as mock_record,
         ):
             from dango.platform.scheduling.jobs import run_scheduled_dbt
 
@@ -395,7 +395,7 @@ class TestRunScheduledDbt:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify"),
-            patch(f"{_JOBS_MOD}._record_execution") as mock_record,
+            patch(f"{_JOBS_MOD}._log_execution_event") as mock_record,
         ):
             from dango.platform.scheduling.jobs import run_scheduled_dbt
 


### PR DESCRIPTION
## Summary

- **Extract `resilience.py`** from `scheduler.py` (571→433 lines, now under 500-line limit) — moves `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread`, `_fire_callbacks` into dedicated module
- **Wire SQLite execution history** — `record_start()` called at job entry, `record_completion`/`record_timeout`/`record_cancellation` at exit, with `register_execution()` for tracking
- **Per-source cancellation** in multi-source sync — iterates sources individually with cancellation check between each, so cancel stops remaining sources mid-job
- **Distinct timeout/cancel statuses** — `JobTimeoutError` records `status="timeout"` and `JobCancelledError` records `status="cancelled"` (previously both were generic "failed")
- **Retry callback wiring** — `SchedulerService.start()` registers `_on_retry_event` callback that broadcasts `sync_retrying` WebSocket event and sends webhook notification
- **Rename `_record_execution` → `_log_execution_event`** — clarifies that the function only logs to structlog, doesn't write SQLite
- **14 new gap-fill unit tests** covering DST transitions, concurrent reload, job store recovery, DbtLock contention, cancellation between sources, retry callback wiring, record_start wiring, timeout/cancel distinct statuses
- **3 new integration tests** using real SQLite for record_start → completion/timeout/cancellation roundtrip

## Files changed (11 files, +1099 / -264)

| File | Change |
|------|--------|
| `dango/platform/scheduling/resilience.py` | **NEW** (211 lines) — extracted from scheduler.py |
| `dango/platform/scheduling/scheduler.py` | 571→433 lines, added retry callback |
| `dango/platform/scheduling/jobs.py` | History wiring, per-source cancel, rename |
| `dango/platform/scheduling/__init__.py` | Updated imports |
| `tests/unit/test_scheduler_gaps.py` | **NEW** (481 lines, 14 tests) |
| `tests/integration/test_scheduler_integration.py` | **NEW** (124 lines, 3 tests) |
| `tests/unit/test_scheduler_resilience.py` | Import paths updated |
| `tests/unit/test_sync_jobs.py` | Patch targets updated |
| `dango/platform/CLAUDE.md` | Updated directory layout |
| `docs/file-exemptions.yml` | Removed scheduler.py, updated jobs.py |
| `pyproject.toml` | Added mypy exemptions for new test files |

## Test plan

- [x] All 2225 tests pass (0 failures, 23 skipped)
- [x] All 150 scheduler-related tests pass
- [x] `ruff check dango/` — clean
- [x] `ruff format --check dango/` — clean
- [x] `mypy dango/` — clean
- [x] `python scripts/check_file_sizes.py --all` — clean
- [x] `scheduler.py` under 500 lines (433)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)