### PR TITLE
DOC-028: Phase 6 documentation sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,8 +110,9 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 | `activity_log.py` | `log_activity()` — append-only JSON activity log |
 | `sync_history.py` | `save_sync_history_entry()`, `load_sync_history()` — per-source sync results |
 | `database.py` | `ensure_dbt_schemas()` — creates raw/staging/intermediate/marts schemas |
-| `db_health.py` | `check_duckdb_health()`, `get_disk_usage_summary()` |
+| `db_health.py` | `check_disk_space()`, `check_duckdb_health()`, `get_disk_usage_summary()`, `get_component_disk_usage()` |
 | `dbt_status.py` | `get_model_statuses()`, `update_model_status()` |
+| `log_rotation.py` | `rotate_jsonl_log()`, `cleanup_old_archives()`, `get_log_disk_usage()` |
 | `data_validation.py` | Data validation utilities |
 
 **Public API:** `DbtLock`, `DbtLockError`, `dbt_lock()`, `log_activity()`, `save_sync_history_entry()`, `load_sync_history()`, `ensure_dbt_schemas()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | `dango/ingestion/dlt_sources/` | Vendored third-party dlt connectors (127 files). Rarely modified. |
 | `dango/web/static/` | Frontend HTML/CSS/JS assets. |
 | `tests/` | Read source module first, then find its tests. |
-| `dango/ingestion/sources/registry.py` | 1440-line metadata registry. Only when adding a new source. |
+| `dango/ingestion/sources/registry.py` | 1466-line metadata registry. Only when adding a new source. |
 | `dango/templates/` | Jinja2 templates. Only when modifying project init or model generation. |
 
 ## Decision Tree
@@ -71,23 +71,25 @@ dango/                          # Python package source
 │   ├── commands/               # Command modules (extracted from main.py by TASK-005)
 │   │   ├── __init__.py         # Package marker
 │   │   ├── auth.py             # auth group (12 subcommands, 538 lines)
+│   │   ├── cleanup.py          # cleanup old logs, dbt artifacts, Python cache
 │   │   ├── oauth.py            # oauth group + 10 subcommands (815 lines)
 │   │   ├── config_cmd.py       # config group (validate/show)
 │   │   ├── dashboard.py        # dashboard group (provision)
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (941 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (964 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (549 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (653 lines)
 │   │   ├── transform.py        # run/docs/generate
+│   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, destroy)
 │   │   ├── deploy_wizard.py    # Interactive deploy wizard (579 lines)
 │   │   ├── deploy_provision.py # Provisioning orchestration (543 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
-│   │   ├── remote.py           # remote group + push/rollback/firewall/domain (651 lines)
+│   │   ├── remote.py           # remote group + push/rollback/firewall/domain (652 lines)
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
 │   │   ├── remote_ops.py       # remote upgrade/resize/migrate
 │   │   ├── remote_backup.py    # remote backup subgroup
@@ -126,7 +128,7 @@ dango/                          # Python package source
 ├── web/                        # Level 2 — FastAPI web server
 │   ├── app.py                  # Entry point (~301 lines) — routers, middleware, admin bootstrap
 │   ├── models.py               # Pydantic request/response DTOs (incl. auth DTOs)
-│   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (798 lines)
+│   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (810 lines)
 │   ├── middleware/             # Request middleware
 │   │   ├── auth.py             # Session/API key auth + CSRF check (~325 lines)
 │   │   └── rate_limit.py       # Rate limiting (~212 lines)
@@ -158,7 +160,7 @@ dango/                          # Python package source
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
-│   ├── metabase.py             # Metabase API (1142 lines)
+│   ├── metabase.py             # Metabase API (1149 lines)
 │   └── dashboard_manager.py    # Dashboard export/import (1113 lines)
 │
 ├── platform/                   # Level 2 — Docker, network, file watcher, scheduling
@@ -206,10 +208,10 @@ dango/                          # Python package source
 │   └── watcher_runner.py       # → local/watcher_runner.py
 │
 ├── ingestion/                  # Level 1 — Data loading
-│   ├── dlt_runner.py           # ⚠ 1759 lines — orchestrates full sync pipeline
+│   ├── dlt_runner.py           # ⚠ 1784 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # CSV loading with dedup (742 lines)
 │   ├── sources/
-│   │   └── registry.py         # Source metadata (1440 lines, 33 source types)
+│   │   └── registry.py         # Source metadata (1466 lines, 33 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
@@ -237,8 +239,9 @@ dango/                          # Python package source
 │   ├── activity_log.py         # Append-only JSON activity log
 │   ├── sync_history.py         # Per-source sync results
 │   ├── database.py             # Schema creation helpers
-│   ├── db_health.py            # DuckDB health checks
+│   ├── db_health.py            # DuckDB health checks + component disk breakdown
 │   ├── dbt_status.py           # dbt model status tracking
+│   ├── log_rotation.py         # JSONL log rotation with gzip compression
 │   ├── data_validation.py      # Data validation utilities
 │   └── env_file.py             # .env file parsing and serialization
 │
@@ -285,32 +288,32 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `ingestion/dlt_runner.py` | 1759 | — (exempt, too risky) |
-| `ingestion/sources/registry.py` | 1440 | — (metadata-only) |
+| `ingestion/dlt_runner.py` | 1784 | — (exempt, too risky) |
+| `ingestion/sources/registry.py` | 1466 | — (metadata-only) |
 | `cli/source_wizard.py` | 1324 | — |
-| `visualization/metabase.py` | 1142 | — |
+| `visualization/metabase.py` | 1149 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/init.py` | 965 | — |
-| `cli/commands/platform.py` | 941 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 964 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | ~854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 815 | — (renamed from auth.py by TASK-093) |
+| `web/helpers.py` | 810 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 801 | — |
-| `web/helpers.py` | 798 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 742 | — |
 | `platform/scheduling/jobs.py` | 732 | — (module-level job functions) |
 | `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
 | `web/routes/upload.py` | 680 | — (extracted from app.py by TASK-085) |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/remote.py` | 651 | — (remote group + push/rollback/firewall/domain) |
