### PR TITLE
P7-010: Add drill-down engine for metric change analysis

### DIFF
--- a/dango/analysis/CLAUDE.md
+++ b/dango/analysis/CLAUDE.md
@@ -31,7 +31,7 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 **Imports from (dango modules):**
 - `exceptions` — `AnalysisConfigError` (config.py)
 - `logging` — `get_logger` (all files)
-- `utils.dango_db` — `connect()` (comparisons.py, metrics.py)
+- `utils.dango_db` — `connect()` (comparisons.py, drilldown.py, metrics.py)
 
 **External packages:** `pydantic`, `yaml`, `duckdb`
 
@@ -45,7 +45,8 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 
 ```
 pytest tests/unit/test_analysis_models.py tests/unit/test_analysis_config.py \
-  tests/unit/test_analysis_comparisons.py tests/unit/test_analysis_metrics.py -v
+  tests/unit/test_analysis_comparisons.py tests/unit/test_analysis_metrics.py \
+  tests/unit/test_analysis_drilldown.py -v
 ```
 
 ## Don't Modify

--- a/dango/analysis/CLAUDE.md
+++ b/dango/analysis/CLAUDE.md
@@ -8,11 +8,12 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 
 | File | Purpose | Key Exports |
 |------|---------|-------------|
-| `__init__.py` | Public API re-exports | `run_analysis`, `load_metrics_config` |
-| `models.py` | Pydantic V2 models | `ComparisonType`, `MetricConfig`, `MetricsConfig`, `MetricValue`, `ComparisonResult`, `AnalysisResult` |
+| `__init__.py` | Public API re-exports | `run_analysis`, `load_metrics_config`, `DimensionContributor`, `DrillDownDimension` |
+| `models.py` | Pydantic V2 models | `ComparisonType`, `MetricConfig`, `MetricsConfig`, `MetricValue`, `ComparisonResult`, `DimensionContributor`, `DrillDownDimension`, `AnalysisResult` |
 | `config.py` | YAML config loader | `load_metrics_config()`, `get_metrics_file_path()` |
 | `comparisons.py` | Comparison engine + trend detection | `compute_comparison()`, `detect_trend()` |
-| `metrics.py` | Orchestration: execute → store → compare | `run_analysis()` |
+| `drilldown.py` | Drill-down engine: GROUP BY breakdown + contributor ranking | `run_drill_down()` |
+| `metrics.py` | Orchestration: execute → store → compare → drill-down | `run_analysis()` |
 
 ## Common Tasks
 
@@ -23,6 +24,7 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 | Change config file format | `config.py` | `pytest tests/unit/test_analysis_config.py` |
 | Modify trend detection | `comparisons.py` (`detect_trend`, `_linear_regression`) | `pytest tests/unit/test_analysis_comparisons.py` |
 | Change metric execution | `metrics.py` (`_execute_metric`, `_build_metric_sql`) | `pytest tests/unit/test_analysis_metrics.py` |
+| Add/modify drill-down logic | `drilldown.py` (`run_drill_down`, `_compute_contributors`) | `pytest tests/unit/test_analysis_drilldown.py` |
 
 ## Dependencies
 
@@ -34,6 +36,7 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 **External packages:** `pydantic`, `yaml`, `duckdb`
 
 **Used by:**
+- `metrics.py` — calls `run_drill_down()` from `drilldown.py` when threshold exceeded
 - `utils/post_sync.py` — `_run_analysis()` stub (populated by P7-011)
 - `web/routes/insights.py` — planned (P7-012)
 - `cli/commands/analyze.py` — planned (P7-012)

--- a/dango/analysis/__init__.py
+++ b/dango/analysis/__init__.py
@@ -5,8 +5,11 @@ Automated data analysis module.
 
 from dango.analysis.config import load_metrics_config
 from dango.analysis.metrics import run_analysis
+from dango.analysis.models import DimensionContributor, DrillDownDimension
 
 __all__: list[str] = [
+    "DimensionContributor",
+    "DrillDownDimension",
     "load_metrics_config",
     "run_analysis",
 ]

