### PR TITLE
P6-002: Add OAuth health monitoring, fix Shopify/Facebook bugs, add re-auth UX

### DIFF
--- a/dango/oauth/storage.py
+++ b/dango/oauth/storage.py
@@ -212,7 +212,11 @@ class OAuthStorage:
             else:
                 # Non-Google: flat parameters are the credentials
                 # Check for common OAuth credential keys
-                if "access_token" in source_section or "api_key" in source_section:
+                if (
+                    "access_token" in source_section
+                    or "api_key" in source_section
+                    or "private_app_password" in source_section
+                ):
                     creds = source_section
                 else:
                     return None
@@ -280,7 +284,11 @@ class OAuthStorage:
                         continue
                 else:
                     # Non-Google: flat parameters are the credentials
-                    if "access_token" in source_section or "api_key" in source_section:
+                    if (
+                        "access_token" in source_section
+                        or "api_key" in source_section
+                        or "private_app_password" in source_section
+                    ):
                         creds = source_section
                     else:
                         continue

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from fastapi import APIRouter
 
+from dango.oauth.storage import OAuthStorage
 from dango.web.helpers import (
     check_service_status_async,
     get_duckdb_path,
@@ -182,6 +183,33 @@ async def get_platform_health() -> dict[str, Any]:
             warnings.append(f"Backup is stale (>{_BACKUP_STALENESS_HOURS}h)")
         elif cloud_data["backup_health"]["status"] == "none":
             warnings.append("No backups configured")
+
+    # OAuth token health
+    oauth_health: list[dict[str, Any]] = []
+    try:
+        oauth_storage = OAuthStorage(project_root)
+        for cred in oauth_storage.list():
+            token_info: dict[str, Any] = {
+                "source_type": cred.source_type,
+                "provider": cred.provider,
+                "is_expired": cred.is_expired(),
+                "days_until_expiry": cred.days_until_expiry(),
+            }
+            oauth_health.append(token_info)
+            if cred.is_expired():
+                critical_issues.append(
+                    f"OAuth token expired for {cred.source_type}"
+                    " \u2014 reconnect at /settings/secrets"
+                )
+            elif cred.is_expiring_soon(days=7):
+                days = cred.days_until_expiry()
+                warnings.append(
+                    f"OAuth token for {cred.source_type} expires in {days} day(s)"
+                    " \u2014 reconnect at /settings/secrets"
+                )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to check OAuth token health")
+    result["oauth_health"] = oauth_health
 
     if critical_issues:
         result["status"] = "critical"

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -208,7 +208,7 @@ async def get_platform_health() -> dict[str, Any]:
                     " \u2014 reconnect at /settings/secrets"
                 )
     except Exception:  # noqa: BLE001
-        logger.warning("Failed to check OAuth token health")
+        logger.warning("Failed to check OAuth token health", exc_info=True)
     result["oauth_health"] = oauth_health
 
     if critical_issues:

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -874,6 +874,22 @@ function updateHealthWidget(health) {
         statusText.textContent = 'Unknown Status';
         statusText.className = 'text-lg font-semibold text-gray-800';
     }