+| `cli/commands/source.py` | 653 | — (extracted from main.py by TASK-005) |
+| `cli/commands/remote.py` | 652 | — (remote group + push/rollback/firewall/domain) |
 | `cli/validate.py` | 651 | — |
 | `cli/commands/deploy_wizard.py` | 579 | — (interactive deploy wizard) |
 | `transformation/generator.py` | 577 | — |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
-| `cli/commands/source.py` | 549 | — (extracted from main.py by TASK-005) |
+| `config/models.py` | 548 | — (Pydantic config models) |
 | `cli/commands/deploy_provision.py` | 543 | — (provisioning orchestration) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
 | `cli/commands/auth.py` | 538 | — (12 auth subcommands) |
-| `config/models.py` | 530 | — (Pydantic config models) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 527 | — (admin user CRUD) |
 | `cli/model_wizard.py` | 507 | — |

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -314,6 +314,18 @@ configure_logging()  # uses DANGO_LOG_LEVEL env var or defaults to INFO
 - `WARNING` — recoverable issues (retry, fallback used)
 - `ERROR` — failures requiring attention
 
+### Log rotation
+
+JSONL log files (audit.jsonl, activity.jsonl) are rotated by `dango/utils/log_rotation.py`. Rotation is triggered on platform startup (`platform/common/startup.py`) and by `dango cleanup`.
+
+**Rotation rules:**
+- Rotate when file exceeds 5 MB or is older than 1 day
+- Archives are gzip-compressed with YYYYMMDD date suffix (e.g., `audit.20260305.jsonl.gz`)
+- Same-day collisions get a counter suffix (e.g., `audit.20260305_1.jsonl.gz`)
+- Old archives are cleaned up after 90 days (configurable via `max_age_days`)
+
+**Never-fail contract:** All public functions in `log_rotation.py` catch exceptions internally and log warnings rather than raising. This prevents log rotation failures from blocking platform startup or cleanup operations.
+
 ---
 
 ## 7. Testing Patterns