--- a/dango/analysis/drilldown.py
+++ b/dango/analysis/drilldown.py
@@ -1,0 +1,279 @@
+"""dango/analysis/drilldown.py
+
+Drill-down engine for identifying top contributors to metric changes.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+from dango.analysis.models import (
+    ComparisonResult,
+    DimensionContributor,
+    DrillDownDimension,
+    MetricConfig,
+    MetricValue,
+)
+from dango.logging import get_logger
+from dango.utils.dango_db import connect
+
+logger = get_logger(__name__)
+
+MAX_GROUPS = 100
+TOP_CONTRIBUTORS = 3
+NULL_SENTINEL = "__null__"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_drill_down(
+    duckdb_path: Path,
+    project_root: Path,
+    metric: MetricConfig,
+    current_value: MetricValue,
+    comparison: ComparisonResult,
+) -> list[DrillDownDimension]:
+    """Run drill-down analysis for each configured dimension.
+
+    For each dimension in ``metric.drill_down``, executes a GROUP BY query,
+    compares against previous snapshot, and identifies top contributors.
+
+    Args:
+        duckdb_path: Path to the DuckDB warehouse file.
+        project_root: Path to the Dango project root.
+        metric: The metric configuration with drill_down dimensions.
+        current_value: The current metric value.
+        comparison: The comparison result that triggered drill-down.
+
+    Returns:
+        A list of ``DrillDownDimension`` objects, one per dimension.
+    """
+    if not metric.drill_down:
+        return []
+
+    results: list[DrillDownDimension] = []
+
+    for dimension in metric.drill_down:
+        breakdown = _query_dimension_breakdown(duckdb_path, metric, dimension)
+        if not breakdown:
+            results.append(DrillDownDimension(dimension=dimension))
+            continue
+
+        previous = _get_previous_snapshot(project_root, metric.name, dimension)
+        _store_snapshot(project_root, metric.name, dimension, breakdown)
+        contributors = _compute_contributors(breakdown, previous)
+
+        results.append(DrillDownDimension(dimension=dimension, contributors=contributors))
+
+    logger.info(
+        "drill_down_complete",
+        metric=metric.name,
+        dimensions=len(results),
+    )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Internal functions
+# ---------------------------------------------------------------------------
+
+
+def _query_dimension_breakdown(
+    duckdb_path: Path,
+    metric: MetricConfig,
+    dimension: str,
+) -> dict[str | None, float]:
+    """Query DuckDB for a GROUP BY breakdown of a metric by dimension.
+
+    Args:
+        duckdb_path: Path to the DuckDB warehouse file.
+        metric: The metric configuration.
+        dimension: The column to group by.
+
+    Returns:
+        A mapping of dimension value to aggregated metric value.
+        Empty dict on error.
+    """
+    sql = (  # noqa: S608
+        f"SELECT CAST({dimension} AS VARCHAR), {metric.value_expression} FROM {metric.source_table}"
+    )
+    if metric.filter:
+        sql += f" WHERE {metric.filter}"
+    sql += f" GROUP BY {dimension} ORDER BY ABS({metric.value_expression}) DESC LIMIT {MAX_GROUPS}"
+
+    try:
+        conn = duckdb.connect(str(duckdb_path), read_only=True)
+        try:
+            rows = conn.execute(sql).fetchall()
+        finally:
+            conn.close()
+    except duckdb.Error as e:
+        logger.warning(
+            "drill_down_query_failed",
+            metric=metric.name,
+            dimension=dimension,
+            error=str(e),
+        )
+        return {}
+
+    result: dict[str | None, float] = {}
+    for row in rows:
+        key = row[0]  # None for NULL dimension values
+        value = float(row[1]) if row[1] is not None else 0.0
+        result[key] = value
+    return result
+
+
+def _get_previous_snapshot(
+    project_root: Path,
+    metric_name: str,
+    dimension: str,
+) -> dict[str | None, float] | None:
+    """Retrieve the most recent drill-down snapshot from metric_results.
+
+    Args:
+        project_root: Path to the Dango project root.
+        metric_name: Name of the metric.
+        dimension: The dimension column name.
+
+    Returns:
+        A mapping of dimension value to metric value, or ``None`` if no
+        previous snapshot exists.
+    """
+    result_type = f"drill_down:{dimension}"
+
+    try:
+        with connect(project_root) as conn:
+            row = conn.execute(
+                "SELECT result_value FROM metric_results "
+                "WHERE metric_name = ? AND result_type = ? "
+                "ORDER BY computed_at DESC LIMIT 1",
+                (metric_name, result_type),
+            ).fetchone()
+    except Exception:
+        logger.warning(
+            "drill_down_snapshot_read_failed",
+            metric=metric_name,
+            dimension=dimension,
+            exc_info=True,
+        )
+        return None
+
+    if row is None:
+        return None
+
+    raw: dict[str, float] = json.loads(row["result_value"])
+    result: dict[str | None, float] = {}
+    for k, v in raw.items():
+        key: str | None = None if k == NULL_SENTINEL else k
+        result[key] = v
+    return result
+
+
+def _store_snapshot(
+    project_root: Path,
+    metric_name: str,
+    dimension: str,
+    breakdown: dict[str | None, float],
+) -> None:
+    """Store a drill-down breakdown as a snapshot in metric_results.
+
+    Uses the resilient cache pattern: failures are logged but never propagated.
+
+    Args:
+        project_root: Path to the Dango project root.
+        metric_name: Name of the metric.
+        dimension: The dimension column name.
+        breakdown: The current GROUP BY breakdown to store.
+    """
+    serialized: dict[str, float] = {}
+    for k, v in breakdown.items():
+        key = NULL_SENTINEL if k is None else k
+        serialized[key] = v
+
+    result_value = json.dumps(serialized)
+    result_type = f"drill_down:{dimension}"
+    now = datetime.now(timezone.utc).isoformat()
+
+    try:
+        with connect(project_root) as conn:
+            conn.execute(
+                "INSERT INTO metric_results "
+                "(metric_name, source, table_name, result_type, result_value, computed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (metric_name, None, None, result_type, result_value, now),
+            )
+            conn.commit()
+    except Exception:
+        logger.warning(
+            "drill_down_snapshot_store_failed",
+            metric=metric_name,
+            dimension=dimension,
+            exc_info=True,
+        )
+
+
+def _compute_contributors(
+    current: dict[str | None, float],
+    previous: dict[str | None, float] | None,
+) -> list[DimensionContributor]:
+    """Compute the top contributors to a metric change between snapshots.
+
+    Args:
+        current: Current GROUP BY breakdown.
+        previous: Previous GROUP BY breakdown, or ``None`` for first run.
+
+    Returns:
+        Top contributors sorted by absolute change, descending.
+        Empty list on first run (no previous snapshot).
+    """
+    if previous is None:
+        return []
+
+    all_keys = set(current) | set(previous)
+    contributors: list[DimensionContributor] = []
+
+    for key in all_keys:
+        cur_val = current.get(key, 0.0)
+        prev_val = previous.get(key)
+
+        if prev_val is None:
+            # New group — no previous value
+            contributors.append(
+                DimensionContributor(
+                    group_value=key,
+                    current_value=cur_val,
+                    previous_value=None,
+                    change_pct=None,
+                    change_abs=None,
+                )
+            )
+            continue
+
+        change_abs = cur_val - prev_val
+        change_pct: float | None = None
+        if prev_val != 0:
+            change_pct = ((cur_val - prev_val) / abs(prev_val)) * 100
+
+        contributors.append(
+            DimensionContributor(
+                group_value=key,
+                current_value=cur_val,
+                previous_value=prev_val,
+                change_pct=change_pct,
+                change_abs=change_abs,
+            )
+        )
+
+    # Sort by absolute change descending, None change_abs treated as 0
+    contributors.sort(
+        key=lambda c: abs(c.change_abs) if c.change_abs is not None else 0, reverse=True
+    )
+    return contributors[:TOP_CONTRIBUTORS]

--- a/dango/analysis/drilldown.py
+++ b/dango/analysis/drilldown.py
@@ -12,11 +12,9 @@ from pathlib import Path
 import duckdb
 
 from dango.analysis.models import (
-    ComparisonResult,
     DimensionContributor,
     DrillDownDimension,
     MetricConfig,
-    MetricValue,
 )
 from dango.logging import get_logger
 from dango.utils.dango_db import connect
@@ -37,8 +35,6 @@ def run_drill_down(
     duckdb_path: Path,
     project_root: Path,
     metric: MetricConfig,
-    current_value: MetricValue,
-    comparison: ComparisonResult,
 ) -> list[DrillDownDimension]:
     """Run drill-down analysis for each configured dimension.
 
