### PR TITLE
DOC-027: Phase 4 end-of-phase doc sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | Shared utilities | `dango/utils/` | [`dango/utils/CLAUDE.md`](dango/utils/CLAUDE.md) |
 | Logging / diagnostics | `dango/logging.py` | Module docstring |
 | Database migrations | `dango/migrations/` | [`dango/migrations/CLAUDE.md`](dango/migrations/CLAUDE.md) |
-| Docker / file watcher / cloud deployment | `dango/platform/` | [`dango/platform/CLAUDE.md`](dango/platform/CLAUDE.md) |
+| Docker / file watcher / cloud / scheduling / notifications | `dango/platform/` | [`dango/platform/CLAUDE.md`](dango/platform/CLAUDE.md) |
+| Scheduling / job orchestration | `dango/platform/scheduling/` | [`dango/platform/scheduling/CLAUDE.md`](dango/platform/scheduling/CLAUDE.md) |
+| Notifications / webhooks | `dango/platform/notifications/` | [`dango/platform/notifications/CLAUDE.md`](dango/platform/notifications/CLAUDE.md) |
 | Jinja2 templates / Dockerfiles | `dango/templates/` | [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md) |
 | Auth / users / sessions | `dango/auth/` | [`dango/auth/CLAUDE.md`](dango/auth/CLAUDE.md) |
 | Notebooks | `dango/notebooks/` | Not yet created (Phase 6) |
@@ -51,6 +53,8 @@ When unsure which module to look at:
   - Config file format (`.dango/*.yml`) → `config/`
 - **Shared utility** (locking, logging, DB helpers) → `utils/`
 - **Docker containers / file watching** → `platform/`
+- **HOW scheduled jobs run** → `platform/scheduling/`
+- **HOW notifications are sent** → `platform/notifications/`
 - **HOW code gets deployed to the cloud** → `platform/cloud/`
 - **CLI for cloud operations** → `cli/commands/remote*.py`, `cli/commands/deploy*.py`
 - **Still unsure** → read `ARCHITECTURE.md` §6 (Cross-Module Workflows)
@@ -87,7 +91,8 @@ dango/                          # Python package source
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
 │   │   ├── remote_ops.py       # remote upgrade/resize/migrate
 │   │   ├── remote_backup.py    # remote backup subgroup
-│   │   └── remote_mgmt.py      # remote status/logs/ssh/query
+│   │   ├── remote_mgmt.py      # remote status/logs/ssh/query
+│   │   └── schedule.py         # schedule group (add/list/remove/status/enable/disable/webhook)
 │   ├── init.py                 # Project initialization wizard
 │   ├── wizard.py               # Interactive setup wizards
 │   ├── source_wizard.py        # Source configuration wizard
@@ -156,7 +161,7 @@ dango/                          # Python package source
 │   ├── metabase.py             # Metabase API (1142 lines)
 │   └── dashboard_manager.py    # Dashboard export/import (1113 lines)
 │
-├── platform/                   # Level 2 — Docker, network, file watcher
+├── platform/                   # Level 2 — Docker, network, file watcher, scheduling
 │   ├── __main__.py             # Platform CLI entry point
 │   ├── docker.py               # Docker Compose lifecycle (shared local + cloud)
 │   ├── CLAUDE.md               # Module navigation doc
@@ -167,6 +172,15 @@ dango/                          # Python package source
 │   │   ├── watcher.py          # File change detection (506 lines)
 │   │   ├── watcher_lifecycle.py # Watcher subprocess lifecycle
 │   │   └── watcher_runner.py   # Background watcher process
+│   ├── scheduling/             # APScheduler-based job scheduling (TASK-036+)
+│   │   ├── scheduler.py        # SchedulerService (lifecycle, events, cancellation)
+│   │   ├── resilience.py       # Retry, timeout, cancellation
+│   │   ├── history.py          # Execution history tracking
+│   │   ├── jobs.py             # Module-level job functions (732 lines)
+│   │   └── sync_trigger.py     # Server-side manual sync runner
+│   ├── notifications/          # Webhook notifications (TASK-043+)
+│   │   ├── webhook.py          # Event types, config, async sender
+│   │   └── slack.py            # Slack Block Kit formatter
 │   ├── cloud/                  # Cloud components (TASK-022+)
 │   │   ├── __init__.py         # Re-exports 63 symbols
 │   │   ├── digitalocean.py     # DO REST API v2 client (542 lines)
@@ -292,6 +306,12 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/source.py` | 549 | — (extracted from main.py by TASK-005) |
 | `cli/commands/deploy_provision.py` | 543 | — (provisioning orchestration) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
+| `platform/scheduling/jobs.py` | 732 | — (module-level job functions) |
+| `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
+| `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
+| `cli/commands/auth.py` | 538 | — (12 auth subcommands) |
+| `config/models.py` | 530 | — (Pydantic config models) |
+| `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 527 | — (admin user CRUD) |
 | `cli/model_wizard.py` | 507 | — |
 | `platform/local/watcher.py` | 506 | — |
