### PR TITLE
P7-008: Notebooks module — web UI tab

### DIFF
--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -41,8 +41,10 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, `/schedules` page (~720 lines) | `router` |
+| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~300 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
+| `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |
 | `static/` | CSS and JS assets (`css/main.css`, `js/app.js`, `js/logs.js`) | — |
 
 ## Architecture
@@ -172,6 +174,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 - `dango.utils/` — `DbtLock`, `DbtLockError`, `activity_log`, `sync_history`, `db_health`, `dbt_status`
 - `dango.oauth/` — `OAuthStorage` (for OAuth token health in `/api/health/platform`)
 - `dango.platform/` — `platform.watcher_lifecycle.get_watcher_status` (for watcher status endpoint)
+- `dango.notebooks/` — locking, manager, snapshot (notebook management endpoints)
 
 **Used by:**
 - `dango/cli/commands/web.py` — imports `from dango.web import app` to run uvicorn

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -41,7 +41,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, `/schedules` page (~720 lines) | `router` |
-| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~300 lines) | `router` |
+| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~490 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -19,7 +19,7 @@ import dango
 import dango.notebooks.templates
 from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
-from dango.auth.permissions import require_permission
+from dango.auth.permissions import has_permission, require_permission
 from dango.logging import get_logger
 from dango.notebooks.locking import (
     acquire_lock,
@@ -284,6 +284,7 @@ async def delete_notebook(
     result = _validate_name(name)
     if isinstance(result, JSONResponse):
         return result
+    name = result
 
     project_root = get_project_root()
 
@@ -314,8 +315,6 @@ async def delete_notebook(
 
     # Check ownership: if user lacks notebooks.manage, they can only delete their own
     if notebook is not None and notebook.get("created_by") != user.email:
-        from dango.auth.permissions import has_permission
-
         if not has_permission(user, "notebooks.manage"):
             return JSONResponse(
                 status_code=403,
@@ -348,6 +347,7 @@ async def lock_notebook(
     result = _validate_name(name)
     if isinstance(result, JSONResponse):
         return result
+    name = result
 
     project_root = get_project_root()
 
@@ -470,6 +470,7 @@ async def copy_notebook(
     result = _validate_name(name)
     if isinstance(result, JSONResponse):
         return result
+    name = result
 
     project_root = get_project_root()
 

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -1,10 +1,471 @@
 """dango/web/routes/notebooks.py
 
-Notebook management API endpoints.
+Notebook management API endpoints and page route.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import asyncio
+import shutil
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
 
-router = APIRouter()
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+import dango
+import dango.notebooks.templates
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.models import User
+from dango.auth.permissions import require_permission
+from dango.logging import get_logger
+from dango.notebooks.locking import (
+    acquire_lock,
+    copy_locked_notebook,
+    force_release_lock,
+    get_lock_info,
+    refresh_lock,
+    release_lock,
+)
+from dango.notebooks.manager import get_marimo_status, start_marimo
+from dango.utils.dango_db import connect
+from dango.validation import validate_identifier
+from dango.web.helpers import get_project_root
+from dango.web.routes.ui import _render_template
+
+router = APIRouter(tags=["notebooks"])
+logger = get_logger(__name__)
+
+_VALID_TEMPLATES = frozenset({"blank", "explore", "quality"})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _audit(
+    event: AuditEvent,
+    user: User,
+    request: Request,
+    project_root: Path,
+    **extra: Any,
+) -> None:
+    """Log an audit event with standard fields."""
+    log_auth_event(
+        event,
+        user_id=user.id,
+        email=user.email,
+        ip=request.client.host if request.client else None,
+        details=extra,
+        log_dir=project_root / ".dango" / "logs",
+    )
+
+
+def _list_notebooks_blocking(project_root: Path) -> list[dict[str, Any]]:
+    """Query notebook metadata, scan filesystem, and merge lock info."""
+    notebooks_dir = project_root / "notebooks"
+
+    # Query metadata table
+    metadata: dict[str, dict[str, Any]] = {}
+    with connect(project_root) as conn:
+        rows = conn.execute(
+            "SELECT id, name, description, created_by, created_at, updated_at "
+            "FROM notebook_metadata ORDER BY created_at DESC"
+        ).fetchall()
+        for row in rows:
+            metadata[row["name"]] = {
+                "id": row["id"],
+                "name": row["name"],
+                "description": row["description"],
+                "created_by": row["created_by"],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+            }
+
+    # Scan filesystem for .py files
+    fs_names: set[str] = set()
+    if notebooks_dir.exists():
+        for f in notebooks_dir.glob("*.py"):
+            if f.name == "__init__.py":
+                continue
+            fs_names.add(f.stem)
+
+    # Merge: metadata entries + unregistered files
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for name, meta in metadata.items():
+        entry: dict[str, Any] = {**meta}
+        entry["file_exists"] = name in fs_names
+        lock = get_lock_info(project_root, name)
+        entry["lock"] = lock
+        result.append(entry)
+        seen.add(name)
+
+    for name in sorted(fs_names - seen):
+        result.append(
+            {
+                "id": None,
+                "name": name,
+                "description": None,
+                "created_by": None,
+                "created_at": None,
+                "updated_at": None,
+                "file_exists": True,
+                "lock": get_lock_info(project_root, name),
+            }
+        )
+
+    return result
+
+
+def _get_notebook_by_name(project_root: Path, name: str) -> dict[str, Any] | None:
+    """Look up a notebook in the metadata table by name."""
+    with connect(project_root) as conn:
+        row = conn.execute(
+            "SELECT id, name, description, created_by, created_at, updated_at "
+            "FROM notebook_metadata WHERE name = ?",
+            (name,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "name": row["name"],
+            "description": row["description"],
+            "created_by": row["created_by"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+
+def _create_notebook_blocking(
+    project_root: Path,
+    name: str,
+    template: str,
+    user_email: str,
+) -> dict[str, Any]:
+    """Copy template file and insert metadata row."""
+    notebooks_dir = project_root / "notebooks"
+    notebooks_dir.mkdir(parents=True, exist_ok=True)
+
+    target = notebooks_dir / f"{name}.py"
+    if target.exists():
+        raise FileExistsError(f"Notebook file already exists: {name}.py")
+
+    # Copy template from package
+    templates_dir = Path(dango.notebooks.templates.__file__).parent
+    template_file = templates_dir / f"{template}.py"
+    shutil.copy2(str(template_file), str(target))
+
+    # Insert metadata
+    new_id = str(uuid.uuid4())
+    now = datetime.now().isoformat()
+
+    with connect(project_root) as conn:
+        conn.execute(
+            "INSERT INTO notebook_metadata (id, name, description, created_by, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (new_id, name, f"Created from {template} template", user_email, now, now),
+        )
+        conn.commit()
+
+    return {"id": new_id, "name": name, "template": template}
+
+
+def _delete_notebook_blocking(project_root: Path, name: str) -> None:
+    """Delete notebook file, metadata row, and any lock."""
+    notebooks_dir = project_root / "notebooks"
+    target = notebooks_dir / f"{name}.py"
+    if target.exists():
+        target.unlink()
+
+    with connect(project_root) as conn:
+        conn.execute("DELETE FROM notebook_metadata WHERE name = ?", (name,))
+        conn.execute("DELETE FROM notebook_locks WHERE notebook_id = ?", (name,))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Page route
+# ---------------------------------------------------------------------------
+
+
+@router.get("/notebooks")
+async def notebooks_page(
+    request: Request,
+    user: User = Depends(require_permission("notebooks.view")),
+) -> HTMLResponse:
+    """Render the notebook management UI page."""
+    return _render_template(
+        "notebooks.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "notebooks",
+            "subtitle": "Notebooks",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/notebooks")
+async def list_notebooks(
+    user: User = Depends(require_permission("notebooks.view")),
+) -> JSONResponse:
+    """List all notebooks with metadata and lock status."""
+    project_root = get_project_root()
+    notebooks = await asyncio.to_thread(_list_notebooks_blocking, project_root)
+    return JSONResponse(content=notebooks)
+
+
+@router.post("/api/notebooks")
+async def create_notebook(
+    request: Request,
+    user: User = Depends(require_permission("notebooks.execute")),
+) -> JSONResponse:
+    """Create a new notebook from a template."""
+    project_root = get_project_root()
+
+    body: dict[str, Any] = await request.json()
+    name = body.get("name", "")
+    template = body.get("template", "blank")
+
+    # Validate name
+    try:
+        name = validate_identifier(name)
+    except Exception:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-NB001",
+                "message": "Invalid notebook name. Use only letters, numbers, and underscores.",
+            },
+        )
+
+    # Validate template
+    if template not in _VALID_TEMPLATES:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-NB002",
+                "message": f"Invalid template. Must be one of: {', '.join(sorted(_VALID_TEMPLATES))}.",
+            },
+        )
+
+    try:
+        result = await asyncio.to_thread(
+            _create_notebook_blocking, project_root, name, template, user.email
+        )
+    except FileExistsError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-NB003",
+                "message": f"Notebook {name!r} already exists.",
+            },
+        )
+
+    _audit(
+        AuditEvent.NOTEBOOK_CREATED,
+        user,
+        request,
+        project_root,
+        notebook_name=name,
+        template=template,
+    )
+
+    return JSONResponse(status_code=201, content=result)
+
+
+@router.delete("/api/notebooks/{name}")
+async def delete_notebook(
+    name: str,
+    request: Request,
+    user: User = Depends(require_permission("notebooks.execute")),
+) -> JSONResponse:
+    """Delete a notebook file and metadata."""
+    project_root = get_project_root()
+
+    notebook = await asyncio.to_thread(_get_notebook_by_name, project_root, name)
+
+    # Check file also exists on disk if not in metadata
+    notebooks_dir = project_root / "notebooks"
+    file_exists = (notebooks_dir / f"{name}.py").exists()
+
+    if notebook is None and not file_exists:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-NB004",
+                "message": f"Notebook {name!r} not found.",
+            },
+        )
+
+    # Check ownership: if user lacks notebooks.manage, they can only delete their own
+    if notebook is not None and notebook.get("created_by") != user.email:
+        from dango.auth.permissions import has_permission
+
+        if not has_permission(user, "notebooks.manage"):
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error_code": "DANGO-NB005",
+                    "message": "You can only delete notebooks you created.",
+                },
+            )
+
+    await asyncio.to_thread(_delete_notebook_blocking, project_root, name)
+
+    _audit(
+        AuditEvent.NOTEBOOK_DELETED,
+        user,
+        request,
+        project_root,
+        notebook_name=name,
+    )
+
+    return JSONResponse(content={"status": "deleted", "name": name})
+
+
+@router.post("/api/notebooks/{name}/lock")
+async def lock_notebook(
+    name: str,
+    request: Request,
+    user: User = Depends(require_permission("notebooks.execute")),
+) -> JSONResponse:
+    """Acquire editing lock and start Marimo if needed."""
+    project_root = get_project_root()
+
+    acquired = await asyncio.to_thread(acquire_lock, project_root, name, user.email)
+    if not acquired:
+        lock = await asyncio.to_thread(get_lock_info, project_root, name)
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error_code": "DANGO-NB006",
+                "message": f"Notebook is locked by {lock['locked_by'] if lock else 'another user'}.",
+                "lock": lock,
+            },
+        )
+
+    # Start Marimo if not running
+    status = await asyncio.to_thread(get_marimo_status, project_root)
+    port: int | None = None
+    if not status["running"]:
+        try:
+            await asyncio.to_thread(start_marimo, project_root)
+            status = await asyncio.to_thread(get_marimo_status, project_root)
+        except RuntimeError:
+            # Already running (race condition) — get status again
+            status = await asyncio.to_thread(get_marimo_status, project_root)
+
+    port = status.get("port") or 7805  # type: ignore[assignment]
+
+    marimo_url = f"http://localhost:{port}/@file/{name}.py"
+
+    return JSONResponse(content={"locked": True, "marimo_url": marimo_url})
+
+
+@router.post("/api/notebooks/{name}/heartbeat")
+async def heartbeat_notebook(
+    name: str,
+    user: User = Depends(require_permission("notebooks.execute")),
+) -> JSONResponse:
+    """Refresh lock expiry for an active editing session."""
+    project_root = get_project_root()
+
+    refreshed = await asyncio.to_thread(refresh_lock, project_root, name, user.email)
+    if not refreshed:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error_code": "DANGO-NB007",
+                "message": "Lock not held by you or has expired.",
+            },
+        )
+
+    return JSONResponse(content={"refreshed": True})
+
+
+@router.post("/api/notebooks/{name}/release")
+async def release_notebook_lock(
+    name: str,
+    user: User = Depends(require_permission("notebooks.execute")),
+) -> JSONResponse:
+    """Release editing lock on a notebook."""
+    project_root = get_project_root()
+
+    released = await asyncio.to_thread(release_lock, project_root, name, user.email)
+    if not released:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error_code": "DANGO-NB008",
+                "message": "Lock not held by you or already released.",
+            },
+        )
+
+    return JSONResponse(content={"released": True})
+
+
+@router.delete("/api/notebooks/{name}/lock")
+async def force_release_notebook_lock(
+    name: str,
+    request: Request,
+    user: User = Depends(require_permission("notebooks.manage")),
+) -> JSONResponse:
+    """Force-release a lock regardless of owner (admin/editor action)."""
+    project_root = get_project_root()
+
+    released = await asyncio.to_thread(force_release_lock, project_root, name)
+    if not released:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-NB009",
+                "message": f"No active lock found on notebook {name!r}.",
+            },
+        )
+
+    _audit(
+        AuditEvent.NOTEBOOK_LOCK_FORCE_RELEASED,
+        user,
+        request,
+        project_root,
+        notebook_name=name,
+    )
+
+    return JSONResponse(content={"force_released": True})
+
+
+@router.post("/api/notebooks/{name}/copy")
+async def copy_notebook(
+    name: str,
+    user: User = Depends(require_permission("notebooks.execute")),
+) -> JSONResponse:
+    """Copy a locked notebook for the current user."""
+    project_root = get_project_root()
+
+    try:
+        copy_name = await asyncio.to_thread(copy_locked_notebook, project_root, name, user.email)
+    except FileNotFoundError:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-NB010",
+                "message": f"Notebook file {name!r} not found.",
+            },
+        )
+
+    return JSONResponse(
+        status_code=201,
+        content={"copy_name": copy_name},
+    )

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -42,10 +42,10 @@ _VALID_TEMPLATES = frozenset({"blank", "explore", "quality"})
 _DEFAULT_MARIMO_PORT = 7805
 
 
-def _validate_name(name: str) -> JSONResponse | None:
-    """Return a 400 response if name is invalid, else None."""
+def _validate_name(name: str) -> str | JSONResponse:
+    """Return the normalized name on success, or a 400 response on failure."""
     try:
-        validate_identifier(name)
+        return validate_identifier(name)
     except Exception:
         return JSONResponse(
             status_code=400,
@@ -54,7 +54,6 @@ def _validate_name(name: str) -> JSONResponse | None:
                 "message": "Invalid notebook name. Use only letters, numbers, and underscores.",
             },
         )
-    return None
 
 
 def _audit(
@@ -237,10 +236,10 @@ async def create_notebook(
     name = body.get("name", "")
     template = body.get("template", "blank")
 
-    err = _validate_name(name)
-    if err is not None:
-        return err
-    name = validate_identifier(name)  # normalize
+    validated = _validate_name(name)
+    if isinstance(validated, JSONResponse):
+        return validated
+    name = validated
     if template not in _VALID_TEMPLATES:
         return JSONResponse(
             status_code=400,
@@ -282,9 +281,9 @@ async def delete_notebook(
     user: User = Depends(require_permission("notebooks.execute")),
 ) -> JSONResponse:
     """Delete a notebook file and metadata."""
-    err = _validate_name(name)
-    if err is not None:
-        return err
+    result = _validate_name(name)
+    if isinstance(result, JSONResponse):
+        return result
 
     project_root = get_project_root()
 
@@ -346,9 +345,9 @@ async def lock_notebook(
     user: User = Depends(require_permission("notebooks.execute")),
 ) -> JSONResponse:
     """Acquire editing lock and start Marimo if needed."""
-    err = _validate_name(name)
-    if err is not None:
-        return err
+    result = _validate_name(name)
+    if isinstance(result, JSONResponse):
+        return result
 
     project_root = get_project_root()
 
@@ -468,9 +467,9 @@ async def copy_notebook(
     user: User = Depends(require_permission("notebooks.execute")),
 ) -> JSONResponse:
     """Copy a locked notebook for the current user."""
-    err = _validate_name(name)
-    if err is not None:
-        return err
+    result = _validate_name(name)
+    if isinstance(result, JSONResponse):
+        return result
 
     project_root = get_project_root()
 

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -39,11 +39,22 @@ router = APIRouter(tags=["notebooks"])
 logger = get_logger(__name__)
 
 _VALID_TEMPLATES = frozenset({"blank", "explore", "quality"})
+_DEFAULT_MARIMO_PORT = 7805
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+def _validate_name(name: str) -> JSONResponse | None:
+    """Return a 400 response if name is invalid, else None."""
+    try:
+        validate_identifier(name)
+    except Exception:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-NB001",
+                "message": "Invalid notebook name. Use only letters, numbers, and underscores.",
+            },
+        )
+    return None
 
 
 def _audit(
@@ -156,12 +167,10 @@ def _create_notebook_blocking(
     if target.exists():
         raise FileExistsError(f"Notebook file already exists: {name}.py")
 
-    # Copy template from package
     templates_dir = Path(dango.notebooks.templates.__file__).parent
     template_file = templates_dir / f"{template}.py"
     shutil.copy2(str(template_file), str(target))
 
-    # Insert metadata
     new_id = str(uuid.uuid4())
     now = datetime.now().isoformat()
 
@@ -189,11 +198,6 @@ def _delete_notebook_blocking(project_root: Path, name: str) -> None:
         conn.commit()
 
 
-# ---------------------------------------------------------------------------
-# Page route
-# ---------------------------------------------------------------------------
-
-
 @router.get("/notebooks")
 async def notebooks_page(
     request: Request,
@@ -209,11 +213,6 @@ async def notebooks_page(
             "subtitle": "Notebooks",
         },
     )
-
-
-# ---------------------------------------------------------------------------
-# API endpoints
-# ---------------------------------------------------------------------------
 
 
 @router.get("/api/notebooks")
@@ -238,19 +237,10 @@ async def create_notebook(
     name = body.get("name", "")
     template = body.get("template", "blank")
 
-    # Validate name
-    try:
-        name = validate_identifier(name)
-    except Exception:
-        return JSONResponse(
-            status_code=400,
-            content={
-                "error_code": "DANGO-NB001",
-                "message": "Invalid notebook name. Use only letters, numbers, and underscores.",
-            },
-        )
-
-    # Validate template
+    err = _validate_name(name)
+    if err is not None:
+        return err
+    name = validate_identifier(name)  # normalize
     if template not in _VALID_TEMPLATES:
         return JSONResponse(
             status_code=400,
@@ -292,11 +282,14 @@ async def delete_notebook(
     user: User = Depends(require_permission("notebooks.execute")),
 ) -> JSONResponse:
     """Delete a notebook file and metadata."""
+    err = _validate_name(name)
+    if err is not None:
+        return err
+
     project_root = get_project_root()
 
     notebook = await asyncio.to_thread(_get_notebook_by_name, project_root, name)
 
-    # Check file also exists on disk if not in metadata
     notebooks_dir = project_root / "notebooks"
     file_exists = (notebooks_dir / f"{name}.py").exists()
 
@@ -306,6 +299,17 @@ async def delete_notebook(
             content={
                 "error_code": "DANGO-NB004",
                 "message": f"Notebook {name!r} not found.",
+            },
+        )
+
+    # Refuse delete if locked by another user
+    lock = await asyncio.to_thread(get_lock_info, project_root, name)
+    if lock and lock["locked_by"] != user.email:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error_code": "DANGO-NB011",
+                "message": f"Notebook is locked by {lock['locked_by']}. Release the lock first.",
             },
         )
 
@@ -342,7 +346,21 @@ async def lock_notebook(
     user: User = Depends(require_permission("notebooks.execute")),
 ) -> JSONResponse:
     """Acquire editing lock and start Marimo if needed."""
+    err = _validate_name(name)
+    if err is not None:
+        return err
+
     project_root = get_project_root()
+
+    notebooks_dir = project_root / "notebooks"
+    if not (notebooks_dir / f"{name}.py").exists():
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-NB004",
+                "message": f"Notebook {name!r} not found.",
+            },
+        )
 
     acquired = await asyncio.to_thread(acquire_lock, project_root, name, user.email)
     if not acquired:
@@ -356,9 +374,7 @@ async def lock_notebook(
             },
         )
 
-    # Start Marimo if not running
     status = await asyncio.to_thread(get_marimo_status, project_root)
-    port: int | None = None
     if not status["running"]:
         try:
             await asyncio.to_thread(start_marimo, project_root)
@@ -367,7 +383,7 @@ async def lock_notebook(
             # Already running (race condition) — get status again
             status = await asyncio.to_thread(get_marimo_status, project_root)
 
-    port = status.get("port") or 7805  # type: ignore[assignment]
+    port = status.get("port") or _DEFAULT_MARIMO_PORT  # type: ignore[assignment]
 
     marimo_url = f"http://localhost:{port}/@file/{name}.py"
 
@@ -452,6 +468,10 @@ async def copy_notebook(
     user: User = Depends(require_permission("notebooks.execute")),
 ) -> JSONResponse:
     """Copy a locked notebook for the current user."""
+    err = _validate_name(name)
+    if err is not None:
+        return err
+
     project_root = get_project_root()
 
     try:

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -88,6 +88,9 @@
                     <a href="/schedules" class="px-3 py-2 rounded-md text-sm font-medium {% if current_page == 'schedules' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors hidden sm:block">
                         Schedules
                     </a>
+                    <a href="/notebooks" class="px-3 py-2 rounded-md text-sm font-medium {% if current_page == 'notebooks' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors hidden sm:block">
+                        Notebooks
+                    </a>
                 </div>
                 <div class="flex items-center space-x-2">
                     {% if request.state.user %}

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -182,6 +182,7 @@ function notebooksPage() {
         // Active editing
         activeNotebook: null,
         heartbeatInterval: null,
+        _boundBeforeUnload: null,
 
         async init() {
             await this.loadNotebooks();
@@ -243,12 +244,20 @@ function notebooksPage() {
                     });
                 } catch (e) { /* ignore heartbeat failures */ }
             }, 60000);
+            this._boundBeforeUnload = () => {
+                navigator.sendBeacon(`/api/notebooks/${name}/release`);
+            };
+            window.addEventListener('beforeunload', this._boundBeforeUnload);
         },
 
         stopHeartbeat() {
             if (this.heartbeatInterval) {
                 clearInterval(this.heartbeatInterval);
                 this.heartbeatInterval = null;
+            }
+            if (this._boundBeforeUnload) {
+                window.removeEventListener('beforeunload', this._boundBeforeUnload);
+                this._boundBeforeUnload = null;
             }
         },
 

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -1,0 +1,315 @@
+{% extends "base.html" %}
+
+{% block title %}Notebooks - Dango{% endblock %}
+
+{% block content %}
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div x-data="notebooksPage()" x-init="init()">
+        <!-- Header -->
+        <div class="flex items-center justify-between mb-6">
+            <h2 class="text-xl font-bold text-gray-900">Notebooks</h2>
+            <template x-if="canExecute">
+                <div class="relative">
+                    <button @click="showCreateDropdown = !showCreateDropdown"
+                            class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors">
+                        New Notebook
+                    </button>
+                    <div x-show="showCreateDropdown" @click.away="showCreateDropdown = false" x-cloak
+                         class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50">
+                        <button @click="createNotebook('blank')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Blank</button>
+                        <button @click="createNotebook('explore')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Data Exploration</button>
+                        <button @click="createNotebook('quality')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Data Quality</button>
+                    </div>
+                </div>
+            </template>
+        </div>
+
+        <!-- Error banner -->
+        <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+            <p class="text-sm text-red-700" x-text="error"></p>
+        </div>
+
+        <!-- Success banner -->
+        <div x-show="success" x-cloak class="mb-4 p-3 bg-green-50 border border-green-200 rounded-md">
+            <p class="text-sm text-green-700" x-text="success"></p>
+        </div>
+
+        <!-- Notebooks table -->
+        <div class="bg-white shadow rounded-lg overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Author</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Last Modified</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Lock Status</th>
+                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    <template x-for="nb in notebooks" :key="nb.name">
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span class="text-sm font-medium text-gray-900" x-text="nb.name"></span>
+                                <template x-if="!nb.file_exists">
+                                    <span class="ml-2 px-1.5 py-0.5 text-xs rounded bg-yellow-100 text-yellow-800">missing file</span>
+                                </template>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell"
+                                x-text="nb.created_by || '—'"></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
+                                x-text="nb.updated_at ? timeAgo(nb.updated_at) : '—'"></td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                <template x-if="!nb.lock">
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Available</span>
+                                </template>
+                                <template x-if="nb.lock && nb.lock.locked_by === userEmail">
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">Editing</span>
+                                </template>
+                                <template x-if="nb.lock && nb.lock.locked_by !== userEmail">
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-orange-100 text-orange-800">
+                                        Locked by <span x-text="nb.lock.locked_by" class="ml-1"></span>
+                                    </span>
+                                </template>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
+                                <div class="flex items-center justify-end space-x-2">
+                                    <template x-if="canExecute && nb.file_exists">
+                                        <button @click="openNotebook(nb)"
+                                                class="text-blue-600 hover:text-blue-800 text-xs font-medium">Open</button>
+                                    </template>
+                                    <template x-if="canExecute && nb.lock && nb.lock.locked_by !== userEmail">
+                                        <button @click="copyNotebook(nb)"
+                                                class="text-gray-600 hover:text-gray-800 text-xs font-medium">Copy</button>
+                                    </template>
+                                    <template x-if="canManage && nb.lock">
+                                        <button @click="forceReleaseLock(nb)"
+                                                class="text-orange-600 hover:text-orange-800 text-xs font-medium">Force Unlock</button>
+                                    </template>
+                                    <template x-if="canExecute">
+                                        <button @click="openDeleteModal(nb)"
+                                                class="text-red-600 hover:text-red-800 text-xs font-medium">Delete</button>
+                                    </template>
+                                </div>
+                            </td>
+                        </tr>
+                    </template>
+                </tbody>
+                <tbody x-show="notebooks.length === 0" x-cloak>
+                    <tr><td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">No notebooks yet. Create one to get started.</td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Create Notebook Modal (name input) -->
+        <div x-show="showCreateModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showCreateModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">New Notebook</h3>
+                    <form @submit.prevent="submitCreate()">
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                            <input type="text" x-model="newNotebookName" required pattern="[a-zA-Z0-9_]+"
+                                   placeholder="my_analysis"
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
+                            <p class="text-xs text-gray-400 mt-1">Letters, numbers, underscores only.</p>
+                        </div>
+                        <div class="flex justify-end space-x-3">
+                            <button type="button" @click="showCreateModal = false"
+                                    class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            <button type="submit" :disabled="createLoading"
+                                    class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">
+                                <span x-show="!createLoading">Create</span>
+                                <span x-show="createLoading" x-cloak>Creating...</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Delete Confirmation Modal -->
+        <div x-show="showDeleteModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showDeleteModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-red-600 mb-2">Delete Notebook</h3>
+                    <p class="text-sm text-gray-500 mb-4">
+                        Are you sure you want to delete
+                        <span class="font-mono font-medium" x-text="deleteTarget?.name"></span>?
+                        This cannot be undone.
+                    </p>
+                    <div class="flex justify-end space-x-3">
+                        <button @click="showDeleteModal = false"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="deleteNotebook()" :disabled="deleteLoading"
+                                class="px-4 py-2 text-sm text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50">Delete</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function notebooksPage() {
+    const headers = {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'};
+    const userRole = {{ request.state.user.role.value | tojson }};
+    const userEmail = {{ request.state.user.email | tojson }};
+
+    return {
+        notebooks: [],
+        error: '', success: '',
+        canExecute: userRole === 'admin' || userRole === 'editor',
+        canManage: userRole === 'admin' || userRole === 'editor',
+        userEmail: userEmail,
+
+        // Create
+        showCreateDropdown: false,
+        showCreateModal: false,
+        newNotebookName: '',
+        selectedTemplate: 'blank',
+        createLoading: false,
+
+        // Delete
+        showDeleteModal: false,
+        deleteTarget: null,
+        deleteLoading: false,
+
+        // Active editing
+        activeNotebook: null,
+        heartbeatInterval: null,
+
+        async init() {
+            await this.loadNotebooks();
+        },
+
+        async loadNotebooks() {
+            try {
+                const res = await fetch('/api/notebooks', { headers });
+                if (res.ok) this.notebooks = await res.json();
+            } catch (e) { this.error = 'Failed to load notebooks'; }
+        },
+
+        createNotebook(template) {
+            this.selectedTemplate = template;
+            this.showCreateDropdown = false;
+            this.newNotebookName = '';
+            this.showCreateModal = true;
+        },
+
+        async submitCreate() {
+            this.createLoading = true; this.error = '';
+            try {
+                const res = await fetch('/api/notebooks', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ name: this.newNotebookName, template: this.selectedTemplate })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to create notebook'; this.createLoading = false; return; }
+                this.showCreateModal = false;
+                this.success = 'Notebook created.';
+                setTimeout(() => this.success = '', 3000);
+                await this.loadNotebooks();
+            } catch (e) { this.error = 'Failed to create notebook'; }
+            this.createLoading = false;
+        },
+
+        async openNotebook(nb) {
+            this.error = '';
+            try {
+                const res = await fetch(`/api/notebooks/${nb.name}/lock`, {
+                    method: 'POST', headers, body: '{}'
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to lock notebook'; return; }
+
+                window.open(data.marimo_url, '_blank');
+                this.activeNotebook = nb.name;
+                this.startHeartbeat(nb.name);
+                await this.loadNotebooks();
+            } catch (e) { this.error = 'Failed to open notebook'; }
+        },
+
+        startHeartbeat(name) {
+            this.stopHeartbeat();
+            this.heartbeatInterval = setInterval(async () => {
+                try {
+                    await fetch(`/api/notebooks/${name}/heartbeat`, {
+                        method: 'POST', headers, body: '{}'
+                    });
+                } catch (e) { /* ignore heartbeat failures */ }
+            }, 60000);
+        },
+
+        stopHeartbeat() {
+            if (this.heartbeatInterval) {
+                clearInterval(this.heartbeatInterval);
+                this.heartbeatInterval = null;
+            }
+        },
+
+        async copyNotebook(nb) {
+            this.error = '';
+            try {
+                const res = await fetch(`/api/notebooks/${nb.name}/copy`, {
+                    method: 'POST', headers, body: '{}'
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to copy notebook'; return; }
+                this.success = `Copied as ${data.copy_name}`;
+                setTimeout(() => this.success = '', 3000);
+                await this.loadNotebooks();
+            } catch (e) { this.error = 'Failed to copy notebook'; }
+        },
+
+        openDeleteModal(nb) {
+            this.deleteTarget = nb;
+            this.showDeleteModal = true;
+        },
+
+        async deleteNotebook() {
+            this.deleteLoading = true; this.error = '';
+            try {
+                const res = await fetch(`/api/notebooks/${this.deleteTarget.name}`, {
+                    method: 'DELETE', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to delete notebook'; this.deleteLoading = false; return; }
+                this.showDeleteModal = false;
+                this.success = 'Notebook deleted.';
+                setTimeout(() => this.success = '', 3000);
+                await this.loadNotebooks();
+            } catch (e) { this.error = 'Failed to delete notebook'; }
+            this.deleteLoading = false;
+        },
+
+        async forceReleaseLock(nb) {
+            this.error = '';
+            try {
+                const res = await fetch(`/api/notebooks/${nb.name}/lock`, {
+                    method: 'DELETE', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to force unlock'; return; }
+                this.success = 'Lock released.';
+                setTimeout(() => this.success = '', 3000);
+                await this.loadNotebooks();
+            } catch (e) { this.error = 'Failed to force unlock'; }
+        },
+
+        timeAgo(iso) {
+            if (!iso) return '—';
+            const diff = (new Date() - new Date(iso)) / 1000;
+            if (diff < 60) return Math.round(diff) + 's ago';
+            if (diff < 3600) return Math.round(diff / 60) + ' min ago';
+            if (diff < 86400) return Math.round(diff / 3600) + 'h ago';
+            return Math.round(diff / 86400) + 'd ago';
+        }
+    }
+}
+</script>
+{% endblock %}

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -245,7 +245,9 @@ function notebooksPage() {
                 } catch (e) { /* ignore heartbeat failures */ }
             }, 60000);
             this._boundBeforeUnload = () => {
-                navigator.sendBeacon(`/api/notebooks/${name}/release`);
+                fetch(`/api/notebooks/${name}/release`, {
+                    method: 'POST', headers, keepalive: true, body: '{}'
+                });
             };
             window.addEventListener('beforeunload', this._boundBeforeUnload);
         },

--- a/tests/unit/test_web_notebooks.py
+++ b/tests/unit/test_web_notebooks.py
@@ -1,0 +1,444 @@
+"""tests/unit/test_web_notebooks.py
+
+Unit tests for notebook web UI page and API endpoints.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import AuthenticationError, AuthorizationError, DangoError, ValidationError
+from dango.utils.dango_db import _schema_initialized, connect
+from dango.web.routes.notebooks import router
+
+_P = "dango.web.routes.notebooks"
+
+
+def _make_user(role: Role = Role.ADMIN, email: str = "test@test.com") -> User:
+    """Create a test user."""
+    return User(id="u-test-1", email=email, password_hash="hashed", role=role, is_active=True)
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the notebooks router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        ValidationError: 400,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def _handler(request: Request, exc: DangoError) -> JSONResponse:
+        """Handle DangoError exceptions."""
+        code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=code, content={"error_code": exc.error_code, "message": exc.user_message}
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _client(tmp_path: Path, role: Role = Role.ADMIN, email: str = "test@test.com") -> TestClient:
+    """Create a test client with auth middleware injecting a user."""
+    user = _make_user(role, email=email)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def _set_user(request: Any, call_next: Any) -> Any:
+        """Inject test user."""
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _init_db(tmp_path: Path) -> None:
+    """Initialize the dango.db schema for tests."""
+    _schema_initialized.clear()
+    with connect(tmp_path):
+        pass
+
+
+def _seed_notebook(tmp_path: Path, name: str, created_by: str = "test@test.com") -> None:
+    """Create a notebook file and metadata entry."""
+    nb_dir = tmp_path / "notebooks"
+    nb_dir.mkdir(parents=True, exist_ok=True)
+    (nb_dir / f"{name}.py").write_text("# notebook\n")
+    now = datetime.now().isoformat()
+    with connect(tmp_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_metadata (id, name, description, created_by, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), name, "Test notebook", created_by, now, now),
+        )
+        conn.commit()
+
+
+def _seed_lock(tmp_path: Path, name: str, locked_by: str = "other@test.com") -> None:
+    """Create a lock entry for a notebook."""
+    with connect(tmp_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_locks (notebook_id, locked_by, locked_at, expires_at) "
+            "VALUES (?, ?, datetime('now'), datetime('now', '+15 minutes'))",
+            (name, locked_by),
+        )
+        conn.commit()
+
+
+@pytest.mark.unit
+class TestNotebooksPage:
+    """Tests for GET /notebooks page route."""
+
+    @patch(f"{_P}.get_project_root")
+    @patch(f"{_P}._render_template")
+    def test_renders_page(
+        self, mock_render: MagicMock, mock_root: MagicMock, tmp_path: Path
+    ) -> None:
+        """Page route returns HTML response."""
+        mock_root.return_value = tmp_path
+        mock_render.return_value = JSONResponse(content={"html": "ok"})
+        resp = _client(tmp_path).get("/notebooks")
+        assert resp.status_code == 200
+        mock_render.assert_called_once()
+        assert mock_render.call_args[0][0] == "notebooks.html"
+        assert mock_render.call_args[0][1]["current_page"] == "notebooks"
+
+    def test_viewer_can_access(self, tmp_path: Path) -> None:
+        """Viewer (notebooks.view) can access the page."""
+        with patch(f"{_P}._render_template") as mock_render:
+            mock_render.return_value = JSONResponse(content={"html": "ok"})
+            assert _client(tmp_path, role=Role.VIEWER).get("/notebooks").status_code == 200
+
+
+@pytest.mark.unit
+class TestListNotebooks:
+    """Tests for GET /api/notebooks."""
+
+    @patch(f"{_P}.get_project_root")
+    def test_empty_list(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns empty list when no notebooks exist."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        resp = _client(tmp_path).get("/api/notebooks")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @patch(f"{_P}.get_project_root")
+    def test_populated_list(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns notebooks with metadata and lock info."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "analysis")
+        _seed_lock(tmp_path, "analysis", locked_by="editor@test.com")
+        data = _client(tmp_path).get("/api/notebooks").json()
+        assert len(data) == 1
+        assert data[0]["name"] == "analysis"
+        assert data[0]["file_exists"] is True
+        assert data[0]["lock"]["locked_by"] == "editor@test.com"
+
+    @patch(f"{_P}.get_project_root")
+    def test_unregistered_file(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Files on disk without metadata appear in the list."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        nb_dir = tmp_path / "notebooks"
+        nb_dir.mkdir(parents=True, exist_ok=True)
+        (nb_dir / "orphan.py").write_text("# orphan\n")
+        data = _client(tmp_path).get("/api/notebooks").json()
+        assert len(data) == 1
+        assert data[0]["name"] == "orphan"
+        assert data[0]["id"] is None
+
+    @patch(f"{_P}.get_project_root")
+    def test_viewer_can_list(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Viewer can list notebooks."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        assert _client(tmp_path, role=Role.VIEWER).get("/api/notebooks").status_code == 200
+
+
+@pytest.mark.unit
+class TestCreateNotebook:
+    """Tests for POST /api/notebooks."""
+
+    @patch(f"{_P}.get_project_root")
+    @patch(f"{_P}.shutil.copy2")
+    def test_create_success(
+        self, mock_copy: MagicMock, mock_root: MagicMock, tmp_path: Path
+    ) -> None:
+        """Creates notebook file and metadata entry."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        (tmp_path / "notebooks").mkdir(parents=True, exist_ok=True)
+        resp = _client(tmp_path).post(
+            "/api/notebooks", json={"name": "my_analysis", "template": "blank"}
+        )
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "my_analysis"
+
+    @patch(f"{_P}.get_project_root")
+    def test_duplicate_name(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 400 for duplicate notebook name."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "existing")
+        resp = _client(tmp_path).post(
+            "/api/notebooks", json={"name": "existing", "template": "blank"}
+        )
+        assert resp.status_code == 400
+        assert "already exists" in resp.json()["message"]
+
+    @patch(f"{_P}.get_project_root")
+    def test_invalid_name(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 400 for invalid notebook name."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        resp = _client(tmp_path).post(
+            "/api/notebooks", json={"name": "bad-name!", "template": "blank"}
+        )
+        assert resp.status_code == 400
+        assert "Invalid notebook name" in resp.json()["message"]
+
+    @patch(f"{_P}.get_project_root")
+    def test_invalid_template(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 400 for invalid template choice."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        resp = _client(tmp_path).post(
+            "/api/notebooks", json={"name": "ok_name", "template": "nonexistent"}
+        )
+        assert resp.status_code == 400
+        assert "Invalid template" in resp.json()["message"]
+
+    @patch(f"{_P}.get_project_root")
+    def test_viewer_forbidden(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Viewer cannot create notebooks."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        resp = _client(tmp_path, role=Role.VIEWER).post(
+            "/api/notebooks", json={"name": "t", "template": "blank"}
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.unit
+class TestDeleteNotebook:
+    """Tests for DELETE /api/notebooks/{name}."""
+
+    @patch(f"{_P}.get_project_root")
+    def test_admin_deletes(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Admin can delete any notebook."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "to_delete", created_by="other@test.com")
+        resp = _client(tmp_path, role=Role.ADMIN).delete("/api/notebooks/to_delete")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+    @patch(f"{_P}.get_project_root")
+    def test_editor_deletes(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Editor (has notebooks.manage) can delete any notebook."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "to_delete", created_by="other@test.com")
+        assert (
+            _client(tmp_path, role=Role.EDITOR).delete("/api/notebooks/to_delete").status_code
+            == 200
+        )
+
+    @patch(f"{_P}.get_project_root")
+    def test_not_found(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 404 for nonexistent notebook."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        assert _client(tmp_path).delete("/api/notebooks/nonexistent").status_code == 404
+
+    @patch(f"{_P}.get_project_root")
+    def test_viewer_forbidden(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Viewer cannot delete notebooks."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "test_nb")
+        assert (
+            _client(tmp_path, role=Role.VIEWER).delete("/api/notebooks/test_nb").status_code == 403
+        )
+
+
+@pytest.mark.unit
+class TestLockNotebook:
+    """Tests for POST /api/notebooks/{name}/lock."""
+
+    @patch(f"{_P}.start_marimo")
+    @patch(f"{_P}.get_marimo_status")
+    @patch(f"{_P}.get_project_root")
+    def test_acquire_success(
+        self,
+        mock_root: MagicMock,
+        mock_status: MagicMock,
+        mock_start: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Acquires lock and returns Marimo URL."""
+        mock_root.return_value = tmp_path
+        mock_status.return_value = {"running": True, "port": 7805, "pid": 123, "log_file": None}
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "test_nb")
+        resp = _client(tmp_path).post("/api/notebooks/test_nb/lock", json={})
+        assert resp.status_code == 200
+        assert resp.json()["locked"] is True
+        assert "test_nb.py" in resp.json()["marimo_url"]
+
+    @patch(f"{_P}.get_project_root")
+    def test_conflict(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 409 when notebook is locked by another user."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "locked_nb")
+        _seed_lock(tmp_path, "locked_nb", locked_by="other@test.com")
+        resp = _client(tmp_path).post("/api/notebooks/locked_nb/lock", json={})
+        assert resp.status_code == 409
+
+    @patch(f"{_P}.get_project_root")
+    def test_viewer_forbidden(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Viewer cannot lock notebooks."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        assert (
+            _client(tmp_path, role=Role.VIEWER).post("/api/notebooks/t/lock", json={}).status_code
+            == 403
+        )
+
+
+@pytest.mark.unit
+class TestHeartbeat:
+    """Tests for POST /api/notebooks/{name}/heartbeat."""
+
+    @patch(f"{_P}.get_project_root")
+    def test_refresh_success(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Refreshes lock when held by the requesting user."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "my_nb")
+        _seed_lock(tmp_path, "my_nb", locked_by="test@test.com")
+        resp = _client(tmp_path).post("/api/notebooks/my_nb/heartbeat", json={})
+        assert resp.status_code == 200
+        assert resp.json()["refreshed"] is True
+
+    @patch(f"{_P}.get_project_root")
+    def test_not_holder(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 409 when lock is held by a different user."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_lock(tmp_path, "other_nb", locked_by="other@test.com")
+        assert (
+            _client(tmp_path).post("/api/notebooks/other_nb/heartbeat", json={}).status_code == 409
+        )
+
+
+@pytest.mark.unit
+class TestReleaseLock:
+    """Tests for POST /api/notebooks/{name}/release."""
+
+    @patch(f"{_P}.get_project_root")
+    def test_release_own_lock(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Releases lock when held by the requesting user."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "my_nb")
+        _seed_lock(tmp_path, "my_nb", locked_by="test@test.com")
+        resp = _client(tmp_path).post("/api/notebooks/my_nb/release", json={})
+        assert resp.status_code == 200
+        assert resp.json()["released"] is True
+
+    @patch(f"{_P}.get_project_root")
+    def test_not_holder(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 409 when lock is held by a different user."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_lock(tmp_path, "other_nb", locked_by="other@test.com")
+        assert _client(tmp_path).post("/api/notebooks/other_nb/release", json={}).status_code == 409
+
+
+@pytest.mark.unit
+class TestForceReleaseLock:
+    """Tests for DELETE /api/notebooks/{name}/lock."""
+
+    @patch(f"{_P}.get_project_root")
+    def test_editor_can_force_release(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Editor (has notebooks.manage) can force-release locks."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_lock(tmp_path, "locked_nb", locked_by="other@test.com")
+        resp = _client(tmp_path, role=Role.EDITOR).delete("/api/notebooks/locked_nb/lock")
+        assert resp.status_code == 200
+        assert resp.json()["force_released"] is True
+
+    @patch(f"{_P}.get_project_root")
+    def test_no_lock_returns_404(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 404 when no lock exists."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        assert _client(tmp_path).delete("/api/notebooks/no_lock/lock").status_code == 404
+
+    @patch(f"{_P}.get_project_root")
+    def test_viewer_forbidden(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Viewer cannot force-release locks."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_lock(tmp_path, "locked_nb", locked_by="other@test.com")
+        assert (
+            _client(tmp_path, role=Role.VIEWER).delete("/api/notebooks/locked_nb/lock").status_code
+            == 403
+        )
+
+
+@pytest.mark.unit
+class TestCopyNotebook:
+    """Tests for POST /api/notebooks/{name}/copy."""
+
+    @patch(f"{_P}.get_project_root")
+    def test_copy_success(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Copies a notebook and returns the copy name."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "original")
+        _seed_lock(tmp_path, "original", locked_by="other@test.com")
+        resp = _client(tmp_path).post("/api/notebooks/original/copy", json={})
+        assert resp.status_code == 201
+        assert "original_copy_" in resp.json()["copy_name"]
+
+    @patch(f"{_P}.get_project_root")
+    def test_not_found(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 404 when notebook file doesn't exist."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        assert _client(tmp_path).post("/api/notebooks/nonexistent/copy", json={}).status_code == 404
+
+    @patch(f"{_P}.get_project_root")
+    def test_viewer_forbidden(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Viewer cannot copy notebooks."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        assert (
+            _client(tmp_path, role=Role.VIEWER).post("/api/notebooks/t/copy", json={}).status_code
+            == 403
+        )

--- a/tests/unit/test_web_notebooks.py
+++ b/tests/unit/test_web_notebooks.py
@@ -180,12 +180,13 @@ class TestListNotebooks:
 class TestCreateNotebook:
     """Tests for POST /api/notebooks."""
 
+    @patch(f"{_P}._audit")
     @patch(f"{_P}.get_project_root")
     @patch(f"{_P}.shutil.copy2")
     def test_create_success(
-        self, mock_copy: MagicMock, mock_root: MagicMock, tmp_path: Path
+        self, _mc: MagicMock, mock_root: MagicMock, mock_audit: MagicMock, tmp_path: Path
     ) -> None:
-        """Creates notebook file and metadata entry."""
+        """Creates notebook file, metadata entry, and logs audit event."""
         mock_root.return_value = tmp_path
         _init_db(tmp_path)
         (tmp_path / "notebooks").mkdir(parents=True, exist_ok=True)
@@ -194,6 +195,8 @@ class TestCreateNotebook:
         )
         assert resp.status_code == 201
         assert resp.json()["name"] == "my_analysis"
+        mock_audit.assert_called_once()
+        assert mock_audit.call_args[0][0].value == "notebook_created"
 
     @patch(f"{_P}.get_project_root")
     def test_duplicate_name(self, mock_root: MagicMock, tmp_path: Path) -> None:
@@ -244,15 +247,20 @@ class TestCreateNotebook:
 class TestDeleteNotebook:
     """Tests for DELETE /api/notebooks/{name}."""
 
+    @patch(f"{_P}._audit")
     @patch(f"{_P}.get_project_root")
-    def test_admin_deletes(self, mock_root: MagicMock, tmp_path: Path) -> None:
-        """Admin can delete any notebook."""
+    def test_admin_deletes(
+        self, mock_root: MagicMock, mock_audit: MagicMock, tmp_path: Path
+    ) -> None:
+        """Admin can delete any notebook and logs audit event."""
         mock_root.return_value = tmp_path
         _init_db(tmp_path)
         _seed_notebook(tmp_path, "to_delete", created_by="other@test.com")
         resp = _client(tmp_path, role=Role.ADMIN).delete("/api/notebooks/to_delete")
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
+        mock_audit.assert_called_once()
+        assert mock_audit.call_args[0][0].value == "notebook_deleted"
 
     @patch(f"{_P}.get_project_root")
     def test_editor_deletes(self, mock_root: MagicMock, tmp_path: Path) -> None:
@@ -281,6 +289,17 @@ class TestDeleteNotebook:
         assert (
             _client(tmp_path, role=Role.VIEWER).delete("/api/notebooks/test_nb").status_code == 403
         )
+
+    @patch(f"{_P}.get_project_root")
+    def test_locked_by_other_blocked(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 409 when notebook is locked by another user."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "locked_nb", created_by="test@test.com")
+        _seed_lock(tmp_path, "locked_nb", locked_by="other@test.com")
+        resp = _client(tmp_path).delete("/api/notebooks/locked_nb")
+        assert resp.status_code == 409
+        assert "locked by" in resp.json()["message"].lower()
 
 
 @pytest.mark.unit
@@ -326,6 +345,31 @@ class TestLockNotebook:
             _client(tmp_path, role=Role.VIEWER).post("/api/notebooks/t/lock", json={}).status_code
             == 403
         )
+
+    @patch(f"{_P}.get_project_root")
+    def test_nonexistent_file_returns_404(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """Returns 404 when notebook file doesn't exist on disk."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        resp = _client(tmp_path).post("/api/notebooks/no_file/lock", json={})
+        assert resp.status_code == 404
+
+    @patch(f"{_P}.start_marimo", side_effect=RuntimeError("already running"))
+    @patch(f"{_P}.get_marimo_status")
+    @patch(f"{_P}.get_project_root")
+    def test_marimo_start_race_condition(
+        self, mock_root: MagicMock, mock_status: MagicMock, _ms: MagicMock, tmp_path: Path
+    ) -> None:
+        """Recovers when start_marimo raises RuntimeError (race condition)."""
+        mock_root.return_value = tmp_path
+        not_running = {"running": False, "port": None, "pid": None, "log_file": None}
+        running = {"running": True, "port": 7805, "pid": 123, "log_file": None}
+        mock_status.side_effect = [not_running, running]
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "race_nb")
+        resp = _client(tmp_path).post("/api/notebooks/race_nb/lock", json={})
+        assert resp.status_code == 200
+        assert resp.json()["locked"] is True
 
 
 @pytest.mark.unit
@@ -382,15 +426,20 @@ class TestReleaseLock:
 class TestForceReleaseLock:
     """Tests for DELETE /api/notebooks/{name}/lock."""
 
+    @patch(f"{_P}._audit")
     @patch(f"{_P}.get_project_root")
-    def test_editor_can_force_release(self, mock_root: MagicMock, tmp_path: Path) -> None:
-        """Editor (has notebooks.manage) can force-release locks."""
+    def test_editor_can_force_release(
+        self, mock_root: MagicMock, mock_audit: MagicMock, tmp_path: Path
+    ) -> None:
+        """Editor (has notebooks.manage) can force-release locks and logs audit."""
         mock_root.return_value = tmp_path
         _init_db(tmp_path)
         _seed_lock(tmp_path, "locked_nb", locked_by="other@test.com")
         resp = _client(tmp_path, role=Role.EDITOR).delete("/api/notebooks/locked_nb/lock")
         assert resp.status_code == 200
         assert resp.json()["force_released"] is True
+        mock_audit.assert_called_once()
+        assert mock_audit.call_args[0][0].value == "notebook_lock_force_released"
 
     @patch(f"{_P}.get_project_root")
     def test_no_lock_returns_404(self, mock_root: MagicMock, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add notebook management web interface with 9 API endpoints (list, create, delete, lock, heartbeat, release, force-release, copy) + page route in `web/routes/notebooks.py`
- Create `notebooks.html` Alpine.js template with create dropdown (blank/explore/quality templates), lock status badges (Available/Editing/Locked by), delete confirmation modal
- Add "Notebooks" nav link in `base.html` after "Schedules"
- 28 unit tests covering all endpoints, permission checks (admin/editor/viewer), lock conflicts, and error cases

## Test plan
- [x] `ruff check dango/` — all checks passed
- [x] `ruff format --check` — all files formatted
- [x] `mypy dango/web/routes/notebooks.py` — no issues
- [x] `pytest tests/unit/test_web_notebooks.py -v` — 28 passed
- [x] `pytest tests/unit/ -x` — 2546 passed, no regressions
- [x] All pre-commit hooks pass (file headers, docstrings, file sizes, CLAUDE.md staleness)
- [ ] Manual: `dango web dev` → browse `/notebooks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)