### PR TITLE
P6-001: Add disk monitoring with per-component breakdown and 80% warning

### DIFF
--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -13,7 +13,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `activity_log.py` | JSONL activity logging to `.dango/logs/activity.jsonl` | `log_activity()`, `get_activity_log_file()` |
 | `sync_history.py` | Per-source sync history (JSON, last 100 entries) | `save_sync_history_entry()`, `load_sync_history()`, `get_sync_history_file()` |
 | `database.py` | DuckDB schema initialization (raw, staging, intermediate, marts) | `ensure_dbt_schemas()` |
-| `db_health.py` | Disk space checks and DuckDB health monitoring | `check_disk_space()`, `check_duckdb_health()`, `get_disk_usage_summary()`, `print_health_summary()` (imports `DiskSpaceError`, `DuckDBHealthError` from `dango.exceptions`) |
+| `db_health.py` | Disk space checks and DuckDB health monitoring | `check_disk_space()`, `check_duckdb_health()`, `get_disk_usage_summary()`, `get_component_disk_usage()`, `print_health_summary()` (imports `DiskSpaceError`, `DuckDBHealthError` from `dango.exceptions`) |
 | `dbt_lock.py` | Cross-process file lock for dbt operations (fcntl/msvcrt) | `DbtLock`, `dbt_lock()` context manager (imports `DbtLockError` from `dango.exceptions`) |
 | `dbt_status.py` | Persistent dbt model status from run_results.json | `update_model_status()`, `get_model_statuses()` |
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -3,7 +3,9 @@
 DuckDB Health Monitoring and Disk Space Utilities.
 """
 
+import logging
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +13,8 @@ import duckdb
 from rich.console import Console
 
 from dango.exceptions import DiskSpaceError, DuckDBHealthError
+
+logger = logging.getLogger(__name__)
 
 console = Console()
 
@@ -207,6 +211,130 @@ def get_disk_usage_summary(project_root: Path) -> dict[str, Any]:
     except Exception as e:
         console.print(f"[yellow]⚠️  Could not get disk usage: {e}[/yellow]")
         return {"free_gb": 0, "total_gb": 0, "used_gb": 0, "used_pct": 0, "status": "unknown"}
+
+
+def _dir_size_bytes(path: Path) -> int:
+    """Sum file sizes in a directory tree.
+
+    Returns 0 if the directory does not exist or is empty.
+    """
+    if not path.is_dir():
+        return 0
+    total = 0
+    try:
+        for f in path.rglob("*"):
+            if f.is_file():
+                try:
+                    total += f.stat().st_size
+                except OSError:
+                    continue
+    except OSError:
+        pass
+    return total
+
+
+def get_component_disk_usage(project_root: Path) -> dict[str, Any]:
+    """Get per-component disk usage breakdown.
+
+    Collects sizes for DuckDB (file + per-schema estimates), Metabase H2,
+    CSV uploads (per source), dbt artifacts, dlt pipeline state, and backups.
+
+    Args:
+        project_root: Path to Dango project root directory.
+
+    Returns:
+        Dictionary with per-component sizes in MB, plus a total.
+        Missing components return 0 or None (never raises).
+    """
+    result: dict[str, Any] = {}
+
+    # DuckDB file size + per-schema estimates
+    duckdb_info: dict[str, Any] = {"file_size_mb": 0, "schema_sizes": {}}
+    duckdb_path = project_root / "data" / "warehouse.duckdb"
+    try:
+        if duckdb_path.exists():
+            duckdb_info["file_size_mb"] = round(duckdb_path.stat().st_size / (1024**2), 2)
+            # Per-schema estimated sizes (read-only connection)
+            try:
+                conn = duckdb.connect(str(duckdb_path), read_only=True)
+                try:
+                    rows = conn.execute(
+                        "SELECT schema_name, COALESCE(SUM(estimated_size), 0) "
+                        "FROM duckdb_tables() GROUP BY schema_name"
+                    ).fetchall()
+                    duckdb_info["schema_sizes"] = {row[0]: int(row[1]) for row in rows}
+                finally:
+                    conn.close()
+            except Exception:  # noqa: BLE001
+                logger.debug("duckdb_schema_sizes_failed", exc_info=True)
+    except Exception:  # noqa: BLE001
+        logger.debug("duckdb_file_size_failed", exc_info=True)
+    result["duckdb"] = duckdb_info
+
+    # Metabase H2 database size (inside Docker container)
+    metabase_info: dict[str, Any] = {"size_mb": None}
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [
+                "docker",
+                "compose",
+                "exec",
+                "-T",
+                "metabase",
+                "stat",
+                "-c",
+                "%s",
+                "/metabase-data/metabase.db.mv.db",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=project_root,
+        )
+        if proc.returncode == 0 and proc.stdout.strip().isdigit():
+            metabase_info["size_mb"] = round(int(proc.stdout.strip()) / (1024**2), 2)
+    except Exception:  # noqa: BLE001
+        pass  # Container not running or Docker unavailable
+    result["metabase"] = metabase_info
+
+    # CSV uploads — per source subdirectory
+    csv_info: dict[str, Any] = {"total_mb": 0, "by_source": {}}
+    uploads_dir = project_root / "data" / "uploads"
+    try:
+        if uploads_dir.is_dir():
+            total_csv_bytes = 0
+            for child in sorted(uploads_dir.iterdir()):
+                if child.is_dir():
+                    source_bytes = _dir_size_bytes(child)
+                    csv_info["by_source"][child.name] = round(source_bytes / (1024**2), 2)
+                    total_csv_bytes += source_bytes
+            csv_info["total_mb"] = round(total_csv_bytes / (1024**2), 2)
+    except Exception:  # noqa: BLE001
+        logger.debug("csv_uploads_size_failed", exc_info=True)
+    result["csv_uploads"] = csv_info
+
+    # dbt artifacts
+    dbt_bytes = _dir_size_bytes(project_root / "dbt" / "target")
+    result["dbt_artifacts"] = {"size_mb": round(dbt_bytes / (1024**2), 2)}
+
+    # dlt pipeline state
+    dlt_bytes = _dir_size_bytes(project_root / ".dlt" / "pipelines")
+    result["dlt_pipelines"] = {"size_mb": round(dlt_bytes / (1024**2), 2)}
+
+    # Local backups
+    backup_bytes = _dir_size_bytes(project_root / ".dango" / "backups")
+    result["backups"] = {"size_mb": round(backup_bytes / (1024**2), 2)}
+
+    # Total across all components
+    total_mb = duckdb_info["file_size_mb"]
+    total_mb += metabase_info["size_mb"] or 0
+    total_mb += csv_info["total_mb"]
+    total_mb += result["dbt_artifacts"]["size_mb"]
+    total_mb += result["dlt_pipelines"]["size_mb"]
+    total_mb += result["backups"]["size_mb"]
+    result["total_mb"] = round(total_mb, 2)
+
+    return result
 
 
 def print_health_summary(project_root: Path, duckdb_path: Path) -> None:

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -6,6 +6,7 @@ DuckDB Health Monitoring and Disk Space Utilities.
 import logging
 import shutil
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
@@ -233,11 +234,19 @@ def _dir_size_bytes(path: Path) -> int:
     return total
 
 
+_component_disk_cache: dict[str, Any] | None = None
+_component_disk_cache_time: float = 0
+_COMPONENT_DISK_TTL: float = 60  # seconds
+
+
 def get_component_disk_usage(project_root: Path) -> dict[str, Any]:
     """Get per-component disk usage breakdown.
 
     Collects sizes for DuckDB (file + per-schema estimates), Metabase H2,
     CSV uploads (per source), dbt artifacts, dlt pipeline state, and backups.