@@ -49,8 +45,6 @@ def run_drill_down(
         duckdb_path: Path to the DuckDB warehouse file.
         project_root: Path to the Dango project root.
         metric: The metric configuration with drill_down dimensions.
-        current_value: The current metric value.
-        comparison: The comparison result that triggered drill-down.
 
     Returns:
         A list of ``DrillDownDimension`` objects, one per dimension.

--- a/dango/analysis/metrics.py
+++ b/dango/analysis/metrics.py
@@ -20,6 +20,7 @@ from dango.analysis.config import load_metrics_config
 from dango.analysis.models import (
     AnalysisResult,
     ComparisonResult,
+    DrillDownDimension,
     MetricConfig,
     MetricValue,
 )
@@ -79,7 +80,25 @@ def run_analysis(
             )
             _store_comparison_result(project_root, comparison)
 
-        results.append(AnalysisResult(metric=metric_value, comparison=comparison))
+        drill_down_results: list[DrillDownDimension] = []
+        if comparison is not None and comparison.exceeds_threshold and metric.drill_down:
+            from dango.analysis.drilldown import run_drill_down
+
+            drill_down_results = run_drill_down(
+                duckdb_path,
+                project_root,
+                metric,
+                metric_value,
+                comparison,
+            )
+
+        results.append(
+            AnalysisResult(
+                metric=metric_value,
+                comparison=comparison,
+                drill_down=drill_down_results,
+            )
+        )
 
     logger.info(
         "analysis_complete",

--- a/dango/analysis/metrics.py
+++ b/dango/analysis/metrics.py
@@ -88,8 +88,6 @@ def run_analysis(
                 duckdb_path,
                 project_root,
                 metric,
-                metric_value,
-                comparison,
             )
 
         results.append(

--- a/dango/analysis/models.py
+++ b/dango/analysis/models.py
@@ -126,6 +126,27 @@ class ComparisonResult(BaseModel):
     forecast_threshold_days: int | None = None
 
 
+class DimensionContributor(BaseModel):
+    """A single group's contribution to a metric change."""
+
+    model_config = ConfigDict(frozen=True)
+
+    group_value: str | None = None
+    current_value: float = 0.0
+    previous_value: float | None = None
+    change_pct: float | None = None
+    change_abs: float | None = None
+
+
+class DrillDownDimension(BaseModel):
+    """Drill-down results for a single dimension."""
+
+    model_config = ConfigDict(frozen=True)
+
+    dimension: str
+    contributors: list[DimensionContributor] = Field(default_factory=list)
+
+
 class AnalysisResult(BaseModel):
     """Bundles a metric value with its optional comparison."""
 
@@ -133,3 +154,4 @@ class AnalysisResult(BaseModel):
 
     metric: MetricValue
     comparison: ComparisonResult | None = None
+    drill_down: list[DrillDownDimension] = Field(default_factory=list)

--- a/dango/analysis/models.py
+++ b/dango/analysis/models.py
@@ -1,10 +1,12 @@
 """dango/analysis/models.py
 
-Pydantic V2 models for the metric engine and comparison system.
+Pydantic V2 models for the metric engine, comparison system, and drill-down.
 
 Defines configuration shapes (``MetricConfig``, ``MetricsConfig``), runtime
-value containers (``MetricValue``, ``ComparisonResult``), and the top-level
-``AnalysisResult`` that bundles a metric value with its comparison.
+value containers (``MetricValue``, ``ComparisonResult``), drill-down models
+(``DimensionContributor``, ``DrillDownDimension``), and the top-level
+``AnalysisResult`` that bundles a metric value with its comparison and
+drill-down results.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,7 @@ module = [
     "tests.unit.test_analysis_config",
     "tests.unit.test_analysis_comparisons",
     "tests.unit.test_analysis_metrics",
+    "tests.unit.test_analysis_drilldown",
     "tests.unit.test_notebook_manager",
     "tests.unit.test_notebook_snapshot",
     "tests.unit.test_notebook_locking",

--- a/tests/unit/test_analysis_drilldown.py
+++ b/tests/unit/test_analysis_drilldown.py
@@ -1,0 +1,383 @@
+"""tests/unit/test_analysis_drilldown.py
+
+Tests for dango.analysis.drilldown — drill-down engine and contributor ranking.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.analysis.drilldown import (
+    NULL_SENTINEL,
+    _compute_contributors,
+    _get_previous_snapshot,
+    _query_dimension_breakdown,
+    _store_snapshot,
+    run_drill_down,
+)
+from dango.analysis.models import (
+    ComparisonResult,
+    ComparisonType,
+    MetricConfig,
+    MetricValue,
+)
+from dango.utils.dango_db import connect
+
+
+def _make_metric(**kwargs):
+    """Create a MetricConfig with defaults."""
+    defaults = {
+        "name": "revenue",
+        "source_table": "raw_stripe.payments",
+        "value_expression": "SUM(amount)",
+    }
+    defaults.update(kwargs)
+    return MetricConfig(**defaults)
+
+
+@pytest.mark.unit
+class TestQueryDimensionBreakdown:
+    """_query_dimension_breakdown GROUP BY queries."""
+
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_builds_group_by_sql(self, mock_duckdb, tmp_path):
+        """SQL includes GROUP BY dimension with filter."""
+        metric = _make_metric(filter="status = 'active'")
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("Widget", 100.0),
+            ("Gadget", 50.0),
+        ]
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        result = _query_dimension_breakdown(tmp_path / "warehouse.duckdb", metric, "product")
+
+        sql_arg = mock_conn.execute.call_args[0][0]
+        assert "GROUP BY product" in sql_arg
+        assert "WHERE status = 'active'" in sql_arg
+        assert "CAST(product AS VARCHAR)" in sql_arg
+        assert result == {"Widget": 100.0, "Gadget": 50.0}
+
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_null_dimension_value(self, mock_duckdb, tmp_path):
+        """DuckDB returning NULL dimension value stored as None key."""
+        metric = _make_metric()
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            (None, 100.0),
+            ("Widget", 50.0),
+        ]
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        result = _query_dimension_breakdown(tmp_path / "warehouse.duckdb", metric, "region")
+
+        assert result[None] == 100.0
+        assert result["Widget"] == 50.0
+
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_handles_duckdb_error(self, mock_duckdb, tmp_path):
+        """DuckDB error returns empty dict."""
+        metric = _make_metric()
+        mock_duckdb.Error = Exception
+        mock_duckdb.connect.side_effect = Exception("Connection failed")
+
+        result = _query_dimension_breakdown(tmp_path / "warehouse.duckdb", metric, "product")
+
+        assert result == {}
+
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_empty_result(self, mock_duckdb, tmp_path):
+        """Empty fetchall returns empty dict."""
+        metric = _make_metric()
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        result = _query_dimension_breakdown(tmp_path / "warehouse.duckdb", metric, "product")
+
+        assert result == {}
+
+
+@pytest.mark.unit
+class TestGetPreviousSnapshot:
+    """_get_previous_snapshot reads from metric_results."""
+
+    def test_returns_previous(self, tmp_path):
+        """Existing snapshot is parsed and returned."""
+        snapshot = json.dumps({"Widget": 100.0, "Gadget": 50.0})
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "INSERT INTO metric_results "
+                "(metric_name, source, table_name, result_type, result_value, computed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("revenue", None, None, "drill_down:product", snapshot, "2026-01-01T00:00:00"),
+            )
+            conn.commit()
+
+        result = _get_previous_snapshot(tmp_path, "revenue", "product")
+
+        assert result == {"Widget": 100.0, "Gadget": 50.0}
+
+    def test_returns_none_when_missing(self, tmp_path):
+        """No snapshot returns None."""
+        result = _get_previous_snapshot(tmp_path, "revenue", "product")
+        assert result is None
+
+    def test_null_sentinel_roundtrip(self, tmp_path):
+        """NULL_SENTINEL in JSON maps back to None key."""
+        snapshot = json.dumps({NULL_SENTINEL: 100.0, "Widget": 50.0})
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "INSERT INTO metric_results "
+                "(metric_name, source, table_name, result_type, result_value, computed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("revenue", None, None, "drill_down:region", snapshot, "2026-01-01T00:00:00"),
+            )
+            conn.commit()
+
+        result = _get_previous_snapshot(tmp_path, "revenue", "region")
+
+        assert result is not None
+        assert result[None] == 100.0
+        assert result["Widget"] == 50.0
+
+
+@pytest.mark.unit
+class TestStoreSnapshot:
+    """_store_snapshot persists to metric_results."""
+
+    def test_stores_snapshot(self, tmp_path):
+        """Breakdown is stored as JSON in metric_results."""
+        breakdown: dict[str | None, float] = {"Widget": 100.0, None: 25.0}
+        _store_snapshot(tmp_path, "revenue", "product", breakdown)
+
+        with connect(tmp_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM metric_results WHERE metric_name = 'revenue'"
+            ).fetchone()
+
+        assert row is not None
+        assert row["result_type"] == "drill_down:product"
+        parsed = json.loads(row["result_value"])
+        assert parsed["Widget"] == 100.0
+        assert parsed[NULL_SENTINEL] == 25.0
+
+    @patch("dango.analysis.drilldown.connect")
+    def test_resilient_on_error(self, mock_connect):
+        """Storage error does not propagate."""
+        mock_connect.side_effect = Exception("DB locked")
+
+        # Should not raise
+        _store_snapshot(
+            MagicMock(),
+            "revenue",
+            "product",
+            {"Widget": 100.0},
+        )
+
+
+@pytest.mark.unit
+class TestComputeContributors:
+    """_compute_contributors pure logic tests."""
+
+    def test_top_three_by_change(self):
+        """Returns top 3 groups by absolute change."""
+        current: dict[str | None, float] = {
+            "A": 100.0,
+            "B": 200.0,
+            "C": 300.0,
+            "D": 400.0,
+            "E": 500.0,
+        }
+        previous: dict[str | None, float] = {
+            "A": 90.0,
+            "B": 250.0,
+            "C": 280.0,
+            "D": 395.0,
+            "E": 600.0,
+        }
+
+        result = _compute_contributors(current, previous)
+
+        assert len(result) == 3
+        # E changed by -100, B changed by -50, C changed by +20
+        assert result[0].group_value == "E"
+        assert result[0].change_abs == -100.0
+        assert result[1].group_value == "B"
+        assert result[1].change_abs == -50.0
+        assert result[2].group_value == "C"
+        assert result[2].change_abs == 20.0
+
+    def test_first_run_empty(self):
+        """previous=None returns empty list."""
+        result = _compute_contributors({"A": 100.0}, None)
+        assert result == []
+
+    def test_new_group(self):
+        """Group in current but not previous has no change_abs."""
+        current: dict[str | None, float] = {"A": 100.0, "NEW": 50.0}
+        previous: dict[str | None, float] = {"A": 90.0}
+
+        result = _compute_contributors(current, previous)
+
+        new_contrib = [c for c in result if c.group_value == "NEW"]
+        assert len(new_contrib) == 1
+        assert new_contrib[0].previous_value is None
+        assert new_contrib[0].change_pct is None
+        assert new_contrib[0].change_abs is None
+
+    def test_disappeared_group(self):
+        """Group in previous but not current gets current_value=0."""
+        current: dict[str | None, float] = {"A": 100.0}
+        previous: dict[str | None, float] = {"A": 90.0, "GONE": 80.0}
+
+        result = _compute_contributors(current, previous)
+
+        gone_contrib = [c for c in result if c.group_value == "GONE"]
+        assert len(gone_contrib) == 1
+        assert gone_contrib[0].current_value == 0.0
+        assert gone_contrib[0].previous_value == 80.0
+        assert gone_contrib[0].change_abs == -80.0
+
+    def test_null_group_value(self):
+        """None key (NULL dimension) is handled."""
+        current: dict[str | None, float] = {None: 100.0, "A": 50.0}
+        previous: dict[str | None, float] = {None: 80.0, "A": 50.0}
+
+        result = _compute_contributors(current, previous)
+
+        null_contrib = [c for c in result if c.group_value is None]
+        assert len(null_contrib) == 1
+        assert null_contrib[0].change_abs == 20.0
+
+    def test_change_pct_computed(self):
+        """change_pct is computed correctly."""
+        current: dict[str | None, float] = {"A": 150.0}
+        previous: dict[str | None, float] = {"A": 100.0}
+
+        result = _compute_contributors(current, previous)
+
+        assert len(result) == 1
+        assert result[0].change_pct == 50.0
+        assert result[0].change_abs == 50.0
+
+    def test_zero_previous_no_pct(self):
+        """Zero previous value yields None change_pct."""
+        current: dict[str | None, float] = {"A": 100.0}
+        previous: dict[str | None, float] = {"A": 0.0}
+
+        result = _compute_contributors(current, previous)
+
+        assert len(result) == 1
+        assert result[0].change_pct is None
+        assert result[0].change_abs == 100.0
+
+
+@pytest.mark.unit
+class TestRunDrillDown:
+    """run_drill_down orchestration tests."""
+
+    def _make_comparison(self, exceeds=True):
+        """Create a ComparisonResult."""
+        return ComparisonResult(
+            metric_name="revenue",
+            comparison_type=ComparisonType.week_over_week,
+            current_value=100.0,
+            baseline_value=110.0,
+            change_pct=-9.1,
+            exceeds_threshold=exceeds,
+        )
+
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_runs_all_dimensions(self, mock_duckdb, tmp_path):
+        """Metric with 2 drill_down dims produces 2 DrillDownDimension results."""
+        metric = _make_metric(drill_down=["product", "region"])
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [("Widget", 100.0)]
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        mv = MetricValue(metric_name="revenue", value=100.0)
+        comparison = self._make_comparison()
+
+        result = run_drill_down(
+            tmp_path / "warehouse.duckdb",
+            tmp_path,
+            metric,
+            mv,
+            comparison,
+        )
+
+        assert len(result) == 2
+        assert result[0].dimension == "product"
+        assert result[1].dimension == "region"
+
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_empty_drill_down_list(self, mock_duckdb, tmp_path):
+        """No dimensions configured returns empty result."""
+        metric = _make_metric(drill_down=[])
+        mv = MetricValue(metric_name="revenue", value=100.0)
+        comparison = self._make_comparison()
+
+        result = run_drill_down(
+            tmp_path / "warehouse.duckdb",
+            tmp_path,
+            metric,
+            mv,
+            comparison,
+        )
+
+        assert result == []
+
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_stores_and_compares_snapshots(self, mock_duckdb, tmp_path):
+        """Second run produces contributors by comparing against stored snapshot."""
+        metric = _make_metric(drill_down=["product"])
+        mock_conn = MagicMock()
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        mv = MetricValue(metric_name="revenue", value=100.0)
+        comparison = self._make_comparison()
+
+        # First run: Widget=100, Gadget=50
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("Widget", 100.0),
+            ("Gadget", 50.0),
+        ]
+        result1 = run_drill_down(
+            tmp_path / "warehouse.duckdb",
+            tmp_path,
+            metric,
+            mv,
+            comparison,
+        )
+        # First run: no previous snapshot → no contributors
+        assert len(result1) == 1
+        assert result1[0].contributors == []
+
+        # Second run: Widget=60, Gadget=90
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("Widget", 60.0),
+            ("Gadget", 90.0),
+        ]
+        result2 = run_drill_down(
+            tmp_path / "warehouse.duckdb",
+            tmp_path,
+            metric,
+            mv,
+            comparison,
+        )
+        # Second run: has previous snapshot → contributors computed
+        assert len(result2) == 1
+        assert len(result2[0].contributors) == 2
+        # Widget dropped 40, Gadget rose 40 — both should appear
+        values = {c.group_value: c.change_abs for c in result2[0].contributors}
+        assert values["Widget"] == -40.0
+        assert values["Gadget"] == 40.0