@@ -317,6 +337,8 @@ Module CLAUDE.md files provide per-module navigation, public API, and patterns.
 - [`dango/auth/CLAUDE.md`](dango/auth/CLAUDE.md)
 
 - [`dango/platform/CLAUDE.md`](dango/platform/CLAUDE.md)
+- [`dango/platform/scheduling/CLAUDE.md`](dango/platform/scheduling/CLAUDE.md)
+- [`dango/platform/notifications/CLAUDE.md`](dango/platform/notifications/CLAUDE.md)
 
 **Planned later phases:**
 - `dango/notebooks/CLAUDE.md` (Phase 6)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,18 +297,18 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `oauth/providers.py` | 801 | — |
 | `web/helpers.py` | 798 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 742 | — |
+| `platform/scheduling/jobs.py` | 732 | — (module-level job functions) |
+| `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
 | `web/routes/upload.py` | 680 | — (extracted from app.py by TASK-085) |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
 | `cli/commands/remote.py` | 651 | — (remote group + push/rollback/firewall/domain) |
 | `cli/validate.py` | 651 | — |
 | `cli/commands/deploy_wizard.py` | 579 | — (interactive deploy wizard) |
 | `transformation/generator.py` | 577 | — |
+| `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/source.py` | 549 | — (extracted from main.py by TASK-005) |
 | `cli/commands/deploy_provision.py` | 543 | — (provisioning orchestration) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
-| `platform/scheduling/jobs.py` | 732 | — (module-level job functions) |
-| `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
-| `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/auth.py` | 538 | — (12 auth subcommands) |
 | `config/models.py` | 530 | — (Pydantic config models) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -385,7 +385,7 @@ Test data factories live in `tests/factories/config_factories.py`. Use `make_*()
 
 ### Test file sizing
 
-Split test files at creation (~300 lines target), not after hitting 500. Review rounds add ~30-50% more tests. When a plan estimates 200+ test lines, create two files upfront. Natural split: models/validation vs. loading/integration.
+Split test files at creation (~300 lines target), not after hitting 500. Review rounds add ~30-50% more tests. When a plan estimates 200+ test lines, create two files upfront. Natural split: models/validation vs. loading/integration. Before creating a new test file, check that the basename doesn't exist in any other test directory — see [§11 Test file naming](#test-file-naming) for the uniqueness rule.
 
 ### Regression and verification
 
@@ -697,6 +697,10 @@ See [§2 File size](#file-size) for the 500-line soft limit and when to split. A
 
 New subpackages must be added to the `packages` list in `pyproject.toml`. `pip install -e .` discovers packages automatically, but PyPI wheel builds don't — missing packages cause import failures for installed users.
 
+### CLAUDE.md cross-references
+
+CLAUDE.md cross-references must use relative paths (`../../STANDARDS.md#section-name`), not bare `#anchor` links. Bare `#anchor` links resolve within the current file on GitHub and break when linking across files.
+
 ### Template verification
 
 After bulk find-and-replace operations on Jinja2 templates, grep to verify zero remaining occurrences of the old string. Automated replacements can silently miss matches in template syntax.
@@ -769,4 +773,4 @@ Default to `from e` for exception re-raises. Use `from None` only when suppressi
 
 ### Mypy-exempt files
 
