### PR TITLE
P7-009: Add analysis module — metric engine & comparison

### DIFF
--- a/dango/analysis/CLAUDE.md
+++ b/dango/analysis/CLAUDE.md
@@ -1,0 +1,54 @@
+# analysis/
+
+## Purpose
+
+Automated metric monitoring and comparison engine. Executes user-defined metrics against DuckDB, stores results in SQLite (`metric_history`, `metric_results` tables in `.dango/dango.db`), and compares current values against historical baselines to detect changes and trends.
+
+## Files
+
+| File | Purpose | Key Exports |
+|------|---------|-------------|
+| `__init__.py` | Public API re-exports | `run_analysis`, `load_metrics_config` |
+| `models.py` | Pydantic V2 models | `ComparisonType`, `MetricConfig`, `MetricsConfig`, `MetricValue`, `ComparisonResult`, `AnalysisResult` |
+| `config.py` | YAML config loader | `load_metrics_config()`, `get_metrics_file_path()` |
+| `comparisons.py` | Comparison engine + trend detection | `compute_comparison()`, `detect_trend()` |
+| `metrics.py` | Orchestration: execute → store → compare | `run_analysis()` |
+
+## Common Tasks
+
+| To... | Modify... | Test with... |
+|-------|-----------|--------------|
+| Add a new comparison type | `models.py` (`ComparisonType` enum) + `comparisons.py` (`_get_baseline`) | `pytest tests/unit/test_analysis_comparisons.py` |
+| Change metric validation | `models.py` (`MetricConfig` validators) | `pytest tests/unit/test_analysis_models.py` |
+| Change config file format | `config.py` | `pytest tests/unit/test_analysis_config.py` |
+| Modify trend detection | `comparisons.py` (`detect_trend`, `_linear_regression`) | `pytest tests/unit/test_analysis_comparisons.py` |
+| Change metric execution | `metrics.py` (`_execute_metric`, `_build_metric_sql`) | `pytest tests/unit/test_analysis_metrics.py` |
+
+## Dependencies
+
+**Imports from (dango modules):**
+- `exceptions` — `AnalysisConfigError` (config.py)
+- `logging` — `get_logger` (all files)
+- `utils.dango_db` — `connect()` (comparisons.py, metrics.py)
+
+**External packages:** `pydantic`, `yaml`, `duckdb`
+
+**Used by:**
+- `utils/post_sync.py` — `_run_analysis()` stub (populated by P7-011)
+- `web/routes/insights.py` — planned (P7-012)
+- `cli/commands/analyze.py` — planned (P7-012)
+
+## Testing
+
+```
+pytest tests/unit/test_analysis_models.py tests/unit/test_analysis_config.py \
+  tests/unit/test_analysis_comparisons.py tests/unit/test_analysis_metrics.py -v
+```
+
+## Don't Modify
+
+| Item | Reason |
+|------|--------|
+| `models.py` field names | P7-010, P7-011, P7-012 depend on exact model shapes |
+| `ComparisonType` enum values | Stored in `metric_results.result_type` column |
+| `metric_history` / `metric_results` table schemas | Defined in `utils/dango_db.py`, shared across modules |

