### PR TITLE
P7-014: COMPATIBILITY.md & SCALABILITY.md generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/source_wizard.py` | 1324 | — |
 | `visualization/metabase.py` | 1149 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/init.py` | 965 | — |
+| `cli/init.py` | 1098 | — |
 | `cli/commands/platform.py` | 964 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | ~854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 815 | — (renamed from auth.py by TASK-093) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -38,7 +38,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/schedule.py` (499 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (965 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1098 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (1324 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -71,6 +71,10 @@ class ProjectInitializer:
             # Create README
             self._create_readme(config)
 
+            # Create COMPATIBILITY.md and SCALABILITY.md
+            self._create_compatibility_md()
+            self._create_scalability_md()
+
             # Create docker-compose.yml
             self._create_docker_compose(config)
 
@@ -357,6 +361,133 @@ When creating dashboards and reports in Metabase, use tables in this priority or
             with open(readme_path, "w", encoding="utf-8") as f:
                 f.write(readme_content)
             print_success("Created README.md")
+
+    def _create_compatibility_md(self):
+        """Create COMPATIBILITY.md with version requirements and platform support."""
+        content = f"""\
+# Compatibility
+
+Version requirements and platform support for this Dango project.
+
+## Python
+
+- **Required:** Python 3.10, 3.11, or 3.12 (`>=3.10,<3.13`)
+- System Python on macOS is 3.9 — use `python3.11` or `python3.12` explicitly
+
+## Operating Systems
+
+| OS | Version | Notes |
+|----|---------|-------|
+| macOS | 12 (Monterey)+ | Primary development platform |
+| Ubuntu | 22.04 LTS | Recommended for cloud deployment |
+| Windows | WSL2 only | Native Windows is not supported |
+
+## Docker
+
+- **Docker Engine:** 20.10+
+- **Docker Compose:** v2 (ships with Docker Desktop)
+- Required for Metabase and the full platform stack (`dango start`)
+
+## Browsers (Metabase + Dango Web UI)
+
+Latest 2 versions of:
+- Chrome
+- Firefox
+- Safari
+- Edge
+
+## Core Dependencies
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| DuckDB | ~1.4.0 | Embedded analytical database |
+| dbt-core | ~1.10.0 | Data transformation framework |
+| dlt | >=1.17.0, <2.0 | Data ingestion toolkit |
+| Metabase | v0.50.26 | Business intelligence / dashboards |
+
+## spaCy (Data Governance)
+
+The `en_core_web_sm` language model is required for PII scanning (data governance).
+
+- **Automatic:** Downloaded on first governance scan
+- **Manual:** `python -m spacy download en_core_web_sm`
+
+## Upgrade Notes
+
+- Pin your Python version in CI/CD — Dango does not yet support Python 3.13+
+- DuckDB minor version upgrades may require a database re-sync (`dango sync`)
+- dbt and dlt versions are pinned to compatible ranges in `pyproject.toml`
+
+---
+
+*Generated with Dango {self._get_dango_version()}*
+"""
+
+        compat_path = self.project_dir / "COMPATIBILITY.md"
+        if not compat_path.exists():
+            with open(compat_path, "w", encoding="utf-8") as f:
+                f.write(content)
+            print_success("Created COMPATIBILITY.md")
+
+    def _create_scalability_md(self):
+        """Create SCALABILITY.md with platform limits and upgrade guidance."""
+        content = f"""\
+# Scalability
+
+Honest guidance on what Dango handles well and when to consider alternatives.
+
+## DuckDB (Data Warehouse)
+
+- **Sweet spot:** Datasets up to ~500 GB on a single machine
+- **Row counts:** Handles billions of rows — query performance depends on data shape \
+and available RAM
+- **Architecture:** In-process columnar engine with no network overhead — excellent for \
+analytics workloads
+- **Single-writer constraint:** Only one process can write at a time. Dango serializes \
+all writes through `DbtLock` (file lock at `.dango/state/dbt.lock`). Concurrent reads \
+during writes are fine.
+
+## Concurrent Users
+
+- **Dango Web UI:** Comfortable for ~10-20 concurrent users
+- **Metabase:** Has its own connection pool and handles concurrent dashboard viewers \
+independently
+- **DuckDB reads:** Multiple users can query simultaneously — reads don't block each other
+
+## File Watcher
+
+- Monitors `data/uploads/` for new CSV files
+- Debounce interval: 10 minutes (configurable in schedule settings)
+- Best suited for small-to-medium file counts — not designed for high-frequency file drops
+
+## Cloud Deployment
+
+- **Default droplet:** `s-2vcpu-4gb` (2 vCPUs, 4 GB RAM) on DigitalOcean
+- **Resize:** `dango remote resize` to scale up without data loss
+- **Migrate:** `dango remote migrate` to move to a different region
+
+## When to Consider Alternatives
+
+| Signal | Consider |
+|--------|----------|
+| Data exceeds single-machine disk/RAM | [MotherDuck](https://motherduck.com/) (managed DuckDB in the cloud) |
+| Need multi-region or multi-tenant | Cloud-managed warehouse (BigQuery, Snowflake, Redshift) |
+| >50 concurrent dashboard users | Dedicated Metabase instance with PostgreSQL backend |
+| Real-time streaming ingestion | Kafka/Flink pipeline feeding a separate warehouse |
+
+Dango is designed for small teams with analytical workloads that fit on one machine. \
+If you outgrow it, your dbt models and SQL are portable — migration is straightforward.
+
+---
+
+*Generated with Dango {self._get_dango_version()}*
+"""
+
+        scale_path = self.project_dir / "SCALABILITY.md"
+        if not scale_path.exists():
+            with open(scale_path, "w", encoding="utf-8") as f:
+                f.write(content)
+            print_success("Created SCALABILITY.md")
 
     def _create_marts_readme(self):
         """Create README.md in marts/ directory with guidance"""
@@ -864,6 +995,8 @@ on-run-end:
             "docker-compose.yml",
             "Dockerfile.metabase",
             "README.md",  # Only if created by us
+            "COMPATIBILITY.md",
+            "SCALABILITY.md",
             ".gitignore",  # Only if created by us
         ]
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -118,9 +118,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 965
+    lines: 1098
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines)."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)


### PR DESCRIPTION
## Summary

- Add `_create_compatibility_md()` and `_create_scalability_md()` to `ProjectInitializer` in `dango/cli/init.py`
- Both files generated during `dango init`, following the existing `_create_readme` pattern (skip if exists, included in rollback cleanup)
- COMPATIBILITY.md: Python/OS/Docker/browser requirements, core dependency versions (DuckDB ~1.4.0, dbt ~1.10.0, dlt >=1.17.0, Metabase v0.50.26), spaCy model instructions
- SCALABILITY.md: DuckDB limits (~500GB), single-writer constraint, concurrent user guidance (~10-20), cloud deployment defaults, upgrade path recommendations

## Verification

- All version claims verified against `pyproject.toml` and `Dockerfile.metabase`
- Tested `dango init --skip-wizard` creates both files
- Tested `dango init --force --skip-wizard` preserves existing files (idempotent)
- All pre-commit hooks pass (ruff, mypy, file size, headers, docstrings)
- `pytest tests/unit/test_cli_commands.py` — 13 passed
- Updated `docs/file-exemptions.yml` (init.py 965 → 1098)
- Updated line counts in `CLAUDE.md` and `dango/cli/CLAUDE.md`

## Test plan

- [ ] `dango init test-project --skip-wizard` → verify COMPATIBILITY.md and SCALABILITY.md exist with correct content
- [ ] `dango init test-project --force --skip-wizard` → verify files are not recreated
- [ ] `pytest tests/unit/test_cli_commands.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)