-17 source files and ~50 test files currently have `ignore_errors = true` in `pyproject.toml`. Policy: fix ALL mypy errors when touching an exempt file — don't add new violations while the exemption is in place.
+17 source files and ~62 test files currently have `ignore_errors = true` in `pyproject.toml`. Policy: fix ALL mypy errors when touching an exempt file — don't add new violations while the exemption is in place.

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -33,6 +33,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query` | `remote_status()`, `remote_logs()` |
+| `commands/schedule.py` (499 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
 | `init.py` (965 lines) | Project initialization wizard | `ProjectInitializer` |
@@ -94,6 +95,8 @@ dango (top-level group)
 │   │   ├── set, remove
 │   └── backup (subgroup)       ← commands/remote_backup.py
 │       ├── list, enable, disable, download, restore
+├── schedule (group)            ← commands/schedule.py
+│   ├── add, list, remove, status, enable, disable, webhook
 ├── deploy (group)              ← commands/deploy.py
 │   ├── (default)  interactive wizard → commands/deploy_wizard.py + deploy_provision.py
 │   └── destroy    tear down cloud infrastructure
@@ -108,6 +111,10 @@ dango (top-level group)
 - **Project root via context:** `ctx.obj["project_root"]` is set by the top-level `cli` group in `main.py` (via `dango.config.helpers.find_project_root`).
 - **Cross-file command registration:** `remote_mgmt.py`, `remote_ops.py`, `remote_env.py`, and `remote_backup.py` import `remote` from `remote.py` and register commands via `@remote.command()` / `@remote.group()`. Registration is triggered by bottom-of-file imports in `remote.py`.
 - **Two SSH users:** `root` for system ops (backup, rollback, domain, server setup) via `load_cloud_config_with_ssh()` in `cli/utils.py`. `dango` for project file ops (.env, .dlt/secrets.toml) via `_ssh_connect_or_fail()` in `remote.py`.
+
+### Key conventions
+
+- **Dual cron preset drift risk:** Both `config/schedules.py` and `cli/commands/schedule.py` define human-readable cron preset maps (e.g., "every 6 hours" → `0 */6 * * *`). These must stay in sync — changes to one without updating the other cause inconsistent behavior between CLI and config validation.
 
 ### Known pre-existing bugs
 

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -50,6 +50,11 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 - **Integration:** `pytest tests/integration/test_config_loading.py`
 - **Manual:** `dango config show` in a dango project directory
 
+## Key Conventions
+
+- **`validate_schedules()` mixed return type:** Returns a tuple of `(errors, warnings)` where both are `list[str]`. Callers filter by string content to distinguish severity — there's no structured severity field. Structured return type deferred to Phase 8.
+- **Dual cron preset drift:** `config/schedules.py` and `cli/commands/schedule.py` both define human-readable cron preset maps. Must stay in sync — see [`cli/CLAUDE.md`](../cli/CLAUDE.md) key conventions.
+
 ## Don't Modify
 
 | File | Reason |

--- a/dango/migrations/CLAUDE.md
+++ b/dango/migrations/CLAUDE.md
@@ -75,6 +75,10 @@ Rules:
 - `dango/cli/commands/platform.py` — auto-migrate on `dango start`
 - `dango/cli/commands/migrate.py` — manual CLI commands
 
+## Key Conventions
+
+- **Testing digit-prefixed migration files:** Can't `import dango.migrations.scheduler.001_execution_history` (invalid Python identifier). Use `importlib.util.spec_from_file_location()` to load and call `upgrade()`. See `tests/unit/test_execution_history.py` for the pattern.
+
 ## Testing
 
 - **Unit:** `pytest tests/unit/test_migrations.py -v`

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -28,10 +28,18 @@ platform/
 │
 ├── scheduling/          # APScheduler-based job scheduling (TASK-036+)
 │   ├── __init__.py      # Re-exports SchedulerService, ResilienceConfig, run_with_resilience, history functions
+│   ├── CLAUDE.md        # Scheduling module navigation doc
 │   ├── scheduler.py     # SchedulerService (lifecycle, events, cancellation, async bridge)
 │   ├── resilience.py    # Resilience: retry, timeout, cancellation (extracted from scheduler.py)
 │   ├── history.py       # Execution history tracking (TASK-039)
-│   └── jobs.py          # Module-level job functions (pickle-safe)
+│   ├── jobs.py          # Module-level job functions (pickle-safe)
+│   └── sync_trigger.py  # Server-side manual sync runner (dango remote sync)
+│
+├── notifications/       # Webhook notification infrastructure (TASK-043+)
+│   ├── __init__.py      # Re-exports WebhookSender, EventType, etc.
+│   ├── CLAUDE.md        # Notifications module navigation doc
+│   ├── webhook.py       # Event types, config, filtering, async sender with retry
+│   └── slack.py         # Slack Block Kit formatter
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
 │   ├── __init__.py      # Re-exports 63 symbols (clients, provisioning, firewall, backup, deploy, etc.)
@@ -73,6 +81,9 @@ platform/
 | `scheduling/resilience.py` | Resilience: retry with backoff, timeout via thread kill, cancellation | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `scheduling/history.py` | Execution history tracking for scheduled jobs | `record_start`, `record_completion`, `record_failure`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
 | `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `scheduling/sync_trigger.py` | Server-side manual sync runner (invoked via SSH) | `main()`, `_run_sync()` |
