### PR TITLE
P6-005: Add `dango cleanup` command for disk space management

### DIFF
--- a/dango/cli/commands/cleanup.py
+++ b/dango/cli/commands/cleanup.py
@@ -1,0 +1,301 @@
+"""dango/cli/commands/cleanup.py
+
+Cleanup old logs, dbt artifacts, and Python cache.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from dango.cli import console
+
+
+def _format_size(size_bytes: int) -> str:
+    """Format byte count as human-readable string."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024**2:
+        return f"{size_bytes / 1024:.1f} KB"
+    elif size_bytes < 1024**3:
+        return f"{size_bytes / 1024**2:.1f} MB"
+    else:
+        return f"{size_bytes / 1024**3:.2f} GB"
+
+
+def _collect_log_archives(log_dir: Path, max_age_days: int) -> list[tuple[Path, int]]:
+    """Find compressed log archives older than *max_age_days*.
+
+    Args:
+        log_dir: Directory containing log archives.
+        max_age_days: Maximum age in days before an archive is eligible.
+
+    Returns:
+        List of (path, size_bytes) for each expired archive.
+    """
+    from datetime import datetime, timezone
+
+    if not log_dir.exists():
+        return []
+
+    cutoff_ts = datetime.now(timezone.utc).timestamp() - (max_age_days * 86_400)
+    results: list[tuple[Path, int]] = []
+
+    for archive in log_dir.glob("*.jsonl.gz"):
+        try:
+            stat = archive.stat()
+            if stat.st_mtime < cutoff_ts:
+                results.append((archive, stat.st_size))
+        except OSError:
+            continue
+
+    return results
+
+
+def _collect_dbt_artifacts(project_root: Path) -> list[tuple[Path, int]]:
+    """Find dbt build artifacts (target/ and logs/ directories).
+
+    Args:
+        project_root: Project root directory.
+
+    Returns:
+        List of (directory_path, total_size_bytes) for each existing directory.
+    """
+    results: list[tuple[Path, int]] = []
+
+    for subdir in ("target", "logs"):
+        dbt_dir = project_root / "dbt" / subdir
+        if not dbt_dir.is_dir():
+            continue
+
+        total_size = 0
+        for path in dbt_dir.rglob("*"):
+            if path.is_file():
+                try:
+                    total_size += path.stat().st_size
+                except OSError:
+                    continue
+
+        results.append((dbt_dir, total_size))
+
+    return results
+
+
+def _collect_pycache(project_root: Path) -> list[tuple[Path, int]]:
+    """Find __pycache__ directories under the project root.
+
+    Args:
+        project_root: Project root directory.
+
+    Returns:
+        List of (directory_path, total_size_bytes) for each __pycache__ dir.
+    """
+    results: list[tuple[Path, int]] = []
+
+    for cache_dir in project_root.rglob("__pycache__"):
+        if not cache_dir.is_dir():
+            continue
+
+        total_size = 0
+        for path in cache_dir.rglob("*"):
+            if path.is_file():
+                try:
+                    total_size += path.stat().st_size
+                except OSError:
+                    continue
+
+        results.append((cache_dir, total_size))
+
+    return results
+
+
+@click.command("cleanup")
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted without deleting.")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+@click.option("--logs-only", is_flag=True, help="Only clean log archives, skip dbt/cache.")
+@click.pass_context
+def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> None:
+    """Remove old log archives, dbt artifacts, and Python cache.
+
+    Cleans up disk space by removing:
+
+    \b
+      - Compressed log archives older than 90 days (.jsonl.gz)
+      - dbt build artifacts (dbt/target/, dbt/logs/)
+      - Python bytecode cache (__pycache__/ directories)
+
+    Examples:
+
+    \b
+      dango cleanup              Clean all with confirmation
+      dango cleanup --dry-run    Show what would be deleted
+      dango cleanup --yes        Clean without confirmation
+      dango cleanup --logs-only  Only clean old log archives
+    """
+    import shutil
+
+    from dango.utils.db_health import get_disk_usage_summary
+    from dango.utils.log_rotation import cleanup_old_archives, get_log_disk_usage
+
+    from ..utils import require_project_context
+
+    console.print("[bold]Cleanup[/bold]\n")
+
+    try:
+        project_root = require_project_context(ctx)
+        log_dir = project_root / ".dango" / "logs"
+        max_age_days = 90
+
+        # --- Capture before state ---
+        disk_before = get_disk_usage_summary(project_root)
+        log_usage_before = get_log_disk_usage(log_dir)
+
+        # --- Collect items to clean ---
+        log_archives = _collect_log_archives(log_dir, max_age_days)
+        dbt_artifacts: list[tuple[Path, int]] = []
+        pycache_dirs: list[tuple[Path, int]] = []
+
+        if not logs_only:
+            dbt_artifacts = _collect_dbt_artifacts(project_root)
+            pycache_dirs = _collect_pycache(project_root)
+
+        log_total = sum(size for _, size in log_archives)
+        dbt_total = sum(size for _, size in dbt_artifacts)
+        cache_total = sum(size for _, size in pycache_dirs)
+        grand_total = log_total + dbt_total + cache_total
+
+        # --- Nothing to clean ---
+        if grand_total == 0:
+            console.print("[green]Nothing to clean up.[/green]")
+            return
+
+        # --- Display summary ---
+        from rich.table import Table
+
+        table = Table(title="Items to remove", show_header=True, header_style="bold cyan")
+        table.add_column("Category", style="white")
+        table.add_column("Items", justify="right")
+        table.add_column("Size", justify="right")
+
+        if log_archives:
+            table.add_row(
+                "Log archives (>90 days)",
+                str(len(log_archives)),
+                _format_size(log_total),
+            )
+        if dbt_artifacts:
+            dirs = ", ".join(p.name for p, _ in dbt_artifacts)
+            table.add_row(
+                f"dbt artifacts ({dirs})", str(len(dbt_artifacts)), _format_size(dbt_total)
+            )
+        if pycache_dirs:
+            table.add_row("Python cache", str(len(pycache_dirs)), _format_size(cache_total))
+
+        table.add_section()
+        table.add_row("[bold]Total[/bold]", "", f"[bold]{_format_size(grand_total)}[/bold]")
+
+        console.print(table)
+        console.print()
+
+        # --- Dry run ---
+        if dry_run:
+            if log_archives:
+                console.print("[dim]Log archives:[/dim]")
+                for path, size in log_archives:
+                    console.print(f"  {path.name}  ({_format_size(size)})")
+            if dbt_artifacts:
+                console.print("[dim]dbt directories:[/dim]")
+                for path, size in dbt_artifacts:
+                    console.print(f"  {path.relative_to(project_root)}/  ({_format_size(size)})")
+            if pycache_dirs:
+                console.print("[dim]Python cache directories:[/dim]")
+                for path, size in pycache_dirs:
+                    console.print(f"  {path.relative_to(project_root)}/  ({_format_size(size)})")
+            console.print()
+            console.print("[yellow]Dry run — no files deleted.[/yellow]")
+            return
+
+        # --- Confirmation ---
+        if not yes:
+            if not click.confirm(f"Delete {_format_size(grand_total)} of files?"):
+                console.print("[yellow]Cancelled.[/yellow]")
+                return
+
+        # --- Perform cleanup ---
+        freed = 0
+
+        # Log archives
+        if log_archives:
+            # Use cleanup_old_archives which handles deletion safely
+            for pattern in ("audit.*.jsonl.gz", "activity.*.jsonl.gz"):
+                cleanup_old_archives(log_dir, pattern, max_age_days)
+            # Also clean any other archive patterns
+            cleanup_old_archives(log_dir, "*.jsonl.gz", max_age_days)
+            freed += log_total
+            console.print(
+                f"[green]\u2713[/green] Removed {len(log_archives)} log archive(s)"
+                f" ({_format_size(log_total)})"
+            )
+
+        # dbt artifacts
+        for path, size in dbt_artifacts:
+            try:
+                shutil.rmtree(path)
+                freed += size
+                console.print(
+                    f"[green]\u2713[/green] Removed {path.relative_to(project_root)}/"
+                    f" ({_format_size(size)})"
+                )
+            except OSError as e:
+                console.print(
+                    f"[red]\u2717[/red] Failed to remove {path.relative_to(project_root)}/: {e}"
+                )
+
+        # Python cache
+        cache_removed = 0
+        for path, size in pycache_dirs:
+            try:
+                shutil.rmtree(path)
+                freed += size
+                cache_removed += 1
+            except OSError:
+                continue
+
+        if cache_removed:
+            console.print(
+                f"[green]\u2713[/green] Removed {cache_removed} __pycache__ dir(s)"
+                f" ({_format_size(cache_total)})"
+            )
+
+        # --- After summary ---
+        console.print()
+        disk_after = get_disk_usage_summary(project_root)
+        log_usage_after = get_log_disk_usage(log_dir)
+
+        console.print("[bold]Disk usage:[/bold]")
+        console.print(
+            f"  System: {disk_before['used_gb']}GB used → {disk_after['used_gb']}GB used"
+            f"  ({disk_after['free_gb']}GB free)"
+        )
+        console.print(
+            f"  Logs:   {_format_size(log_usage_before['total_bytes'])}"
+            f" → {_format_size(log_usage_after['total_bytes'])}"
+        )
+        console.print()
+        console.print(f"[green]Freed {_format_size(freed)}.[/green]")
+
+    except click.Abort:
+        raise
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Cancelled.[/yellow]")
+        raise click.Abort() from None
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
+        raise click.Abort() from e

