### PR TITLE
TEST-021: Add OAuth storage + health tests, fix exists()/delete() Shopify bugs

### DIFF
--- a/dango/oauth/storage.py
+++ b/dango/oauth/storage.py
@@ -352,6 +352,7 @@ class OAuthStorage:
                         "api_secret",
                         "refresh_token",
                         "shop_url",
+                        "private_app_password",
                     }
                     for key in CREDENTIAL_KEYS:
                         if key in secrets["sources"][source_type]:
@@ -395,4 +396,8 @@ class OAuthStorage:
             return creds is not None and "client_id" in creds
         else:
             # Non-Google: check for common OAuth credential keys
-            return "access_token" in source_section or "api_key" in source_section
+            return (
+                "access_token" in source_section
+                or "api_key" in source_section
+                or "private_app_password" in source_section
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,6 +273,7 @@ module = [
     "tests.unit.test_remote_sync_cli",
     "tests.unit.test_web_schedule_page",
     "tests.unit.test_log_rotation",
+    "tests.unit.test_oauth_storage",
     "tests.integration.test_sync_notification",
     "tests.integration.test_digitalocean",
     "tests.integration.test_deploy",

--- a/tests/unit/test_oauth_storage.py
+++ b/tests/unit/test_oauth_storage.py
@@ -168,11 +168,11 @@ class TestFacebookStorage:
 
 @pytest.mark.unit
 class TestExistsBug:
-    """Document that exists() does not check private_app_password.
+    """Regression tests for exists() Shopify detection.
 
-    The P6-002 fix updated get() and list() to detect Shopify credentials
-    via ``private_app_password``, but missed updating exists().  This test
-    verifies the fix once exists() is patched.
+    P6-002 originally updated get() and list() to detect Shopify credentials
+    via ``private_app_password``, but missed exists() and delete().  This PR
+    fixes both; these tests prevent regression.
     """
 
     def test_exists_detects_shopify_after_fix(self, tmp_path: Path) -> None:

--- a/tests/unit/test_oauth_storage.py
+++ b/tests/unit/test_oauth_storage.py
@@ -1,0 +1,229 @@
+"""tests/unit/test_oauth_storage.py
+
+Tests for dango.oauth.storage — OAuthCredential model and OAuthStorage CRUD.
+
+Focuses on:
+- OAuthCredential expiry helpers (is_expired, is_expiring_soon, days_until_expiry)
+- Shopify credential save/get round-trip (P6-002 bug fix regression)
+- Facebook credential save/get round-trip (factory provider name)
+- exists() incomplete fix (Shopify private_app_password not checked)
+- Graceful degradation on corrupt/missing secrets
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from dango.oauth.storage import OAuthStorage
+from tests.factories.oauth_factories import (
+    make_facebook_credential,
+    make_google_credential,
+    make_shopify_credential,
+)
+
+# ---------------------------------------------------------------------------
+# OAuthCredential model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOAuthCredentialExpiry:
+    """Tests for OAuthCredential expiry helper methods."""
+
+    def test_no_expiry_is_not_expired(self) -> None:
+        cred = make_google_credential(expires_at=None)
+        assert cred.is_expired() is False
+
+    def test_no_expiry_days_until_expiry_none(self) -> None:
+        cred = make_google_credential(expires_at=None)
+        assert cred.days_until_expiry() is None
+
+    def test_no_expiry_is_not_expiring_soon(self) -> None:
+        cred = make_google_credential(expires_at=None)
+        assert cred.is_expiring_soon() is False
+
+    def test_future_expiry_not_expired(self) -> None:
+        cred = make_facebook_credential(expires_at=datetime.now() + timedelta(days=30))
+        assert cred.is_expired() is False
+
+    def test_past_expiry_is_expired(self) -> None:
+        cred = make_facebook_credential(expires_at=datetime.now() - timedelta(hours=1))
+        assert cred.is_expired() is True
+
+    def test_days_until_expiry_positive(self) -> None:
+        cred = make_facebook_credential(expires_at=datetime.now() + timedelta(days=10))
+        days = cred.days_until_expiry()
+        assert days is not None
+        assert days >= 9  # allow for sub-day rounding
+
+    def test_days_until_expiry_zero_when_expired(self) -> None:
+        cred = make_facebook_credential(expires_at=datetime.now() - timedelta(days=5))
+        assert cred.days_until_expiry() == 0
+
+    def test_expiring_soon_within_7_days(self) -> None:
+        cred = make_facebook_credential(expires_at=datetime.now() + timedelta(days=3))
+        assert cred.is_expiring_soon(days=7) is True
+
+    def test_not_expiring_soon_beyond_threshold(self) -> None:
+        cred = make_facebook_credential(expires_at=datetime.now() + timedelta(days=30))
+        assert cred.is_expiring_soon(days=7) is False
+
+    def test_expiring_soon_custom_threshold(self) -> None:
+        cred = make_facebook_credential(expires_at=datetime.now() + timedelta(days=25))
+        assert cred.is_expiring_soon(days=30) is True
+        assert cred.is_expiring_soon(days=7) is False
+
+
+# ---------------------------------------------------------------------------
+# Shopify storage (P6-002 regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestShopifyStorage:
+    """Regression tests for Shopify credential retrieval (P6-002 fix).
+
+    The P6-002 fix added ``private_app_password`` to the credential detection
+    keys in ``get()`` and ``list()``.  These tests ensure the fix is not reverted.
+    """
+
+    def test_save_and_get_round_trip(self, tmp_path: Path) -> None:
+        """Shopify cred saved via save() is retrievable via get()."""
+        storage = OAuthStorage(tmp_path)
+        cred = make_shopify_credential()
+        assert storage.save(cred) is True
+
+        loaded = storage.get("shopify")
+        assert loaded is not None
+        assert loaded.source_type == "shopify"
+        assert loaded.provider == "shopify"
+        assert loaded.credentials["private_app_password"] == "shpat_abcdef123456"
+        assert loaded.credentials["shop_url"] == "mystore.myshopify.com"
+
+    def test_list_includes_shopify(self, tmp_path: Path) -> None:
+        """list() returns Shopify credentials alongside other providers."""
+        storage = OAuthStorage(tmp_path)
+        storage.save(make_shopify_credential())
+        storage.save(make_facebook_credential())
+
+        creds = storage.list()
+        source_types = {c.source_type for c in creds}
+        assert "shopify" in source_types
+        assert "facebook_ads" in source_types
+
+    def test_delete_cleans_shopify_keys(self, tmp_path: Path) -> None:
+        """delete() removes Shopify credential keys from secrets.toml."""
+        storage = OAuthStorage(tmp_path)
+        storage.save(make_shopify_credential())
+        assert storage.get("shopify") is not None
+
+        assert storage.delete("shopify") is True
+        assert storage.get("shopify") is None
+
+    def test_list_filtered_by_provider(self, tmp_path: Path) -> None:
+        """list(provider='shopify') returns only Shopify credentials."""
+        storage = OAuthStorage(tmp_path)
+        storage.save(make_shopify_credential())
+        storage.save(make_facebook_credential())
+
+        creds = storage.list(provider="shopify")
+        assert len(creds) == 1
+        assert creds[0].provider == "shopify"
+
+
+# ---------------------------------------------------------------------------
+# Facebook storage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFacebookStorage:
+    """Tests for Facebook credential storage and factory provider name."""
+
+    def test_factory_provider_name(self) -> None:
+        """Factory sets provider='facebook' (not 'facebook_ads')."""
+        cred = make_facebook_credential()
+        assert cred.provider == "facebook"
+        assert cred.source_type == "facebook_ads"
+
+    def test_save_and_get_round_trip(self, tmp_path: Path) -> None:
+        """Facebook cred with access_token is retrievable via get()."""
+        storage = OAuthStorage(tmp_path)
+        cred = make_facebook_credential()
+        assert storage.save(cred) is True
+
+        loaded = storage.get("facebook_ads")
+        assert loaded is not None
+        assert loaded.provider == "facebook"
+        assert "access_token" in loaded.credentials
+
+
+# ---------------------------------------------------------------------------
+# exists() bug — incomplete P6-002 fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExistsBug:
+    """Document that exists() does not check private_app_password.
+
+    The P6-002 fix updated get() and list() to detect Shopify credentials
+    via ``private_app_password``, but missed updating exists().  This test
+    verifies the fix once exists() is patched.
+    """
+
+    def test_exists_detects_shopify_after_fix(self, tmp_path: Path) -> None:
+        """exists('shopify') returns True after save (requires fix)."""
+        storage = OAuthStorage(tmp_path)
+        storage.save(make_shopify_credential())
+        # After the exists() fix, this should be True
+        assert storage.exists("shopify") is True
+
+    def test_exists_detects_facebook(self, tmp_path: Path) -> None:
+        """exists('facebook_ads') works for access_token-based creds."""
+        storage = OAuthStorage(tmp_path)
+        storage.save(make_facebook_credential())
+        assert storage.exists("facebook_ads") is True
+
+    def test_exists_false_for_missing(self, tmp_path: Path) -> None:
+        """exists() returns False for source with no credentials."""
+        storage = OAuthStorage(tmp_path)
+        assert storage.exists("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStorageGracefulDegradation:
+    """Storage operations handle corrupt or missing data gracefully."""
+
+    def test_get_corrupt_toml_returns_none(self, tmp_path: Path) -> None:
+        """Corrupt secrets.toml → get() returns None."""
+        storage = OAuthStorage(tmp_path)
+        storage.secrets_file.write_text("{{{{not valid toml")
+        assert storage.get("google_sheets") is None
+
+    def test_list_corrupt_toml_returns_empty(self, tmp_path: Path) -> None:
+        """Corrupt secrets.toml → list() returns empty list."""
+        storage = OAuthStorage(tmp_path)
+        storage.secrets_file.write_text("{{{{not valid toml")
+        assert storage.list() == []
+
+    def test_get_empty_source_returns_none(self, tmp_path: Path) -> None:
+        """Empty source section → get() returns None."""
+        storage = OAuthStorage(tmp_path)
+        storage.secrets_file.write_text("[sources.shopify]\n")
+        assert storage.get("shopify") is None
+
+    def test_init_creates_dlt_directory(self, tmp_path: Path) -> None:
+        """OAuthStorage.__init__ creates .dlt directory if missing."""
+        dlt_dir = tmp_path / ".dlt"
+        assert not dlt_dir.exists()
+        OAuthStorage(tmp_path)
+        assert dlt_dir.exists()

--- a/tests/unit/test_web_health.py
+++ b/tests/unit/test_web_health.py
@@ -2,18 +2,17 @@
 
 Tests for dango.web.routes.health — platform health endpoint.
 
-Focuses on the disk warning deduplication logic in get_platform_health():
-- Critical disk → critical_issues (no duplicate warning)
-- Disk >80% used → actionable 80% warning (suppresses "Low disk space")
-- Disk warning but <80% → generic "Low disk space"
-- Cloud vs local message variants
+Focuses on:
+- Disk warning deduplication logic in get_platform_health()
+- OAuth token health: expired → critical, expiring-soon → warning
+- Storage failure graceful degradation
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -232,3 +231,177 @@ class TestDiskWarningDeduplication:
         body = resp.json()
 
         assert body["disk_breakdown"] == {}
+
+
+# ---------------------------------------------------------------------------
+# OAuth health in platform health response
+# ---------------------------------------------------------------------------
+
+
+def _make_expired_credential() -> MagicMock:
+    """Create a mock OAuthCredential that is expired."""
+    cred = MagicMock()
+    cred.source_type = "facebook_ads"
+    cred.provider = "facebook"
+    cred.is_expired.return_value = True
+    cred.is_expiring_soon.return_value = True
+    cred.days_until_expiry.return_value = 0
+    return cred
+
+
+def _make_expiring_credential(days: int = 3) -> MagicMock:
+    """Create a mock OAuthCredential expiring in N days."""
+    cred = MagicMock()
+    cred.source_type = "shopify"
+    cred.provider = "shopify"
+    cred.is_expired.return_value = False
+    cred.is_expiring_soon.return_value = True
+    cred.days_until_expiry.return_value = days
+    return cred
+
+
+def _make_healthy_credential() -> MagicMock:
+    """Create a mock OAuthCredential with no expiry concerns."""
+    cred = MagicMock()
+    cred.source_type = "google_sheets"
+    cred.provider = "google"
+    cred.is_expired.return_value = False
+    cred.is_expiring_soon.return_value = False
+    cred.days_until_expiry.return_value = None
+    return cred
+
+
+@pytest.mark.unit
+class TestOAuthHealth:
+    """OAuth token health in the /api/health/platform response."""
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    @patch("dango.web.routes.health.OAuthStorage")
+    def test_expired_token_in_critical_issues(
+        self,
+        mock_storage_cls: MagicMock,
+        mock_data: AsyncMock,
+        mock_cloud: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Expired OAuth token → critical_issues entry."""
+        mock_data.return_value = _base_health_data()
+        mock_storage_cls.return_value.list.return_value = [_make_expired_credential()]
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        oauth_criticals = [i for i in body["critical_issues"] if "OAuth" in i]
+        assert len(oauth_criticals) == 1
+        assert "facebook_ads" in oauth_criticals[0]
+        assert body["status"] == "critical"
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    @patch("dango.web.routes.health.OAuthStorage")
+    def test_expiring_soon_in_warnings(
+        self,
+        mock_storage_cls: MagicMock,
+        mock_data: AsyncMock,
+        mock_cloud: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Token expiring in 3 days → warning entry."""
+        mock_data.return_value = _base_health_data()
+        mock_storage_cls.return_value.list.return_value = [_make_expiring_credential(days=3)]
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        oauth_warnings = [w for w in body["warnings"] if "OAuth" in w]
+        assert len(oauth_warnings) == 1
+        assert "3 day" in oauth_warnings[0]
+        assert "shopify" in oauth_warnings[0]
+        assert body["status"] == "warning"
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    @patch("dango.web.routes.health.OAuthStorage")
+    def test_no_expiry_no_warning(
+        self,
+        mock_storage_cls: MagicMock,
+        mock_data: AsyncMock,
+        mock_cloud: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """Credential with no expiry → no OAuth warnings or criticals."""
+        mock_data.return_value = _base_health_data()
+        mock_storage_cls.return_value.list.return_value = [_make_healthy_credential()]
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        oauth_warnings = [w for w in body["warnings"] if "OAuth" in w]
+        oauth_criticals = [i for i in body["critical_issues"] if "OAuth" in i]
+        assert oauth_warnings == []
+        assert oauth_criticals == []
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    @patch("dango.web.routes.health.OAuthStorage")
+    def test_storage_failure_graceful(
+        self,
+        mock_storage_cls: MagicMock,
+        mock_data: AsyncMock,
+        mock_cloud: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """OAuthStorage failure → oauth_health is empty list, no crash."""
+        mock_data.return_value = _base_health_data()
+        mock_storage_cls.side_effect = RuntimeError("disk read failed")
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert resp.status_code == 200
+        assert body["oauth_health"] == []
+
+    @patch(
+        "dango.web.routes.health._get_cloud_health_data", new_callable=AsyncMock, return_value=None
+    )
+    @patch("dango.web.routes.health.get_platform_health_data", new_callable=AsyncMock)
+    @patch("dango.web.routes.health.OAuthStorage")
+    def test_oauth_health_field_structure(
+        self,
+        mock_storage_cls: MagicMock,
+        mock_data: AsyncMock,
+        mock_cloud: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """oauth_health entries have expected fields."""
+        mock_data.return_value = _base_health_data()
+        mock_storage_cls.return_value.list.return_value = [_make_expiring_credential(days=5)]
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        resp = client.get("/api/health/platform")
+        body = resp.json()
+
+        assert len(body["oauth_health"]) == 1
+        entry = body["oauth_health"][0]
+        assert entry["source_type"] == "shopify"
+        assert entry["provider"] == "shopify"
+        assert entry["is_expired"] is False
+        assert entry["days_until_expiry"] == 5


### PR DESCRIPTION
## Summary

- **Coverage audit** of all 5 Phase 6 implementation tasks (P6-001 through P6-005). Found 4 of 5 areas already had comprehensive tests from implementation tasks.
- **New test file** `tests/unit/test_oauth_storage.py` (23 tests) — OAuthCredential expiry helpers, Shopify save/get/list/delete round-trips (P6-002 regression), Facebook factory verification, `exists()` detection, graceful degradation on corrupt secrets
- **Extended** `tests/unit/test_web_health.py` (+5 tests) — expired token in critical_issues, expiring-soon in warnings, no-expiry credential, storage failure graceful degradation, oauth_health field structure
- **Bug fixes** in `dango/oauth/storage.py`: `exists()` and `delete()` were missing `private_app_password` check (incomplete P6-002 Shopify fix)

## Test plan

- [x] All 37 new/modified tests pass
- [x] Full unit suite passes (2336 passed, 1 pre-existing failure in test_auth_audit.py)
- [x] ruff check + format clean
- [x] Shopify regression tests verify save/get/list/delete/exists round-trips
- [x] OAuth health tests verify expired → critical, expiring → warning, failure → graceful

<https://claude.ai/code/session_01W6kCWK4MYt7Tr46h18ANsi>