### PR TITLE
P7-006: Add PII detection to governance module

### DIFF
--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -65,6 +65,7 @@ class AuditEvent(str, Enum):
     NOTEBOOK_DELETED          = "notebook_deleted"
     NOTEBOOK_LOCK_FORCE_RELEASED = "notebook_lock_force_released"
     GOVERNANCE_DRIFT_VIEWED      = "governance_drift_viewed"
+    GOVERNANCE_PII_VIEWED        = "governance_pii_viewed"
     CATALOG_VIEWED               = "catalog_viewed"
     # fmt: on
 

--- a/dango/cli/commands/governance.py
+++ b/dango/cli/commands/governance.py
@@ -66,3 +66,60 @@ def drift_report(
         )
 
     console.print(tbl)
+
+
+@governance.command("pii-report")
+@click.option("--source", default=None, help="Filter by source name.")
+@click.option("--table", default=None, help="Filter by table name.")
+@click.option("--limit", default=50, type=int, help="Max findings to show.")
+@click.pass_context
+def pii_report(
+    ctx: click.Context,
+    source: str | None,
+    table: str | None,
+    limit: int,
+) -> None:
+    """Show PII findings."""
+    from rich.table import Table
+
+    from dango.cli.utils import require_project_context
+    from dango.governance.pii_detector import get_pii_findings
+
+    project_root = require_project_context(ctx)
+
+    findings = get_pii_findings(
+        project_root,
+        source=source,
+        table_name=table,
+        limit=limit,
+    )
+
+    if not findings:
+        console.print("[dim]No PII findings found.[/dim]")
+        return
+
+    tbl = Table(title="PII Findings")
+    tbl.add_column("ID", style="dim")
+    tbl.add_column("Source", style="bold")
+    tbl.add_column("Table")
+    tbl.add_column("Column")
+    tbl.add_column("Entity Type")
+    tbl.add_column("Confidence")
+    tbl.add_column("Samples")
+    tbl.add_column("Scanned At")
+
+    for f in findings:
+        confidence = f"{f['confidence']:.2f}" if f.get("confidence") is not None else "-"
+        samples = str(f["sample_count"]) if f.get("sample_count") is not None else "-"
+        tbl.add_row(
+            str(f["id"]),
+            f["source"],
+            f["table_name"],
+            f["column_name"],
+            f["entity_type"],
+            confidence,
+            samples,
+            f["scanned_at"],
+        )
+
+    console.print(tbl)

--- a/dango/governance/CLAUDE.md
+++ b/dango/governance/CLAUDE.md
@@ -2,15 +2,16 @@
 
 ## Purpose
 
-Data governance module: schema drift detection and PII scanning. Monitors DuckDB warehouse schemas for changes between syncs, records drift events, and alerts via webhooks.
+Data governance module: schema drift detection and PII scanning. Monitors DuckDB warehouse schemas for changes between syncs, records drift events, scans for PII in string columns, and alerts via webhooks.
 
 ## Files
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `__init__.py` | Re-exports public API | `DriftEvent`, `DriftResponse`, `detect_drift_for_sources`, `detect_table_drift`, `get_drift_history` |
-| `models.py` (~35 lines) | Pydantic V2 response models | `DriftEvent`, `DriftResponse` |
+| `__init__.py` | Re-exports public API | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse`, `detect_drift_for_sources`, `detect_table_drift`, `get_drift_history`, `scan_sources_for_pii`, `scan_table_for_pii`, `get_pii_findings` |
+| `models.py` (~60 lines) | Pydantic V2 response models | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse` |
 | `schema_drift.py` (~490 lines) | Schema drift detection engine | `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()`, `_send_drift_webhook()` |
+| `pii_detector.py` (~280 lines) | PII scanning engine (Presidio + spaCy) | `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`, `_send_pii_webhook()` |
 
 ## Common Tasks
 
@@ -18,9 +19,14 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 |-------|-----------|--------------|
 | Add a new drift event type | `schema_drift.py` (`detect_table_drift()` diff logic) | `pytest tests/unit/test_drift_detection.py` |
 | Query drift history | `schema_drift.py` (`get_drift_history()`) | `pytest tests/unit/test_drift_detection.py` |
-| Change webhook notification format | `schema_drift.py` (`_send_drift_webhook()`) | `pytest tests/unit/test_drift_detection.py` |
+| Change drift webhook format | `schema_drift.py` (`_send_drift_webhook()`) | `pytest tests/unit/test_drift_detection.py` |
 | Add drift CLI output columns | `dango/cli/commands/governance.py` | `dango governance drift-report` |
 | View drift via API | `dango/web/routes/governance.py` | `GET /api/governance/schema-drift` |
+| Add PII entity types | `pii_detector.py` (`SCAN_ENTITIES` constant) | `pytest tests/unit/test_pii_detection.py` |
+| Change PII scan threshold | `pii_detector.py` (`SCORE_THRESHOLD` constant) | `pytest tests/unit/test_pii_detection.py` |
+| Query PII findings | `pii_detector.py` (`get_pii_findings()`) | `pytest tests/unit/test_pii_detection.py` |
+| Add PII CLI output columns | `dango/cli/commands/governance.py` | `dango governance pii-report` |
+| View PII via API | `dango/web/routes/governance.py` | `GET /api/governance/pii` |
 
 ## Dependencies
 
@@ -32,16 +38,20 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 - `dango.platform.notifications.slack` — `format_slack_message()`
 - `duckdb` — read-only DuckDB access (lazy import)
 - `httpx` — sync webhook delivery (lazy import)
+- `spacy` — NLP model for Presidio (lazy import, `pii_detector.py`)
+- `presidio_analyzer` — PII analysis engine (lazy import, `pii_detector.py`)
 
 **Used by:**