--- a/dango/analysis/__init__.py
+++ b/dango/analysis/__init__.py
@@ -3,4 +3,10 @@
 Automated data analysis module.
 """
 
-__all__: list[str] = []
+from dango.analysis.config import load_metrics_config
+from dango.analysis.metrics import run_analysis
+
+__all__: list[str] = [
+    "load_metrics_config",
+    "run_analysis",
+]

--- a/dango/analysis/comparisons.py
+++ b/dango/analysis/comparisons.py
@@ -1,0 +1,264 @@
+"""dango/analysis/comparisons.py
+
+Comparison engine for metric values against historical baselines.
+
+Queries the ``metric_history`` table in ``.dango/dango.db`` (SQLite) to
+compute week-over-week, rolling average, and prior-period comparisons.
+Also provides linear-regression trend detection over the last 30 data points.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from pathlib import Path
+
+from dango.analysis.models import ComparisonResult, ComparisonType, MetricValue
+from dango.logging import get_logger
+from dango.utils.dango_db import connect
+
+logger = get_logger(__name__)
+
+MIN_TREND_POINTS = 14
+MAX_TREND_POINTS = 30
+TREND_THRESHOLD_PCT = 0.01  # 1% of mean
+MAX_FORECAST_DAYS = 365
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_comparison(
+    project_root: Path,
+    metric_value: MetricValue,
+    comparison_type: ComparisonType,
+    warn_threshold: float | None,
+) -> ComparisonResult:
+    """Compare a metric value against its historical baseline.
+
+    Args:
+        project_root: Path to the Dango project root.
+        metric_value: The current metric value.
+        comparison_type: Which comparison strategy to use.
+        warn_threshold: Percentage change threshold for warnings.
+
+    Returns:
+        A ``ComparisonResult`` with computed change percentage and threshold flag.
+    """
+    current = metric_value.value
+    if current is None:
+        return ComparisonResult(
+            metric_name=metric_value.metric_name,
+            comparison_type=comparison_type,
+        )
+
+    with connect(project_root) as conn:
+        baseline = _get_baseline(conn, metric_value.metric_name, comparison_type)
+
+    change_pct = _compute_change_pct(current, baseline)
+    exceeds = (
+        warn_threshold is not None and change_pct is not None and abs(change_pct) >= warn_threshold
+    )
+
+    slope, direction, forecast_days = detect_trend(
+        project_root, metric_value.metric_name, warn_threshold
+    )
+
+    return ComparisonResult(
+        metric_name=metric_value.metric_name,
+        comparison_type=comparison_type,
+        current_value=current,
+        baseline_value=baseline,
+        change_pct=change_pct,
+        exceeds_threshold=exceeds,
+        trend_slope=slope,
+        trend_direction=direction,
+        forecast_threshold_days=forecast_days,
+    )
+
+
+def detect_trend(
+    project_root: Path,
+    metric_name: str,
+    warn_threshold: float | None = None,
+) -> tuple[float | None, str | None, int | None]:
+    """Detect a linear trend over the last 30 data points.
+
+    Requires at least ``MIN_TREND_POINTS`` (14) data points.
+
+    Args:
+        project_root: Path to the Dango project root.
+        metric_name: Name of the metric to analyse.
+        warn_threshold: Optional threshold percentage for forecasting.
+
+    Returns:
+        A tuple of ``(slope, direction, forecast_days)``.  All ``None`` if
+        insufficient data.
+    """
+    with connect(project_root) as conn:
+        rows = conn.execute(
+            "SELECT metric_value FROM metric_history "
+            "WHERE metric_name = ? AND metric_value IS NOT NULL "
+            "ORDER BY recorded_at DESC LIMIT ?",
+            (metric_name, MAX_TREND_POINTS),
+        ).fetchall()
+
+    if len(rows) < MIN_TREND_POINTS:
+        return None, None, None
+
+    # Oldest first for regression
+    ys = [float(r["metric_value"]) for r in reversed(rows)]
+    xs = list(range(len(ys)))
+
+    slope, _intercept = _linear_regression(xs, ys)
+
+    mean_y = sum(ys) / len(ys) if ys else 0.0
+    threshold_abs = abs(mean_y * TREND_THRESHOLD_PCT) if mean_y != 0 else 0.0
+
+    if slope > threshold_abs:
+        direction = "increasing"
+    elif slope < -threshold_abs:
+        direction = "decreasing"
+    else:
+        direction = "stable"
+
+    forecast_days = _forecast_threshold_days(ys[-1], slope, warn_threshold, mean_y)
+
+    return slope, direction, forecast_days
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_baseline(
+    conn: sqlite3.Connection,
+    metric_name: str,
+    comparison_type: ComparisonType,
+) -> float | None:
+    """Dispatch to the appropriate baseline computation."""
+    if comparison_type == ComparisonType.week_over_week:
+        return _compare_week_over_week(conn, metric_name)
+    if comparison_type == ComparisonType.rolling_7day_avg:
+        return _compare_rolling_avg(conn, metric_name, 7)
+    if comparison_type == ComparisonType.rolling_30day_avg:
+        return _compare_rolling_avg(conn, metric_name, 30)
+    if comparison_type == ComparisonType.prior_period:
+        return _compare_prior_period(conn, metric_name)
+    return None  # pragma: no cover
+
+
+def _compare_week_over_week(
+    conn: sqlite3.Connection,
+    metric_name: str,
+) -> float | None:
+    """Return the value closest to 7 days ago."""
+    row = conn.execute(
+        "SELECT metric_value FROM metric_history "
+        "WHERE metric_name = ? AND metric_value IS NOT NULL "
+        "ORDER BY ABS(julianday(recorded_at) - julianday('now', '-7 days')) "
+        "LIMIT 1",
+        (metric_name,),
+    ).fetchone()
+    return float(row["metric_value"]) if row else None
+
+
+def _compare_rolling_avg(
+    conn: sqlite3.Connection,
+    metric_name: str,
+    days: int,
+) -> float | None:
+    """Return the average metric value over the last *days* days."""
+    row = conn.execute(
+        "SELECT AVG(metric_value) AS avg_val FROM metric_history "
+        "WHERE metric_name = ? AND metric_value IS NOT NULL "
+        "AND recorded_at >= datetime('now', ?)",
+        (metric_name, f"-{days} days"),
+    ).fetchone()
+    if row and row["avg_val"] is not None:
+        return float(row["avg_val"])
+    return None
+
+
+def _compare_prior_period(
+    conn: sqlite3.Connection,
+    metric_name: str,
+) -> float | None:
+    """Return the most recent previous value (skipping the latest)."""
+    row = conn.execute(
+        "SELECT metric_value FROM metric_history "
+        "WHERE metric_name = ? AND metric_value IS NOT NULL "
+        "ORDER BY recorded_at DESC LIMIT 1 OFFSET 1",
+        (metric_name,),
+    ).fetchone()
+    return float(row["metric_value"]) if row else None
+
+
+def _compute_change_pct(
+    current: float,
+    baseline: float | None,
+) -> float | None:
+    """Compute percentage change from baseline to current.
+
+    Returns ``None`` when baseline is ``None`` or zero (avoid division by zero).
+    """
+    if baseline is None or baseline == 0:
+        return None
+    return ((current - baseline) / abs(baseline)) * 100
+
+
+def _linear_regression(
+    xs: Sequence[int | float],
+    ys: Sequence[float],
+) -> tuple[float, float]:
+    """Ordinary least squares for a simple linear model.
+
+    Args:
+        xs: Independent variable values.
+        ys: Dependent variable values.
+
+    Returns:
+        ``(slope, intercept)`` tuple.
+    """
+    n = len(xs)
+    sum_x = sum(xs)
+    sum_y = sum(ys)
+    sum_xy = sum(x * y for x, y in zip(xs, ys, strict=True))
+    sum_x2 = sum(x * x for x in xs)
+
+    denominator = n * sum_x2 - sum_x * sum_x
+    if denominator == 0:
+        return 0.0, (sum_y / n if n else 0.0)
+
+    slope = (n * sum_xy - sum_x * sum_y) / denominator
+    intercept = (sum_y - slope * sum_x) / n
+    return slope, intercept
+
+
+def _forecast_threshold_days(
+    current_value: float,
+    slope: float,
+    warn_threshold: float | None,
+    mean_value: float,
+) -> int | None:
+    """Estimate days until the warn_threshold percentage change is exceeded.
+
+    Returns ``None`` when forecasting is not applicable (no threshold,
+    zero slope, or already exceeded).
+    """
+    if warn_threshold is None or slope == 0 or mean_value == 0:
+        return None
+
+    # Threshold in absolute terms relative to mean
+    threshold_abs = abs(mean_value * warn_threshold / 100)
+    distance = threshold_abs - abs(current_value - mean_value)
+
+    if distance <= 0:
+        # Already exceeded
+        return 0
+
+    days = int(distance / abs(slope))
+    return min(days, MAX_FORECAST_DAYS) if days > 0 else None