+
+    Results are cached for 60 seconds to avoid repeated directory traversal
+    on the 30-second health poll interval.
 
     Args:
         project_root: Path to Dango project root directory.
@@ -246,6 +255,13 @@ def get_component_disk_usage(project_root: Path) -> dict[str, Any]:
         Dictionary with per-component sizes in MB, plus a total.
         Missing components return 0 or None (never raises).
     """
+    global _component_disk_cache, _component_disk_cache_time  # noqa: PLW0603
+    now = time.monotonic()
+    if (
+        _component_disk_cache is not None
+        and (now - _component_disk_cache_time) < _COMPONENT_DISK_TTL
+    ):
+        return _component_disk_cache
     result: dict[str, Any] = {}
 
     # DuckDB file size + per-schema estimates
@@ -333,6 +349,9 @@ def get_component_disk_usage(project_root: Path) -> dict[str, Any]:
     total_mb += result["dlt_pipelines"]["size_mb"]
     total_mb += result["backups"]["size_mb"]
     result["total_mb"] = round(total_mb, 2)
+
+    _component_disk_cache = result
+    _component_disk_cache_time = now
 
     return result
 

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -630,7 +630,11 @@ async def check_service_status_async(service_name: str) -> str:
 
 async def get_platform_health_data():
     """Gather platform health data (runs blocking operations in thread pool)."""
-    from dango.utils.db_health import check_duckdb_health, get_disk_usage_summary
+    from dango.utils.db_health import (
+        check_duckdb_health,
+        get_component_disk_usage,
+        get_disk_usage_summary,
+    )
 
     project_root = get_project_root()
     duckdb_path = get_duckdb_path()
@@ -655,6 +659,7 @@ async def get_platform_health_data():
     )
 
     disk_task = asyncio.create_task(asyncio.to_thread(get_disk_usage_summary, project_root))
+    breakdown_task = asyncio.create_task(asyncio.to_thread(get_component_disk_usage, project_root))
     sources_task = asyncio.create_task(asyncio.to_thread(load_sources_config))
 
     # Wait for all tasks
@@ -674,6 +679,12 @@ async def get_platform_health_data():
 
     disk = await disk_task
     sources_config = await sources_task
+
+    try:
+        disk_breakdown = await breakdown_task
+    except Exception as e:
+        logger.error(f"Error getting disk breakdown: {e}")
+        disk_breakdown: dict[str, Any] = {}
 
     # Check for failed syncs
     failed_syncs = []
@@ -734,6 +745,7 @@ async def get_platform_health_data():
     return {
         "db_health": db_health,
         "disk": disk,
+        "disk_breakdown": disk_breakdown,
         "sources_config": sources_config,
         "failed_syncs": failed_syncs,
         "failed_dbt": failed_dbt,

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -133,6 +133,14 @@ async def get_platform_health() -> dict[str, Any]:
     elif disk["status"] == "warning":
         warnings.append("Low disk space")
 
+    # Percentage-based proactive warning (independent of absolute GB thresholds)
+    if disk.get("used_pct", 0) > 80 and disk["status"] != "critical":
+        cloud_yml = Path(get_project_root()) / ".dango" / "cloud.yml"
+        if cloud_yml.exists():
+            warnings.append("Disk usage above 80% \u2014 consider resizing or running cleanup")
+        else:
+            warnings.append("Disk usage above 80% \u2014 run `dango cleanup` to free space")
+
     if db_health["status"] == "critical":
         warnings.append("Very large database")
     elif db_health["status"] == "large":
@@ -149,6 +157,7 @@ async def get_platform_health() -> dict[str, Any]:
         "timestamp": datetime.now().isoformat(),
         "database": db_health,
         "disk": disk,
+        "disk_breakdown": data.get("disk_breakdown", {}),
         "sync_failures": failed_syncs,
         "dbt_failures": failed_dbt,
         "total_sources": len(sources_config),

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -128,18 +128,19 @@ async def get_platform_health() -> dict[str, Any]:
     critical_issues: list[str] = []
     warnings: list[str] = []
 
+    project_root = Path(get_project_root())
+    is_cloud = (project_root / ".dango" / "cloud.yml").exists()
+
     if disk["status"] == "critical":
         critical_issues.append("Critical disk space")
-    elif disk["status"] == "warning":
-        warnings.append("Low disk space")
-
-    # Percentage-based proactive warning (independent of absolute GB thresholds)
-    if disk.get("used_pct", 0) > 80 and disk["status"] != "critical":
-        cloud_yml = Path(get_project_root()) / ".dango" / "cloud.yml"
-        if cloud_yml.exists():
+    elif disk.get("used_pct", 0) > 80:
+        # Prefer the actionable 80% message over generic "Low disk space"
+        if is_cloud:
             warnings.append("Disk usage above 80% \u2014 consider resizing or running cleanup")
         else:
             warnings.append("Disk usage above 80% \u2014 run `dango cleanup` to free space")
+    elif disk["status"] == "warning":
+        warnings.append("Low disk space")
 
     if db_health["status"] == "critical":
         warnings.append("Very large database")

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -24,6 +24,19 @@ let loadSourcesRetryTimeout = null;
 let activeFileOperations = new Map();
 
 /**
+ * Format a file size in bytes to a human-readable string (B/KB/MB/GB).
+ * @param {number} bytes - Size in bytes
+ * @returns {string} Formatted size string
+ */
+function formatFileSize(bytes) {
+    if (!bytes || bytes === 0) return '-';
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+    return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
+}
+
+/**
  * Add a file operation for tracking
  * @param {string} sourceName - Source name
  * @param {string} operationId - Unique operation ID
@@ -1279,7 +1292,7 @@ async function loadCsvFilesList(sourceName) {
                 statusIcon = '⚠';
             }
 
-            const sizeDisplay = file.size ? `${(file.size / 1024).toFixed(1)} KB` : '-';
+            const sizeDisplay = formatFileSize(file.size);
             const rowsDisplay = file.rows_loaded ? `${file.rows_loaded.toLocaleString()} rows` : '';
 
             // Add delete button for files on disk

--- a/dango/web/templates/health.html
+++ b/dango/web/templates/health.html
@@ -51,8 +51,8 @@
                 <div id="ram-detail" class="text-sm text-gray-500 mt-1">-</div>
             </div>
 
-            <!-- Disk Space - shown when cloud resources present -->
-            <div id="disk-card" class="bg-white rounded-lg shadow p-6 hidden">
+            <!-- Disk Space -->
+            <div id="disk-card" class="bg-white rounded-lg shadow p-6">
                 <div class="flex items-center justify-between mb-2">
                     <h3 class="text-sm font-medium text-gray-600">💾 Disk Space</h3>
                     <span id="disk-status-badge" class="px-2 py-1 text-xs rounded-full bg-gray-100 text-gray-800">Loading...</span>
@@ -133,8 +133,8 @@
                 </div>
             </div>
 
-            <!-- Disk Details - shown when cloud resources present -->
-            <div id="disk-details" class="bg-white rounded-lg shadow hidden">
+            <!-- Disk Details -->
+            <div id="disk-details" class="bg-white rounded-lg shadow">
                 <div class="px-6 py-4 border-b border-gray-200">
                     <h2 class="text-lg font-semibold text-gray-900">Disk Usage</h2>
                 </div>
@@ -156,6 +156,17 @@
                             <dt class="text-sm text-gray-600">Usage Percentage</dt>
                             <dd id="disk-used-pct" class="text-sm font-medium text-gray-900">-</dd>
                         </div>
+                    </dl>
+                </div>
+            </div>
+
+            <!-- Disk Breakdown by Component -->
+            <div id="disk-breakdown" class="bg-white rounded-lg shadow hidden">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">Disk Breakdown by Component</h2>
+                </div>
+                <div class="p-6">
+                    <dl id="disk-breakdown-list" class="space-y-3">
                     </dl>
                 </div>
             </div>
@@ -280,13 +291,100 @@
                 diskBadge.textContent = 'Critical';
             }
 
-            // Cloud resources (CPU, RAM, Disk card, Backup)
+            // Disk Breakdown by Component
+            if (health.disk_breakdown && Object.keys(health.disk_breakdown).length > 0) {
+                const bd = health.disk_breakdown;
+                const breakdownEl = document.getElementById('disk-breakdown');
+                const listEl = document.getElementById('disk-breakdown-list');
+                breakdownEl.classList.remove('hidden');
+
+                function fmtMB(mb) {
+                    if (mb === null || mb === undefined) return 'N/A';
+                    if (mb < 1) return (mb * 1024).toFixed(0) + ' KB';
+                    if (mb >= 1024) return (mb / 1024).toFixed(2) + ' GB';
+                    return mb.toFixed(1) + ' MB';
+                }
+
+                let rows = '';
+
+                // DuckDB
+                if (bd.duckdb) {
+                    rows += `<div class="flex justify-between">
+                        <dt class="text-sm text-gray-600">DuckDB Database</dt>
+                        <dd class="text-sm font-medium text-gray-900">${fmtMB(bd.duckdb.file_size_mb)}</dd>
+                    </div>`;
+                    if (bd.duckdb.schema_sizes && Object.keys(bd.duckdb.schema_sizes).length > 0) {
+                        for (const [schema, bytes] of Object.entries(bd.duckdb.schema_sizes)) {
+                            rows += `<div class="flex justify-between pl-4">
+                                <dt class="text-xs text-gray-500">${escapeHtml(schema)}</dt>
+                                <dd class="text-xs text-gray-700">${fmtMB(bytes / (1024 * 1024))}</dd>
+                            </div>`;
+                        }
+                    }
+                }
+
+                // Metabase
+                if (bd.metabase) {
+                    rows += `<div class="flex justify-between">
+                        <dt class="text-sm text-gray-600">Metabase Database</dt>
+                        <dd class="text-sm font-medium text-gray-900">${fmtMB(bd.metabase.size_mb)}</dd>
+                    </div>`;
+                }
+
+                // CSV Uploads
+                if (bd.csv_uploads) {
+                    rows += `<div class="flex justify-between">
+                        <dt class="text-sm text-gray-600">CSV Uploads</dt>
+                        <dd class="text-sm font-medium text-gray-900">${fmtMB(bd.csv_uploads.total_mb)}</dd>
+                    </div>`;
+                    if (bd.csv_uploads.by_source && Object.keys(bd.csv_uploads.by_source).length > 0) {
+                        for (const [source, mb] of Object.entries(bd.csv_uploads.by_source)) {
+                            rows += `<div class="flex justify-between pl-4">
+                                <dt class="text-xs text-gray-500">${escapeHtml(source)}</dt>
+                                <dd class="text-xs text-gray-700">${fmtMB(mb)}</dd>
+                            </div>`;
+                        }
+                    }
+                }
+
+                // dbt Artifacts
+                if (bd.dbt_artifacts) {
+                    rows += `<div class="flex justify-between">
+                        <dt class="text-sm text-gray-600">dbt Artifacts</dt>
+                        <dd class="text-sm font-medium text-gray-900">${fmtMB(bd.dbt_artifacts.size_mb)}</dd>
+                    </div>`;
+                }
+
+                // dlt Pipelines
+                if (bd.dlt_pipelines) {
+                    rows += `<div class="flex justify-between">
+                        <dt class="text-sm text-gray-600">dlt Pipeline State</dt>
+                        <dd class="text-sm font-medium text-gray-900">${fmtMB(bd.dlt_pipelines.size_mb)}</dd>
+                    </div>`;
+                }
+
+                // Backups
+                if (bd.backups) {
+                    rows += `<div class="flex justify-between">
+                        <dt class="text-sm text-gray-600">Local Backups</dt>
+                        <dd class="text-sm font-medium text-gray-900">${fmtMB(bd.backups.size_mb)}</dd>
+                    </div>`;
+                }
+
+                // Total
+                if (bd.total_mb !== undefined) {
+                    rows += `<div class="flex justify-between border-t border-gray-200 pt-3 mt-3">
+                        <dt class="text-sm font-semibold text-gray-700">Total Tracked</dt>
+                        <dd class="text-sm font-bold text-gray-900">${fmtMB(bd.total_mb)}</dd>
+                    </div>`;
+                }
+
+                listEl.innerHTML = rows;
+            }
+
+            // Cloud resources (CPU, RAM, Backup)
             if (health.resources) {
                 const res = health.resources;
-
-                // Show disk card and details on cloud
-                document.getElementById('disk-card').classList.remove('hidden');
-                document.getElementById('disk-details').classList.remove('hidden');
 
                 // CPU card
                 if (res.cpu_usage_pct !== null) {

--- a/dango/web/templates/health.html
+++ b/dango/web/templates/health.html
@@ -199,6 +199,13 @@
             return div.innerHTML;
         }
 
+        function fmtMB(mb) {
+            if (mb === null || mb === undefined) return 'N/A';
+            if (mb < 1) return (mb * 1024).toFixed(0) + ' KB';
+            if (mb >= 1024) return (mb / 1024).toFixed(2) + ' GB';
+            return mb.toFixed(1) + ' MB';
+        }
+
         async function fetchHealth() {
             try {
                 const response = await fetch('/api/health/platform');
@@ -297,13 +304,6 @@
                 const breakdownEl = document.getElementById('disk-breakdown');
                 const listEl = document.getElementById('disk-breakdown-list');
                 breakdownEl.classList.remove('hidden');
-
-                function fmtMB(mb) {
-                    if (mb === null || mb === undefined) return 'N/A';
-                    if (mb < 1) return (mb * 1024).toFixed(0) + ' KB';
-                    if (mb >= 1024) return (mb / 1024).toFixed(2) + ' GB';
-                    return mb.toFixed(1) + ' MB';
-                }
 
                 let rows = '';
 

--- a/tests/unit/test_db_health_disk.py
+++ b/tests/unit/test_db_health_disk.py
@@ -1,9 +1,8 @@
 """tests/unit/test_db_health_disk.py
 