+
+    // OAuth expiry warning banner
+    const oauthBanner = document.getElementById('oauth-expiry-banner');
+    if (oauthBanner && health.oauth_health) {
+        const expiring = health.oauth_health.filter(
+            t => t.is_expired || (t.days_until_expiry !== null && t.days_until_expiry <= 7)
+        );
+        if (expiring.length > 0 && !oauthBanner.dataset.dismissed) {
+            oauthBanner.classList.remove('hidden');
+            const text = document.getElementById('oauth-banner-text');
+            if (text) {
+                const names = expiring.map(t => t.source_type).join(', ');
+                text.textContent = `OAuth token${expiring.length > 1 ? 's' : ''} expiring soon: ${names}`;
+            }
+        }
+    }
 }
 
 function showSourcesLoading() {

--- a/dango/web/templates/dashboard.html
+++ b/dango/web/templates/dashboard.html
@@ -97,6 +97,27 @@
             </a>
         </div>
 
+        <!-- OAuth Expiry Warning Banner -->
+        <div id="oauth-expiry-banner" class="mb-6 hidden" x-data="{ dismissed: false }" x-show="!dismissed">
+            <div class="rounded-lg shadow p-4 border-l-4 bg-yellow-50 border-yellow-500">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center space-x-3">
+                        <span class="text-2xl">&#128273;</span>
+                        <div>
+                            <p class="text-sm font-medium text-yellow-800" id="oauth-banner-text">OAuth tokens expiring soon</p>
+                            <a href="/settings/secrets" class="text-xs text-yellow-700 hover:text-yellow-900 underline">Manage credentials &rarr;</a>
+                        </div>
+                    </div>
+                    <button @click="dismissed = true; document.getElementById('oauth-expiry-banner').classList.add('hidden')"
+                            class="text-gray-400 hover:text-gray-600">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+
         <!-- Service Status Cards - Logical workflow order: Data Catalog, Query Database, Dashboards, Activity Logs -->
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 mb-6 sm:mb-8">
             <!-- dbt Docs (Data Catalog) -->

--- a/dango/web/templates/dashboard.html
+++ b/dango/web/templates/dashboard.html
@@ -108,7 +108,7 @@
                             <a href="/settings/secrets" class="text-xs text-yellow-700 hover:text-yellow-900 underline">Manage credentials &rarr;</a>
                         </div>
                     </div>
-                    <button @click="dismissed = true; document.getElementById('oauth-expiry-banner').classList.add('hidden')"
+                    <button @click="dismissed = true; $el.closest('#oauth-expiry-banner').dataset.dismissed = 'true'; document.getElementById('oauth-expiry-banner').classList.add('hidden')"
                             class="text-gray-400 hover:text-gray-600">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>

--- a/dango/web/templates/health.html
+++ b/dango/web/templates/health.html
@@ -160,6 +160,19 @@
                 </div>
             </div>
 
+            <!-- OAuth Token Health -->
+            <div id="oauth-health" class="bg-white rounded-lg shadow hidden">
+                <div class="px-6 py-4 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">OAuth Tokens</h2>
+                </div>
+                <div class="p-6">
+                    <div id="oauth-health-list" class="space-y-3"></div>
+                    <div class="mt-4">
+                        <a href="/settings/secrets" class="text-sm text-blue-600 hover:text-blue-800">Manage credentials &rarr;</a>
+                    </div>
+                </div>
+            </div>
+
             <!-- Disk Breakdown by Component -->
             <div id="disk-breakdown" class="bg-white rounded-lg shadow hidden">
                 <div class="px-6 py-4 border-b border-gray-200">
@@ -380,6 +393,29 @@
                 }
 
                 listEl.innerHTML = rows;
+            }
+
+            // OAuth Token Health
+            if (health.oauth_health && health.oauth_health.length > 0) {
+                document.getElementById('oauth-health').classList.remove('hidden');
+                const oauthList = document.getElementById('oauth-health-list');
+                oauthList.innerHTML = health.oauth_health.map(t => {
+                    let statusClass, statusText;
+                    if (t.is_expired) {
+                        statusClass = 'bg-red-100 text-red-800';
+                        statusText = 'Expired';
+                    } else if (t.days_until_expiry !== null && t.days_until_expiry <= 7) {
+                        statusClass = 'bg-yellow-100 text-yellow-800';
+                        statusText = `Expires in ${t.days_until_expiry}d`;
+                    } else {
+                        statusClass = 'bg-green-100 text-green-800';
+                        statusText = t.days_until_expiry !== null ? `${t.days_until_expiry}d remaining` : 'No expiry';
+                    }
+                    return `<div class="flex justify-between items-center">
+                        <dt class="text-sm text-gray-600">${escapeHtml(t.source_type)} <span class="text-xs text-gray-400">(${escapeHtml(t.provider)})</span></dt>
+                        <dd><span class="px-2 py-1 text-xs rounded-full ${statusClass}">${escapeHtml(statusText)}</span></dd>
+                    </div>`;
+                }).join('');
             }
 
             // Cloud resources (CPU, RAM, Backup)

--- a/dango/web/templates/secrets.html
+++ b/dango/web/templates/secrets.html
@@ -94,10 +94,18 @@
                                 </template>
                             </div>
                         </div>