--- a/dango/CLAUDE.md
+++ b/dango/CLAUDE.md
@@ -27,7 +27,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 
 **Used by:**
 - `dango/cli/main.py`, `dango/cli/init.py`, `dango/cli/wizard.py` — import `__version__`
-- `dango.logging` — not yet imported by any module (available for future use)
+- `dango.logging` — `get_logger()` used by `web/routes/`, `web/middleware/`, `web/app.py`, `platform/scheduling/`, `platform/notifications/`, `oauth/web_flow.py`, `utils/log_rotation.py`, `cli/commands/schedule.py`, `cli/commands/remote_env.py`; `configure_logging()` called by entry points
 - `pyproject.toml` defines `getdango` as the installable package
 - Entry point: `dango.cli.main:cli` (configured in `pyproject.toml`)
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,17 +13,19 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (521 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (941 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
-| `commands/auth.py` (500 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
+| `commands/source.py` (653 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/platform.py` (964 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/auth.py` (538 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
+| `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (815 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
 | `commands/transform.py` (326 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
+| `commands/upgrade.py` (236 lines) | `upgrade` command — local Dango upgrade via pip + migrations | `upgrade()`, `get_latest_version_cached()` |
 | `commands/data.py` (360 lines) | `db` group (`status`, `clean`) + `validate` | `db`, `validate()` |
 | `commands/config_cmd.py` (179 lines) | `config` group (`validate`, `show`) | `config` |
 | `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
-| `commands/remote.py` (~650 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
+| `commands/remote.py` (652 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~152 lines) | `serve` production foreground server | `serve()` |
 | `commands/deploy.py` (~460 lines) | `deploy` group (wizard default, destroy) | `deploy`, `deploy_destroy()` |
@@ -60,6 +62,8 @@ dango (top-level group)
 ├── init, rename, info          ← commands/project.py
 ├── start, stop, status         ← commands/platform.py
 ├── serve                       ← commands/serve.py
+├── upgrade                     ← commands/upgrade.py
+├── cleanup                     ← commands/cleanup.py
 ├── sync                        ← commands/source.py
 ├── run, docs, generate         ← commands/transform.py
 ├── validate                    ← commands/data.py

--- a/dango/oauth/CLAUDE.md
+++ b/dango/oauth/CLAUDE.md
@@ -11,7 +11,7 @@ Manages browser-based OAuth authentication flows, provider-specific token exchan
 | `__init__.py` | OAuth flow orchestration and local callback server | `OAuthManager`, `OAuthCallbackHandler`, `create_oauth_manager`, re-exports from `validation.py` |
 | `providers.py` | Provider-specific OAuth implementations | `BaseOAuthProvider`, `GoogleOAuthProvider`, `FacebookOAuthProvider`, `ShopifyOAuthProvider` |
 | `router.py` | Routes OAuth requests to correct provider | `run_oauth_for_source`, `check_oauth_credentials_exist`, `OAUTH_PROVIDER_MAP` |
-| `storage.py` | Token persistence to `.dlt/secrets.toml` with metadata | `OAuthStorage`, `OAuthCredential` |
+| `storage.py` | Token persistence to `.dlt/secrets.toml` with metadata. `OAuthCredential` includes health methods: `is_expired()`, `days_until_expiry()`, `is_expiring_soon()` | `OAuthStorage`, `OAuthCredential` |
 | `validation.py` | Live token validation and refresh checking via API calls | `TokenValidationResult`, `validate_token`, `validate_all_tokens`, `validate_before_sync`, `validate_google_token`, `validate_facebook_token`, `validate_shopify_token` |
 | `web_flow.py` | Browser-based OAuth token exchange for cloud deployments | `OAuthFlowError`, `SUPPORTED_OAUTH_SOURCES`, `build_google_auth_url()`, `exchange_google_code()`, `fetch_google_user_info()`, `build_facebook_auth_url()`, `exchange_facebook_code()` |
 
@@ -40,6 +40,9 @@ Manages browser-based OAuth authentication flows, provider-specific token exchan
 - `dango/cli/source_wizard.py` — inline OAuth during `dango add`
 - `dango/cli/validate.py` — credential validation
 - `dango/ingestion/dlt_runner.py` — `OAuthStorage` for token expiry checks before sync
+- `dango/web/routes/health.py` — OAuth token health in `/api/health/platform`
+- `dango/web/routes/secrets.py` — OAuth credential management (admin-only)
+- `dango/web/routes/oauth_connect.py` — web-based OAuth connect/callback
 - `dango/web/routes/sync.py` — pre-sync validation before web-triggered syncs
 
 ## Testing

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -253,6 +253,7 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 - `dango.exceptions` — CloudError, CloudAPIError, CloudAuthError, CloudProvisioningError (cloud/)
 - `dango.migrations` — apply_all_pending (startup.py)
 - `dango.utils.database` — ensure_dbt_schemas (startup.py)
+- `dango.utils.log_rotation` — rotate_jsonl_log (startup.py)
 - `dango.utils.process` — is_process_running, kill_process (watcher_lifecycle.py)
 - `dango.visualization` — setup_metabase, import_dashboards (startup.py)
 - `httpx` — HTTP transport for DigitalOcean API (cloud/digitalocean.py)

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -13,8 +13,9 @@ Shared utilities for process management, activity logging, sync history tracking
 | `activity_log.py` | JSONL activity logging to `.dango/logs/activity.jsonl` | `log_activity()`, `get_activity_log_file()` |
 | `sync_history.py` | Per-source sync history (JSON, last 100 entries) | `save_sync_history_entry()`, `load_sync_history()`, `get_sync_history_file()` |
 | `database.py` | DuckDB schema initialization (raw, staging, intermediate, marts) | `ensure_dbt_schemas()` |
-| `db_health.py` | Disk space checks and DuckDB health monitoring | `check_disk_space()`, `check_duckdb_health()`, `get_disk_usage_summary()`, `get_component_disk_usage()`, `print_health_summary()` (imports `DiskSpaceError`, `DuckDBHealthError` from `dango.exceptions`) |
+| `db_health.py` | Disk space checks, DuckDB health monitoring, and per-component disk breakdown with 60-second TTL cache | `check_disk_space()`, `check_duckdb_health()`, `get_disk_usage_summary()`, `get_component_disk_usage()`, `print_health_summary()` (imports `DiskSpaceError`, `DuckDBHealthError` from `dango.exceptions`) |
 | `dbt_lock.py` | Cross-process file lock for dbt operations (fcntl/msvcrt) | `DbtLock`, `dbt_lock()` context manager (imports `DbtLockError` from `dango.exceptions`) |
+| `log_rotation.py` | JSONL log rotation with gzip compression and retention management. Rotates audit.jsonl and activity.jsonl when >5 MB or >1 day old. All public functions follow the never-fail contract. | `rotate_jsonl_log()`, `cleanup_old_archives()`, `get_log_disk_usage()` |
 | `dbt_status.py` | Persistent dbt model status from run_results.json | `update_model_status()`, `get_model_statuses()` |
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
@@ -30,6 +31,8 @@ Shared utilities for process management, activity logging, sync history tracking
 | Change dbt lock behavior | `dbt_lock.py` | Manual: acquire lock from two processes, verify conflict |
 | Change dbt status tracking | `dbt_status.py` | Manual: run dbt, call `get_model_statuses()` |
 | Add a data validation check | `data_validation.py` | Manual: call against a DuckDB with test data |
+| Rotate JSONL logs | `log_rotation.py` | `pytest tests/unit/test_log_rotation.py` |
+| Change log archive retention | `log_rotation.py` (`max_age_days` param, default 90) | `pytest tests/unit/test_log_rotation.py` |
 
 ## Dependencies
 
@@ -41,19 +44,23 @@ Shared utilities for process management, activity logging, sync history tracking
 - `fcntl` / `msvcrt` — platform-specific file locking in dbt_lock.py
 
 **Used by:**
-- `dango/web/app.py` — dbt_status, sync_history, activity_log, db_health, dbt_lock
+- `dango/web/helpers.py` — db_health, sync_history, activity_log, dbt_status
+- `dango/web/routes/sync.py` — dbt_lock, sync_history, activity_log
 - `dango/ingestion/dlt_runner.py` — activity_log, sync_history, db_health
-- `dango/cli/main.py` — database, dbt_lock, dbt_status
-- `dango/platform/watcher_runner.py` — dbt_lock, dbt_status
+- `dango/cli/commands/platform.py` — database, dbt_lock, dbt_status
+- `dango/cli/commands/data.py` — database, dbt_lock
+- `dango/cli/commands/cleanup.py` — db_health, log_rotation
+- `dango/platform/local/watcher_runner.py` — dbt_lock, dbt_status
+- `dango/platform/common/startup.py` — log_rotation
 - `dango/transformation/__init__.py` — dbt_status
 
 **Not yet imported:** `data_validation.py` (prepared utility, not integrated into any module)
 
 ## Testing
 
-- **Unit:** None yet (will be `tests/unit/test_utils.py`)
+- **Unit:** `pytest tests/unit/test_db_health_disk.py tests/unit/test_log_rotation.py`
 - **Integration:** None yet
-- **Manual:** `dango start` exercises database.py; `dango sync` exercises activity_log, sync_history, db_health, dbt_lock
+- **Manual:** `dango start` exercises database.py; `dango sync` exercises activity_log, sync_history, db_health, dbt_lock; `dango cleanup` exercises log_rotation, db_health
 
 ## Key Conventions
 

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -45,10 +45,9 @@ Shared utilities for process management, activity logging, sync history tracking
 
 **Used by:**
 - `dango/web/helpers.py` — db_health, sync_history, activity_log, dbt_status
-- `dango/web/routes/sync.py` — dbt_lock, sync_history, activity_log
+- `dango/web/routes/sync.py` — dbt_lock
 - `dango/ingestion/dlt_runner.py` — activity_log, sync_history, db_health
-- `dango/cli/commands/platform.py` — database, dbt_lock, dbt_status
-- `dango/cli/commands/data.py` — database, dbt_lock
+- `dango/cli/commands/platform.py` — process (kill_process)
 - `dango/cli/commands/cleanup.py` — db_health, log_rotation
 - `dango/platform/local/watcher_runner.py` — dbt_lock, dbt_status
 - `dango/platform/common/startup.py` — log_rotation

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -28,7 +28,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/auth.py` | Login/logout, password change, OAuth flows, invite accept, API key CRUD (~854 lines) | `_bridge_metabase_session()`, `_set_session_cookie()` |
 | `routes/auth_2fa.py` | TOTP 2FA setup/verify/disable/recovery (~328 lines) | — |
 | `routes/users.py` | Admin user CRUD: create, edit, deactivate, delete, unlock, invite (525 lines) | — |
-| `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` | — |
+| `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` (incl. OAuth token health, component disk breakdown, cloud resource metrics, backup staleness) | — |
 | `routes/config.py` | `/api/config`, `/api/metabase-config` | — |
 | `routes/sources.py` | `/api/sources`, `/api/sources/{name}/details` | — |
 | `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + background `run_sync_task()` (~558 lines) | `run_sync_task()` |
@@ -170,6 +170,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 - `dango.transformation/` — `run_dbt_models` (triggered by upload delete)
 - `dango.visualization/` — `sync_metabase_schema`, `refresh_metabase_connection` (after sync/dbt runs)
 - `dango.utils/` — `DbtLock`, `DbtLockError`, `activity_log`, `sync_history`, `db_health`, `dbt_status`
+- `dango.oauth/` — `OAuthStorage` (for OAuth token health in `/api/health/platform`)
 - `dango.platform/` — `platform.watcher_lifecycle.get_watcher_status` (for watcher status endpoint)
 
 **Used by:**

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -1,6 +1,6 @@
 # Exemption registry for files exceeding the 500-line soft limit (STANDARDS.md §2).
 # Consumed by scripts/check_file_sizes.py for CI and pre-commit checks.
-# Line counts refreshed 2026-02-15 (DOC-024) — informational, not enforced by script.
+# Line counts refreshed 2026-03-06 (DOC-028) — informational, not enforced by script.
 #
 # Categories:
 #   refactor — planned for refactoring in v1 (linked to a task)
@@ -12,7 +12,7 @@ limit: 500  # Informational — scripts/check_file_sizes.py owns the enforced th
 exemptions:
   # --- Post-TASK-085 split results (from web/app.py 3032 → web/routes/) ---
   - file: dango/web/helpers.py
-    lines: 798
+    lines: 810
     category: exempt
     reason: "Shared helper functions for web routes. Consolidates DuckDB queries, config loading, service health checks, and log management. Extracted from web/app.py by TASK-085. Mirrors cli/utils.py pattern."
     review_by: "v1.1"
@@ -50,20 +50,20 @@ exemptions:
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
-    lines: 576
+    lines: 579
     category: exempt
     reason: "TASK-029: Interactive wizard steps 1-9 + non-interactive validation mode. Sequential prompt flow with display logic — splitting would scatter closely coupled wizard steps."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy_provision.py
-    lines: 547
+    lines: 543
     category: exempt
     reason: "TASK-029: 10-step provisioning orchestration with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
     review_by: "v1.1"
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 1026
+    lines: 964
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
@@ -81,14 +81,14 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/remote.py
-    lines: 650
+    lines: 652
     category: exempt
     reason: "Remote server management: push + rollback + firewall subgroup + domain subgroup + registration of management and backup subgroups. Each subgroup is a thin CLI layer delegating to platform/cloud modules."
     review_by: "v1.1"
 
   # --- Exempt (stable, not modified in v1) ---
   - file: dango/ingestion/dlt_runner.py
-    lines: 1759
+    lines: 1784
     category: exempt
     reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage."
     review_by: "v1.1"
@@ -106,7 +106,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
-    lines: 1142
+    lines: 1149
     category: exempt
     reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations."
     review_by: "v1.1"
@@ -177,13 +177,13 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_digitalocean_client.py
-    lines: 620
+    lines: 628
     category: exempt
     reason: "TASK-022+023+025: 36 tests covering DigitalOceanClient init, retry/backoff logic (9 cases), Droplet/SSH Key/Firewall CRUD (incl. get_firewall, update_firewall), and error handling. Retry tests require per-test mock setup for call sequencing — each is self-contained for readability."
     review_by: "v1.1"
 
   - file: tests/unit/test_provisioning.py
-    lines: 539
+    lines: 538
     category: exempt
     reason: "TASK-023: 8 test classes covering size tiers, region info, nearest-region suggestion, wait_for_droplet_ready, wait_for_ssh, extract_public_ipv4, provision_droplet (6 scenarios incl. cleanup), and save_provisioning_metadata. Each scenario requires isolated mock setup."
     review_by: "v1.1"
@@ -195,7 +195,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/config/models.py
-    lines: 530
+    lines: 548
     category: exempt
     reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"
@@ -243,19 +243,19 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_deploy_provision.py
-    lines: 533
+    lines: 530
     category: exempt
     reason: "TASK-029: 9 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, and sync trigger. Each requires isolated mock setup."
     review_by: "v1.1"
 
   - file: tests/unit/test_sync_jobs.py
-    lines: 562
+    lines: 569
     category: exempt
     reason: "TASK-041: 25 tests across 6 classes covering configure_jobs, _broadcast, _notify, run_scheduled_sync (8 tests incl. lock failure, no sources, exception), run_scheduled_dbt (6 tests incl. lock failure, exception), and _check_freshness. Each test requires isolated mock setup for lazy-import patching."
     review_by: "v1.1"
 
   - file: tests/unit/test_scheduler.py
-    lines: 604
+    lines: 596
     category: exempt
     reason: "TASK-036+039: 10 test classes covering SchedulerService init, lifecycle, jobs, status, event listeners, history integration, coroutine bridge, cloud warning, startup summary, health endpoint, and job stubs. Each class requires isolated mock setup with APScheduler dual-patch pattern."
     review_by: "v1.1"
@@ -269,7 +269,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/sync.py
-    lines: 552
+    lines: 558
     category: exempt
     reason: "TASK-040c: Added remote sync trigger API (POST /api/sync/trigger, GET /api/sync/status/{id}) with background task + execution history. Extends existing per-source sync endpoint."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary

End-of-phase documentation sweep for Phase 6 (Operations & Monitoring). Updates all CLAUDE.md files, ARCHITECTURE.md, STANDARDS.md, and `docs/file-exemptions.yml` to reflect P6-001 through P6-005.

**10 files modified (78 insertions, 46 deletions):**

- **Root `CLAUDE.md`**: Added `cleanup.py` + `upgrade.py` to repo structure tree; refreshed 10 line counts in monolithic files table; re-sorted by descending line count
- **`utils/CLAUDE.md`**: Added `log_rotation.py`; updated `db_health.py` description (component disk breakdown, TTL cache); fixed stale "Used by" (web/app.py → web/helpers.py, cli/main.py → cli/commands/); added unit test references
- **`web/CLAUDE.md`**: Updated `routes/health.py` description (OAuth token health, component disk breakdown, cloud resource metrics, backup staleness); added `dango.oauth/` to imports
- **`cli/CLAUDE.md`**: Added `cleanup.py` (322 lines) and `upgrade.py` (236 lines) to files table + command hierarchy; updated line counts for platform.py, source.py, remote.py, auth.py
- **`oauth/CLAUDE.md`**: Documented `OAuthCredential` health methods (`is_expired()`, `days_until_expiry()`, `is_expiring_soon()`); added 3 web route consumers to "Used by"
- **`dango/CLAUDE.md`** (package root): Fixed stale "not yet imported" claim — `dango.logging.get_logger()` is used by 20+ modules
- **`platform/CLAUDE.md`**: Added `dango.utils.log_rotation` to Dependencies
- **`ARCHITECTURE.md`**: Added `log_rotation.py` to utils file table; added `get_component_disk_usage()` to db_health entry
- **`STANDARDS.md`**: Added log rotation patterns subsection to §6 (rotation rules, never-fail contract, gzip naming)
- **`docs/file-exemptions.yml`**: Refreshed date to DOC-028; updated 13 file line counts

## Test plan

- [x] All referenced test files verified to exist on disk (`ls tests/unit/test_*`)
- [x] All "Used by" claims verified with `grep`
- [x] All line counts verified with `wc -l`
- [x] `ruff check` and `ruff format --check` pass
- [x] `docs/file-exemptions.yml` validates as YAML
- [x] Doc-only changes — no source code modified

<https://claude.ai/code/session_01AXg8ohcJSk1qNGjWc7G7Sp>