-Tests for disk monitoring utilities in dango.utils.db_health:
-- _dir_size_bytes()
-- get_component_disk_usage()
-- TTL cache for get_component_disk_usage()
+Tests for disk monitoring utilities in dango.utils.db_health.
+
+Covers _dir_size_bytes(), get_component_disk_usage(), and TTL cache behavior.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_db_health_disk.py
+++ b/tests/unit/test_db_health_disk.py
@@ -1,0 +1,234 @@
+"""tests/unit/test_db_health_disk.py
+
+Tests for disk monitoring utilities in dango.utils.db_health:
+- _dir_size_bytes()
+- get_component_disk_usage()
+- TTL cache for get_component_disk_usage()
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestDirSizeBytes:
+    """Tests for _dir_size_bytes()."""
+
+    def test_nonexistent_directory_returns_zero(self, tmp_path: Path) -> None:
+        from dango.utils.db_health import _dir_size_bytes
+
+        assert _dir_size_bytes(tmp_path / "nope") == 0
+
+    def test_empty_directory_returns_zero(self, tmp_path: Path) -> None:
+        from dango.utils.db_health import _dir_size_bytes
+
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert _dir_size_bytes(empty) == 0
+
+    def test_single_file(self, tmp_path: Path) -> None:
+        from dango.utils.db_health import _dir_size_bytes
+
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"x" * 1024)
+        assert _dir_size_bytes(tmp_path) == 1024
+
+    def test_nested_files(self, tmp_path: Path) -> None:
+        from dango.utils.db_health import _dir_size_bytes
+
+        sub = tmp_path / "a" / "b"
+        sub.mkdir(parents=True)
+        (tmp_path / "top.txt").write_bytes(b"A" * 100)
+        (sub / "deep.txt").write_bytes(b"B" * 200)
+        assert _dir_size_bytes(tmp_path) == 300
+
+    def test_oserror_on_rglob_is_handled(self, tmp_path: Path) -> None:
+        """OSError during rglob traversal is silently caught."""
+        from dango.utils.db_health import _dir_size_bytes
+
+        (tmp_path / "ok.txt").write_bytes(b"x" * 50)
+
+        def boom(*args, **kwargs):
+            raise OSError("Permission denied")
+
+        with patch.object(Path, "rglob", side_effect=boom):
+            result = _dir_size_bytes(tmp_path)
+
+        assert result == 0  # outer OSError caught, returns accumulated total
+
+    def test_file_path_returns_zero(self, tmp_path: Path) -> None:
+        """Passing a file (not a directory) returns 0."""
+        from dango.utils.db_health import _dir_size_bytes
+
+        f = tmp_path / "file.txt"
+        f.write_bytes(b"data")
+        assert _dir_size_bytes(f) == 0
+
+
+@pytest.mark.unit
+class TestGetComponentDiskUsage:
+    """Tests for get_component_disk_usage()."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self) -> None:
+        """Reset the TTL cache before each test."""
+        import dango.utils.db_health as mod
+
+        mod._component_disk_cache = None
+        mod._component_disk_cache_time = 0
+
+    def _make_project(self, tmp_path: Path) -> Path:
+        """Create a minimal project directory structure."""
+        (tmp_path / "data" / "uploads" / "stripe").mkdir(parents=True)
+        (tmp_path / "data" / "uploads" / "stripe" / "charges.csv").write_bytes(b"x" * (1024 * 1024))
+        (tmp_path / "dbt" / "target").mkdir(parents=True)
+        (tmp_path / "dbt" / "target" / "manifest.json").write_bytes(b"y" * (1024 * 1024))
+        (tmp_path / ".dlt" / "pipelines").mkdir(parents=True)
+        (tmp_path / ".dango" / "backups").mkdir(parents=True)
+        return tmp_path
+
+    @patch("dango.utils.db_health.duckdb")
+    @patch("dango.utils.db_health.subprocess.run")
+    def test_basic_breakdown(
+        self, mock_run: MagicMock, mock_duckdb: MagicMock, tmp_path: Path
+    ) -> None:
+        from dango.utils.db_health import get_component_disk_usage
+
+        project = self._make_project(tmp_path)
+
+        # No DuckDB file
+        mock_run.return_value = MagicMock(returncode=1)  # Docker not available
+
+        result = get_component_disk_usage(project)
+
+        assert "duckdb" in result
+        assert "metabase" in result
+        assert "csv_uploads" in result
+        assert "dbt_artifacts" in result
+        assert "dlt_pipelines" in result
+        assert "backups" in result
+        assert "total_mb" in result
+
+        # CSV uploads should have stripe source
+        assert "stripe" in result["csv_uploads"]["by_source"]
+        assert result["csv_uploads"]["total_mb"] > 0
+
+        # dbt artifacts should be non-zero
+        assert result["dbt_artifacts"]["size_mb"] > 0
+
+    @patch("dango.utils.db_health.duckdb")
+    @patch("dango.utils.db_health.subprocess.run")
+    def test_duckdb_file_size(
+        self, mock_run: MagicMock, mock_duckdb: MagicMock, tmp_path: Path
+    ) -> None:
+        from dango.utils.db_health import get_component_disk_usage
+
+        project = self._make_project(tmp_path)
+
+        # Create a fake DuckDB file
+        db_file = project / "data" / "warehouse.duckdb"
+        db_file.write_bytes(b"\x00" * (1024 * 1024))  # 1 MB
+
+        # Mock DuckDB connection for schema sizes
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("raw", 500000),
+            ("staging", 300000),
+        ]
+        mock_duckdb.connect.return_value = mock_conn
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result = get_component_disk_usage(project)
+
+        assert result["duckdb"]["file_size_mb"] == 1.0
+        assert result["duckdb"]["schema_sizes"] == {"raw": 500000, "staging": 300000}
+
+    @patch("dango.utils.db_health.duckdb")
+    @patch("dango.utils.db_health.subprocess.run")
+    def test_metabase_size_from_docker(
+        self, mock_run: MagicMock, mock_duckdb: MagicMock, tmp_path: Path
+    ) -> None:
+        from dango.utils.db_health import get_component_disk_usage
+
+        project = self._make_project(tmp_path)
+
+        # Simulate successful docker stat
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="5242880\n",  # 5 MB in bytes
+        )
+
+        result = get_component_disk_usage(project)
+
+        assert result["metabase"]["size_mb"] == 5.0
+
+    @patch("dango.utils.db_health.duckdb")
+    @patch("dango.utils.db_health.subprocess.run")
+    def test_docker_not_available(
+        self, mock_run: MagicMock, mock_duckdb: MagicMock, tmp_path: Path
+    ) -> None:
+        from dango.utils.db_health import get_component_disk_usage
+
+        project = self._make_project(tmp_path)
+        mock_run.side_effect = FileNotFoundError("docker not found")
+
+        result = get_component_disk_usage(project)
+
+        assert result["metabase"]["size_mb"] is None
+
+    @patch("dango.utils.db_health.duckdb")
+    @patch("dango.utils.db_health.subprocess.run")
+    def test_empty_project(
+        self, mock_run: MagicMock, mock_duckdb: MagicMock, tmp_path: Path
+    ) -> None:
+        """A project with no data directories still returns valid structure."""
+        from dango.utils.db_health import get_component_disk_usage
+
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result = get_component_disk_usage(tmp_path)
+
+        assert result["duckdb"]["file_size_mb"] == 0
+        assert result["csv_uploads"]["total_mb"] == 0
+        assert result["total_mb"] == 0
+
+    @patch("dango.utils.db_health.duckdb")
+    @patch("dango.utils.db_health.subprocess.run")
+    def test_cache_returns_same_result(
+        self, mock_run: MagicMock, mock_duckdb: MagicMock, tmp_path: Path
+    ) -> None:
+        """Second call within TTL returns cached result without recomputing."""
+        from dango.utils.db_health import get_component_disk_usage
+
+        project = self._make_project(tmp_path)
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result1 = get_component_disk_usage(project)
+        result2 = get_component_disk_usage(project)
+
+        assert result1 is result2  # same object = from cache
+
+    @patch("dango.utils.db_health.duckdb")
+    @patch("dango.utils.db_health.subprocess.run")
+    def test_cache_expires(
+        self, mock_run: MagicMock, mock_duckdb: MagicMock, tmp_path: Path
+    ) -> None:
+        """After TTL expires, result is recomputed."""
+        import dango.utils.db_health as mod
+        from dango.utils.db_health import get_component_disk_usage
+
+        project = self._make_project(tmp_path)
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result1 = get_component_disk_usage(project)
+
+        # Force cache expiry by backdating the cache time
+        mod._component_disk_cache_time -= mod._COMPONENT_DISK_TTL + 1
+
+        result2 = get_component_disk_usage(project)
+
+        assert result1 is not result2  # different object = recomputed