--- a/dango/analysis/config.py
+++ b/dango/analysis/config.py
@@ -1,0 +1,63 @@
+"""dango/analysis/config.py
+
+Load and validate the metrics configuration from ``.dango/metrics.yml``.
+
+Mirrors the ``load_schedules_config()`` pattern in ``dango/config/schedules.py``.
+Missing file → empty ``MetricsConfig``.  Invalid YAML or Pydantic errors →
+``AnalysisConfigError``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from dango.analysis.models import MetricsConfig
+from dango.exceptions import AnalysisConfigError
+from dango.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def get_metrics_file_path(project_root: Path) -> Path:
+    """Return the path to ``.dango/metrics.yml``.
+
+    Args:
+        project_root: Path to the Dango project root.
+
+    Returns:
+        Absolute path to the metrics configuration file.
+    """
+    return project_root / ".dango" / "metrics.yml"
+
+
+def load_metrics_config(project_root: Path) -> MetricsConfig:
+    """Load metrics config from ``.dango/metrics.yml``.
+
+    Returns an empty ``MetricsConfig`` if the file is missing.
+
+    Args:
+        project_root: Path to the Dango project root.
+
+    Returns:
+        Parsed metrics configuration.
+
+    Raises:
+        AnalysisConfigError: If the file exists but contains invalid data.
+    """
+    path = get_metrics_file_path(project_root)
+    if not path.exists():
+        return MetricsConfig()
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data: dict[str, Any] = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        raise AnalysisConfigError(f"Invalid YAML in {path}:\n{e}") from e
+
+    try:
+        return MetricsConfig(**data)
+    except Exception as e:
+        raise AnalysisConfigError(f"Invalid metrics configuration in {path}:\n{e}") from e

--- a/dango/analysis/metrics.py
+++ b/dango/analysis/metrics.py
@@ -1,0 +1,247 @@
+"""dango/analysis/metrics.py
+
+Metric engine orchestration.
+
+Loads configured metrics, executes each against DuckDB (read-only), stores
+values in ``metric_history``, runs comparisons against historical data, and
+stores comparison results in ``metric_results``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+from dango.analysis.comparisons import compute_comparison
+from dango.analysis.config import load_metrics_config
+from dango.analysis.models import (
+    AnalysisResult,
+    ComparisonResult,
+    MetricConfig,
+    MetricValue,
+)
+from dango.logging import get_logger
+from dango.utils.dango_db import connect
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_analysis(
+    project_root: Path,
+    *,
+    source_filter: list[str] | None = None,
+) -> list[AnalysisResult]:
+    """Run all configured metrics and return analysis results.
+
+    Args:
+        project_root: Path to the Dango project root.
+        source_filter: If provided, only run metrics whose ``source_table``
+            starts with one of these source names.
+
+    Returns:
+        A list of ``AnalysisResult`` objects, one per metric.
+    """
+    config = load_metrics_config(project_root)
+    if not config.enabled or not config.metrics:
+        return []
+
+    duckdb_path = project_root / "data" / "warehouse.duckdb"
+    if not duckdb_path.exists():
+        logger.warning("analysis_skip_no_warehouse", path=str(duckdb_path))
+        return []
+
+    results: list[AnalysisResult] = []
+
+    for metric in config.metrics:
+        if source_filter is not None:
+            source, _table = _parse_source_from_table(metric.source_table)
+            if source and source not in source_filter:
+                continue
+
+        metric_value = _execute_metric(duckdb_path, metric)
+        _store_metric_value(project_root, metric_value)
+
+        comparison: ComparisonResult | None = None
+        if metric_value.error is None:
+            comparison = compute_comparison(
+                project_root,
+                metric_value,
+                metric.compare,
+                metric.warn_threshold,
+            )
+            _store_comparison_result(project_root, comparison)
+
+        results.append(AnalysisResult(metric=metric_value, comparison=comparison))
+
+    logger.info(
+        "analysis_complete",
+        total=len(results),
+        errors=sum(1 for r in results if r.metric.error),
+    )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Metric execution
+# ---------------------------------------------------------------------------
+
+
+def _execute_metric(duckdb_path: Path, metric: MetricConfig) -> MetricValue:
+    """Execute a single metric query against DuckDB.
+
+    Args:
+        duckdb_path: Path to the DuckDB warehouse file.
+        metric: The metric configuration to execute.
+
+    Returns:
+        A ``MetricValue`` with the query result or an error message.
+    """
+    source, table = _parse_source_from_table(metric.source_table)
+    sql = _build_metric_sql(metric)
+
+    try:
+        conn = duckdb.connect(str(duckdb_path), read_only=True)
+        try:
+            row = conn.execute(sql).fetchone()
+        finally:
+            conn.close()
+    except duckdb.Error as e:
+        logger.warning(
+            "metric_execution_failed",
+            metric=metric.name,
+            error=str(e),
+        )
+        return MetricValue(
+            metric_name=metric.name,
+            source=source,
+            table_name=table,
+            error=str(e),
+        )
+
+    value = float(row[0]) if row and row[0] is not None else None
+
+    return MetricValue(
+        metric_name=metric.name,
+        source=source,
+        table_name=table,
+        value=value,
+    )
+
+
+def _build_metric_sql(metric: MetricConfig) -> str:
+    """Build the SQL query for a metric.
+
+    Args:
+        metric: The metric configuration.
+
+    Returns:
+        A SQL SELECT string.
+    """
+    sql = f"SELECT {metric.value_expression} FROM {metric.source_table}"  # noqa: S608
+    if metric.filter:
+        sql += f" WHERE {metric.filter}"
+    return sql
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+
+def _store_metric_value(project_root: Path, metric_value: MetricValue) -> None:
+    """Insert a metric value into the ``metric_history`` table.
+
+    Args:
+        project_root: Path to the Dango project root.
+        metric_value: The value to store.
+    """
+    if metric_value.value is None:
+        return
+
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        with connect(project_root) as conn:
+            conn.execute(
+                "INSERT INTO metric_history "
+                "(metric_name, source, table_name, metric_value, recorded_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    metric_value.metric_name,
+                    metric_value.source,
+                    metric_value.table_name,
+                    metric_value.value,
+                    now,
+                ),
+            )
+            conn.commit()
+    except Exception:
+        logger.warning(
+            "metric_history_store_failed",
+            metric=metric_value.metric_name,
+            exc_info=True,
+        )
+
+
+def _store_comparison_result(
+    project_root: Path,
+    result: ComparisonResult,
+) -> None:
+    """Insert a comparison result into the ``metric_results`` table.
+
+    Args:
+        project_root: Path to the Dango project root.
+        result: The comparison result to store.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    result_value = json.dumps(result.model_dump(mode="json"))
+    try:
+        with connect(project_root) as conn:
+            conn.execute(
+                "INSERT INTO metric_results "
+                "(metric_name, source, table_name, result_type, result_value, computed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    result.metric_name,
+                    None,
+                    None,
+                    result.comparison_type.value,
+                    result_value,
+                    now,
+                ),
+            )
+            conn.commit()
+    except Exception:
+        logger.warning(
+            "metric_result_store_failed",
+            metric=result.metric_name,
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_source_from_table(source_table: str) -> tuple[str | None, str | None]:
+    """Split ``schema.table`` into ``(source, table)`` components.
+
+    Args:
+        source_table: A schema-qualified table name.
+
+    Returns:
+        A tuple of ``(source, table)``.  Both ``None`` if the string
+        does not contain a dot.
+    """
+    if "." not in source_table:
+        return None, None
+    parts = source_table.split(".", 1)
+    return parts[0], parts[1]

--- a/dango/analysis/models.py
+++ b/dango/analysis/models.py
@@ -1,0 +1,135 @@
+"""dango/analysis/models.py
+
+Pydantic V2 models for the metric engine and comparison system.
+
+Defines configuration shapes (``MetricConfig``, ``MetricsConfig``), runtime
+value containers (``MetricValue``, ``ComparisonResult``), and the top-level
+``AnalysisResult`` that bundles a metric value with its comparison.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+_SLUG_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class ComparisonType(str, Enum):
+    """Supported comparison strategies."""
+
+    week_over_week = "week_over_week"
+    rolling_7day_avg = "rolling_7day_avg"
+    rolling_30day_avg = "rolling_30day_avg"
+    prior_period = "prior_period"
+
+
+# ---------------------------------------------------------------------------
+# Configuration models
+# ---------------------------------------------------------------------------
+
+
+class MetricConfig(BaseModel):
+    """Single metric definition from ``.dango/metrics.yml``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    source_table: str
+    value_expression: str
+    filter: str | None = None
+    compare: ComparisonType = ComparisonType.week_over_week
+    warn_threshold: float | None = None
+    drill_down: list[str] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def _name_is_slug(cls, v: str) -> str:
+        if not _SLUG_RE.match(v):
+            msg = (
+                f"Metric name must be lowercase alphanumeric with underscores, "
+                f"starting with a letter: {v!r}"
+            )
+            raise ValueError(msg)
+        return v
+
+    @field_validator("source_table")
+    @classmethod
+    def _source_table_has_dot(cls, v: str) -> str:
+        if "." not in v:
+            msg = f"source_table must be schema-qualified (schema.table): {v!r}"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("value_expression")
+    @classmethod
+    def _value_expression_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            msg = "value_expression must not be empty"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("warn_threshold")
+    @classmethod
+    def _warn_threshold_positive(cls, v: float | None) -> float | None:
+        if v is not None and v <= 0:
+            msg = f"warn_threshold must be positive: {v}"
+            raise ValueError(msg)
+        return v
+
+
+class MetricsConfig(BaseModel):
+    """Top-level metrics configuration from ``.dango/metrics.yml``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    metrics: list[MetricConfig] = Field(default_factory=list)
+    enabled: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Runtime value models
+# ---------------------------------------------------------------------------
+
+
+class MetricValue(BaseModel):
+    """Result of executing a single metric query against DuckDB."""
+
+    model_config = ConfigDict(frozen=True)
+
+    metric_name: str
+    source: str | None = None
+    table_name: str | None = None
+    value: float | None = None
+    error: str | None = None
+
+
+class ComparisonResult(BaseModel):
+    """Result of comparing a metric value against a historical baseline."""
+
+    model_config = ConfigDict(frozen=True)
+
+    metric_name: str
+    comparison_type: ComparisonType
+    current_value: float | None = None
+    baseline_value: float | None = None
+    change_pct: float | None = None
+    exceeds_threshold: bool = False
+    trend_slope: float | None = None
+    trend_direction: str | None = None
+    forecast_threshold_days: int | None = None
+
+
+class AnalysisResult(BaseModel):
+    """Bundles a metric value with its optional comparison."""
+
+    model_config = ConfigDict(frozen=True)
+
+    metric: MetricValue
+    comparison: ComparisonResult | None = None

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -62,6 +62,8 @@ __all__ = [
     "CloudAuthError",
     "CloudSSHError",
     "CloudProvisioningError",
+    "AnalysisError",
+    "AnalysisConfigError",
     "is_debug_mode",
 ]
 