+| `notifications/webhook.py` | Event types, config models, event filtering, async sender with retry | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload` |
+| `notifications/slack.py` | Slack Block Kit formatter for webhook payloads | `format_slack_message` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |
 | `cloud/provisioning.py` | Droplet size tiers, regions, provisioning orchestration | `DropletSizeTier`, `RegionInfo`, `SIZE_TIERS`, `DEFAULT_TIER`, `provision_droplet`, `wait_for_droplet_ready`, `wait_for_ssh`, `suggest_nearest_region`, `save_provisioning_metadata` |
 | `cloud/firewall.py` | Firewall lifecycle and IP allowlisting | `create_default_firewall`, `add_allowed_ip`, `restrict_web_to_ips`, `allow_all_web`, `validate_ip_or_cidr`, `save_firewall_metadata` |
@@ -180,6 +191,9 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 |-------|-----------|--------------|
 | Add/modify scheduled jobs | `scheduling/scheduler.py`, `scheduling/jobs.py` | `pytest tests/unit/test_scheduler.py` |
 | Query execution history | `scheduling/history.py` | `pytest tests/unit/test_execution_history.py` |
+| Trigger manual sync from SSH | `scheduling/sync_trigger.py` | `pytest tests/unit/test_sync_trigger.py` |
+| Configure webhook notifications | `notifications/webhook.py` | `pytest tests/unit/test_webhook_notifications.py` |
+| Add a notification format | Create `notifications/{format}.py`, add dispatch in `webhook.py` | `pytest tests/unit/test_webhook_notifications.py` |
 | Add a startup step for both local + cloud | `common/startup.py` | `pytest tests/unit/test_platform_startup.py` |
 | Add a local-only startup step | `local/` and `cli/commands/platform.py` | `dango start` manually |
 | Add cloud infrastructure | `cloud/` | `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py` |
@@ -248,6 +262,8 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - `watchdog` — Observer, FileSystemEventHandler (watcher.py)
 - `apscheduler` — AsyncIOScheduler, SQLAlchemyJobStore (scheduling/)
 - `sqlalchemy` — Required by APScheduler job store (scheduling/)
+- `pydantic` — Notification config models (notifications/)
+- `yaml` — Notification config loading (notifications/)
 
 **Used by:**
 - `dango.cli.commands.platform` — start/stop/status commands
@@ -259,7 +275,9 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - `dango.cli.commands.remote_env` — remote env var management (uses file_sync)
 - `dango.cli.commands.remote_mgmt` — remote status/logs/ssh/query
 - `dango.web.routes.health` — get_watcher_status, scheduler status
+- `dango.web.routes.schedules` — schedule CRUD, trigger, cancel, history, notification config
 - `dango.web.app` — SchedulerService lifecycle (startup/shutdown)
+- `dango.cli.commands.schedule` — CLI schedule management
 
 ## Cloud Deployment Flow
 
@@ -319,7 +337,8 @@ Post-deployment hardening (not automated by Dango):
 
 ## Testing
 
-- **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py`
+- **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py tests/unit/test_scheduler_jobs.py tests/unit/test_sync_trigger.py`
+- **Notifications:** `pytest tests/unit/test_webhook_notifications.py tests/unit/test_slack_formatter.py`
 - **Local platform:** `pytest tests/unit/test_platform_startup.py tests/unit/test_watcher_lifecycle.py`
 - **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
 - **Manual:** `dango start` (local platform), `dango deploy` (cloud provisioning)

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -192,8 +192,8 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | Add/modify scheduled jobs | `scheduling/scheduler.py`, `scheduling/jobs.py` | `pytest tests/unit/test_scheduler.py` |
 | Query execution history | `scheduling/history.py` | `pytest tests/unit/test_execution_history.py` |
 | Trigger manual sync from SSH | `scheduling/sync_trigger.py` | `pytest tests/unit/test_sync_trigger.py` |
-| Configure webhook notifications | `notifications/webhook.py` | `pytest tests/unit/test_webhook_notifications.py` |
-| Add a notification format | Create `notifications/{format}.py`, add dispatch in `webhook.py` | `pytest tests/unit/test_webhook_notifications.py` |
+| Configure webhook notifications | `notifications/webhook.py` | `pytest tests/unit/test_webhook.py` |
+| Add a notification format | Create `notifications/{format}.py`, add dispatch in `webhook.py` | `pytest tests/unit/test_webhook.py` |
 | Add a startup step for both local + cloud | `common/startup.py` | `pytest tests/unit/test_platform_startup.py` |
 | Add a local-only startup step | `local/` and `cli/commands/platform.py` | `dango start` manually |
 | Add cloud infrastructure | `cloud/` | `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py` |
@@ -337,8 +337,8 @@ Post-deployment hardening (not automated by Dango):
 
 ## Testing
 
-- **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py tests/unit/test_scheduler_jobs.py tests/unit/test_sync_trigger.py`
-- **Notifications:** `pytest tests/unit/test_webhook_notifications.py tests/unit/test_slack_formatter.py`
+- **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py tests/unit/test_sync_jobs.py tests/unit/test_sync_trigger.py`
+- **Notifications:** `pytest tests/unit/test_webhook.py tests/unit/test_slack_formatter.py`
 - **Local platform:** `pytest tests/unit/test_platform_startup.py tests/unit/test_watcher_lifecycle.py`
 - **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
 - **Manual:** `dango start` (local platform), `dango deploy` (cloud provisioning)

--- a/dango/platform/notifications/CLAUDE.md
+++ b/dango/platform/notifications/CLAUDE.md
@@ -1,0 +1,56 @@
+# notifications/
+
+## Purpose
+
+Webhook notification infrastructure for sync event notifications. Sends configurable HTTP webhooks on sync completion, failure, staleness, and retry events. Supports Slack Block Kit formatting and per-schedule notification overrides.
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` (28 lines) | Re-exports public API from `webhook.py` | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload`, `load_notification_config`, `should_notify` |
+| `webhook.py` (365 lines) | Event types, config models, event filtering, async sender with retry | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload`, `EVENT_TO_CATEGORY`, `load_notification_config`, `should_notify` |
+| `slack.py` (124 lines) | Slack Block Kit formatter for webhook payloads | `format_slack_message` |
+
+## Key Conventions
+
+- **"Never raises" contract:** `WebhookSender.send()` wraps its full body in `try/except Exception` with `logger.warning`. Notification failures must never block the sync pipeline. Setup code before the guarded section can still propagate — ensure the entire function body is wrapped.
+- **HTTP retry baseline:** Use `_RETRYABLE_ERRORS = (httpx.TimeoutException, httpx.ConnectError)` as the retry tuple. Connection errors (reset, DNS blip) are the most common retry-worthy failures. Don't limit retries to only 5xx status codes + timeout.
+- **Event filtering with per-schedule overrides:** `WebhookSender.send()` checks `on_success` (default `false`), `on_failure` (default `true`), and `on_stale` (default `true`) at the global config level. Per-schedule `notify` blocks can override these defaults.
+- **Lazy imports only for formatter modules:** Don't add eager imports to `__init__.py` for `slack.py` or future format plugins. `webhook.py`'s `_format_payload()` dispatches lazily based on the `format` config field. Future format plugins (Teams, Discord) follow the same pattern.
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new event type | `webhook.py` (`EventType` enum + `EVENT_TO_CATEGORY` mapping) | `pytest tests/unit/test_webhook_notifications.py` |
+| Add a new notification format | Create `{format}.py` with `format_{format}_message()`, add dispatch in `webhook.py` `_format_payload()` | `pytest tests/unit/test_webhook_notifications.py` |
+| Change retry behavior | `webhook.py` (`_RETRYABLE_ERRORS`, `_MAX_RETRIES`, `_RETRY_DELAYS`) | `pytest tests/unit/test_webhook_notifications.py` |
+| Modify event filtering logic | `webhook.py` (`should_notify()`) | `pytest tests/unit/test_webhook_notifications.py` |
+| Update Slack message layout | `slack.py` | `pytest tests/unit/test_slack_formatter.py` |
+
+## Dependencies
+
+**Imports from:**
+- `httpx` — async HTTP client for webhook delivery
+- `yaml` — load notification config from `schedules.yml`
+- `pydantic` — config models (`WebhookConfig`, `NotificationConfig`)
+- `dango.logging` — `get_logger`
+
+**Used by:**
+- `dango.platform.scheduling.jobs` — sends notifications on sync completion/failure
+- `dango.web.routes.schedules` — notification config/test endpoints
+- `dango.config.schedules` — notification config validation
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_webhook_notifications.py tests/unit/test_slack_formatter.py`
+- **Manual:** Configure webhook in `schedules.yml`, trigger sync, observe delivery
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `EventType` enum values | Persisted in notification configs and webhook payloads |
+| `WebhookPayload` field names | External webhook receivers depend on the JSON structure |
+| `__init__.py` re-exports | Other modules import notification types from the package |

--- a/dango/platform/notifications/CLAUDE.md
+++ b/dango/platform/notifications/CLAUDE.md
@@ -23,10 +23,10 @@ Webhook notification infrastructure for sync event notifications. Sends configur
 
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
-| Add a new event type | `webhook.py` (`EventType` enum + `EVENT_TO_CATEGORY` mapping) | `pytest tests/unit/test_webhook_notifications.py` |
-| Add a new notification format | Create `{format}.py` with `format_{format}_message()`, add dispatch in `webhook.py` `_format_payload()` | `pytest tests/unit/test_webhook_notifications.py` |
-| Change retry behavior | `webhook.py` (`_RETRYABLE_ERRORS`, `_MAX_RETRIES`, `_RETRY_DELAYS`) | `pytest tests/unit/test_webhook_notifications.py` |
-| Modify event filtering logic | `webhook.py` (`should_notify()`) | `pytest tests/unit/test_webhook_notifications.py` |
+| Add a new event type | `webhook.py` (`EventType` enum + `EVENT_TO_CATEGORY` mapping) | `pytest tests/unit/test_webhook.py` |
+| Add a new notification format | Create `{format}.py` with `format_{format}_message()`, add dispatch in `webhook.py` `_format_payload()` | `pytest tests/unit/test_webhook.py` |
+| Change retry behavior | `webhook.py` (`_RETRYABLE_ERRORS`, `_MAX_RETRIES`, `_RETRY_DELAYS`) | `pytest tests/unit/test_webhook.py` |
+| Modify event filtering logic | `webhook.py` (`should_notify()`) | `pytest tests/unit/test_webhook.py` |
 | Update Slack message layout | `slack.py` | `pytest tests/unit/test_slack_formatter.py` |
 
 ## Dependencies
@@ -44,7 +44,7 @@ Webhook notification infrastructure for sync event notifications. Sends configur
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_webhook_notifications.py tests/unit/test_slack_formatter.py`
+- **Unit:** `pytest tests/unit/test_webhook.py tests/unit/test_slack_formatter.py`
 - **Manual:** Configure webhook in `schedules.yml`, trigger sync, observe delivery
 
 ## Don't Modify

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -58,7 +58,6 @@ For additional scheduling patterns, see [`platform/CLAUDE.md`](../CLAUDE.md) § 
 - `dango.web.routes.schedules` — schedule CRUD, trigger, cancel, history
 - `dango.web.routes.health` — scheduler status in platform health
 - `dango.cli.commands.schedule` — CLI schedule management