--- a/tests/unit/test_web_health.py
+++ b/tests/unit/test_web_health.py
@@ -1,0 +1,216 @@
+"""tests/unit/test_web_health.py
+
+Tests for dango.web.routes.health — platform health endpoint.
+
+Focuses on the disk warning deduplication logic in get_platform_health():
+- Critical disk → critical_issues (no duplicate warning)
+- Disk >80% used → actionable 80% warning (suppresses "Low disk space")
+- Disk warning but <80% → generic "Low disk space"
+- Cloud vs local message variants
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dango.web.routes.health import router
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with just the health router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+    app.state.scheduler = None
+    app.include_router(router)
+    return app
+
+
+def _base_health_data(
+    disk_status: str = "healthy",
+    used_pct: float = 50.0,
+) -> dict[str, Any]:
+    """Build a minimal health data dict with configurable disk fields."""
+    return {
+        "db_health": {
+            "size_gb": 1,
+            "size_mb": 1024,
+            "tables": 10,
+            "status": "healthy",
+            "raw_tables": 5,
+            "staging_tables": 3,
+            "marts_tables": 2,
+        },
+        "disk": {
+            "free_gb": 20,
+            "total_gb": 100,
+            "used_gb": 80,
+            "used_pct": used_pct,
+            "status": disk_status,
+        },
+        "disk_breakdown": {},
+        "sources_config": [],
+        "failed_syncs": [],
+        "failed_dbt": [],
+    }
+
+
+@pytest.mark.unit
+class TestDiskWarningDeduplication:
+    """Verify the elif chain produces exactly one disk warning."""
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_critical_disk_no_warning(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Critical disk status → critical_issues only, no warnings."""
+        mock_data.return_value = _base_health_data(disk_status="critical", used_pct=98)
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert "Critical disk space" in body["critical_issues"]
+        disk_warnings = [w for w in body["warnings"] if "disk" in w.lower() or "80%" in w]
+        assert disk_warnings == []
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_above_80pct_warning_suppresses_low_disk(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Disk at 85% with warning status → only 80% message, not "Low disk space"."""
+        mock_data.return_value = _base_health_data(disk_status="warning", used_pct=85)
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert any("80%" in w for w in body["warnings"])
+        assert "Low disk space" not in body["warnings"]
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_warning_below_80pct_shows_low_disk(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Disk in warning status but below 80% → generic "Low disk space"."""
+        mock_data.return_value = _base_health_data(disk_status="warning", used_pct=75)
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert "Low disk space" in body["warnings"]
+        assert not any("80%" in w for w in body["warnings"])
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_healthy_disk_no_warnings(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Healthy disk → no disk-related warnings."""
+        mock_data.return_value = _base_health_data(disk_status="healthy", used_pct=40)
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        disk_warnings = [w for w in body["warnings"] if "disk" in w.lower() or "80%" in w]
+        assert disk_warnings == []
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_cloud_80pct_message(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Cloud deployment → 80% message suggests resizing."""
+        mock_data.return_value = _base_health_data(disk_status="warning", used_pct=85)
+        # Create cloud.yml to simulate cloud deployment
+        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".dango" / "cloud.yml").write_text("droplet_id: 123\n")
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch("dango.web.routes.health.get_project_root", return_value=tmp_path):
+            resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert any("resizing" in w for w in body["warnings"])
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_local_80pct_message(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Local deployment → 80% message suggests dango cleanup."""
+        mock_data.return_value = _base_health_data(disk_status="warning", used_pct=85)
+        # No cloud.yml → local
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert any("cleanup" in w for w in body["warnings"])
+        assert not any("resizing" in w for w in body["warnings"])
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_disk_breakdown_in_response(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """disk_breakdown field is present in response."""
+        data = _base_health_data()
+        data["disk_breakdown"] = {"duckdb": {"file_size_mb": 100}}
+        mock_data.return_value = data
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert body["disk_breakdown"] == {"duckdb": {"file_size_mb": 100}}
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_missing_disk_breakdown_defaults_empty(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """If disk_breakdown is missing from data, response uses empty dict."""
+        data = _base_health_data()
+        del data["disk_breakdown"]
+        mock_data.return_value = data
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert body["disk_breakdown"] == {}

--- a/tests/unit/test_web_health.py
+++ b/tests/unit/test_web_health.py
@@ -141,6 +141,24 @@ class TestDiskWarningDeduplication:
         "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
     )
     @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    def test_exactly_80pct_shows_low_disk(
+        self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Exactly 80% → generic 'Low disk space', not the 80% actionable message."""
+        mock_data.return_value = _base_health_data(disk_status="warning", used_pct=80.0)
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert "Low disk space" in body["warnings"]
+        assert not any("80%" in w for w in body["warnings"])
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
     def test_cloud_80pct_message(
         self, mock_data: AsyncMock, mock_cloud: AsyncMock, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- Add `get_component_disk_usage()` to `utils/db_health.py` — returns per-component disk sizes for DuckDB (file + per-schema estimates), Metabase H2, CSV uploads (per source), dbt artifacts, dlt pipelines, and local backups
- Wire `disk_breakdown` into `/api/health/platform` response via concurrent `asyncio.to_thread` task in `get_platform_health_data()`
- Add proactive 80% disk usage warning with context-aware message (local: "run `dango cleanup`", cloud: "consider resizing or running cleanup")
- Make disk card and disk details always visible on health page (previously cloud-only)
- Add "Disk Breakdown by Component" section to health page with per-schema and per-source sub-items
- Add `formatFileSize()` JS helper (B/KB/MB/GB) and use it for CSV file size display

## Changes

| File | Lines | What |
|------|-------|------|
| `dango/utils/db_health.py` | +128 | `_dir_size_bytes()` helper + `get_component_disk_usage()` |
| `dango/web/helpers.py` | +14 | Concurrent breakdown task in `get_platform_health_data()` |
| `dango/web/routes/health.py` | +9 | 80% warning + `disk_breakdown` in response dict |
| `dango/web/templates/health.html` | +116/-7 | Always-visible disk card, breakdown section + JS rendering |
| `dango/web/static/js/app.js` | +15/-1 | `formatFileSize()` helper, updated CSV size display |
| `dango/utils/CLAUDE.md` | +1/-1 | Documented new public function |

## Design decisions

- **Graceful degradation**: Each component wrapped in independent try/except — a Docker timeout or DuckDB lock never crashes the health endpoint
- **Metabase sizing**: Uses `docker compose exec -T metabase stat -c %s` inside the container (GNU stat, always Linux) with 5s timeout
- **80% warning**: Only fires when disk status isn't already "critical" (avoids duplicate warnings with the existing <5GB critical alert)
- **Concurrent execution**: `get_component_disk_usage` runs in a thread pool alongside existing disk/db health tasks — no added latency

## Test plan

- [x] `ruff check` — passes
- [x] `ruff format --check` — passes
- [x] `mypy` — no new errors
- [x] `pytest` — 2343 passed, 23 skipped
- [x] File sizes within limits (`db_health.py`: 380 lines)
- [ ] Manual: `/api/health/platform` returns `disk_breakdown` with component sizes
- [ ] Manual: Health page shows disk card + breakdown section
- [ ] Manual: CSV upload modal shows file sizes in KB/MB/GB format
- [ ] Manual: Graceful degradation when Metabase container is stopped (shows "N/A")