--- a/tests/unit/test_analysis_drilldown.py
+++ b/tests/unit/test_analysis_drilldown.py
@@ -19,10 +19,7 @@ from dango.analysis.drilldown import (
     run_drill_down,
 )
 from dango.analysis.models import (
-    ComparisonResult,
-    ComparisonType,
     MetricConfig,
-    MetricValue,
 )
 from dango.utils.dango_db import connect
 
@@ -103,6 +100,23 @@ class TestQueryDimensionBreakdown:
 
         assert result == {}
 
+    @patch("dango.analysis.drilldown.duckdb")
+    def test_null_metric_value_defaults_to_zero(self, mock_duckdb, tmp_path):
+        """NULL aggregated value (row[1]) defaults to 0.0."""
+        metric = _make_metric()
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("Widget", None),
+            ("Gadget", 50.0),
+        ]
+        mock_duckdb.connect.return_value = mock_conn
+        mock_duckdb.Error = Exception
+
+        result = _query_dimension_breakdown(tmp_path / "warehouse.duckdb", metric, "product")
+
+        assert result["Widget"] == 0.0
+        assert result["Gadget"] == 50.0
+
 
 @pytest.mark.unit
 class TestGetPreviousSnapshot:
@@ -128,6 +142,29 @@ class TestGetPreviousSnapshot:
         """No snapshot returns None."""
         result = _get_previous_snapshot(tmp_path, "revenue", "product")
         assert result is None