@@ -437,3 +439,20 @@ class CloudProvisioningError(CloudError):
     """Server setup or provisioning step failed."""
 
     _default_error_code = "DANGO-D005"
+
+
+# ---------------------------------------------------------------------------
+# Analysis exceptions  (DANGO-N***)
+# ---------------------------------------------------------------------------
+
+
+class AnalysisError(DangoError):
+    """Analysis operation failed."""
+
+    _default_error_code = "DANGO-N001"
+
+
+class AnalysisConfigError(AnalysisError):
+    """Analysis configuration is invalid."""
+
+    _default_error_code = "DANGO-N002"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,6 +298,10 @@ module = [
     "tests.unit.test_profiling",
     "tests.unit.test_catalog_api",
     "tests.integration.test_catalog_integration",
+    "tests.unit.test_analysis_models",
+    "tests.unit.test_analysis_config",
+    "tests.unit.test_analysis_comparisons",
+    "tests.unit.test_analysis_metrics",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_analysis_comparisons.py
+++ b/tests/unit/test_analysis_comparisons.py
@@ -1,0 +1,217 @@
+"""tests/unit/test_analysis_comparisons.py
+
+Tests for the comparison engine (dango/analysis/comparisons.py).
+
+Uses real SQLite via ``dango.utils.dango_db.connect()`` with pre-populated
+``metric_history`` data in ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dango.analysis.comparisons import (
+    _compute_change_pct,
+    _linear_regression,
+    compute_comparison,
+    detect_trend,
+)
+from dango.analysis.models import ComparisonType, MetricValue
+from dango.utils.dango_db import connect
+
+
+def _insert_history(tmp_path, metric_name, value, days_ago=0):
+    """Insert a metric_history row at a given offset from now."""
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    with connect(tmp_path) as conn:
+        conn.execute(
+            "INSERT INTO metric_history (metric_name, metric_value, recorded_at) VALUES (?, ?, ?)",
+            (metric_name, value, ts),
+        )
+        conn.commit()
+
+
+@pytest.mark.unit
+class TestComputeChangePct:
+    """_compute_change_pct edge cases."""
+
+    def test_normal(self):
+        """Normal percentage change."""
+        assert _compute_change_pct(110, 100) == pytest.approx(10.0)
+
+    def test_negative_change(self):
+        """Decrease from baseline."""
+        assert _compute_change_pct(90, 100) == pytest.approx(-10.0)
+
+    def test_baseline_none(self):
+        """None baseline returns None."""
+        assert _compute_change_pct(100, None) is None
+
+    def test_baseline_zero(self):
+        """Zero baseline returns None (avoid division by zero)."""
+        assert _compute_change_pct(100, 0) is None
+
+    def test_negative_baseline(self):
+        """Negative baseline uses absolute value for denominator."""
+        result = _compute_change_pct(-80, -100)
+        assert result == pytest.approx(20.0)
+
+
+@pytest.mark.unit
+class TestLinearRegression:
+    """_linear_regression OLS formula."""
+
+    def test_perfect_positive(self):
+        """Perfect linear increase."""
+        slope, intercept = _linear_regression([0, 1, 2, 3], [0, 1, 2, 3])
+        assert slope == pytest.approx(1.0)
+        assert intercept == pytest.approx(0.0)
+
+    def test_flat(self):
+        """Constant values → slope 0."""
+        slope, _intercept = _linear_regression([0, 1, 2, 3], [5, 5, 5, 5])
+        assert slope == pytest.approx(0.0)
+
+    def test_negative_slope(self):
+        """Decreasing values."""
+        slope, _intercept = _linear_regression([0, 1, 2], [10, 5, 0])
+        assert slope == pytest.approx(-5.0)
+
+    def test_single_point(self):
+        """Single point returns zero slope."""
+        slope, intercept = _linear_regression([0], [42])
+        assert slope == pytest.approx(0.0)
+        assert intercept == pytest.approx(42.0)
+
+
+@pytest.mark.unit
+class TestComputeComparison:
+    """compute_comparison integration with SQLite history."""
+
+    def test_week_over_week(self, tmp_path):
+        """Week-over-week comparison finds value from ~7 days ago."""
+        _insert_history(tmp_path, "revenue", 100.0, days_ago=7)
+        _insert_history(tmp_path, "revenue", 110.0, days_ago=0)
+
+        mv = MetricValue(metric_name="revenue", value=110.0)
+        result = compute_comparison(
+            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=15.0
+        )
+        assert result.baseline_value == pytest.approx(100.0)
+        assert result.change_pct == pytest.approx(10.0)
+        assert result.exceeds_threshold is False
+
+    def test_exceeds_threshold(self, tmp_path):
+        """Threshold exceeded when change_pct >= warn_threshold."""
+        _insert_history(tmp_path, "revenue", 100.0, days_ago=7)
+        _insert_history(tmp_path, "revenue", 120.0, days_ago=0)
+
+        mv = MetricValue(metric_name="revenue", value=120.0)
+        result = compute_comparison(
+            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=10.0
+        )
+        assert result.exceeds_threshold is True
+
+    def test_rolling_7day_avg(self, tmp_path):
+        """Rolling 7-day average comparison."""
+        for i in range(7):
+            _insert_history(tmp_path, "users", 100.0 + i, days_ago=i)
+
+        mv = MetricValue(metric_name="users", value=110.0)
+        result = compute_comparison(
+            tmp_path, mv, ComparisonType.rolling_7day_avg, warn_threshold=None
+        )
+        assert result.baseline_value is not None
+        assert result.baseline_value == pytest.approx(103.0)
+
+    def test_rolling_30day_avg(self, tmp_path):
+        """Rolling 30-day average comparison."""
+        for i in range(10):
+            _insert_history(tmp_path, "orders", 50.0, days_ago=i)
+
+        mv = MetricValue(metric_name="orders", value=60.0)
+        result = compute_comparison(
+            tmp_path, mv, ComparisonType.rolling_30day_avg, warn_threshold=None
+        )
+        assert result.baseline_value == pytest.approx(50.0)
+
+    def test_prior_period(self, tmp_path):
+        """Prior period comparison uses second-most-recent value."""
+        _insert_history(tmp_path, "signups", 80.0, days_ago=1)
+        _insert_history(tmp_path, "signups", 90.0, days_ago=0)
+
+        mv = MetricValue(metric_name="signups", value=90.0)
+        result = compute_comparison(tmp_path, mv, ComparisonType.prior_period, warn_threshold=None)
+        assert result.baseline_value == pytest.approx(80.0)
+
+    def test_no_history_returns_none_baseline(self, tmp_path):
+        """First run — no history returns None baseline and change_pct."""
+        mv = MetricValue(metric_name="new_metric", value=100.0)
+        result = compute_comparison(
+            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=10.0
+        )
+        assert result.baseline_value is None
+        assert result.change_pct is None
+        assert result.exceeds_threshold is False
+
+    def test_none_value_returns_empty_result(self, tmp_path):
+        """Metric with None value returns minimal ComparisonResult."""
+        mv = MetricValue(metric_name="broken", value=None, error="query failed")
+        result = compute_comparison(
+            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=10.0
+        )
+        assert result.current_value is None
+        assert result.baseline_value is None
+
+
+@pytest.mark.unit
+class TestDetectTrend:
+    """detect_trend linear regression on metric_history."""
+
+    def test_insufficient_data(self, tmp_path):
+        """Fewer than 14 data points returns all None."""
+        for i in range(10):
+            _insert_history(tmp_path, "sparse", 100.0, days_ago=i)
+
+        slope, direction, forecast = detect_trend(tmp_path, "sparse")
+        assert slope is None
+        assert direction is None
+        assert forecast is None
+
+    def test_increasing_trend(self, tmp_path):
+        """Clear upward trend detected."""
+        for i in range(20):
+            _insert_history(tmp_path, "growing", float(100 + i * 10), days_ago=20 - i)
+
+        slope, direction, _forecast = detect_trend(tmp_path, "growing")
+        assert slope is not None
+        assert slope > 0
+        assert direction == "increasing"
+
+    def test_decreasing_trend(self, tmp_path):
+        """Clear downward trend detected."""
+        for i in range(20):
+            _insert_history(tmp_path, "shrinking", float(200 - i * 10), days_ago=20 - i)
+
+        slope, direction, _forecast = detect_trend(tmp_path, "shrinking")
+        assert slope is not None
+        assert slope < 0
+        assert direction == "decreasing"
+
+    def test_stable_trend(self, tmp_path):
+        """Flat data detected as stable."""
+        for i in range(20):
+            _insert_history(tmp_path, "flat", 100.0, days_ago=20 - i)
+
+        slope, direction, _forecast = detect_trend(tmp_path, "flat")
+        assert slope is not None
+        assert direction == "stable"
+
+    def test_no_data(self, tmp_path):
+        """No data at all returns all None."""
+        slope, direction, forecast = detect_trend(tmp_path, "nonexistent")
+        assert slope is None
+        assert direction is None
+        assert forecast is None

--- a/tests/unit/test_analysis_config.py
+++ b/tests/unit/test_analysis_config.py
@@ -1,0 +1,112 @@
+"""tests/unit/test_analysis_config.py
+
+Tests for metrics config loading (dango/analysis/config.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dango.analysis.config import get_metrics_file_path, load_metrics_config
+from dango.analysis.models import ComparisonType
+from dango.exceptions import AnalysisConfigError
+
+
+@pytest.mark.unit
+class TestGetMetricsFilePath:
+    """get_metrics_file_path returns the expected path."""
+
+    def test_returns_path(self, tmp_path):
+        """Path is .dango/metrics.yml under project root."""
+        assert get_metrics_file_path(tmp_path) == tmp_path / ".dango" / "metrics.yml"
+
+
+@pytest.mark.unit
+class TestLoadMetricsConfig:
+    """load_metrics_config loading behaviour."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Missing file returns empty MetricsConfig."""
+        cfg = load_metrics_config(tmp_path)
+        assert cfg.metrics == []
+        assert cfg.enabled is True
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        """Empty YAML file returns empty MetricsConfig."""
+        metrics_dir = tmp_path / ".dango"
+        metrics_dir.mkdir()
+        (metrics_dir / "metrics.yml").write_text("")
+        cfg = load_metrics_config(tmp_path)
+        assert cfg.metrics == []
+
+    def test_valid_config(self, tmp_path):
+        """Valid YAML loads correctly."""
+        metrics_dir = tmp_path / ".dango"
+        metrics_dir.mkdir()
+        (metrics_dir / "metrics.yml").write_text(
+            """\
+enabled: true
+metrics:
+  - name: daily_revenue
+    source_table: raw_stripe.payments
+    value_expression: "SUM(amount)"
+    filter: "status = 'succeeded'"
+    compare: week_over_week
+    warn_threshold: 10
+    drill_down:
+      - product_name
+      - country
+  - name: user_count
+    source_table: raw_app.users
+    value_expression: "COUNT(*)"
+"""
+        )
+        cfg = load_metrics_config(tmp_path)
+        assert cfg.enabled is True
+        assert len(cfg.metrics) == 2
+        assert cfg.metrics[0].name == "daily_revenue"
+        assert cfg.metrics[0].compare == ComparisonType.week_over_week
+        assert cfg.metrics[0].warn_threshold == 10.0
+        assert cfg.metrics[0].drill_down == ["product_name", "country"]
+        assert cfg.metrics[1].name == "user_count"
+        assert cfg.metrics[1].filter is None
+
+    def test_disabled_config(self, tmp_path):
+        """Config with enabled: false."""
+        metrics_dir = tmp_path / ".dango"
+        metrics_dir.mkdir()
+        (metrics_dir / "metrics.yml").write_text("enabled: false\nmetrics: []\n")
+        cfg = load_metrics_config(tmp_path)
+        assert cfg.enabled is False
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        """Malformed YAML raises AnalysisConfigError."""
+        metrics_dir = tmp_path / ".dango"
+        metrics_dir.mkdir()
+        (metrics_dir / "metrics.yml").write_text("metrics: [invalid: yaml: content\n")
+        with pytest.raises(AnalysisConfigError, match="Invalid YAML"):
+            load_metrics_config(tmp_path)
+
+    def test_invalid_metric_raises(self, tmp_path):
+        """Invalid metric config raises AnalysisConfigError."""
+        metrics_dir = tmp_path / ".dango"
+        metrics_dir.mkdir()
+        (metrics_dir / "metrics.yml").write_text(
+            """\
+metrics:
+  - name: BadName
+    source_table: no_dot
+    value_expression: "SUM(x)"
+"""
+        )
+        with pytest.raises(AnalysisConfigError, match="Invalid metrics configuration"):
+            load_metrics_config(tmp_path)
+
+    def test_no_metrics_key_returns_empty(self, tmp_path):
+        """YAML with unrelated keys returns empty MetricsConfig."""
+        metrics_dir = tmp_path / ".dango"
+        metrics_dir.mkdir()
+        (metrics_dir / "metrics.yml").write_text("some_other_key: true\n")
+        cfg = load_metrics_config(tmp_path)
+        # MetricsConfig accepts extra keys — metrics defaults to []
+        assert cfg.metrics == []

--- a/tests/unit/test_analysis_metrics.py
+++ b/tests/unit/test_analysis_metrics.py
@@ -1,0 +1,275 @@
+"""tests/unit/test_analysis_metrics.py
+
+Tests for the metric engine (dango/analysis/metrics.py).
+
+Mocks ``duckdb.connect`` at ``dango.analysis.metrics.duckdb`` for DuckDB queries
+and uses real SQLite via ``dango.utils.dango_db.connect()`` for storage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.analysis.metrics import (
+    _build_metric_sql,
+    _parse_source_from_table,
+    _store_comparison_result,
+    _store_metric_value,
+    run_analysis,
+)
+from dango.analysis.models import (
+    ComparisonResult,
+    ComparisonType,
+    MetricConfig,
+    MetricValue,
+)
+from dango.utils.dango_db import connect
+
+
+@pytest.mark.unit
+class TestParseSourceFromTable:
+    """_parse_source_from_table splits schema.table."""
+
+    def test_normal(self):
+        """Schema-qualified name splits correctly."""
+        source, table = _parse_source_from_table("raw_stripe.payments")
+        assert source == "raw_stripe"
+        assert table == "payments"
+
+    def test_no_dot(self):
+        """No dot returns (None, None)."""
+        source, table = _parse_source_from_table("payments")
+        assert source is None
+        assert table is None
+
+    def test_multiple_dots(self):
+        """Multiple dots split on first dot only."""
+        source, table = _parse_source_from_table("raw.stripe.payments")
+        assert source == "raw"
+        assert table == "stripe.payments"
+
+
+@pytest.mark.unit
+class TestBuildMetricSql:
+    """_build_metric_sql constructs SQL."""
+
+    def test_without_filter(self):
+        """SQL without WHERE clause."""
+        mc = MetricConfig(name="m", source_table="s.t", value_expression="COUNT(*)")
+        sql = _build_metric_sql(mc)
+        assert sql == "SELECT COUNT(*) FROM s.t"
+
+    def test_with_filter(self):
+        """SQL with WHERE clause."""
+        mc = MetricConfig(
+            name="m",
+            source_table="s.t",
+            value_expression="SUM(amount)",
+            filter="status = 'active'",
+        )
+        sql = _build_metric_sql(mc)
+        assert sql == "SELECT SUM(amount) FROM s.t WHERE status = 'active'"
+
+
+@pytest.mark.unit
+class TestStoreMetricValue:
+    """_store_metric_value inserts into metric_history."""
+
+    def test_stores_value(self, tmp_path):
+        """Value is stored in metric_history table."""
+        mv = MetricValue(
+            metric_name="revenue",
+            source="raw_stripe",
+            table_name="payments",
+            value=42.5,
+        )
+        _store_metric_value(tmp_path, mv)
+
+        with connect(tmp_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM metric_history WHERE metric_name = 'revenue'"
+            ).fetchone()
+        assert row is not None
+        assert row["metric_value"] == 42.5
+
+    def test_skips_none_value(self, tmp_path):
+        """None value is not stored."""
+        mv = MetricValue(metric_name="broken", value=None, error="fail")
+        _store_metric_value(tmp_path, mv)
+
+        with connect(tmp_path) as conn:
+            rows = conn.execute("SELECT * FROM metric_history").fetchall()
+        assert len(rows) == 0
+
+
+@pytest.mark.unit
+class TestStoreComparisonResult:
+    """_store_comparison_result inserts into metric_results."""
+
+    def test_stores_result(self, tmp_path):
+        """Comparison result is stored in metric_results table."""
+        cr = ComparisonResult(
+            metric_name="revenue",
+            comparison_type=ComparisonType.week_over_week,
+            current_value=110.0,
+            baseline_value=100.0,
+            change_pct=10.0,
+        )
+        _store_comparison_result(tmp_path, cr)
+
+        with connect(tmp_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM metric_results WHERE metric_name = 'revenue'"
+            ).fetchone()
+        assert row is not None
+        assert row["result_type"] == "week_over_week"
+        assert "110.0" in row["result_value"]
+
+
+@pytest.mark.unit
+class TestRunAnalysis:
+    """run_analysis orchestration."""
+
+    def _write_config(self, tmp_path, yaml_content):
+        """Write metrics.yml config."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir(exist_ok=True)
+        (dango_dir / "metrics.yml").write_text(yaml_content)
+
+    def _create_warehouse(self, tmp_path):
+        """Create a minimal DuckDB warehouse file."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir(exist_ok=True)
+        return data_dir / "warehouse.duckdb"
+
+    def test_empty_config_returns_empty(self, tmp_path):
+        """No config file returns empty results."""
+        results = run_analysis(tmp_path)
+        assert results == []
+
+    def test_disabled_config_returns_empty(self, tmp_path):
+        """Disabled config returns empty results."""
+        self._write_config(tmp_path, "enabled: false\nmetrics: []\n")
+        results = run_analysis(tmp_path)
+        assert results == []
+
+    def test_no_warehouse_returns_empty(self, tmp_path):
+        """Missing DuckDB warehouse returns empty results."""
+        self._write_config(
+            tmp_path,
+            """\
+metrics:
+  - name: m1
+    source_table: s.t
+    value_expression: "COUNT(*)"
+""",
+        )
+        results = run_analysis(tmp_path)
+        assert results == []
+
+    @patch("dango.analysis.metrics.duckdb")
+    def test_runs_metrics(self, mock_duckdb, tmp_path):
+        """Runs metrics and returns AnalysisResult objects."""
+        self._write_config(
+            tmp_path,
+            """\
+metrics:
+  - name: revenue
+    source_table: raw_stripe.payments
+    value_expression: "SUM(amount)"
+""",
+        )
+        warehouse_path = self._create_warehouse(tmp_path)
+        warehouse_path.touch()
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = (42.5,)
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        results = run_analysis(tmp_path)
+
+        assert len(results) == 1
+        assert results[0].metric.metric_name == "revenue"
+        assert results[0].metric.value == 42.5
+        assert results[0].comparison is not None
+
+    @patch("dango.analysis.metrics.duckdb")
+    def test_handles_query_error(self, mock_duckdb, tmp_path):
+        """DuckDB query error is caught and stored in MetricValue.error."""
+        self._write_config(
+            tmp_path,
+            """\
+metrics:
+  - name: bad_metric
+    source_table: raw.missing_table
+    value_expression: "COUNT(*)"
+""",
+        )
+        warehouse_path = self._create_warehouse(tmp_path)
+        warehouse_path.touch()
+
+        mock_duckdb.Error = Exception
+        mock_duckdb.connect.return_value.execute.side_effect = Exception("Table not found")
+
+        results = run_analysis(tmp_path)
+
+        assert len(results) == 1
+        assert results[0].metric.error == "Table not found"
+        assert results[0].comparison is None
+
+    @patch("dango.analysis.metrics.duckdb")
+    def test_source_filter(self, mock_duckdb, tmp_path):
+        """source_filter limits which metrics are executed."""
+        self._write_config(
+            tmp_path,
+            """\
+metrics:
+  - name: m1
+    source_table: raw_stripe.payments
+    value_expression: "SUM(amount)"
+  - name: m2
+    source_table: raw_app.users
+    value_expression: "COUNT(*)"
+""",
+        )
+        warehouse_path = self._create_warehouse(tmp_path)
+        warehouse_path.touch()
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = (10.0,)
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        results = run_analysis(tmp_path, source_filter=["raw_stripe"])
+
+        assert len(results) == 1
+        assert results[0].metric.metric_name == "m1"
+
+    @patch("dango.analysis.metrics.duckdb")
+    def test_null_result_from_duckdb(self, mock_duckdb, tmp_path):
+        """DuckDB returning NULL is stored as None value."""
+        self._write_config(
+            tmp_path,
+            """\
+metrics:
+  - name: empty_metric
+    source_table: raw.t
+    value_expression: "SUM(amount)"
+""",
+        )
+        warehouse_path = self._create_warehouse(tmp_path)
+        warehouse_path.touch()
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = (None,)
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        results = run_analysis(tmp_path)
+
+        assert len(results) == 1
+        assert results[0].metric.value is None
+        assert results[0].metric.error is None

--- a/tests/unit/test_analysis_models.py
+++ b/tests/unit/test_analysis_models.py
@@ -1,0 +1,222 @@
+"""tests/unit/test_analysis_models.py
+
+Tests for analysis Pydantic models (dango/analysis/models.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from dango.analysis.models import (
+    AnalysisResult,
+    ComparisonResult,
+    ComparisonType,
+    MetricConfig,
+    MetricsConfig,
+    MetricValue,
+)
+
+
+@pytest.mark.unit
+class TestComparisonType:
+    """ComparisonType enum values."""
+
+    def test_all_values(self):
+        """All four comparison types exist."""
+        assert ComparisonType.week_over_week == "week_over_week"
+        assert ComparisonType.rolling_7day_avg == "rolling_7day_avg"
+        assert ComparisonType.rolling_30day_avg == "rolling_30day_avg"
+        assert ComparisonType.prior_period == "prior_period"
+
+
+@pytest.mark.unit
+class TestMetricConfig:
+    """MetricConfig validation."""
+
+    def test_valid_config(self):
+        """Valid config creates successfully."""
+        mc = MetricConfig(
+            name="daily_revenue",
+            source_table="raw_stripe.payments",
+            value_expression="SUM(amount)",
+        )
+        assert mc.name == "daily_revenue"
+        assert mc.compare == ComparisonType.week_over_week
+        assert mc.drill_down == []
+
+    def test_full_config(self):
+        """Config with all optional fields."""
+        mc = MetricConfig(
+            name="daily_revenue",
+            source_table="raw_stripe.payments",
+            value_expression="SUM(amount)",
+            filter="status = 'succeeded'",
+            compare=ComparisonType.rolling_7day_avg,
+            warn_threshold=10.0,
+            drill_down=["product_name", "country"],
+        )
+        assert mc.filter == "status = 'succeeded'"
+        assert mc.warn_threshold == 10.0
+        assert mc.drill_down == ["product_name", "country"]
+
+    def test_name_must_be_slug(self):
+        """Name with uppercase or special chars is rejected."""
+        with pytest.raises(ValidationError, match="lowercase alphanumeric"):
+            MetricConfig(
+                name="DailyRevenue",
+                source_table="raw.t",
+                value_expression="SUM(x)",
+            )
+
+    def test_name_must_start_with_letter(self):
+        """Name starting with digit is rejected."""
+        with pytest.raises(ValidationError, match="lowercase alphanumeric"):
+            MetricConfig(
+                name="1metric",
+                source_table="raw.t",
+                value_expression="SUM(x)",
+            )
+
+    def test_source_table_must_have_dot(self):
+        """source_table without schema qualifier is rejected."""
+        with pytest.raises(ValidationError, match="schema-qualified"):
+            MetricConfig(
+                name="my_metric",
+                source_table="payments",
+                value_expression="SUM(amount)",
+            )
+
+    def test_value_expression_not_empty(self):
+        """Empty value_expression is rejected."""
+        with pytest.raises(ValidationError, match="must not be empty"):
+            MetricConfig(
+                name="my_metric",
+                source_table="raw.t",
+                value_expression="   ",
+            )
+
+    def test_warn_threshold_must_be_positive(self):
+        """Non-positive warn_threshold is rejected."""
+        with pytest.raises(ValidationError, match="must be positive"):
+            MetricConfig(
+                name="my_metric",
+                source_table="raw.t",
+                value_expression="SUM(x)",
+                warn_threshold=-5.0,
+            )
+
+    def test_warn_threshold_zero_rejected(self):
+        """Zero warn_threshold is rejected."""
+        with pytest.raises(ValidationError, match="must be positive"):
+            MetricConfig(
+                name="my_metric",
+                source_table="raw.t",
+                value_expression="SUM(x)",
+                warn_threshold=0,
+            )
+
+    def test_frozen(self):
+        """MetricConfig is immutable."""
+        mc = MetricConfig(name="m", source_table="s.t", value_expression="COUNT(*)")
+        with pytest.raises(ValidationError):
+            mc.name = "other"
+
+
+@pytest.mark.unit
+class TestMetricsConfig:
+    """MetricsConfig model."""
+
+    def test_empty_default(self):
+        """Empty config has no metrics and is enabled."""
+        cfg = MetricsConfig()
+        assert cfg.metrics == []
+        assert cfg.enabled is True
+
+    def test_with_metrics(self):
+        """Config with a list of metrics."""
+        cfg = MetricsConfig(
+            metrics=[
+                MetricConfig(
+                    name="m1",
+                    source_table="s.t",
+                    value_expression="COUNT(*)",
+                ),
+            ],
+        )
+        assert len(cfg.metrics) == 1
+
+    def test_disabled(self):
+        """Config can be disabled."""
+        cfg = MetricsConfig(enabled=False)
+        assert cfg.enabled is False
+
+
+@pytest.mark.unit
+class TestMetricValue:
+    """MetricValue model."""
+
+    def test_success_value(self):
+        """Value with no error."""
+        mv = MetricValue(metric_name="m", value=42.5)
+        assert mv.value == 42.5
+        assert mv.error is None
+
+    def test_error_value(self):
+        """Value with error has no value."""
+        mv = MetricValue(metric_name="m", error="table not found")
+        assert mv.value is None
+        assert mv.error == "table not found"
+
+
+@pytest.mark.unit
+class TestComparisonResult:
+    """ComparisonResult model."""
+
+    def test_defaults(self):
+        """Default comparison has no threshold exceeded."""
+        cr = ComparisonResult(
+            metric_name="m",
+            comparison_type=ComparisonType.week_over_week,
+        )
+        assert cr.exceeds_threshold is False
+        assert cr.change_pct is None
+
+    def test_full_result(self):
+        """Full comparison result with all fields."""
+        cr = ComparisonResult(
+            metric_name="m",
+            comparison_type=ComparisonType.rolling_7day_avg,
+            current_value=100.0,
+            baseline_value=90.0,
+            change_pct=11.1,
+            exceeds_threshold=True,
+            trend_slope=0.5,
+            trend_direction="increasing",
+            forecast_threshold_days=30,
+        )
+        assert cr.exceeds_threshold is True
+        assert cr.trend_direction == "increasing"
+
+
+@pytest.mark.unit
+class TestAnalysisResult:
+    """AnalysisResult model."""
+
+    def test_metric_only(self):
+        """Result with no comparison."""
+        ar = AnalysisResult(
+            metric=MetricValue(metric_name="m", value=10.0),
+        )
+        assert ar.comparison is None
+
+    def test_with_comparison(self):
+        """Result with comparison."""
+        ar = AnalysisResult(
+            metric=MetricValue(metric_name="m", value=10.0),
+            comparison=ComparisonResult(
+                metric_name="m",
+                comparison_type=ComparisonType.prior_period,
+            ),
+        )
+        assert ar.comparison is not None


### PR DESCRIPTION
## Summary

- Add `dango/analysis/` module with metric engine and comparison system (4 new source files + CLAUDE.md)
- Implement 4 comparison strategies: week-over-week, rolling 7/30-day avg, prior period
- Linear regression trend detection over 14–30 data points with threshold forecasting
- YAML config loader for `.dango/metrics.yml` (mirrors `schedules.py` pattern)
- `AnalysisError` / `AnalysisConfigError` exception classes (DANGO-N prefix)
- 63 unit tests across models, config, comparisons, and metrics orchestration

## Test plan

- [x] 63 analysis unit tests pass (`pytest tests/unit/test_analysis_*.py -v`)
- [x] Full test suite: 2466 passed, 0 failures
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy dango/analysis/` clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)