-- `dango.cli.commands.platform` — scheduler start/stop on `dango start`
 
 ## Testing
 

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -22,7 +22,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 - **`_on_job_missed` only logs:** Missed runs do not create execution history records. This is a known v1 limitation — missed jobs are invisible in the history UI and excluded from average duration calculations.
 - **Exception handler side-effect completeness:** When adding exception handlers that mirror existing ones (e.g., `JobTimeoutError` alongside `JobCancelledError`), copy ALL side-effect calls: broadcast + notify + log + record. Omitting any one creates silent inconsistencies.
 
-For additional scheduling patterns, see [`../../platform/CLAUDE.md`](../CLAUDE.md) § Scheduling patterns:
+For additional scheduling patterns, see [`platform/CLAUDE.md`](../CLAUDE.md) § Scheduling patterns:
 - APScheduler dual-patch testing (mock both `SQLAlchemyJobStore` and `AsyncIOScheduler`)
 - No atomic trigger update (remove + re-add)
 - Cron interval estimation needs sampling (5+ intervals, return minimum)
@@ -34,7 +34,7 @@ For additional scheduling patterns, see [`../../platform/CLAUDE.md`](../CLAUDE.m
 
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
-| Add a new scheduled job type | `jobs.py`, `config/schedules.py` | `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_jobs.py` |
+| Add a new scheduled job type | `jobs.py`, `config/schedules.py` | `pytest tests/unit/test_scheduler.py tests/unit/test_sync_jobs.py` |
 | Change retry/timeout defaults | `resilience.py` (`ResilienceConfig`) | `pytest tests/unit/test_scheduler_resilience.py` |
 | Query execution history | `history.py` | `pytest tests/unit/test_execution_history.py` |
 | Add a new history status | `history.py` (add constant + recording function) | `pytest tests/unit/test_execution_history.py` |
@@ -62,7 +62,7 @@ For additional scheduling patterns, see [`../../platform/CLAUDE.md`](../CLAUDE.m
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py tests/unit/test_scheduler_jobs.py tests/unit/test_sync_trigger.py`
+- **Unit:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py tests/unit/test_sync_jobs.py tests/unit/test_sync_trigger.py`
 - **Manual:** `dango start` (starts scheduler), web UI `/schedules` page
 
 ## Don't Modify

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -1,0 +1,74 @@
+# scheduling/
+
+## Purpose
+
+APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syncs and dbt runs with retry, timeout, cancellation, and execution history tracking. Used by both `dango start` (local) and `dango serve` (cloud).
+
+## Files
+
+| File | Purpose | Key Functions/Classes |
+|------|---------|----------------------|
+| `__init__.py` (64 lines) | Re-exports public API | `SchedulerService`, `ResilienceConfig`, `run_with_resilience`, history functions, job functions |
+| `scheduler.py` (430 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
+| `resilience.py` (211 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
+| `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
+| `jobs.py` (732 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `sync_trigger.py` (147 lines) | Server-side manual sync runner invoked via SSH from `dango remote sync` | `main()`, `_run_sync()` |
+
+## Key Conventions
+
+- **Resilience callback kwargs contract:** Retry callbacks receive `job_id, attempt, max_retries, next_retry_delay, error`. Timeout callbacks receive `job_id, timeout_minutes`. Cancel callbacks receive `job_id`. All callers (TASK-039/041) must match these signatures.
+- **CPython-specific timeout kill:** `_raise_in_thread()` uses `PyThreadState_SetAsyncExc` — only works for Python bytecode. Threads blocked in C extensions (DuckDB queries, network I/O) defer the exception until returning to bytecode. Use DuckDB query timeouts and DbtLock timeouts as additional backstops.
+- **`_on_job_missed` only logs:** Missed runs do not create execution history records. This is a known v1 limitation — missed jobs are invisible in the history UI and excluded from average duration calculations.
+- **Exception handler side-effect completeness:** When adding exception handlers that mirror existing ones (e.g., `JobTimeoutError` alongside `JobCancelledError`), copy ALL side-effect calls: broadcast + notify + log + record. Omitting any one creates silent inconsistencies.
+
+For additional scheduling patterns, see [`../../platform/CLAUDE.md`](../CLAUDE.md) § Scheduling patterns:
+- APScheduler dual-patch testing (mock both `SQLAlchemyJobStore` and `AsyncIOScheduler`)
+- No atomic trigger update (remove + re-add)
+- Cron interval estimation needs sampling (5+ intervals, return minimum)
+- `dbt_lock` module/function collision workaround
+- Job function signature coupling with `config/schedules.py`
+- APScheduler is untyped (budget review time)
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new scheduled job type | `jobs.py`, `config/schedules.py` | `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_jobs.py` |
+| Change retry/timeout defaults | `resilience.py` (`ResilienceConfig`) | `pytest tests/unit/test_scheduler_resilience.py` |
+| Query execution history | `history.py` | `pytest tests/unit/test_execution_history.py` |
+| Add a new history status | `history.py` (add constant + recording function) | `pytest tests/unit/test_execution_history.py` |
+| Modify scheduler lifecycle | `scheduler.py` (`SchedulerService`) | `pytest tests/unit/test_scheduler.py` |
+| Trigger manual sync from SSH | `sync_trigger.py` | `pytest tests/unit/test_sync_trigger.py` |
+
+## Dependencies
+
+**Imports from:**
+- `apscheduler` — `AsyncIOScheduler`, `SQLAlchemyJobStore`, `ThreadPoolExecutor`, event types
+- `sqlalchemy` — required by APScheduler job store
+- `dango.config` — `ConfigLoader`, schedule config models, `reload_schedules`
+- `dango.ingestion` — `run_sync` (via lazy import in `jobs.py`)
+- `dango.transformation` — `run_dbt_models` (via lazy import in `jobs.py`)
+- `dango.utils` — `DbtLock`, `activity_log`, `sync_history`
+- `dango.exceptions` — `JobCancelledError`, `JobTimeoutError`
+- `dango.logging` — `get_logger`
+
+**Used by:**
+- `dango.web.app` — `SchedulerService` lifecycle (startup/shutdown)
+- `dango.web.routes.schedules` — schedule CRUD, trigger, cancel, history
+- `dango.web.routes.health` — scheduler status in platform health
+- `dango.cli.commands.schedule` — CLI schedule management
+- `dango.cli.commands.platform` — scheduler start/stop on `dango start`
+
+## Testing
+
+- **Unit:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py tests/unit/test_scheduler_jobs.py tests/unit/test_sync_trigger.py`
+- **Manual:** `dango start` (starts scheduler), web UI `/schedules` page
+
+## Don't Modify
+
+| File | Reason |
+|------|--------|
+| `history.py` table schema | Existing scheduler.db files depend on this schema; migrations required for changes |
+| `jobs.py` function names | APScheduler job store references functions by module path; renames break persisted jobs |
+| `__init__.py` export list | `web/`, `cli/`, and `config/` depend on re-exported symbols |

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -55,6 +55,10 @@ Shared utilities for process management, activity logging, sync history tracking
 - **Integration:** None yet
 - **Manual:** `dango start` exercises database.py; `dango sync` exercises activity_log, sync_history, db_health, dbt_lock
 
+## Key Conventions
+
+- **`dbt_lock` module/function name collision:** `__init__.py` exports a function `dbt_lock` that shadows the submodule `dango.utils.dbt_lock`. On Python 3.10, `patch("dango.utils.dbt_lock.DbtLock")` resolves to the function, not the module. Fix: `import dango.utils.dbt_lock; _mod = sys.modules["dango.utils.dbt_lock"]` then `patch.object(_mod, "DbtLock", ...)`. See [STANDARDS.md §7](../../STANDARDS.md#mocking-and-patching).
+
 ## Don't Modify
 
 | File | Reason |

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -40,7 +40,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/metabase_proxy.py` | All Metabase proxy routes + SSO session state | `proxy_to_metabase()`, `get_metabase_session()` |
 | `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
-| `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, `/schedules` page, notification config/test (~726 lines) | `router` |
+| `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, `/schedules` page (~720 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `static/` | CSS and JS assets (`css/main.css`, `js/app.js`, `js/logs.js`) | — |
@@ -82,6 +82,12 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 - **FastAPI route ordering:** Literal routes (e.g., `/api/schedules/history/recent`) must be registered BEFORE parameterized routes (e.g., `/api/schedules/{name}/history`), or FastAPI captures the literal segment as the path parameter.
 - **Manual body parsing needs try/except:** `await request.json()` + `Model(**body)` bypasses FastAPI's built-in validation handler. Wrap in try/except to return proper 422 responses.
 - **Every admin endpoint must call `log_auth_event()`** from `dango.auth.audit` — this is a mandatory checklist item for audit compliance.
+- **BackgroundTasks run synchronously in TestClient:** Starlette's `TestClient` executes `background_tasks.add_task(fn, ...)` before returning the response. Mock the background function at the route module level (e.g., `@patch("dango.web.routes.sync._run_manual_sync")`).
+- **TOCTOU in validate-then-background-execute:** Endpoints that validate inputs then launch background tasks must re-validate inside the background function. State can change between validation and execution — add explicit guards.
+- **Rename-via-PUT guard:** Any CRUD API where the resource name is in both URL path and request body must check `body.name != url_name → 400`. Without this, renames silently orphan related records (e.g., execution history keyed by schedule name).
+- **`load_sources_config()` patching:** `load_sources_config()` in `helpers.py` internally calls `get_project_root()`. Patching `get_project_root` at the route module level doesn't reach the call inside `load_sources_config()`. Patch `load_sources_config` directly at the route module level instead.
+- **Alpine.js object reactivity:** Proxy doesn't track `delete obj[key]` or direct property mutation. Must use object spread reassignment (`this.obj = {...updated}`) for reactive updates. Arrays with `.push()`/`.splice()` work fine; objects do not.
+- **Dual logger debt in `routes/sync.py`:** Uses both stdlib `logging` and structlog `get_logger`. Known debt — consolidate when touching the file.
 
 ## Adding a New Page
 

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -31,7 +31,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` | — |
 | `routes/config.py` | `/api/config`, `/api/metabase-config` | — |
 | `routes/sources.py` | `/api/sources`, `/api/sources/{name}/details` | — |
-| `routes/sync.py` | `/api/sources/{name}/sync` + background `run_sync_task()` | `run_sync_task()` |
+| `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + background `run_sync_task()` (~558 lines) | `run_sync_task()` |
 | `routes/logs.py` | `/api/logs`, `/api/sources/{name}/logs` | — |
 | `routes/dbt.py` | `/api/dbt/models`, `/api/dbt/models/{name}/run` + dbt docs proxy (`/manifest.json`, `/catalog.json`, `/dbt-docs/*`) | `run_dbt_model_task()` |
 | `routes/upload.py` | CSV upload/list/delete + background `run_dbt_after_delete()` | `run_dbt_after_delete()` |


### PR DESCRIPTION
## Summary

- Create `dango/platform/scheduling/CLAUDE.md` and `dango/platform/notifications/CLAUDE.md` (STD-002 compliant)
- Update root, platform, web, cli, config, utils, and migrations CLAUDE.md files with Phase 4 additions
- Update STANDARDS.md: add CLAUDE.md cross-reference rule (§12), pytest name collision cross-ref (§7), update mypy-exempt count
- Clean up MEMORY.md from 216 → 145 lines (removed ~40 items migrated to repo docs by TASK-109 and DOC-027)
- Audit results: no new `__init__.py` export shadows, no missing rename-via-PUT guards, all STD-003 headers present

## Changes

### New files
- `dango/platform/scheduling/CLAUDE.md` — resilience callback kwargs, CPython timeout kill, `_on_job_missed` limitation, exception handler completeness
- `dango/platform/notifications/CLAUDE.md` — "never raises" contract, HTTP retry baseline, event filtering, lazy formatter imports

### Updated files
- `CLAUDE.md` (root) — routing table, decision tree, structure tree, monolithic files table (+6 entries), module index
- `dango/platform/CLAUDE.md` — sync_trigger.py, notifications entries, sub-CLAUDE.md references
- `dango/web/CLAUDE.md` — 7 new key conventions (BackgroundTasks, TOCTOU, rename guard, Alpine.js, etc.)
- `dango/cli/CLAUDE.md` — schedule command group, dual cron preset drift
- `dango/config/CLAUDE.md` — validate_schedules return type, cron drift cross-reference
- `dango/utils/CLAUDE.md` — dbt_lock module/function collision note
- `dango/migrations/CLAUDE.md` — digit-prefixed migration testing note
- `STANDARDS.md` — §12 CLAUDE.md cross-references, §7 test file naming cross-ref, §14 count update

### MEMORY.md cleanup
- Removed ~40 items already migrated to STANDARDS.md §7/§11/§12/§13/§14 by TASK-109
- Removed Phase 4 Implementation Patterns section (items moved to scheduling/notifications/web CLAUDE.md)
- Removed stale Phase 4 Planning Notes (6 items resolved during implementation)
- Updated counts: 23 → 31 files over 500 lines, ~50 → ~62 mypy-exempt test files

## Audits
- **`__init__.py` export shadows:** Only known `dango/utils/dbt_lock` collision. No new findings.
- **Rename-via-PUT guard:** Only `schedules.py` has the pattern, already guarded. No other routes need it.
- **STD-003 headers:** All Phase 4 files pass.
- **CLAUDE.md validation:** Both new files pass `validate_claude_md.py`.

## Test plan
- [x] `ruff check dango/` — passed
- [x] `ruff format --check dango/` — passed
- [x] `mypy dango/` — passed
- [x] `python scripts/check_file_sizes.py --all` — passed
- [x] `python scripts/validate_claude_md.py` on both new files — passed
- [x] `pytest tests/unit/ -x -q` — 2212 passed
- [x] `wc -l MEMORY.md` — 145 lines (under 200 limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)