+
+    def test_returns_most_recent_snapshot(self, tmp_path):
+        """Multiple snapshots returns the most recent one."""
+        old_snapshot = json.dumps({"Widget": 50.0})
+        new_snapshot = json.dumps({"Widget": 200.0})
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "INSERT INTO metric_results "
+                "(metric_name, source, table_name, result_type, result_value, computed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("revenue", None, None, "drill_down:product", old_snapshot, "2026-01-01T00:00:00"),
+            )
+            conn.execute(
+                "INSERT INTO metric_results "
+                "(metric_name, source, table_name, result_type, result_value, computed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("revenue", None, None, "drill_down:product", new_snapshot, "2026-01-02T00:00:00"),
+            )
+            conn.commit()
+
+        result = _get_previous_snapshot(tmp_path, "revenue", "product")
+
+        assert result == {"Widget": 200.0}
 
     def test_null_sentinel_roundtrip(self, tmp_path):
         """NULL_SENTINEL in JSON maps back to None key."""
@@ -283,17 +320,6 @@ class TestComputeContributors:
 class TestRunDrillDown:
     """run_drill_down orchestration tests."""
 
-    def _make_comparison(self, exceeds=True):
-        """Create a ComparisonResult."""
-        return ComparisonResult(
-            metric_name="revenue",
-            comparison_type=ComparisonType.week_over_week,
-            current_value=100.0,
-            baseline_value=110.0,
-            change_pct=-9.1,
-            exceeds_threshold=exceeds,
-        )
-
     @patch("dango.analysis.drilldown.duckdb")
     def test_runs_all_dimensions(self, mock_duckdb, tmp_path):
         """Metric with 2 drill_down dims produces 2 DrillDownDimension results."""