--- a/dango/cli/commands/cleanup.py
+++ b/dango/cli/commands/cleanup.py
@@ -82,8 +82,14 @@ def _collect_dbt_artifacts(project_root: Path) -> list[tuple[Path, int]]:
     return results
 
 
+_SKIP_DIRS = {"venv", ".venv", "node_modules", ".git", ".tox"}
+
+
 def _collect_pycache(project_root: Path) -> list[tuple[Path, int]]:
     """Find __pycache__ directories under the project root.
+
+    Skips virtual environments, node_modules, and .git directories to avoid
+    unnecessary traversal and churn.
 
     Args:
         project_root: Project root directory.
@@ -92,9 +98,19 @@ def _collect_pycache(project_root: Path) -> list[tuple[Path, int]]:
         List of (directory_path, total_size_bytes) for each __pycache__ dir.
     """
     results: list[tuple[Path, int]] = []
+    seen_parents: set[Path] = set()
 
     for cache_dir in project_root.rglob("__pycache__"):
         if not cache_dir.is_dir():
+            continue
+
+        # Skip directories inside venv, .git, etc.
+        parts = cache_dir.relative_to(project_root).parts
+        if _SKIP_DIRS.intersection(parts):
+            continue
+
+        # Skip nested __pycache__ already covered by a parent
+        if any(cache_dir.is_relative_to(parent) for parent in seen_parents):
             continue
 
         total_size = 0