-- `dango/utils/post_sync.py` — `_run_drift_detection()` calls `detect_drift_for_sources()`
-- `dango/web/routes/governance.py` — `GET /api/governance/schema-drift` calls `get_drift_history()`
-- `dango/cli/commands/governance.py` — `dango governance drift-report` calls `get_drift_history()`
+- `dango/utils/post_sync.py` — `_run_drift_detection()` calls `detect_drift_for_sources()`, `_run_pii_scan()` calls `scan_sources_for_pii()`
+- `dango/web/routes/governance.py` — `GET /api/governance/schema-drift` calls `get_drift_history()`, `GET /api/governance/pii` calls `get_pii_findings()`
+- `dango/cli/commands/governance.py` — `dango governance drift-report` calls `get_drift_history()`, `dango governance pii-report` calls `get_pii_findings()`
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_drift_detection.py`
-- **Integration:** `pytest tests/integration/test_drift_integration.py`
+- **Unit (drift):** `pytest tests/unit/test_drift_detection.py`
+- **Unit (PII):** `pytest tests/unit/test_pii_detection.py`
+- **Integration (drift):** `pytest tests/integration/test_drift_integration.py`
+- **Integration (PII):** `pytest tests/integration/test_pii_integration.py`
 - **Related:** `pytest tests/unit/test_post_sync.py tests/unit/test_webhook.py tests/unit/test_slack_formatter.py`
 
 ## Don't Modify
@@ -50,4 +60,6 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 |------|--------|
 | `drift_events` table schema | Existing events depend on the column structure (defined in `dango/utils/dango_db.py`) |
 | `schema_baselines` table schema | Baseline comparison logic depends on exact columns |
+| `pii_findings` table schema | Cached findings depend on the column structure (defined in `dango/utils/dango_db.py`) |
 | `DriftEvent` field names | Web API consumers depend on the response shape |
+| `PiiFinding` field names | Web API consumers depend on the response shape |

--- a/dango/governance/__init__.py
+++ b/dango/governance/__init__.py
@@ -3,7 +3,12 @@
 Data governance module: schema drift detection and PII scanning.
 """
 
-from dango.governance.models import DriftEvent, DriftResponse
+from dango.governance.models import DriftEvent, DriftResponse, PiiFinding, PiiResponse
+from dango.governance.pii_detector import (
+    get_pii_findings,
+    scan_sources_for_pii,
+    scan_table_for_pii,
+)
 from dango.governance.schema_drift import (
     detect_drift_for_sources,
     detect_table_drift,
@@ -13,7 +18,12 @@ from dango.governance.schema_drift import (
 __all__ = [
     "DriftEvent",
     "DriftResponse",
+    "PiiFinding",
+    "PiiResponse",
     "detect_drift_for_sources",
     "detect_table_drift",
     "get_drift_history",
+    "get_pii_findings",
+    "scan_sources_for_pii",
+    "scan_table_for_pii",
 ]

--- a/dango/governance/models.py
+++ b/dango/governance/models.py
@@ -31,3 +31,29 @@ class DriftResponse(BaseModel):
     count: int
     source: str | None
     table_name: str | None
+
+
+class PiiFinding(BaseModel):
+    """A single PII finding from column scanning."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: int
+    source: str
+    table_name: str
+    column_name: str
+    entity_type: str
+    confidence: float | None
+    sample_count: int | None
+    scanned_at: str
+
+
+class PiiResponse(BaseModel):
+    """Response model for the PII findings endpoint."""
+
+    model_config = ConfigDict(frozen=True)
+
+    findings: list[PiiFinding]
+    count: int
+    source: str | None
+    table_name: str | None

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -90,6 +90,7 @@ def scan_sources_for_pii(
 
     for source in sources:
         try:
+            validate_source_name(source)
             logger.debug("pii_source_start", source=source)
 
             # Get existing keys BEFORE scanning for first-detection logic

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -1,0 +1,453 @@
+"""dango/governance/pii_detector.py
+
+PII detection engine using Presidio and spaCy.  Called after each sync via
+the post-sync hook dispatcher, with results cached in ``pii_findings``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from dango.logging import get_logger
+from dango.utils.dango_db import connect
+from dango.validation import validate_identifier, validate_source_name
+
+logger = get_logger(__name__)
+
+SCAN_ENTITIES = [
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "CREDIT_CARD",
+    "US_SSN",
+    "IP_ADDRESS",
+    "PERSON",
+    "IBAN_CODE",
+    "US_PASSPORT",
+    "US_DRIVER_LICENSE",
+    "CRYPTO",
+]
+
+SCORE_THRESHOLD = 0.5
+DEFAULT_SAMPLE_SIZE = 100
+
+_STRING_TYPES = frozenset({"VARCHAR", "TEXT", "STRING", "CHAR", "BPCHAR"})
+
+_analyzer: Any = None
+
+
+def _get_analyzer() -> Any:
+    """Return a cached Presidio ``AnalyzerEngine``, downloading spaCy model if needed."""
+    global _analyzer  # noqa: PLW0603
+    if _analyzer is not None:
+        return _analyzer
+
+    import spacy  # lazy import
+
+    try:
+        spacy.load("en_core_web_sm")
+    except OSError:
+        try:
+            spacy.cli.download("en_core_web_sm")  # type: ignore[attr-defined]
+        except Exception:
+            msg = (
+                "Failed to download spaCy model 'en_core_web_sm'. "
+                "Install manually: python -m spacy download en_core_web_sm"
+            )
+            raise RuntimeError(msg) from None
+
+    from presidio_analyzer import AnalyzerEngine  # lazy import
+
+    _analyzer = AnalyzerEngine()
+    return _analyzer
+
+
+def scan_sources_for_pii(
+    project_root: Path,
+    sources: list[str],
+) -> list[dict[str, Any]]:
+    """Scan freshly synced sources for PII.
+
+    Discovers tables per source, runs PII analysis, and sends webhook
+    notifications only for newly detected findings.
+
+    Args:
+        project_root: Path to the Dango project root.
+        sources: Names of sources that synced successfully.
+
+    Returns:
+        Flat list of all finding dicts across all sources and tables.
+    """
+    import duckdb  # lazy import
+
+    db_path = project_root / "data" / "warehouse.duckdb"
+    if not db_path.exists():
+        logger.debug("pii_skip_no_warehouse", path=str(db_path))
+        return []
+
+    all_findings: list[dict[str, Any]] = []
+
+    for source in sources:
+        try:
+            logger.debug("pii_source_start", source=source)
+
+            # Get existing keys BEFORE scanning for first-detection logic
+            existing_keys = _get_existing_keys(project_root, source)
+
+            schema = f"raw_{source}"
+            conn = duckdb.connect(str(db_path), read_only=True)
+            try:
+                tables = conn.execute(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = ? "
+                    "AND table_name NOT LIKE '_dlt_%' "
+                    "ORDER BY table_name",
+                    [schema],
+                ).fetchall()
+            finally:
+                conn.close()
+
+            source_findings: list[dict[str, Any]] = []
+            for (tbl_name,) in tables:
+                try:
+                    tbl_name = validate_identifier(tbl_name)
+                    findings = scan_table_for_pii(project_root, source, tbl_name)
+                    source_findings.extend(findings)
+                except Exception:
+                    logger.warning(
+                        "pii_table_error",
+                        source=source,
+                        table=tbl_name,
+                    )
+
+            all_findings.extend(source_findings)
+
+            # Send webhook only for truly new findings
+            new_findings = [
+                f
+                for f in source_findings
+                if (f["source"], f["table_name"], f["column_name"], f["entity_type"])
+                not in existing_keys
+            ]
+            if new_findings:
+                _send_pii_webhook(project_root, sources, new_findings)
+
+            logger.debug("pii_source_complete", source=source)
+        except Exception:
+            logger.warning("pii_source_error", source=source)
+
+    return all_findings
+
+
+def scan_table_for_pii(
+    project_root: Path,
+    source: str,
+    table_name: str,
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+) -> list[dict[str, Any]]:
+    """Scan a single table for PII by sampling string columns.
+
+    Args:
+        project_root: Path to the Dango project root.
+        source: Source name (used as ``raw_{source}`` schema).
+        table_name: Table name within the source schema.
+        sample_size: Maximum number of distinct values to sample per column.
+
+    Returns:
+        List of finding dicts (source, table_name, column_name, entity_type,
+        confidence, sample_count, scanned_at).
+    """
+    import duckdb  # lazy import
+
+    source = validate_source_name(source)
+    table_name = validate_identifier(table_name)
+
+    db_path = project_root / "data" / "warehouse.duckdb"
+    schema = f"raw_{source}"
+
+    conn = duckdb.connect(str(db_path), read_only=True)
+    try:
+        columns = conn.execute(
+            "SELECT column_name, data_type "
+            "FROM information_schema.columns "
+            "WHERE table_schema = ? AND table_name = ? "
+            "ORDER BY ordinal_position",
+            [schema, table_name],
+        ).fetchall()
+    finally:
+        conn.close()
+
+    now = datetime.now(timezone.utc).isoformat()
+    findings: list[dict[str, Any]] = []
+
+    for col_name, data_type in columns:
+        if not _is_string_type(data_type):
+            continue
+
+        try:
+            col_name = validate_identifier(col_name)
+
+            conn = duckdb.connect(str(db_path), read_only=True)
+            try:
+                values = conn.execute(
+                    f'SELECT DISTINCT "{col_name}"::VARCHAR '
+                    f'FROM "{schema}"."{table_name}" '
+                    f'WHERE "{col_name}" IS NOT NULL LIMIT ?',
+                    [sample_size],
+                ).fetchall()
+            finally:
+                conn.close()
+
+            str_values = [row[0] for row in values if row[0]]
+            if not str_values:
+                continue
+
+            detected = _scan_column(str_values)
+            for entity_type, info in detected.items():
+                findings.append(
+                    {
+                        "source": source,
+                        "table_name": table_name,
+                        "column_name": col_name,
+                        "entity_type": entity_type,
+                        "confidence": info["confidence"],
+                        "sample_count": info["count"],
+                        "scanned_at": now,
+                    }
+                )
+        except Exception:
+            logger.warning(
+                "pii_column_error",
+                source=source,
+                table=table_name,
+                column=col_name,
+            )
+
+    # Resilient cache pattern: compute → try cache → return regardless
+    try:
+        _cache_findings(project_root, source, table_name, findings)
+    except Exception:
+        logger.warning(
+            "pii_cache_error",
+            source=source,
+            table=table_name,
+        )
+
+    return findings
+
+
+def get_pii_findings(
+    project_root: Path,
+    *,
+    source: str | None = None,
+    table_name: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Query cached PII findings, newest first.
+
+    Args:
+        project_root: Path to the Dango project root.
+        source: Optional source name filter.
+        table_name: Optional table name filter.
+        limit: Maximum number of findings to return.
+
+    Returns:
+        List of finding dicts, newest first.
+    """
+    conditions: list[str] = []
+    params: list[str | int] = []
+
+    if source is not None:
+        source = validate_source_name(source)
+        conditions.append("source = ?")
+        params.append(source)
+
+    if table_name is not None:
+        table_name = validate_identifier(table_name)
+        conditions.append("table_name = ?")
+        params.append(table_name)
+
+    where_clause = ""
+    if conditions:
+        where_clause = "WHERE " + " AND ".join(conditions)
+
+    params.append(limit)
+
+    query = (
+        "SELECT id, source, table_name, column_name, entity_type, "
+        "confidence, sample_count, scanned_at "
+        f"FROM pii_findings {where_clause} "
+        "ORDER BY id DESC LIMIT ?"
+    )
+
+    with connect(project_root) as conn:
+        rows = conn.execute(query, params).fetchall()
+
+    return [
+        {
+            "id": row[0],
+            "source": row[1],
+            "table_name": row[2],
+            "column_name": row[3],
+            "entity_type": row[4],
+            "confidence": row[5],
+            "sample_count": row[6],
+            "scanned_at": row[7],
+        }
+        for row in rows
+    ]
+
+
+def _is_string_type(data_type: str) -> bool:
+    """Check whether a DuckDB data type is a string type."""
+    return data_type.upper() in _STRING_TYPES
+
+
+def _scan_column(values: list[str]) -> dict[str, dict[str, Any]]:
+    """Run Presidio analyzer on sampled values, aggregating by entity type."""
+    analyzer = _get_analyzer()
+    detections: dict[str, dict[str, Any]] = {}
+
+    for val in values:
+        results = analyzer.analyze(
+            text=val,
+            entities=SCAN_ENTITIES,
+            language="en",
+        )
+        for result in results:
+            if result.score < SCORE_THRESHOLD:
+                continue
+            entity = result.entity_type
+            if entity not in detections:
+                detections[entity] = {"confidence": result.score, "count": 1}
+            else:
+                detections[entity]["count"] += 1
+                if result.score > detections[entity]["confidence"]:
+                    detections[entity]["confidence"] = result.score
+
+    return detections
+
+
+def _cache_findings(
+    project_root: Path,
+    source: str,
+    table_name: str,
+    findings: list[dict[str, Any]],
+) -> None:
+    """Cache PII findings in SQLite (DELETE + INSERT for same source/table)."""
+    with connect(project_root) as conn:
+        conn.execute(
+            "DELETE FROM pii_findings WHERE source = ? AND table_name = ?",
+            (source, table_name),
+        )
+        for f in findings:
+            conn.execute(
+                "INSERT INTO pii_findings "
+                "(source, table_name, column_name, entity_type, confidence, "
+                "sample_count, scanned_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    f["source"],
+                    f["table_name"],
+                    f["column_name"],
+                    f["entity_type"],
+                    f["confidence"],
+                    f["sample_count"],
+                    f["scanned_at"],
+                ),
+            )
+        conn.commit()
+
+
+def _get_existing_keys(
+    project_root: Path,
+    source: str,
+) -> set[tuple[str, str, str, str]]:
+    """Return existing (source, table, column, entity_type) tuples from cache."""
+    try:
+        with connect(project_root) as conn:
+            rows = conn.execute(
+                "SELECT source, table_name, column_name, entity_type "
+                "FROM pii_findings WHERE source = ?",
+                (source,),
+            ).fetchall()
+        return {(row[0], row[1], row[2], row[3]) for row in rows}
+    except Exception:
+        logger.warning("pii_existing_keys_error", source=source)
+        return set()
+
+
+def _send_pii_webhook(
+    project_root: Path,
+    sources: list[str],
+    findings: list[dict[str, Any]],
+) -> None:
+    """Send webhook notification for detected PII findings.  Never raises."""
+    try:
+        from dango.platform.notifications.webhook import (
+            EventType,
+            WebhookPayload,
+            load_notification_config,
+            should_notify,
+        )
+
+        config = load_notification_config(project_root)
+        if config is None:
+            return
+
+        if not should_notify(EventType.PII_DETECTED, config):
+            return
+
+        if not config.webhooks:
+            return
+
+        # Build summary string
+        entity_counts: dict[str, int] = {}
+        for f in findings:
+            entity_counts[f["entity_type"]] = entity_counts.get(f["entity_type"], 0) + 1
+        summary_parts = [f"{count} {etype}" for etype, count in entity_counts.items()]
+        summary = f"PII detected: {', '.join(summary_parts)}"
+
+        payload = WebhookPayload(
+            event_type=EventType.PII_DETECTED,
+            schedule_name="post_sync",
+            sources=sources,
+            error=summary,
+            occurred_at=datetime.now(tz=timezone.utc),
+        )
+
+        import httpx  # lazy import
+
+        for webhook in config.webhooks:
+            try:
+                if webhook.format == "slack":
+                    from dango.platform.notifications.slack import format_slack_message
+
+                    json_payload: dict[str, Any] = format_slack_message(payload)
+                else:
+                    json_payload = {
+                        "event": payload.event_type.value,
+                        "schedule": payload.schedule_name,
+                        "sources": payload.sources,
+                        "error": payload.error,
+                        "timestamp": (
+                            payload.occurred_at.isoformat() if payload.occurred_at else None
+                        ),
+                    }
+
+                with httpx.Client(timeout=10.0) as client:
+                    resp = client.post(webhook.url, json=json_payload)
+
+                logger.info(
+                    "pii_webhook_delivered",
+                    webhook=webhook.name,
+                    status=resp.status_code,
+                )
+            except Exception:
+                logger.warning(
+                    "pii_webhook_error",
+                    webhook=webhook.name,
+                    exc_info=True,
+                )
+    except Exception:
+        logger.warning("pii_webhook_unexpected_error", exc_info=True)

--- a/dango/platform/notifications/slack.py
+++ b/dango/platform/notifications/slack.py
@@ -22,6 +22,7 @@ _COLORS: dict[EventType, str] = {
     EventType.SYNC_STALE: "#ecb22e",  # amber
     EventType.SYNC_RETRYING: "#aaaaaa",  # gray
     EventType.SCHEMA_DRIFT_DETECTED: "#e0a514",  # dark amber
+    EventType.PII_DETECTED: "#e01e5a",  # red
 }
 
 _HEADERS: dict[EventType, str] = {
@@ -30,6 +31,7 @@ _HEADERS: dict[EventType, str] = {
     EventType.SYNC_STALE: "Sync Stale",
     EventType.SYNC_RETRYING: "Sync Retrying",
     EventType.SCHEMA_DRIFT_DETECTED: "Schema Drift Detected",
+    EventType.PII_DETECTED: "PII Detected",
 }
 
 
@@ -86,6 +88,10 @@ def _build_body(payload: WebhookPayload) -> str:
             lines.append(f"*Next retry:* {utc_time.strftime('%H:%M:%S UTC')}")
 
     elif payload.event_type == EventType.SCHEMA_DRIFT_DETECTED:
+        if payload.error:
+            lines.append(f"*Details:* {payload.error}")
+
+    elif payload.event_type == EventType.PII_DETECTED:
         if payload.error:
             lines.append(f"*Details:* {payload.error}")
 

--- a/dango/platform/notifications/webhook.py
+++ b/dango/platform/notifications/webhook.py
@@ -51,6 +51,7 @@ class EventType(str, Enum):
     SYNC_STALE = "sync_stale"
     SYNC_RETRYING = "sync_retrying"
     SCHEMA_DRIFT_DETECTED = "schema_drift_detected"
+    PII_DETECTED = "pii_detected"
 
 
 class EventCategory(str, Enum):
@@ -68,6 +69,7 @@ EVENT_TO_CATEGORY: dict[EventType, EventCategory] = {
     EventType.SYNC_STALE: EventCategory.STALE,
     EventType.SYNC_RETRYING: EventCategory.FAILURE,
     EventType.SCHEMA_DRIFT_DETECTED: EventCategory.GOVERNANCE,
+    EventType.PII_DETECTED: EventCategory.GOVERNANCE,
 }
 
 # ---------------------------------------------------------------------------

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -389,8 +389,16 @@ def _run_drift_detection(project_root: Path, sources: list[str]) -> None:
 def _run_pii_scan(project_root: Path, sources: list[str]) -> None:
     """Scan for PII in freshly synced sources.
 
-    Populated by P7-006.
+    Args:
+        project_root: Path to the Dango project root.
+        sources: Names of sources that synced successfully.
     """
+    try:
+        from dango.governance.pii_detector import scan_sources_for_pii
+
+        scan_sources_for_pii(project_root, sources)
+    except Exception:
+        logger.warning("pii_scan_error", sources=sources, exc_info=True)
 
 
 def _run_analysis(project_root: Path, sources: list[str]) -> None:

--- a/dango/web/routes/governance.py
+++ b/dango/web/routes/governance.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, Query
 from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
 from dango.auth.permissions import require_permission
-from dango.governance.models import DriftEvent, DriftResponse
+from dango.governance.models import DriftEvent, DriftResponse, PiiFinding, PiiResponse
 from dango.logging import get_logger
 from dango.validation import validate_identifier, validate_source_name
 from dango.web.helpers import get_project_root
@@ -66,6 +66,55 @@ async def get_schema_drift(
     return DriftResponse(
         events=drift_events,
         count=len(drift_events),
+        source=validated_source,
+        table_name=validated_table,
+    )
+
+
+@router.get("/api/governance/pii")
+async def get_pii(
+    source: str | None = Query(None, description="Filter by source name"),
+    table: str | None = Query(None, description="Filter by table name"),
+    limit: int = Query(100, ge=1, le=1000, description="Max findings"),
+    user: User = Depends(require_permission("governance.view")),
+) -> PiiResponse:
+    """Query cached PII findings.
+
+    Returns PII findings from SQLite, newest first.
+    """
+    project_root = get_project_root()
+
+    # Validate filters
+    validated_source: str | None = None
+    if source is not None:
+        validated_source = validate_source_name(source)
+
+    validated_table: str | None = None
+    if table is not None:
+        validated_table = validate_identifier(table)
+
+    from dango.governance.pii_detector import get_pii_findings
+
+    findings = await asyncio.to_thread(
+        get_pii_findings,
+        project_root,
+        source=validated_source,
+        table_name=validated_table,
+        limit=limit,
+    )
+
+    log_auth_event(
+        AuditEvent.GOVERNANCE_PII_VIEWED,
+        user_id=user.id,
+        email=user.email,
+        details={"source": validated_source, "table": validated_table, "limit": limit},
+    )
+
+    pii_findings = [PiiFinding(**f) for f in findings]
+
+    return PiiResponse(
+        findings=pii_findings,
+        count=len(pii_findings),
         source=validated_source,
         table_name=validated_table,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,6 +314,8 @@ module = [
     "tests.unit.test_notebook_locking",
     "tests.unit.test_notebook_proxy",
     "tests.unit.test_notebook_cli",
+    "tests.unit.test_pii_detection",
+    "tests.integration.test_pii_integration",
     "tests.unit.test_error_messages",
 ]
 ignore_errors = true

--- a/tests/integration/test_pii_integration.py
+++ b/tests/integration/test_pii_integration.py
@@ -1,0 +1,203 @@
+"""tests/integration/test_pii_integration.py
+
+Integration tests for PII detection using real DuckDB and SQLite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import pytest
+
+from dango.governance.pii_detector import (
+    get_pii_findings,
+    scan_sources_for_pii,
+    scan_table_for_pii,
+)
+from dango.utils.dango_db import _schema_initialized, connect
+from dango.utils.post_sync import dispatch_post_sync_hooks
+
+_PII = "dango.governance.pii_detector"
+
+
+def _create_test_warehouse(tmp_path: Path) -> Path:
+    """Create a real DuckDB warehouse with test data including PII-like values.
+
+    Returns:
+        Path to the DuckDB file.
+    """
+    db_path = tmp_path / "data" / "warehouse.duckdb"
+    db_path.parent.mkdir(parents=True)
+
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE SCHEMA raw_testshop")
+    conn.execute("""
+        CREATE TABLE raw_testshop.customers (
+            id INTEGER NOT NULL,
+            email VARCHAR,
+            phone VARCHAR,
+            total DOUBLE
+        )
+    """)
+    conn.execute("""
+        INSERT INTO raw_testshop.customers VALUES
+        (1, 'alice@example.com', '555-123-4567', 10.50),
+        (2, 'bob@example.com', '555-987-6543', 25.00)
+    """)
+
+    # dlt internal table (should be excluded)
+    conn.execute("""
+        CREATE TABLE raw_testshop._dlt_loads (
+            load_id VARCHAR,
+            status INTEGER
+        )
+    """)
+
+    conn.close()
+    return db_path
+
+
+def _clear_schema_cache() -> None:
+    """Clear the dango_db schema initialization cache for test isolation."""
+    _schema_initialized.clear()
+
+
+def _mock_analyzer_with_findings() -> MagicMock:
+    """Create a mock analyzer that returns findings for email-like strings."""
+    mock_analyzer = MagicMock()
+
+    def analyze(text, entities, language):
+        results = []
+        if "@" in text:
+            r = MagicMock()
+            r.entity_type = "EMAIL_ADDRESS"
+            r.score = 0.95
+            results.append(r)
+        return results
+
+    mock_analyzer.analyze.side_effect = analyze
+    return mock_analyzer
+
+
+@pytest.mark.integration
+class TestPiiScanIntegration:
+    """Integration tests for PII scanning with real databases."""
+
+    def test_scan_table_creates_findings(self, tmp_path: Path) -> None:
+        """Scanning a table with PII-like data produces findings."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+        mock_analyzer = _mock_analyzer_with_findings()
+
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            findings = scan_table_for_pii(tmp_path, "testshop", "customers")
+
+        # Should find EMAIL_ADDRESS in the email column
+        email_findings = [f for f in findings if f["entity_type"] == "EMAIL_ADDRESS"]
+        assert len(email_findings) >= 1
+        assert email_findings[0]["column_name"] == "email"
+
+    def test_findings_cached_in_sqlite(self, tmp_path: Path) -> None:
+        """Scan results are persisted to the pii_findings SQLite table."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+        mock_analyzer = _mock_analyzer_with_findings()
+
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            scan_table_for_pii(tmp_path, "testshop", "customers")
+
+        # Query cached findings
+        findings = get_pii_findings(tmp_path)
+        assert len(findings) >= 1
+
+    def test_repeat_scan_replaces_old(self, tmp_path: Path) -> None:
+        """Second scan replaces findings from the first scan."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+        mock_analyzer = _mock_analyzer_with_findings()
+
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            scan_table_for_pii(tmp_path, "testshop", "customers")
+            first_count = len(get_pii_findings(tmp_path, source="testshop"))
+
+            # Scan again — should replace, not duplicate
+            scan_table_for_pii(tmp_path, "testshop", "customers")
+            second_count = len(get_pii_findings(tmp_path, source="testshop"))
+
+        assert second_count == first_count
+
+    def test_non_string_columns_skipped(self, tmp_path: Path) -> None:
+        """Non-string columns (INTEGER, DOUBLE) are not scanned."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.return_value = []
+
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            scan_table_for_pii(tmp_path, "testshop", "customers")
+
+        # Analyzer should only be called for string columns (email, phone)
+        # not for id (INTEGER) or total (DOUBLE)
+        for call in mock_analyzer.analyze.call_args_list:
+            text = call.kwargs.get("text") or call.args[0] if call.args else None
+            if text:
+                # Should never see numeric values
+                assert not text.replace(".", "").isdigit()
+
+
+@pytest.mark.integration
+class TestPiiHookBoundaryIntegration:
+    """Integration tests for the full hook boundary path."""
+
+    def test_dispatch_to_pii_scan(self, tmp_path: Path) -> None:
+        """dispatch_post_sync_hooks → _run_pii_scan → scan_sources_for_pii."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+        mock_analyzer = _mock_analyzer_with_findings()
+
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+
+        # Verify findings were recorded in SQLite
+        with connect(tmp_path) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM pii_findings WHERE source = 'testshop'"
+            ).fetchone()[0]
+
+        assert count >= 1
+
+
+@pytest.mark.integration
+class TestPiiFindingsQuery:
+    """Integration tests for PII findings queries."""
+
+    def test_query_with_filters(self, tmp_path: Path) -> None:
+        """Query findings with source and table filters."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+        mock_analyzer = _mock_analyzer_with_findings()
+
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            scan_sources_for_pii(tmp_path, ["testshop"])
+
+        # Query all
+        all_findings = get_pii_findings(tmp_path)
+        assert len(all_findings) >= 1
+
+        # Query with source filter
+        filtered = get_pii_findings(tmp_path, source="testshop")
+        assert len(filtered) >= 1
+
+        # Query with table filter
+        table_filtered = get_pii_findings(tmp_path, source="testshop", table_name="customers")
+        assert len(table_filtered) >= 1
+
+        # Query with limit
+        limited = get_pii_findings(tmp_path, limit=1)
+        assert len(limited) == 1
+
+        # Newest first
+        assert limited[0]["id"] == all_findings[0]["id"]

--- a/tests/unit/test_pii_detection.py
+++ b/tests/unit/test_pii_detection.py
@@ -1,0 +1,461 @@
+"""tests/unit/test_pii_detection.py
+
+Unit tests for PII detection (dango/governance/pii_detector.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.governance.pii_detector import (
+    _cache_findings,
+    _get_analyzer,
+    _get_existing_keys,
+    _is_string_type,
+    _scan_column,
+    _send_pii_webhook,
+    get_pii_findings,
+    scan_sources_for_pii,
+    scan_table_for_pii,
+)
+
+_PII = "dango.governance.pii_detector"
+_WH = "dango.platform.notifications.webhook"
+
+
+def _make_warehouse(tmp_path: Path) -> Path:
+    db_path = tmp_path / "data" / "warehouse.duckdb"
+    db_path.parent.mkdir(parents=True)
+    db_path.touch()
+    return db_path
+
+
+def _mock_httpx_client(status_code: int = 200) -> tuple[MagicMock, MagicMock]:
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.post.return_value = mock_response
+    return mock_client, mock_response
+
+
+def _mock_connect(mock_conn: MagicMock) -> MagicMock:
+    """Return a patch target for connect() that yields mock_conn."""
+    mock_ctx = MagicMock()
+    mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_ctx
+
+
+@pytest.mark.unit
+class TestIsStringType:
+    """Unit tests for _is_string_type helper."""
+
+    def test_varchar_is_string(self) -> None:
+        assert _is_string_type("VARCHAR") is True
+
+    def test_text_is_string(self) -> None:
+        assert _is_string_type("TEXT") is True
+
+    def test_integer_is_not_string(self) -> None:
+        assert _is_string_type("INTEGER") is False
+
+    def test_case_insensitive(self) -> None:
+        assert _is_string_type("varchar") is True
+        assert _is_string_type("Varchar") is True
+
+
+@pytest.mark.unit
+class TestGetAnalyzer:
+    """Unit tests for _get_analyzer singleton."""
+
+    def test_caches_analyzer(self) -> None:
+        import sys
+
+        mock_analyzer = MagicMock()
+        with (
+            patch(f"{_PII}._analyzer", None),
+            patch(f"{_PII}.spacy", create=True) as mock_spacy,
+            patch("presidio_analyzer.AnalyzerEngine", return_value=mock_analyzer) as mock_cls,
+        ):
+            sys.modules["spacy"] = mock_spacy
+            try:
+                result = _get_analyzer()
+                assert result is mock_analyzer
+                mock_cls.assert_called_once()
+            finally:
+                del sys.modules["spacy"]
+
+    def test_download_fallback(self) -> None:
+        import sys
+
+        mock_spacy = MagicMock()
+        mock_spacy.load.side_effect = OSError("Model not found")
+        mock_analyzer = MagicMock()
+        sys.modules["spacy"] = mock_spacy
+        try:
+            with (
+                patch(f"{_PII}._analyzer", None),
+                patch("presidio_analyzer.AnalyzerEngine", return_value=mock_analyzer),
+            ):
+                result = _get_analyzer()
+                mock_spacy.cli.download.assert_called_once_with("en_core_web_sm")
+                assert result is mock_analyzer
+        finally:
+            del sys.modules["spacy"]
+
+    def test_runtime_error_on_download_failure(self) -> None:
+        import sys
+
+        mock_spacy = MagicMock()
+        mock_spacy.load.side_effect = OSError("Model not found")
+        mock_spacy.cli.download.side_effect = RuntimeError("download failed")
+        sys.modules["spacy"] = mock_spacy
+        try:
+            with patch(f"{_PII}._analyzer", None):
+                with pytest.raises(RuntimeError, match="spaCy model"):
+                    _get_analyzer()
+        finally:
+            del sys.modules["spacy"]
+
+
+@pytest.mark.unit
+class TestScanColumn:
+    """Unit tests for _scan_column."""
+
+    def test_detects_entities(self) -> None:
+        r = MagicMock(entity_type="EMAIL_ADDRESS", score=0.85)
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.return_value = [r]
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            result = _scan_column(["test@example.com"])
+        assert "EMAIL_ADDRESS" in result
+        assert result["EMAIL_ADDRESS"]["confidence"] == 0.85
+        assert result["EMAIL_ADDRESS"]["count"] == 1
+
+    def test_filters_below_threshold(self) -> None:
+        r = MagicMock(entity_type="PERSON", score=0.3)
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.return_value = [r]
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            result = _scan_column(["John"])
+        assert result == {}
+
+    def test_aggregates_multiple_detections(self) -> None:
+        r1 = MagicMock(entity_type="EMAIL_ADDRESS", score=0.7)
+        r2 = MagicMock(entity_type="EMAIL_ADDRESS", score=0.9)
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.side_effect = [[r1], [r2]]
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            result = _scan_column(["a@b.com", "c@d.com"])
+        assert result["EMAIL_ADDRESS"]["confidence"] == 0.9
+        assert result["EMAIL_ADDRESS"]["count"] == 2
+
+    def test_empty_values(self) -> None:
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.return_value = []
+        with patch(f"{_PII}._get_analyzer", return_value=mock_analyzer):
+            result = _scan_column([])
+        assert result == {}
+
+
+@pytest.mark.unit
+class TestScanTableForPii:
+    """Unit tests for scan_table_for_pii."""
+
+    def test_scans_string_columns_only(self) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.side_effect = [
+            [("email", "VARCHAR"), ("age", "INTEGER"), ("name", "TEXT")],
+            [("test@example.com",)],
+            [("John",)],
+        ]
+        with (
+            patch("duckdb.connect", return_value=mock_conn),
+            patch(f"{_PII}._scan_column", return_value={}) as mock_scan,
+            patch(f"{_PII}._cache_findings"),
+        ):
+            scan_table_for_pii(Path("/tmp/test"), "shopify", "orders")
+        assert mock_scan.call_count == 2
+
+    def test_resilient_cache_returns_findings(self) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.side_effect = [
+            [("email", "VARCHAR")],
+            [("test@example.com",)],
+        ]
+        with (
+            patch("duckdb.connect", return_value=mock_conn),
+            patch(
+                f"{_PII}._scan_column",
+                return_value={"EMAIL_ADDRESS": {"confidence": 0.9, "count": 1}},
+            ),
+            patch(f"{_PII}._cache_findings", side_effect=OSError("disk full")),
+        ):
+            result = scan_table_for_pii(Path("/tmp/test"), "shopify", "orders")
+        assert len(result) == 1
+        assert result[0]["entity_type"] == "EMAIL_ADDRESS"
+
+    def test_per_column_error_isolation(self) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.side_effect = [
+            [("email", "VARCHAR"), ("phone", "VARCHAR")],
+            RuntimeError("column error"),
+            [("555-1234",)],
+        ]
+        with (
+            patch("duckdb.connect", return_value=mock_conn),
+            patch(f"{_PII}._scan_column", return_value={}),
+            patch(f"{_PII}._cache_findings"),
+        ):
+            scan_table_for_pii(Path("/tmp/test"), "shopify", "orders")
+
+
+@pytest.mark.unit
+class TestScanSourcesForPii:
+    """Unit tests for scan_sources_for_pii."""
+
+    def test_missing_warehouse_skips(self, tmp_path: Path) -> None:
+        assert scan_sources_for_pii(tmp_path, ["shopify"]) == []
+
+    def test_table_discovery_per_source(self, tmp_path: Path) -> None:
+        _make_warehouse(tmp_path)
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [("orders",)]
+        with (
+            patch("duckdb.connect", return_value=mock_conn),
+            patch(f"{_PII}.scan_table_for_pii", return_value=[]) as mock_scan,
+            patch(f"{_PII}._get_existing_keys", return_value=set()),
+            patch(f"{_PII}._send_pii_webhook"),
+        ):
+            scan_sources_for_pii(tmp_path, ["shopify"])
+        mock_scan.assert_called_once_with(tmp_path, "shopify", "orders")
+
+    def test_per_source_error_isolation(self, tmp_path: Path) -> None:
+        _make_warehouse(tmp_path)
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mc = MagicMock()
+            if call_count == 1:
+                mc.execute.side_effect = RuntimeError("source error")
+            else:
+                mc.execute.return_value.fetchall.return_value = [("items",)]
+            return mc
+
+        with (
+            patch("duckdb.connect", side_effect=side_effect),
+            patch(f"{_PII}.scan_table_for_pii", return_value=[]) as mock_scan,
+            patch(f"{_PII}._get_existing_keys", return_value=set()),
+            patch(f"{_PII}._send_pii_webhook"),
+        ):
+            scan_sources_for_pii(tmp_path, ["bad_source", "good_source"])
+        mock_scan.assert_called_once_with(tmp_path, "good_source", "items")
+
+    def test_webhook_for_new_findings_only(self, tmp_path: Path) -> None:
+        _make_warehouse(tmp_path)
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [("orders",)]
+        existing = {("shopify", "orders", "email", "EMAIL_ADDRESS")}
+        new_f = {
+            "source": "shopify",
+            "table_name": "orders",
+            "column_name": "phone",
+            "entity_type": "PHONE_NUMBER",
+            "confidence": 0.8,
+            "sample_count": 5,
+            "scanned_at": "2026-01-01",
+        }
+        old_f = {
+            "source": "shopify",
+            "table_name": "orders",
+            "column_name": "email",
+            "entity_type": "EMAIL_ADDRESS",
+            "confidence": 0.9,
+            "sample_count": 10,
+            "scanned_at": "2026-01-01",
+        }
+        with (
+            patch("duckdb.connect", return_value=mock_conn),
+            patch(f"{_PII}.scan_table_for_pii", return_value=[new_f, old_f]),
+            patch(f"{_PII}._get_existing_keys", return_value=existing),
+            patch(f"{_PII}._send_pii_webhook") as mock_webhook,
+        ):
+            scan_sources_for_pii(tmp_path, ["shopify"])
+        mock_webhook.assert_called_once()
+        sent = mock_webhook.call_args[0][2]
+        assert len(sent) == 1
+        assert sent[0]["entity_type"] == "PHONE_NUMBER"
+
+    def test_no_webhook_when_all_existing(self, tmp_path: Path) -> None:
+        _make_warehouse(tmp_path)
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [("orders",)]
+        existing = {("shopify", "orders", "email", "EMAIL_ADDRESS")}
+        old_f = {
+            "source": "shopify",
+            "table_name": "orders",
+            "column_name": "email",
+            "entity_type": "EMAIL_ADDRESS",
+            "confidence": 0.9,
+            "sample_count": 10,
+            "scanned_at": "2026-01-01",
+        }
+        with (
+            patch("duckdb.connect", return_value=mock_conn),
+            patch(f"{_PII}.scan_table_for_pii", return_value=[old_f]),
+            patch(f"{_PII}._get_existing_keys", return_value=existing),
+            patch(f"{_PII}._send_pii_webhook") as mock_webhook,
+        ):
+            scan_sources_for_pii(tmp_path, ["shopify"])
+        mock_webhook.assert_not_called()
+
+
+@pytest.mark.unit
+class TestGetPiiFindings:
+    """Unit tests for get_pii_findings."""
+
+    def test_newest_first_ordering(self, tmp_path: Path) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            (2, "shopify", "orders", "phone", "PHONE_NUMBER", 0.8, 5, "2026-01-02"),
+            (1, "shopify", "orders", "email", "EMAIL_ADDRESS", 0.9, 10, "2026-01-01"),
+        ]
+        with patch(f"{_PII}.connect", _mock_connect(mock_conn)):
+            result = get_pii_findings(tmp_path)
+        assert result[0]["id"] == 2
+        assert result[1]["id"] == 1
+
+    def test_source_filter(self, tmp_path: Path) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        with patch(f"{_PII}.connect", _mock_connect(mock_conn)):
+            get_pii_findings(tmp_path, source="shopify")
+        assert "source = ?" in mock_conn.execute.call_args[0][0]
+
+    def test_table_filter(self, tmp_path: Path) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        with patch(f"{_PII}.connect", _mock_connect(mock_conn)):
+            get_pii_findings(tmp_path, table_name="orders")
+        assert "table_name = ?" in mock_conn.execute.call_args[0][0]
+
+    def test_limit_applied(self, tmp_path: Path) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        with patch(f"{_PII}.connect", _mock_connect(mock_conn)):
+            get_pii_findings(tmp_path, limit=25)
+        assert 25 in mock_conn.execute.call_args[0][1]
+
+    def test_empty_result(self, tmp_path: Path) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = []
+        with patch(f"{_PII}.connect", _mock_connect(mock_conn)):
+            result = get_pii_findings(tmp_path)
+        assert result == []
+
+
+@pytest.mark.unit
+class TestSendPiiWebhook:
+    """Unit tests for _send_pii_webhook."""
+
+    _findings: list[dict[str, str]] = [{"entity_type": "EMAIL_ADDRESS", "column_name": "email"}]
+
+    def test_no_config_returns_silently(self, tmp_path: Path) -> None:
+        with patch(f"{_WH}.load_notification_config", return_value=None):
+            _send_pii_webhook(tmp_path, ["shopify"], self._findings)
+
+    def test_on_governance_false_skips(self, tmp_path: Path) -> None:
+        mock_config = MagicMock()
+        mock_config.webhooks = [MagicMock(name="t", url="https://e.com", format="generic")]
+        with (
+            patch(f"{_WH}.load_notification_config", return_value=mock_config),
+            patch(f"{_WH}.should_notify", return_value=False),
+        ):
+            _send_pii_webhook(tmp_path, ["shopify"], self._findings)
+
+    def test_successful_send(self, tmp_path: Path) -> None:
+        mock_config = MagicMock()
+        wh = MagicMock()
+        wh.name, wh.url, wh.format = "test-wh", "https://example.com/hook", "generic"
+        mock_config.webhooks = [wh]
+        mock_client, _ = _mock_httpx_client()
+        with (
+            patch(f"{_WH}.load_notification_config", return_value=mock_config),
+            patch(f"{_WH}.should_notify", return_value=True),
+            patch("httpx.Client", return_value=mock_client),
+        ):
+            _send_pii_webhook(tmp_path, ["shopify"], self._findings)
+        mock_client.post.assert_called_once()
+
+    def test_never_raises_on_failure(self, tmp_path: Path) -> None:
+        with patch(f"{_WH}.load_notification_config", side_effect=RuntimeError("err")):
+            _send_pii_webhook(tmp_path, ["shopify"], self._findings)
+
+    def test_slack_format_dispatch(self, tmp_path: Path) -> None:
+        mock_config = MagicMock()
+        wh = MagicMock()
+        wh.name, wh.url, wh.format = "slack-hook", "https://hooks.slack.com/t", "slack"
+        mock_config.webhooks = [wh]
+        mock_client, _ = _mock_httpx_client()
+        with (
+            patch(f"{_WH}.load_notification_config", return_value=mock_config),
+            patch(f"{_WH}.should_notify", return_value=True),
+            patch("httpx.Client", return_value=mock_client),
+            patch(
+                "dango.platform.notifications.slack.format_slack_message",
+                return_value={"attachments": []},
+            ) as mock_fmt,
+        ):
+            _send_pii_webhook(tmp_path, ["shopify"], self._findings)
+        mock_fmt.assert_called_once()
+
+
+@pytest.mark.unit
+class TestCacheFindings:
+    """Unit tests for _cache_findings."""
+
+    def test_deletes_before_insert(self, tmp_path: Path) -> None:
+        mock_conn = MagicMock()
+        with patch(f"{_PII}.connect", _mock_connect(mock_conn)):
+            findings = [
+                {
+                    "source": "shopify",
+                    "table_name": "orders",
+                    "column_name": "email",
+                    "entity_type": "EMAIL_ADDRESS",
+                    "confidence": 0.9,
+                    "sample_count": 10,
+                    "scanned_at": "2026-01-01",
+                }
+            ]
+            _cache_findings(tmp_path, "shopify", "orders", findings)
+        first_sql = mock_conn.execute.call_args_list[0][0][0]
+        assert "DELETE FROM pii_findings" in first_sql
+        second_sql = mock_conn.execute.call_args_list[1][0][0]
+        assert "INSERT INTO pii_findings" in second_sql
+
+
+@pytest.mark.unit
+class TestGetExistingKeys:
+    """Unit tests for _get_existing_keys."""
+
+    def test_returns_tuples(self, tmp_path: Path) -> None:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("shopify", "orders", "email", "EMAIL_ADDRESS"),
+        ]
+        with patch(f"{_PII}.connect", _mock_connect(mock_conn)):
+            result = _get_existing_keys(tmp_path, "shopify")
+        assert result == {("shopify", "orders", "email", "EMAIL_ADDRESS")}
+
+    def test_returns_empty_on_error(self, tmp_path: Path) -> None:
+        with patch(f"{_PII}.connect", side_effect=OSError("db error")):
+            result = _get_existing_keys(tmp_path, "shopify")
+        assert result == set()


### PR DESCRIPTION
## Summary

- Add PII scanning engine (`governance/pii_detector.py`, 453 lines) using Presidio + spaCy to detect sensitive data patterns (email, phone, SSN, credit card, etc.) in DuckDB warehouse string columns
- Integrate into post-sync hook pipeline via `_run_pii_scan` stub — scans run automatically after each `dango sync`
- Add webhook notifications (generic + Slack) for newly detected PII findings, with first-detection dedup logic
- Add `GET /api/governance/pii` endpoint and `dango governance pii-report` CLI command for querying cached results
- Add `PiiFinding`/`PiiResponse` Pydantic models, `PII_DETECTED` event type, `GOVERNANCE_PII_VIEWED` audit event

## Test plan

- [x] 32 unit tests pass (`pytest tests/unit/test_pii_detection.py`)
- [x] 6 integration tests pass (`pytest tests/integration/test_pii_integration.py`)
- [x] Related tests still pass (drift, post_sync, webhook, slack — 72 tests)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy dango/governance/pii_detector.py` clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)