@@ -303,16 +329,7 @@ class TestRunDrillDown:
         mock_duckdb.connect.return_value = mock_conn
         mock_duckdb.Error = Exception
 
-        mv = MetricValue(metric_name="revenue", value=100.0)
-        comparison = self._make_comparison()
-
-        result = run_drill_down(
-            tmp_path / "warehouse.duckdb",
-            tmp_path,
-            metric,
-            mv,
-            comparison,
-        )
+        result = run_drill_down(tmp_path / "warehouse.duckdb", tmp_path, metric)
 
         assert len(result) == 2
         assert result[0].dimension == "product"
@@ -322,16 +339,8 @@ class TestRunDrillDown:
     def test_empty_drill_down_list(self, mock_duckdb, tmp_path):
         """No dimensions configured returns empty result."""
         metric = _make_metric(drill_down=[])
-        mv = MetricValue(metric_name="revenue", value=100.0)
-        comparison = self._make_comparison()
 
-        result = run_drill_down(
-            tmp_path / "warehouse.duckdb",
-            tmp_path,
-            metric,
-            mv,
-            comparison,
-        )
+        result = run_drill_down(tmp_path / "warehouse.duckdb", tmp_path, metric)
 
         assert result == []
 
@@ -343,21 +352,12 @@ class TestRunDrillDown:
         mock_duckdb.connect.return_value = mock_conn
         mock_duckdb.Error = Exception
 
