### PR TITLE
P7-002: Catalog lineage & impact analysis endpoints

### DIFF
--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -407,25 +407,28 @@ def _get_impact_tree(
     reverse_map: dict[str, list[str]],
     node_id: str,
     all_nodes: dict[str, dict[str, Any]],
-    visited: set[str] | None = None,
+    ancestors: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Recursively build downstream impact tree from a node.
+
+    Uses an ancestor chain (not a shared visited set) so diamond dependencies
+    expand fully under each branch while true back-edge cycles are detected.
 
     Args:
         reverse_map: Mapping of node_id → list of downstream node_ids.
         node_id: Starting node unique_id.
         all_nodes: Combined dict of all manifest nodes + sources.
-        visited: Set of already-visited node_ids for cycle detection.
+        ancestors: Immutable set of ancestor node_ids for cycle detection.
 
     Returns:
         Tree dict with ``name``, ``type``, ``children``,
         ``total_downstream_count``, and optionally ``cycle``.
     """
-    if visited is None:
-        visited = set()
+    if ancestors is None:
+        ancestors = frozenset()
 
     node = all_nodes.get(node_id, {})
-    if node_id in visited:
+    if node_id in ancestors:
         return {
             "name": node.get("name", node_id),
             "type": node.get("resource_type", "unknown"),
@@ -434,11 +437,11 @@ def _get_impact_tree(
             "total_downstream_count": 0,
         }
 
-    visited.add(node_id)
+    new_ancestors = ancestors | {node_id}
     children = []
     total = 0
     for child_id in reverse_map.get(node_id, []):
-        child_tree = _get_impact_tree(reverse_map, child_id, all_nodes, visited)
+        child_tree = _get_impact_tree(reverse_map, child_id, all_nodes, new_ancestors)
         children.append(child_tree)
         total += 1 + child_tree["total_downstream_count"]
 
@@ -447,6 +450,62 @@ def _get_impact_tree(
         "type": node.get("resource_type", "unknown"),
         "children": children,
         "total_downstream_count": total,
+    }
+
+
+def _build_impact_response(
+    manifest: dict[str, Any],
+    model_name: str,
+) -> dict[str, Any] | None:
+    """Build impact analysis response from manifest (blocking helper).
+
+    Searches models first, then sources, so models take priority when
+    names collide (common in dbt: source "orders" + model "orders").
+
+    Args:
+        manifest: Parsed dbt manifest dict.
+        model_name: Validated model/source name to look up.
+
+    Returns:
+        Impact response dict, or ``None`` if *model_name* not found.
+    """
+    all_nodes: dict[str, dict[str, Any]] = {}
+    reverse_map: dict[str, list[str]] = {}
+
+    for uid, node in manifest.get("nodes", {}).items():
+        all_nodes[uid] = node
+        if node.get("resource_type") == "model":
+            for dep in node.get("depends_on", {}).get("nodes", []):
+                reverse_map.setdefault(dep, []).append(uid)
+
+    for uid, src in manifest.get("sources", {}).items():
+        all_nodes[uid] = src
+
+    # Find target — prefer models over sources for name collisions
+    target_id: str | None = None
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") == "model" and node.get("name") == model_name:
+            target_id = uid
+            break
+    if target_id is None:
+        for uid in manifest.get("sources", {}):
+            if all_nodes[uid].get("name") == model_name:
+                target_id = uid
+                break
+
+    if target_id is None:
+        return None
+
+    tree = _get_impact_tree(reverse_map, target_id, all_nodes)
+    direct = reverse_map.get(target_id, [])
+    node_info = all_nodes[target_id]
+
+    return {
+        "model": model_name,
+        "type": node_info.get("resource_type", "unknown"),
+        "direct_dependents": [all_nodes.get(d, {}).get("name", d) for d in direct],
+        "tree": tree,
+        "total_downstream_count": tree["total_downstream_count"],
     }
 
 
@@ -498,40 +557,10 @@ async def get_impact(
             detail="No dbt manifest found. Run dbt first to generate lineage data.",
         )
 
-    # Build combined node lookup and reverse map
-    all_nodes: dict[str, dict[str, Any]] = {}
-    reverse_map: dict[str, list[str]] = {}
-
-    for uid, node in manifest.get("nodes", {}).items():
-        all_nodes[uid] = node
-        if node.get("resource_type") == "model":
-            for dep in node.get("depends_on", {}).get("nodes", []):
-                reverse_map.setdefault(dep, []).append(uid)
-
-    for uid, src in manifest.get("sources", {}).items():
-        all_nodes[uid] = src
-
-    # Find the target model by name
-    target_id: str | None = None
-    for uid, node in all_nodes.items():
-        if node.get("name") == model_name:
-            target_id = uid
-            break
-
-    if target_id is None:
+    result = await asyncio.to_thread(_build_impact_response, manifest, model_name)
+    if result is None:
         raise HTTPException(
             status_code=404,
             detail=f"Model '{model_name}' not found in dbt manifest.",
         )
-
-    tree = _get_impact_tree(reverse_map, target_id, all_nodes)
-    direct = reverse_map.get(target_id, [])
-    node_info = all_nodes[target_id]
-
-    return {
-        "model": model_name,
-        "type": node_info.get("resource_type", "unknown"),
-        "direct_dependents": [all_nodes.get(d, {}).get("name", d) for d in direct],
-        "tree": tree,
-        "total_downstream_count": tree["total_downstream_count"],
-    }
+    return result

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -1,6 +1,7 @@
 """dango/web/routes/catalog.py
 
-Data catalog API endpoints for column schema introspection and profiling.
+Data catalog API endpoints for column schema introspection, profiling,
+lineage, and impact analysis.
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ from dango.logging import get_logger
 from dango.utils.dango_db import connect
 from dango.utils.post_sync import profile_table
 from dango.validation import validate_identifier, validate_source_name
-from dango.web.helpers import get_project_root
+from dango.web.helpers import get_dbt_manifest, get_project_root
 
 logger = get_logger(__name__)
 
@@ -315,4 +316,222 @@ async def refresh_table_profile(
         "row_count": row_count,
         "profiled_at": profiled_at,
         "columns": columns,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lineage helpers (called via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _build_lineage_dag() -> dict[str, Any] | None:
+    """Build full DAG from dbt manifest (sources + models + edges).
+
+    Returns:
+        Dict with ``nodes`` and ``edges`` lists, or ``None`` if no manifest.
+    """
+    manifest = get_dbt_manifest()
+    if manifest is None:
+        return None
+
+    nodes_out: list[dict[str, Any]] = []
+    edges: list[dict[str, str]] = []
+    depended_on_by: dict[str, list[str]] = {}
+    test_map: dict[str, list[str]] = {}
+
+    # Collect model dependencies and test associations
+    for uid, node in manifest.get("nodes", {}).items():
+        rtype = node.get("resource_type", "")
+        if rtype == "model":
+            deps = node.get("depends_on", {}).get("nodes", [])
+            for dep in deps:
+                depended_on_by.setdefault(dep, []).append(uid)
+                edges.append({"source": dep, "target": uid})
+        elif rtype == "test":
+            for dep in node.get("depends_on", {}).get("nodes", []):
+                test_map.setdefault(dep, []).append(node.get("name", uid))
+
+    # Build node list — models
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "model":
+            continue
+        columns = node.get("columns", {})
+        cols_documented = sum(1 for c in columns.values() if c.get("description"))
+        deps = node.get("depends_on", {}).get("nodes", [])
+        tests = test_map.get(uid, [])
+        nodes_out.append(
+            {
+                "id": uid,
+                "name": node.get("name", ""),
+                "type": "model",
+                "schema": node.get("schema", ""),
+                "materialization": node.get("config", {}).get("materialized"),
+                "description": node.get("description", ""),
+                "depends_on": deps,
+                "depended_on_by": depended_on_by.get(uid, []),
+                "test_count": len(tests),
+                "test_names": tests,
+                "has_description": bool(node.get("description")),
+                "columns_documented": cols_documented,
+                "columns_total": len(columns),
+            }
+        )
+
+    # Build node list — sources
+    for uid, src in manifest.get("sources", {}).items():
+        columns = src.get("columns", {})
+        cols_documented = sum(1 for c in columns.values() if c.get("description"))
+        tests = test_map.get(uid, [])
+        nodes_out.append(
+            {
+                "id": uid,
+                "name": src.get("name", ""),
+                "type": "source",
+                "schema": src.get("schema", ""),
+                "materialization": None,
+                "description": src.get("description", ""),
+                "depends_on": [],
+                "depended_on_by": depended_on_by.get(uid, []),
+                "test_count": len(tests),
+                "test_names": tests,
+                "has_description": bool(src.get("description")),
+                "columns_documented": cols_documented,
+                "columns_total": len(columns),
+            }
+        )
+
+    return {"nodes": nodes_out, "edges": edges}
+
+
+def _get_impact_tree(
+    reverse_map: dict[str, list[str]],
+    node_id: str,
+    all_nodes: dict[str, dict[str, Any]],
+    visited: set[str] | None = None,
+) -> dict[str, Any]:
+    """Recursively build downstream impact tree from a node.
+
+    Args:
+        reverse_map: Mapping of node_id → list of downstream node_ids.
+        node_id: Starting node unique_id.
+        all_nodes: Combined dict of all manifest nodes + sources.
+        visited: Set of already-visited node_ids for cycle detection.
+
+    Returns:
+        Tree dict with ``name``, ``type``, ``children``,
+        ``total_downstream_count``, and optionally ``cycle``.
+    """
+    if visited is None:
+        visited = set()
+
+    node = all_nodes.get(node_id, {})
+    if node_id in visited:
+        return {
+            "name": node.get("name", node_id),
+            "type": node.get("resource_type", "unknown"),
+            "cycle": True,
+            "children": [],
+            "total_downstream_count": 0,
+        }
+
+    visited.add(node_id)
+    children = []
+    total = 0
+    for child_id in reverse_map.get(node_id, []):
+        child_tree = _get_impact_tree(reverse_map, child_id, all_nodes, visited)
+        children.append(child_tree)
+        total += 1 + child_tree["total_downstream_count"]
+
+    return {
+        "name": node.get("name", node_id),
+        "type": node.get("resource_type", "unknown"),
+        "children": children,
+        "total_downstream_count": total,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lineage endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/catalog/lineage")
+async def get_lineage(
+    user: User = Depends(require_permission("governance.view")),  # noqa: ARG001
+) -> dict[str, Any]:
+    """Return the full lineage DAG from the dbt manifest.
+
+    Args:
+        user: Authenticated user with ``governance.view`` permission.
+
+    Returns:
+        Dict with ``nodes`` and ``edges`` lists.
+    """
+    dag = await asyncio.to_thread(_build_lineage_dag)
+    if dag is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No dbt manifest found. Run dbt first to generate lineage data.",
+        )
+    return dag
+
+
+@router.get("/api/catalog/impact/{model_name}")
+async def get_impact(
+    model_name: str,
+    user: User = Depends(require_permission("governance.view")),  # noqa: ARG001
+) -> dict[str, Any]:
+    """Return the downstream impact tree for a model.
+
+    Args:
+        model_name: Model name (URL path parameter).
+        user: Authenticated user with ``governance.view`` permission.
+
+    Returns:
+        Impact tree with direct dependents and total downstream count.
+    """
+    model_name = validate_identifier(model_name)
+    manifest = await asyncio.to_thread(get_dbt_manifest)
+    if manifest is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No dbt manifest found. Run dbt first to generate lineage data.",
+        )
+
+    # Build combined node lookup and reverse map
+    all_nodes: dict[str, dict[str, Any]] = {}
+    reverse_map: dict[str, list[str]] = {}
+
+    for uid, node in manifest.get("nodes", {}).items():
+        all_nodes[uid] = node
+        if node.get("resource_type") == "model":
+            for dep in node.get("depends_on", {}).get("nodes", []):
+                reverse_map.setdefault(dep, []).append(uid)
+
+    for uid, src in manifest.get("sources", {}).items():
+        all_nodes[uid] = src
+
+    # Find the target model by name
+    target_id: str | None = None
+    for uid, node in all_nodes.items():
+        if node.get("name") == model_name:
+            target_id = uid
+            break
+
+    if target_id is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model '{model_name}' not found in dbt manifest.",
+        )
+
+    tree = _get_impact_tree(reverse_map, target_id, all_nodes)
+    direct = reverse_map.get(target_id, [])
+    node_info = all_nodes[target_id]
+
+    return {
+        "model": model_name,
+        "type": node_info.get("resource_type", "unknown"),
+        "direct_dependents": [all_nodes.get(d, {}).get("name", d) for d in direct],
+        "tree": tree,
+        "total_downstream_count": tree["total_downstream_count"],
     }

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -170,6 +170,12 @@ exemptions:
     reason: "35 tests covering all provider validators, routing, and pre-sync gate. Test methods are intentionally verbose for readability — each sets up mocks explicitly."
     review_by: "v1.1"
 
+  - file: tests/unit/test_catalog_lineage.py
+    lines: 550
+    category: exempt
+    reason: "P7-002: 14 tests covering lineage DAG (7) + impact analysis (7). Separate file from test_catalog_api.py per STANDARDS.md §7 split-at-creation rule."
+    review_by: "v1.1"
+
   - file: tests/unit/test_auth_database.py
     lines: 504
     category: exempt
@@ -272,6 +278,12 @@ exemptions:
     lines: 558
     category: exempt
     reason: "TASK-040c: Added remote sync trigger API (POST /api/sync/trigger, GET /api/sync/status/{id}) with background task + execution history. Extends existing per-source sync endpoint."
+    review_by: "v1.1"
+
+  - file: dango/web/routes/catalog.py
+    lines: 537
+    category: exempt
+    reason: "P7-001+P7-002: Column schema, profiling, lineage DAG, and impact analysis endpoints. Single router file per file conflict matrix — lineage helpers are private to the same module."
     review_by: "v1.1"
 
   - file: tests/unit/test_schedule_crud_api.py

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -171,9 +171,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_catalog_lineage.py
-    lines: 550
+    lines: 599
     category: exempt
-    reason: "P7-002: 14 tests covering lineage DAG (7) + impact analysis (7). Separate file from test_catalog_api.py per STANDARDS.md §7 split-at-creation rule."
+    reason: "P7-002: 16 tests covering lineage DAG (7) + impact analysis (9). Separate file from test_catalog_api.py per STANDARDS.md §7 split-at-creation rule."
     review_by: "v1.1"
 
   - file: tests/unit/test_auth_database.py
@@ -281,7 +281,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/catalog.py
-    lines: 537
+    lines: 566
     category: exempt
     reason: "P7-001+P7-002: Column schema, profiling, lineage DAG, and impact analysis endpoints. Single router file per file conflict matrix — lineage helpers are private to the same module."
     review_by: "v1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,7 @@ module = [
     "tests.unit.test_post_sync",
     "tests.unit.test_profiling",
     "tests.unit.test_catalog_api",
+    "tests.unit.test_catalog_lineage",
     "tests.integration.test_catalog_integration",
     "tests.unit.test_analysis_models",
     "tests.unit.test_analysis_config",

--- a/tests/integration/test_catalog_integration.py
+++ b/tests/integration/test_catalog_integration.py
@@ -1,12 +1,13 @@
 """tests/integration/test_catalog_integration.py
 
-Integration tests for catalog profiling using real DuckDB and SQLite databases.
+Integration tests for catalog profiling and lineage using real DuckDB and SQLite databases.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import duckdb
 import pytest
@@ -17,6 +18,7 @@ from dango.utils.post_sync import (
     dispatch_post_sync_hooks,
     profile_table,
 )
+from dango.web.routes.catalog import _build_lineage_dag, _get_impact_tree
 
 
 def _create_test_warehouse(tmp_path: Path) -> Path:
@@ -228,3 +230,116 @@ class TestProfilingPerformance:
         assert "username" in stats
         # Should complete well under 5 seconds on any reasonable hardware
         assert elapsed < 5.0
+
+
+def _create_test_manifest(tmp_path: Path) -> Path:
+    """Write a realistic manifest.json with sources, models, tests, and deps.
+
+    Returns:
+        Path to the manifest file.
+    """
+    manifest: dict[str, Any] = {
+        "nodes": {
+            "model.shop.stg_orders": {
+                "resource_type": "model",
+                "name": "stg_orders",
+                "schema": "analytics",
+                "config": {"materialized": "view"},
+                "description": "Staging orders",
+                "depends_on": {"nodes": ["source.shop.raw.orders"]},
+                "columns": {
+                    "id": {"name": "id", "description": "Order ID"},
+                    "total": {"name": "total", "description": ""},
+                },
+            },
+            "model.shop.fct_revenue": {
+                "resource_type": "model",
+                "name": "fct_revenue",
+                "schema": "analytics",
+                "config": {"materialized": "table"},
+                "description": "",
+                "depends_on": {"nodes": ["model.shop.stg_orders"]},
+                "columns": {},
+            },
+            "test.shop.not_null_stg_orders_id": {
+                "resource_type": "test",
+                "name": "not_null_stg_orders_id",
+                "depends_on": {"nodes": ["model.shop.stg_orders"]},
+            },
+        },
+        "sources": {
+            "source.shop.raw.orders": {
+                "name": "orders",
+                "schema": "raw_shop",
+                "description": "Raw orders table",
+                "columns": {},
+                "resource_type": "source",
+            },
+        },
+    }
+    manifest_dir = tmp_path / "dbt" / "target"
+    manifest_dir.mkdir(parents=True)
+    manifest_path = manifest_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest_path
+
+
+@pytest.mark.integration
+class TestLineageIntegration:
+    """Integration tests for lineage DAG and impact tree with real manifest."""
+
+    def test_build_lineage_dag_from_manifest(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """_build_lineage_dag returns correct nodes + edges from manifest."""
+        _create_test_manifest(tmp_path)
+        monkeypatch.setattr(
+            "dango.web.routes.catalog.get_dbt_manifest",
+            lambda: json.loads((tmp_path / "dbt" / "target" / "manifest.json").read_text()),
+        )
+
+        dag = _build_lineage_dag()
+
+        assert dag is not None
+        assert len(dag["nodes"]) == 3  # 1 source + 2 models
+        assert len(dag["edges"]) == 2  # source→stg, stg→fct
+
+        names = {n["name"] for n in dag["nodes"]}
+        assert names == {"orders", "stg_orders", "fct_revenue"}
+
+        # Verify reverse lookup
+        stg = next(n for n in dag["nodes"] if n["name"] == "stg_orders")
+        assert "model.shop.fct_revenue" in stg["depended_on_by"]
+        assert stg["test_count"] == 1
+        assert stg["columns_documented"] == 1  # id has desc, total doesn't
+        assert stg["columns_total"] == 2
+
+    def test_impact_tree_from_manifest(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """_get_impact_tree returns correct downstream tree."""
+        _create_test_manifest(tmp_path)
+        manifest: dict[str, Any] = json.loads(
+            (tmp_path / "dbt" / "target" / "manifest.json").read_text()
+        )
+
+        # Build combined node lookup and reverse map
+        all_nodes: dict[str, dict[str, Any]] = {}
+        reverse_map: dict[str, list[str]] = {}
+        for uid, node in manifest["nodes"].items():
+            all_nodes[uid] = node
+            if node.get("resource_type") == "model":
+                for dep in node.get("depends_on", {}).get("nodes", []):
+                    reverse_map.setdefault(dep, []).append(uid)
+        for uid, src in manifest["sources"].items():
+            all_nodes[uid] = src
+
+        tree = _get_impact_tree(reverse_map, "source.shop.raw.orders", all_nodes)
+
+        assert tree["name"] == "orders"
+        assert tree["total_downstream_count"] == 2
+        assert len(tree["children"]) == 1
+        assert tree["children"][0]["name"] == "stg_orders"

--- a/tests/unit/test_catalog_lineage.py
+++ b/tests/unit/test_catalog_lineage.py
@@ -1,0 +1,550 @@
+"""tests/unit/test_catalog_lineage.py
+
+Unit tests for catalog lineage and impact analysis endpoints.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    DangoError,
+    ValidationError,
+)
+from dango.web.routes.catalog import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.ADMIN) -> User:
+    """Create a test user."""
+    return User(
+        id="u-test-1",
+        email="test@test.com",
+        password_hash="hashed",
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the catalog router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        ValidationError: 400,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(
+        request: Request,
+        exc: DangoError,
+    ) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_client(
+    tmp_path: Path,
+    role: Role = Role.ADMIN,
+) -> tuple[TestClient, Path]:
+    """Create a test client with auth middleware injecting a user."""
+    user = _make_user(role)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+def _make_manifest(
+    models: dict[str, dict[str, Any]] | None = None,
+    sources: dict[str, dict[str, Any]] | None = None,
+    tests: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal dbt manifest for testing.
+
+    Args:
+        models: Model node overrides keyed by unique_id.
+        sources: Source node overrides keyed by unique_id.
+        tests: Test node overrides keyed by unique_id.
+
+    Returns:
+        Manifest dict with ``nodes`` and ``sources``.
+    """
+    nodes: dict[str, Any] = {}
+    if models:
+        for uid, m in models.items():
+            nodes[uid] = {
+                "resource_type": "model",
+                "name": m.get("name", uid.split(".")[-1]),
+                "schema": m.get("schema", "analytics"),
+                "config": {"materialized": m.get("materialized", "view")},
+                "description": m.get("description", ""),
+                "depends_on": {"nodes": m.get("depends_on", [])},
+                "columns": m.get("columns", {}),
+                **{
+                    k: v
+                    for k, v in m.items()
+                    if k
+                    not in {
+                        "name",
+                        "schema",
+                        "materialized",
+                        "description",
+                        "depends_on",
+                        "columns",
+                    }
+                },
+            }
+    if tests:
+        for uid, t in tests.items():
+            nodes[uid] = {
+                "resource_type": "test",
+                "name": t.get("name", uid.split(".")[-1]),
+                "depends_on": {"nodes": t.get("depends_on", [])},
+                **{
+                    k: v
+                    for k, v in t.items()
+                    if k
+                    not in {
+                        "name",
+                        "depends_on",
+                    }
+                },
+            }
+
+    src: dict[str, Any] = {}
+    if sources:
+        for uid, s in sources.items():
+            src[uid] = {
+                "name": s.get("name", uid.split(".")[-1]),
+                "schema": s.get("schema", "raw_shop"),
+                "description": s.get("description", ""),
+                "columns": s.get("columns", {}),
+                "resource_type": "source",
+                **{
+                    k: v
+                    for k, v in s.items()
+                    if k
+                    not in {
+                        "name",
+                        "schema",
+                        "description",
+                        "columns",
+                    }
+                },
+            }
+
+    return {"nodes": nodes, "sources": src}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/catalog/lineage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetLineage:
+    """Tests for GET /api/catalog/lineage."""
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_full_dag_response_shape(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Response has correct nodes/edges structure."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {"name": "orders"},
+                "source.proj.shop.customers": {"name": "customers"},
+            },
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "depends_on": ["source.proj.shop.orders"],
+                },
+                "model.proj.stg_customers": {
+                    "name": "stg_customers",
+                    "depends_on": ["source.proj.shop.customers"],
+                },
+                "model.proj.fct_orders": {
+                    "name": "fct_orders",
+                    "depends_on": [
+                        "model.proj.stg_orders",
+                        "model.proj.stg_customers",
+                    ],
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/lineage")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "nodes" in data
+        assert "edges" in data
+        assert len(data["nodes"]) == 5  # 2 sources + 3 models
+        assert len(data["edges"]) == 4  # 4 dependency edges
+
+        node_names = {n["name"] for n in data["nodes"]}
+        assert node_names == {
+            "orders",
+            "customers",
+            "stg_orders",
+            "stg_customers",
+            "fct_orders",
+        }
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_reverse_lookup_correct(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """depended_on_by is populated correctly."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {"name": "orders"},
+            },
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "depends_on": ["source.proj.shop.orders"],
+                },
+                "model.proj.fct_orders": {
+                    "name": "fct_orders",
+                    "depends_on": ["model.proj.stg_orders"],
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/lineage")
+        data = resp.json()
+
+        # Source 'orders' should be depended on by stg_orders
+        source_node = next(n for n in data["nodes"] if n["name"] == "orders")
+        assert "model.proj.stg_orders" in source_node["depended_on_by"]
+
+        # stg_orders should be depended on by fct_orders
+        stg_node = next(n for n in data["nodes"] if n["name"] == "stg_orders")
+        assert "model.proj.fct_orders" in stg_node["depended_on_by"]
+
+        # fct_orders is a leaf — no downstream
+        fct_node = next(n for n in data["nodes"] if n["name"] == "fct_orders")
+        assert fct_node["depended_on_by"] == []
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_test_associations(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test nodes are mapped back to their parent models."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {"name": "stg_orders"},
+            },
+            tests={
+                "test.proj.not_null_stg_orders_id": {
+                    "name": "not_null_stg_orders_id",
+                    "depends_on": ["model.proj.stg_orders"],
+                },
+                "test.proj.unique_stg_orders_id": {
+                    "name": "unique_stg_orders_id",
+                    "depends_on": ["model.proj.stg_orders"],
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/lineage")
+        data = resp.json()
+
+        stg_node = next(n for n in data["nodes"] if n["name"] == "stg_orders")
+        assert stg_node["test_count"] == 2
+        assert set(stg_node["test_names"]) == {
+            "not_null_stg_orders_id",
+            "unique_stg_orders_id",
+        }
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_documentation_status(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Models report documentation status for model and columns."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.documented": {
+                    "name": "documented",
+                    "description": "A well-documented model",
+                    "columns": {
+                        "id": {"name": "id", "description": "Primary key"},
+                        "name": {"name": "name", "description": ""},
+                        "email": {"name": "email", "description": "User email"},
+                    },
+                },
+                "model.proj.undocumented": {
+                    "name": "undocumented",
+                    "description": "",
+                    "columns": {},
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/lineage")
+        data = resp.json()
+
+        doc_node = next(n for n in data["nodes"] if n["name"] == "documented")
+        assert doc_node["has_description"] is True
+        assert doc_node["columns_documented"] == 2  # id + email
+        assert doc_node["columns_total"] == 3
+
+        undoc_node = next(n for n in data["nodes"] if n["name"] == "undocumented")
+        assert undoc_node["has_description"] is False
+        assert undoc_node["columns_documented"] == 0
+        assert undoc_node["columns_total"] == 0
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_404_no_manifest(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """404 when no dbt manifest exists."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = None
+
+        resp = client.get("/api/catalog/lineage")
+
+        assert resp.status_code == 404
+        assert "manifest" in resp.json()["detail"].lower()
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_sources_included(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Source nodes appear in DAG with type 'source'."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {"name": "orders"},
+            },
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "depends_on": ["source.proj.shop.orders"],
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/lineage")
+        data = resp.json()
+
+        source_nodes = [n for n in data["nodes"] if n["type"] == "source"]
+        assert len(source_nodes) == 1
+        assert source_nodes[0]["name"] == "orders"
+        assert source_nodes[0]["materialization"] is None
+
+    def test_requires_permission(self, tmp_path: Path) -> None:
+        """Endpoint requires governance.view permission (viewer has it)."""
+        client, _ = _setup_client(tmp_path, role=Role.VIEWER)
+        resp = client.get("/api/catalog/lineage")
+        assert resp.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# GET /api/catalog/impact/{model_name}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetImpact:
+    """Tests for GET /api/catalog/impact/{model_name}."""
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_recursive_tree(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Chain A→B→C returns tree with B and C as descendants."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.raw": {"name": "raw"},
+            },
+            models={
+                "model.proj.stg": {
+                    "name": "stg",
+                    "depends_on": ["source.proj.shop.raw"],
+                },
+                "model.proj.fct": {
+                    "name": "fct",
+                    "depends_on": ["model.proj.stg"],
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/impact/raw")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == "raw"
+        assert "stg" in data["direct_dependents"]
+        assert data["total_downstream_count"] == 2  # stg + fct
+
+        # Verify tree structure
+        tree = data["tree"]
+        assert tree["name"] == "raw"
+        assert len(tree["children"]) == 1
+        assert tree["children"][0]["name"] == "stg"
+        assert len(tree["children"][0]["children"]) == 1
+        assert tree["children"][0]["children"][0]["name"] == "fct"
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_model_not_found(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """404 for nonexistent model."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {"name": "stg_orders"},
+            },
+        )
+
+        resp = client.get("/api/catalog/impact/nonexistent")
+
+        assert resp.status_code == 404
+        assert "nonexistent" in resp.json()["detail"]
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_model_no_dependents(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Leaf model returns empty tree."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.leaf": {"name": "leaf"},
+            },
+        )
+
+        resp = client.get("/api/catalog/impact/leaf")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["direct_dependents"] == []
+        assert data["total_downstream_count"] == 0
+        assert data["tree"]["children"] == []
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_circular_dependency_detection(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Circular dependencies don't cause infinite loops."""
+        client, _ = _setup_client(tmp_path)
+        # Manually build a manifest with a cycle: A → B → A
+        manifest: dict[str, Any] = {
+            "nodes": {
+                "model.proj.a": {
+                    "resource_type": "model",
+                    "name": "a",
+                    "schema": "analytics",
+                    "config": {"materialized": "view"},
+                    "description": "",
+                    "depends_on": {"nodes": ["model.proj.b"]},
+                    "columns": {},
+                },
+                "model.proj.b": {
+                    "resource_type": "model",
+                    "name": "b",
+                    "schema": "analytics",
+                    "config": {"materialized": "view"},
+                    "description": "",
+                    "depends_on": {"nodes": ["model.proj.a"]},
+                    "columns": {},
+                },
+            },
+            "sources": {},
+        }
+        mock_manifest.return_value = manifest
+
+        resp = client.get("/api/catalog/impact/a")
+
+        assert resp.status_code == 200
+        # Should complete without hanging
+
+    def test_400_invalid_model_name(self, tmp_path: Path) -> None:
+        """400 for model name with special characters."""
+        client, _ = _setup_client(tmp_path)
+
+        resp = client.get("/api/catalog/impact/bad-name!")
+
+        assert resp.status_code == 400
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_404_no_manifest(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """404 when no dbt manifest exists."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = None
+
+        resp = client.get("/api/catalog/impact/orders")
+
+        assert resp.status_code == 404
+
+    def test_requires_permission(self, tmp_path: Path) -> None:
+        """Endpoint requires governance.view permission (viewer has it)."""
+        client, _ = _setup_client(tmp_path, role=Role.VIEWER)
+        resp = client.get("/api/catalog/impact/orders")
+        assert resp.status_code != 403

--- a/tests/unit/test_catalog_lineage.py
+++ b/tests/unit/test_catalog_lineage.py
@@ -114,19 +114,6 @@ def _make_manifest(
                 "description": m.get("description", ""),
                 "depends_on": {"nodes": m.get("depends_on", [])},
                 "columns": m.get("columns", {}),
-                **{
-                    k: v
-                    for k, v in m.items()
-                    if k
-                    not in {
-                        "name",
-                        "schema",
-                        "materialized",
-                        "description",
-                        "depends_on",
-                        "columns",
-                    }
-                },
             }
     if tests:
         for uid, t in tests.items():
@@ -134,15 +121,6 @@ def _make_manifest(
                 "resource_type": "test",
                 "name": t.get("name", uid.split(".")[-1]),
                 "depends_on": {"nodes": t.get("depends_on", [])},
-                **{
-                    k: v
-                    for k, v in t.items()
-                    if k
-                    not in {
-                        "name",
-                        "depends_on",
-                    }
-                },
             }
 
     src: dict[str, Any] = {}
@@ -154,17 +132,6 @@ def _make_manifest(
                 "description": s.get("description", ""),
                 "columns": s.get("columns", {}),
                 "resource_type": "source",
-                **{
-                    k: v
-                    for k, v in s.items()
-                    if k
-                    not in {
-                        "name",
-                        "schema",
-                        "description",
-                        "columns",
-                    }
-                },
             }
 
     return {"nodes": nodes, "sources": src}
@@ -488,7 +455,7 @@ class TestGetImpact:
         mock_manifest: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Circular dependencies don't cause infinite loops."""
+        """Circular dependencies are flagged with cycle=True."""
         client, _ = _setup_client(tmp_path)
         # Manually build a manifest with a cycle: A → B → A
         manifest: dict[str, Any] = {
@@ -519,7 +486,63 @@ class TestGetImpact:
         resp = client.get("/api/catalog/impact/a")
 
         assert resp.status_code == 200
-        # Should complete without hanging
+        tree = resp.json()["tree"]
+        # a → b → a(cycle)
+        assert tree["name"] == "a"
+        assert len(tree["children"]) == 1
+        b_node = tree["children"][0]
+        assert b_node["name"] == "b"
+        assert len(b_node["children"]) == 1
+        cycle_node = b_node["children"][0]
+        assert cycle_node["cycle"] is True
+        assert cycle_node["children"] == []
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_diamond_dependency_not_flagged_as_cycle(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Diamond deps expand fully under each branch (no false cycles)."""
+        client, _ = _setup_client(tmp_path)
+        # stg_base → model_a → final, stg_base → model_b → final
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_base": {
+                    "name": "stg_base",
+                },
+                "model.proj.model_a": {
+                    "name": "model_a",
+                    "depends_on": ["model.proj.stg_base"],
+                },
+                "model.proj.model_b": {
+                    "name": "model_b",
+                    "depends_on": ["model.proj.stg_base"],
+                },
+                "model.proj.final": {
+                    "name": "final",
+                    "depends_on": [
+                        "model.proj.model_a",
+                        "model.proj.model_b",
+                    ],
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/impact/stg_base")
+
+        assert resp.status_code == 200
+        tree = resp.json()["tree"]
+        # stg_base has 2 direct children: model_a and model_b
+        assert len(tree["children"]) == 2
+        child_names = {c["name"] for c in tree["children"]}
+        assert child_names == {"model_a", "model_b"}
+        # Both branches should show "final" as a child — no cycle flag
+        for child in tree["children"]:
+            assert len(child["children"]) == 1
+            grandchild = child["children"][0]
+            assert grandchild["name"] == "final"
+            assert "cycle" not in grandchild
 
     def test_400_invalid_model_name(self, tmp_path: Path) -> None:
         """400 for model name with special characters."""
@@ -542,6 +565,32 @@ class TestGetImpact:
         resp = client.get("/api/catalog/impact/orders")
 
         assert resp.status_code == 404
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_model_preferred_over_source_on_name_collision(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """When a source and model share a name, the model is preferred."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {"name": "orders"},
+            },
+            models={
+                "model.proj.orders": {
+                    "name": "orders",
+                    "depends_on": ["source.proj.shop.orders"],
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/impact/orders")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["type"] == "model"
 
     def test_requires_permission(self, tmp_path: Path) -> None:
         """Endpoint requires governance.view permission (viewer has it)."""


### PR DESCRIPTION
## Summary
- Add `GET /api/catalog/lineage` endpoint returning full DAG (nodes + edges) from dbt manifest, including reverse dependency lookup, test associations, and documentation status per model/source
- Add `GET /api/catalog/impact/{model_name}` endpoint returning recursive downstream impact tree with circular dependency detection
- Both endpoints gated by `governance.view` permission, return 404 with clear message when no dbt manifest exists

## Test plan
- [x] 14 unit tests in new `test_catalog_lineage.py` (DAG shape, reverse lookup, test associations, doc status, 404s, validation, permissions, recursive tree, cycle detection)
- [x] 2 integration tests in `test_catalog_integration.py` (real manifest file parsing for DAG + impact tree)
- [x] Existing 13 catalog tests still pass
- [x] Full suite: 2599 passed, 0 failures
- [x] All pre-commit hooks pass (ruff, mypy, headers, file sizes, docstrings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)