@@ -106,6 +122,7 @@ def _collect_pycache(project_root: Path) -> list[tuple[Path, int]]:
                     continue
 
         results.append((cache_dir, total_size))
+        seen_parents.add(cache_dir)
 
     return results
 
@@ -227,15 +244,14 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
 
         # Log archives
         if log_archives:
-            # Use cleanup_old_archives which handles deletion safely
-            for pattern in ("audit.*.jsonl.gz", "activity.*.jsonl.gz"):
-                cleanup_old_archives(log_dir, pattern, max_age_days)
-            # Also clean any other archive patterns
+            log_size_before = get_log_disk_usage(log_dir)["total_bytes"]
             cleanup_old_archives(log_dir, "*.jsonl.gz", max_age_days)
-            freed += log_total
+            log_size_after = get_log_disk_usage(log_dir)["total_bytes"]
+            log_freed = max(0, log_size_before - log_size_after)
+            freed += log_freed
             console.print(
                 f"[green]\u2713[/green] Removed {len(log_archives)} log archive(s)"
-                f" ({_format_size(log_total)})"
+                f" ({_format_size(log_freed)})"
             )
 
         # dbt artifacts
@@ -254,18 +270,23 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
 
         # Python cache
         cache_removed = 0
+        cache_freed = 0
         for path, size in pycache_dirs:
+            if not path.exists():
+                # Already removed as child of a parent __pycache__
+                continue
             try:
                 shutil.rmtree(path)
-                freed += size
+                cache_freed += size
                 cache_removed += 1
             except OSError:
                 continue
 
+        freed += cache_freed
         if cache_removed:
             console.print(
                 f"[green]\u2713[/green] Removed {cache_removed} __pycache__ dir(s)"
-                f" ({_format_size(cache_total)})"
+                f" ({_format_size(cache_freed)})"
             )
 
         # --- After summary ---

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -10,6 +10,7 @@ import click
 
 from dango import __version__
 from dango.cli.commands.auth import auth
+from dango.cli.commands.cleanup import cleanup
 from dango.cli.commands.config_cmd import config
 from dango.cli.commands.dashboard import dashboard
 from dango.cli.commands.data import db, validate
@@ -75,6 +76,7 @@ cli.add_command(validate)
 cli.add_command(web)
 cli.add_command(serve)
 cli.add_command(upgrade)
+cli.add_command(cleanup)
 
 # --- Register command groups ---
 cli.add_command(source)

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,0 +1,415 @@
+"""tests/unit/test_cleanup.py
+
+Unit tests for the ``dango cleanup`` CLI command.
+"""
+
+from __future__ import annotations
+
+import gzip
+import os
+import re
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.cleanup import (
+    _collect_dbt_artifacts,
+    _collect_log_archives,
+    _collect_pycache,
+    _format_size,
+    cleanup,
+)
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# Patch targets (lazy imports inside the command function body)
+# ---------------------------------------------------------------------------
+_CMD = "dango.cli.commands.cleanup"
+_UTILS = "dango.cli.utils"
+_DB_HEALTH = "dango.utils.db_health"
+_LOG_ROT = "dango.utils.log_rotation"
+
+
+def _disk_summary(**overrides: object) -> dict:
+    defaults = {"free_gb": 50.0, "total_gb": 100.0, "used_gb": 50.0, "status": "healthy"}
+    defaults.update(overrides)
+    return defaults
+
+
+def _log_usage(total_bytes: int = 0) -> dict:
+    return {"files": {}, "total_bytes": total_bytes}
+
+
+def _make_old_archive(log_dir: Path, name: str, size: int = 1024, age_days: int = 120) -> Path:
+    """Create a fake .jsonl.gz archive with an old mtime."""
+    archive = log_dir / name
+    archive.write_bytes(gzip.compress(b"x" * size))
+    old_ts = time.time() - (age_days * 86_400)
+    os.utime(archive, (old_ts, old_ts))
+    return archive
+
+
+def _make_recent_archive(log_dir: Path, name: str, size: int = 512) -> Path:
+    archive = log_dir / name
+    archive.write_bytes(gzip.compress(b"y" * size))
+    return archive
+
+
+# ---------------------------------------------------------------------------
+# _format_size
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestFormatSize:
+    def test_bytes(self) -> None:
+        assert _format_size(0) == "0 B"
+        assert _format_size(512) == "512 B"
+
+    def test_kilobytes(self) -> None:
+        assert _format_size(1024) == "1.0 KB"
+        assert _format_size(1536) == "1.5 KB"
+
+    def test_megabytes(self) -> None:
+        assert _format_size(1024**2) == "1.0 MB"
+
+    def test_gigabytes(self) -> None:
+        assert _format_size(1024**3) == "1.00 GB"
+
+
+# ---------------------------------------------------------------------------
+# _collect_log_archives
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestCollectLogArchives:
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        assert _collect_log_archives(log_dir, max_age_days=90) == []
+
+    def test_missing_dir(self, tmp_path: Path) -> None:
+        assert _collect_log_archives(tmp_path / "nope", max_age_days=90) == []
+
+    def test_finds_old_archives(self, tmp_path: Path) -> None:
+        _make_old_archive(tmp_path, "audit.2025-01-01.jsonl.gz", age_days=120)
+        _make_recent_archive(tmp_path, "audit.2026-03-01.jsonl.gz")
+
+        results = _collect_log_archives(tmp_path, max_age_days=90)
+        assert len(results) == 1
+        assert results[0][0].name == "audit.2025-01-01.jsonl.gz"
+
+    def test_ignores_non_gz(self, tmp_path: Path) -> None:
+        old = tmp_path / "audit.jsonl"
+        old.write_text("data")
+        old_ts = time.time() - (120 * 86_400)
+        os.utime(old, (old_ts, old_ts))
+
+        assert _collect_log_archives(tmp_path, max_age_days=90) == []
+
+
+# ---------------------------------------------------------------------------
+# _collect_dbt_artifacts
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestCollectDbtArtifacts:
+    def test_no_dbt_dir(self, tmp_path: Path) -> None:
+        assert _collect_dbt_artifacts(tmp_path) == []
+
+    def test_finds_target_and_logs(self, tmp_path: Path) -> None:
+        for subdir in ("target", "logs"):
+            d = tmp_path / "dbt" / subdir
+            d.mkdir(parents=True)
+            (d / "file.txt").write_text("data")
+
+        results = _collect_dbt_artifacts(tmp_path)
+        assert len(results) == 2
+        names = {p.name for p, _ in results}
+        assert names == {"target", "logs"}
+
+    def test_calculates_size(self, tmp_path: Path) -> None:
+        target = tmp_path / "dbt" / "target"
+        target.mkdir(parents=True)
+        (target / "a.json").write_text("a" * 100)
+        (target / "b.json").write_text("b" * 200)
+
+        results = _collect_dbt_artifacts(tmp_path)
+        assert len(results) == 1
+        assert results[0][1] == 300
+
+
+# ---------------------------------------------------------------------------
+# _collect_pycache
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestCollectPycache:
+    def test_finds_pycache(self, tmp_path: Path) -> None:
+        cache = tmp_path / "pkg" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "mod.pyc").write_bytes(b"\x00" * 64)
+
+        results = _collect_pycache(tmp_path)
+        assert len(results) == 1
+        assert results[0][1] == 64
+
+    def test_skips_venv(self, tmp_path: Path) -> None:
+        cache = tmp_path / "venv" / "lib" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "mod.pyc").write_bytes(b"\x00" * 64)
+
+        assert _collect_pycache(tmp_path) == []
+
+    def test_skips_dot_venv(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".venv" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "mod.pyc").write_bytes(b"\x00")
+
+        assert _collect_pycache(tmp_path) == []
+
+    def test_skips_node_modules(self, tmp_path: Path) -> None:
+        cache = tmp_path / "node_modules" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "mod.pyc").write_bytes(b"\x00")
+
+        assert _collect_pycache(tmp_path) == []
+
+    def test_skips_dot_git(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".git" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "mod.pyc").write_bytes(b"\x00")
+
+        assert _collect_pycache(tmp_path) == []
+
+    def test_no_double_counting_nested(self, tmp_path: Path) -> None:
+        """Nested __pycache__ inside __pycache__ should not be double-counted."""
+        outer = tmp_path / "pkg" / "__pycache__"
+        inner = outer / "sub" / "__pycache__"
+        inner.mkdir(parents=True)
+        (outer / "a.pyc").write_bytes(b"\x00" * 10)
+        (inner / "b.pyc").write_bytes(b"\x00" * 20)
+
+        results = _collect_pycache(tmp_path)
+        # Only the outer cache should appear; inner is nested within it.
+        assert len(results) == 1
+        assert results[0][0] == outer
+        # Size should include all files under outer (including nested)
+        assert results[0][1] == 30
+
+    def test_empty_project(self, tmp_path: Path) -> None:
+        assert _collect_pycache(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# cleanup command (Click integration)
+# ---------------------------------------------------------------------------
+def _invoke_cleanup(
+    tmp_path: Path,
+    args: list[str] | None = None,
+    log_archives: list[tuple[Path, int]] | None = None,
+    dbt_artifacts: list[tuple[Path, int]] | None = None,
+    pycache_dirs: list[tuple[Path, int]] | None = None,
+    disk_before: dict | None = None,
+    disk_after: dict | None = None,
+    log_before: int = 5000,
+    log_after: int = 0,
+):
+    """Invoke the cleanup command with standard mocks."""
+    runner = CliRunner()
+
+    if log_archives is None:
+        log_archives = []
+    if dbt_artifacts is None:
+        dbt_artifacts = []
+    if pycache_dirs is None:
+        pycache_dirs = []
+    if disk_before is None:
+        disk_before = _disk_summary(used_gb=55.0)
+    if disk_after is None:
+        disk_after = _disk_summary(used_gb=54.9)
+
+    log_usage_calls = [_log_usage(log_before), _log_usage(log_after)]
+    # During cleanup, log usage may be called extra times for actual measurement
+    # Pad with final value to avoid StopIteration
+    log_side = log_usage_calls + [_log_usage(log_after)] * 5
+
+    with (
+        patch(f"{_UTILS}.require_project_context", return_value=tmp_path),
+        patch(f"{_DB_HEALTH}.get_disk_usage_summary", side_effect=[disk_before, disk_after]),
+        patch(f"{_LOG_ROT}.get_log_disk_usage", side_effect=log_side),
+        patch(f"{_LOG_ROT}.cleanup_old_archives"),
+        patch(f"{_CMD}._collect_log_archives", return_value=log_archives),
+        patch(f"{_CMD}._collect_dbt_artifacts", return_value=dbt_artifacts),
+        patch(f"{_CMD}._collect_pycache", return_value=pycache_dirs),
+    ):
+        result = runner.invoke(cleanup, args or [], obj={"project_root": str(tmp_path)})
+
+    return result
+
+
+@pytest.mark.unit
+class TestCleanupCommand:
+    def test_nothing_to_clean(self, tmp_path: Path) -> None:
+        result = _invoke_cleanup(tmp_path)
+        assert result.exit_code == 0
+        assert "Nothing to clean up" in _strip(result.output)
+
+    def test_dry_run_shows_items(self, tmp_path: Path) -> None:
+        archive = tmp_path / ".dango" / "logs" / "audit.2025-01-01.jsonl.gz"
+        result = _invoke_cleanup(
+            tmp_path,
+            args=["--dry-run"],
+            log_archives=[(archive, 2048)],
+        )
+        assert result.exit_code == 0
+        out = _strip(result.output)
+        assert "Dry run" in out
+        assert "Log archives" in out
+
+    def test_dry_run_no_deletion(self, tmp_path: Path) -> None:
+        """--dry-run should not call cleanup_old_archives."""
+        archive = tmp_path / ".dango" / "logs" / "old.jsonl.gz"
+        runner = CliRunner()
+
+        mock_cleanup = MagicMock()
+        with (
+            patch(f"{_UTILS}.require_project_context", return_value=tmp_path),
+            patch(f"{_DB_HEALTH}.get_disk_usage_summary", return_value=_disk_summary()),
+            patch(f"{_LOG_ROT}.get_log_disk_usage", return_value=_log_usage(1000)),
+            patch(f"{_LOG_ROT}.cleanup_old_archives", mock_cleanup),
+            patch(f"{_CMD}._collect_log_archives", return_value=[(archive, 1000)]),
+            patch(f"{_CMD}._collect_dbt_artifacts", return_value=[]),
+            patch(f"{_CMD}._collect_pycache", return_value=[]),
+        ):
+            result = runner.invoke(cleanup, ["--dry-run"], obj={"project_root": str(tmp_path)})
+
+        assert result.exit_code == 0
+        mock_cleanup.assert_not_called()
+
+    def test_yes_skips_confirmation(self, tmp_path: Path) -> None:
+        archive = tmp_path / ".dango" / "logs" / "old.jsonl.gz"
+        result = _invoke_cleanup(
+            tmp_path,
+            args=["--yes"],
+            log_archives=[(archive, 500)],
+        )
+        assert result.exit_code == 0
+        out = _strip(result.output)
+        assert "Removed" in out
+        assert "Freed" in out
+
+    def test_logs_only_skips_dbt_and_cache(self, tmp_path: Path) -> None:
+        archive = tmp_path / ".dango" / "logs" / "old.jsonl.gz"
+        runner = CliRunner()
+
+        mock_dbt = MagicMock(return_value=[])
+        mock_cache = MagicMock(return_value=[])
+
+        with (
+            patch(f"{_UTILS}.require_project_context", return_value=tmp_path),
+            patch(f"{_DB_HEALTH}.get_disk_usage_summary", return_value=_disk_summary()),
+            patch(f"{_LOG_ROT}.get_log_disk_usage", return_value=_log_usage(500)),
+            patch(f"{_LOG_ROT}.cleanup_old_archives"),
+            patch(f"{_CMD}._collect_log_archives", return_value=[(archive, 500)]),
+            patch(f"{_CMD}._collect_dbt_artifacts", mock_dbt),
+            patch(f"{_CMD}._collect_pycache", mock_cache),
+        ):
+            result = runner.invoke(
+                cleanup, ["--logs-only", "--yes"], obj={"project_root": str(tmp_path)}
+            )
+
+        assert result.exit_code == 0
+        mock_dbt.assert_not_called()
+        mock_cache.assert_not_called()
+
+    def test_summary_table_shows_all_categories(self, tmp_path: Path) -> None:
+        archive = tmp_path / ".dango" / "logs" / "old.jsonl.gz"
+        dbt_dir = tmp_path / "dbt" / "target"
+        cache_dir = tmp_path / "pkg" / "__pycache__"
+
+        result = _invoke_cleanup(
+            tmp_path,
+            args=["--dry-run"],
+            log_archives=[(archive, 1024)],
+            dbt_artifacts=[(dbt_dir, 2048)],
+            pycache_dirs=[(cache_dir, 512)],
+        )
+        assert result.exit_code == 0
+        out = _strip(result.output)
+        assert "Log archives" in out
+        assert "dbt artifacts" in out
+        assert "Python cache" in out
+        assert "Total" in out
+
+    def test_cancelled_by_user(self, tmp_path: Path) -> None:
+        """User answering 'n' to confirmation should cancel."""
+        archive = tmp_path / ".dango" / "logs" / "old.jsonl.gz"
+        runner = CliRunner()
+
+        with (
+            patch(f"{_UTILS}.require_project_context", return_value=tmp_path),
+            patch(f"{_DB_HEALTH}.get_disk_usage_summary", return_value=_disk_summary()),
+            patch(f"{_LOG_ROT}.get_log_disk_usage", return_value=_log_usage(1000)),
+            patch(f"{_LOG_ROT}.cleanup_old_archives"),
+            patch(f"{_CMD}._collect_log_archives", return_value=[(archive, 1000)]),
+            patch(f"{_CMD}._collect_dbt_artifacts", return_value=[]),
+            patch(f"{_CMD}._collect_pycache", return_value=[]),
+        ):
+            result = runner.invoke(cleanup, [], input="n\n", obj={"project_root": str(tmp_path)})
+
+        assert result.exit_code == 0
+        assert "Cancelled" in _strip(result.output)
+
+    def test_dbt_removal_failure_reported(self, tmp_path: Path) -> None:
+        """OSError during dbt rmtree is reported but doesn't abort."""
+        dbt_dir = tmp_path / "dbt" / "target"
+        runner = CliRunner()
+
+        with (
+            patch(f"{_UTILS}.require_project_context", return_value=tmp_path),
+            patch(f"{_DB_HEALTH}.get_disk_usage_summary", return_value=_disk_summary()),
+            patch(f"{_LOG_ROT}.get_log_disk_usage", return_value=_log_usage(0)),
+            patch(f"{_LOG_ROT}.cleanup_old_archives"),
+            patch(f"{_CMD}._collect_log_archives", return_value=[]),
+            patch(f"{_CMD}._collect_dbt_artifacts", return_value=[(dbt_dir, 4096)]),
+            patch(f"{_CMD}._collect_pycache", return_value=[]),
+            patch("shutil.rmtree", side_effect=OSError("Permission denied")),
+        ):
+            result = runner.invoke(cleanup, ["--yes"], obj={"project_root": str(tmp_path)})
+
+        assert result.exit_code == 0
+        out = _strip(result.output)
+        assert "Failed to remove" in out
+
+    def test_pycache_already_removed_skipped(self, tmp_path: Path) -> None:
+        """Cache dirs that no longer exist at deletion time are skipped."""
+        ghost = tmp_path / "pkg" / "__pycache__"
+        # ghost doesn't exist on disk — simulates parent already removed it
+
+        result = _invoke_cleanup(
+            tmp_path,
+            args=["--yes"],
+            pycache_dirs=[(ghost, 256)],
+        )
+        assert result.exit_code == 0
+        # Should not report any cache removed (ghost didn't exist)
+        out = _strip(result.output)
+        assert "__pycache__" not in out
+
+    def test_freed_size_in_output(self, tmp_path: Path) -> None:
+        archive = tmp_path / ".dango" / "logs" / "old.jsonl.gz"
+        result = _invoke_cleanup(
+            tmp_path,
+            args=["--yes"],
+            log_archives=[(archive, 2048)],
+            log_before=5000,
+            log_after=3000,
+        )
+        assert result.exit_code == 0
+        out = _strip(result.output)
+        assert "Freed" in out


### PR DESCRIPTION
## Summary
- Adds `dango cleanup` command that removes old log archives (>90 days), dbt build artifacts (`dbt/target/`, `dbt/logs/`), and Python bytecode cache (`__pycache__/` directories)
- Supports `--dry-run` (preview without deleting), `--yes`/`-y` (skip confirmation), and `--logs-only` (restrict to log archives) flags
- Shows before/after disk usage breakdown reusing `get_disk_usage_summary()` from `utils/db_health.py` and `get_log_disk_usage()` from `utils/log_rotation.py`

## Changes

### New file
- **`dango/cli/commands/cleanup.py`** (~220 lines) — `dango cleanup` command with three cleanup targets:
  - Log archives: finds `.jsonl.gz` files older than 90 days, delegates deletion to `cleanup_old_archives()`
  - dbt artifacts: removes `dbt/target/` and `dbt/logs/` via `shutil.rmtree()`
  - Python cache: removes all `__pycache__/` directories under project root
  - Rich table summary of items to remove (category, count, size)
  - Before/after disk usage comparison

### Modified file
- **`dango/cli/main.py`** (+2 lines) — import and register `cleanup` command

## Design decisions
- **No orphan process kill** — PID reuse makes this dangerous
- **No Docker prune** — cross-project safety risk
- **No remote backup delete** — retention auto-manages
- **90-day archive cutoff** — matches `cleanup_old_archives()` default; consistent with log rotation retention
- **Confirmation required by default** — destructive operation, `--yes` to skip
- **Graceful on missing dirs** — no error if `dbt/target/` or `.dango/logs/` doesn't exist

## Test plan
- [ ] `dango cleanup --help` shows usage with all three flags
- [ ] `dango cleanup --dry-run` lists items to remove with sizes, deletes nothing
- [ ] `dango cleanup --yes` deletes without interactive confirmation
- [ ] `dango cleanup --logs-only` only removes log archives, skips dbt/cache
- [ ] `dango cleanup` with no old archives or artifacts shows "Nothing to clean up"
- [ ] Missing directories handled gracefully (no error if `dbt/target/` doesn't exist)
- [ ] Before/after disk usage summary displays correctly
- [ ] `ruff check`, `ruff format --check`, `mypy` pass on new file

## Dependencies
- **P6-004** (log rotation) — merged; uses `cleanup_old_archives()` and `get_log_disk_usage()` from `utils/log_rotation.py`

<https://claude.ai/code/session_01Gtf7eaayi83gCpoGNATkzJ>