-        mv = MetricValue(metric_name="revenue", value=100.0)
-        comparison = self._make_comparison()
-
         # First run: Widget=100, Gadget=50
         mock_conn.execute.return_value.fetchall.return_value = [
             ("Widget", 100.0),
             ("Gadget", 50.0),
         ]
-        result1 = run_drill_down(
-            tmp_path / "warehouse.duckdb",
-            tmp_path,
-            metric,
-            mv,
-            comparison,
-        )
+        result1 = run_drill_down(tmp_path / "warehouse.duckdb", tmp_path, metric)
         # First run: no previous snapshot → no contributors
         assert len(result1) == 1
         assert result1[0].contributors == []
@@ -367,13 +367,7 @@ class TestRunDrillDown:
             ("Widget", 60.0),
             ("Gadget", 90.0),
         ]
-        result2 = run_drill_down(
-            tmp_path / "warehouse.duckdb",
-            tmp_path,
-            metric,
-            mv,
-            comparison,
-        )
+        result2 = run_drill_down(tmp_path / "warehouse.duckdb", tmp_path, metric)
         # Second run: has previous snapshot → contributors computed
         assert len(result2) == 1
         assert len(result2[0].contributors) == 2


### PR DESCRIPTION
## Summary
- Implements automatic GROUP BY breakdown analysis that identifies top contributors when a metric crosses its `warn_threshold`
- Stores per-dimension snapshots in `metric_results` table for comparison across runs; first run silently stores baseline, subsequent runs compute top 3 movers by absolute change
- Adds `DimensionContributor` and `DrillDownDimension` models, `drill_down` field on `AnalysisResult`, and lazy-imports `run_drill_down()` from `metrics.py` only when threshold is breached

## Test plan
- [x] 19 new unit tests covering all internal functions (`_query_dimension_breakdown`, `_get_previous_snapshot`, `_store_snapshot`, `_compute_contributors`, `run_drill_down`)
- [x] All 82 analysis module tests pass (no regressions)
- [x] Full test suite passes (2602 passed)
- [x] Pre-commit hooks pass (ruff lint/format, mypy, headers, docstrings, file sizes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)