-                        <button @click="confirmDisconnectOAuth(cred.source_type)"
-                                class="px-3 py-1.5 text-sm text-red-600 border border-red-200 rounded-md hover:bg-red-50">
-                            Disconnect
-                        </button>
+                        <div class="flex space-x-2">
+                            <template x-if="cred.is_expired || (cred.days_until_expiry !== null && cred.days_until_expiry <= 7)">
+                                <button @click="connectOAuth(cred.source_type)"
+                                        class="px-3 py-1.5 text-sm text-white bg-blue-600 rounded-md hover:bg-blue-700">
+                                    Reconnect
+                                </button>
+                            </template>
+                            <button @click="confirmDisconnectOAuth(cred.source_type)"
+                                    class="px-3 py-1.5 text-sm text-red-600 border border-red-200 rounded-md hover:bg-red-50">
+                                Disconnect
+                            </button>
+                        </div>
                     </div>
                 </template>
             </div>

--- a/tests/factories/oauth_factories.py
+++ b/tests/factories/oauth_factories.py
@@ -57,7 +57,7 @@ def make_facebook_credential(**overrides: Any) -> OAuthCredential:
     """Create a Facebook OAuth credential."""
     defaults: dict[str, Any] = {
         "source_type": "facebook_ads",
-        "provider": "facebook_ads",
+        "provider": "facebook",
         "identifier": "123456789",
         "account_info": "Facebook Ads Account (123456789)",
         "credentials": {

--- a/tests/unit/test_oauth_validation.py
+++ b/tests/unit/test_oauth_validation.py
@@ -365,7 +365,7 @@ class TestValidateToken:
 
     @patch("dango.oauth.validation.requests")
     def test_routes_facebook(self, mock_requests: MagicMock) -> None:
-        """Routes facebook_ads provider to validate_facebook_token."""
+        """Routes facebook provider to validate_facebook_token."""
         resp = MagicMock()
         resp.status_code = 200
         resp.json.return_value = {"name": "Test", "id": "123"}

--- a/tests/unit/test_oauth_validation.py
+++ b/tests/unit/test_oauth_validation.py
@@ -374,7 +374,7 @@ class TestValidateToken:
         cred = make_facebook_credential()
         result = validate_token(cred)
         assert result.valid is True
-        assert result.provider == "facebook_ads"
+        assert result.provider == "facebook"
 
     @patch("dango.oauth.validation.requests")
     def test_routes_shopify(self, mock_requests: MagicMock) -> None:
@@ -559,7 +559,7 @@ class TestValidateAllTokens:
                 source_type="google_sheets", provider="google", valid=True, message="ok"
             ),
             TokenValidationResult(
-                source_type="facebook_ads", provider="facebook_ads", valid=False, message="revoked"
+                source_type="facebook_ads", provider="facebook", valid=False, message="revoked"
             ),
         ]
 


### PR DESCRIPTION
## Summary

- **Fix Shopify credential retrieval bug**: `OAuthStorage.get()` and `list()` now include `private_app_password` in credential key checks, so Shopify credentials are no longer silently dropped
- **Fix Facebook test factory**: Changed `provider="facebook_ads"` to `provider="facebook"` (canonical name matching Google/Shopify convention), updated 2 test assertions
- **Add OAuth health to `/api/health/platform`**: New `oauth_health` section with per-source token status; expired tokens surface as `critical_issues`, expiring-soon (≤7 days) as `warnings`; OAuth storage failures caught gracefully
- **Health page OAuth section**: Color-coded token status badges (green/yellow/red) with link to secrets page
- **Secrets page Reconnect button**: Shown for expired/expiring OAuth sources, triggers existing OAuth connect flow
- **Dashboard expiry warning banner**: Dismissible yellow banner when tokens expire within 7 days, links to secrets page

## Test plan

- [x] `pytest tests/unit/test_oauth_validation.py` — all 35 tests pass (factory + routing changes verified)
- [x] `pytest -m unit` — 2308 passed, 1 pre-existing failure (unrelated `test_auth_audit.py`)
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Manual: verify `/api/health/platform` includes `oauth_health` array
- [ ] Manual: verify health page shows OAuth Tokens section
- [ ] Manual: verify secrets page shows Reconnect button for expiring creds
- [ ] Manual: verify dashboard shows dismissible warning banner

<https://claude.ai/code/session_017ryS4QCjPVgkvXBXEHsaa1>