### PR TITLE
P7-011: Analysis templates, post-sync hook, CLI integration

### DIFF
--- a/dango/analysis/CLAUDE.md
+++ b/dango/analysis/CLAUDE.md
@@ -2,18 +2,19 @@
 
 ## Purpose
 
-Automated metric monitoring and comparison engine. Executes user-defined metrics against DuckDB, stores results in SQLite (`metric_history`, `metric_results` tables in `.dango/dango.db`), and compares current values against historical baselines to detect changes and trends.
+Automated metric monitoring and comparison engine. Executes user-defined metrics against DuckDB, stores results in SQLite (`metric_history`, `metric_results` tables in `.dango/dango.db`), and compares current values against historical baselines to detect changes and trends. Pre-built templates auto-generate metrics for common sources.
 
 ## Files
 
 | File | Purpose | Key Exports |
 |------|---------|-------------|
-| `__init__.py` | Public API re-exports | `run_analysis`, `load_metrics_config`, `DimensionContributor`, `DrillDownDimension` |
+| `__init__.py` | Public API re-exports | `run_analysis`, `load_metrics_config`, `save_metrics_config`, `add_metrics_to_config`, `generate_metrics_for_source`, `DimensionContributor`, `DrillDownDimension` |
 | `models.py` | Pydantic V2 models | `ComparisonType`, `MetricConfig`, `MetricsConfig`, `MetricValue`, `ComparisonResult`, `DimensionContributor`, `DrillDownDimension`, `AnalysisResult` |
-| `config.py` | YAML config loader | `load_metrics_config()`, `get_metrics_file_path()` |
+| `config.py` | YAML config load/save | `load_metrics_config()`, `save_metrics_config()`, `add_metrics_to_config()`, `get_metrics_file_path()` |
 | `comparisons.py` | Comparison engine + trend detection | `compute_comparison()`, `detect_trend()` |
 | `drilldown.py` | Drill-down engine: GROUP BY breakdown + contributor ranking | `run_drill_down()` |
 | `metrics.py` | Orchestration: execute → store → compare → drill-down | `run_analysis()` |
+| `templates.py` | Pre-built metric templates for common sources | `generate_metrics_for_source()` |
 
 ## Common Tasks
 
@@ -22,6 +23,8 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 | Add a new comparison type | `models.py` (`ComparisonType` enum) + `comparisons.py` (`_get_baseline`) | `pytest tests/unit/test_analysis_comparisons.py` |
 | Change metric validation | `models.py` (`MetricConfig` validators) | `pytest tests/unit/test_analysis_models.py` |
 | Change config file format | `config.py` | `pytest tests/unit/test_analysis_config.py` |
+| Save/merge metrics config | `config.py` (`save_metrics_config`, `add_metrics_to_config`) | `pytest tests/unit/test_analysis_config.py` |
+| Add source template | `templates.py` (add generator + register in dispatch dict) | `pytest tests/unit/test_analysis_templates.py` |
 | Modify trend detection | `comparisons.py` (`detect_trend`, `_linear_regression`) | `pytest tests/unit/test_analysis_comparisons.py` |
 | Change metric execution | `metrics.py` (`_execute_metric`, `_build_metric_sql`) | `pytest tests/unit/test_analysis_metrics.py` |
 | Add/modify drill-down logic | `drilldown.py` (`run_drill_down`, `_compute_contributors`) | `pytest tests/unit/test_analysis_drilldown.py` |
@@ -37,7 +40,9 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 
 **Used by:**
 - `metrics.py` — calls `run_drill_down()` from `drilldown.py` when threshold exceeded
-- `utils/post_sync.py` — `_run_analysis()` stub (populated by P7-011)
+- `utils/post_sync.py` — `_run_analysis()` calls `run_analysis` with `raw_`-prefixed source filter
+- `cli/source_wizard.py` — `generate_metrics_for_source()` + `add_metrics_to_config()` on source add
+- `cli/init.py` — `save_metrics_config()` + `generate_metrics_for_source()` on project init
 - `web/routes/insights.py` — planned (P7-012)
 - `cli/commands/analyze.py` — planned (P7-012)
 
@@ -46,7 +51,8 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 ```
 pytest tests/unit/test_analysis_models.py tests/unit/test_analysis_config.py \
   tests/unit/test_analysis_comparisons.py tests/unit/test_analysis_metrics.py \
-  tests/unit/test_analysis_drilldown.py -v
+  tests/unit/test_analysis_drilldown.py tests/unit/test_analysis_templates.py -v
+pytest tests/integration/test_analysis_integration.py -v
 ```
 
 ## Don't Modify

--- a/dango/analysis/__init__.py
+++ b/dango/analysis/__init__.py
@@ -3,13 +3,21 @@
 Automated data analysis module.
 """
 
-from dango.analysis.config import load_metrics_config
+from dango.analysis.config import (
+    add_metrics_to_config,
+    load_metrics_config,
+    save_metrics_config,
+)
 from dango.analysis.metrics import run_analysis
 from dango.analysis.models import DimensionContributor, DrillDownDimension
+from dango.analysis.templates import generate_metrics_for_source
 
 __all__: list[str] = [
     "DimensionContributor",
     "DrillDownDimension",
+    "add_metrics_to_config",
+    "generate_metrics_for_source",
     "load_metrics_config",
     "run_analysis",
+    "save_metrics_config",
 ]

--- a/dango/analysis/config.py
+++ b/dango/analysis/config.py
@@ -1,6 +1,6 @@
 """dango/analysis/config.py
 
-Load and validate the metrics configuration from ``.dango/metrics.yml``.
+Load, save, and validate the metrics configuration from ``.dango/metrics.yml``.
 
 Mirrors the ``load_schedules_config()`` pattern in ``dango/config/schedules.py``.
 Missing file → empty ``MetricsConfig``.  Invalid YAML or Pydantic errors →
@@ -14,7 +14,7 @@ from typing import Any
 
 import yaml
 
-from dango.analysis.models import MetricsConfig
+from dango.analysis.models import MetricConfig, MetricsConfig
 from dango.exceptions import AnalysisConfigError
 from dango.logging import get_logger
 
@@ -61,3 +61,61 @@ def load_metrics_config(project_root: Path) -> MetricsConfig:
         return MetricsConfig(**data)
     except Exception as e:
         raise AnalysisConfigError(f"Invalid metrics configuration in {path}:\n{e}") from e
+
+
+def save_metrics_config(
+    project_root: Path,
+    config: MetricsConfig,
+    *,
+    header_comment: str | None = None,
+) -> None:
+    """Serialize ``MetricsConfig`` to ``.dango/metrics.yml``.
+
+    Args:
+        project_root: Path to the Dango project root.
+        config: The metrics configuration to save.
+        header_comment: Optional comment block prepended to the file.
+    """
+    path = get_metrics_file_path(project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    data: dict[str, Any] = {
+        "enabled": config.enabled,
+        "metrics": [m.model_dump(exclude_none=True, mode="json") for m in config.metrics],
+    }
+
+    lines: list[str] = []
+    if header_comment:
+        for line in header_comment.splitlines():
+            lines.append(f"# {line}" if line.strip() else "#")
+        lines.append("")
+
+    lines.append(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def add_metrics_to_config(
+    project_root: Path,
+    new_metrics: list[MetricConfig],
+    *,
+    header_comment: str | None = None,
+) -> MetricsConfig:
+    """Load existing config, append new metrics (dedup by name), and save.
+
+    Existing metrics with the same name are preserved (not overwritten).
+
+    Args:
+        project_root: Path to the Dango project root.
+        new_metrics: Metrics to add.
+        header_comment: Optional comment block prepended to the file.
+
+    Returns:
+        The merged ``MetricsConfig``.
+    """
+    existing = load_metrics_config(project_root)
+    existing_names = {m.name for m in existing.metrics}
+    merged = list(existing.metrics) + [m for m in new_metrics if m.name not in existing_names]
+    config = MetricsConfig(enabled=existing.enabled, metrics=merged)
+    save_metrics_config(project_root, config, header_comment=header_comment)
+    return config

--- a/dango/analysis/templates.py
+++ b/dango/analysis/templates.py
@@ -1,0 +1,126 @@
+"""dango/analysis/templates.py
+
+Pre-built metric templates for common data sources.
+
+Generates sensible default ``MetricConfig`` objects when users add a new source,
+so analysis starts working automatically from the first sync.
+"""
+
+from __future__ import annotations
+
+from dango.analysis.models import ComparisonType, MetricConfig
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_metrics_for_source(
+    source_type: str,
+    source_name: str,
+) -> list[MetricConfig]:
+    """Generate pre-built metric templates for a data source.
+
+    Args:
+        source_type: The type of source (e.g. ``"stripe"``, ``"google_analytics"``).
+        source_name: The user-chosen name for this source instance.
+
+    Returns:
+        A list of ``MetricConfig`` objects.  Empty if the source type has no
+        pre-built templates.
+    """
+    generators = {
+        "stripe": _stripe_metrics,
+        "google_analytics": _google_analytics_metrics,
+        "csv": _csv_metrics,
+    }
+    generator = generators.get(source_type)
+    if generator is None:
+        return []
+    return generator(source_name)
+
+
+# ---------------------------------------------------------------------------
+# Private template generators
+# ---------------------------------------------------------------------------
+
+
+def _stripe_metrics(name: str) -> list[MetricConfig]:
+    """Stripe metrics: revenue, customers, refund rate, AOV."""
+    schema = f"raw_{name}"
+    return [
+        MetricConfig(
+            name=f"{name}_daily_revenue",
+            source_table=f"{schema}.charge",
+            value_expression="SUM(amount) / 100.0",
+            filter="status = 'succeeded'",
+            compare=ComparisonType.week_over_week,
+            warn_threshold=20.0,
+            drill_down=["currency"],
+        ),
+        MetricConfig(
+            name=f"{name}_new_customers",
+            source_table=f"{schema}.customer",
+            value_expression="COUNT(*)",
+            compare=ComparisonType.week_over_week,
+            warn_threshold=25.0,
+        ),
+        MetricConfig(
+            name=f"{name}_refund_rate",
+            source_table=f"{schema}.charge",
+            value_expression=("COUNT(CASE WHEN refunded THEN 1 END) * 100.0 / NULLIF(COUNT(*), 0)"),
+            compare=ComparisonType.rolling_7day_avg,
+            warn_threshold=50.0,
+        ),
+        MetricConfig(
+            name=f"{name}_avg_order_value",
+            source_table=f"{schema}.charge",
+            value_expression="AVG(amount) / 100.0",
+            filter="status = 'succeeded'",
+            compare=ComparisonType.rolling_7day_avg,
+            warn_threshold=15.0,
+        ),
+    ]
+
+
+def _google_analytics_metrics(name: str) -> list[MetricConfig]:
+    """Google Analytics metrics: sessions, bounce rate, avg session duration."""
+    schema = f"raw_{name}"
+    return [
+        MetricConfig(
+            name=f"{name}_daily_sessions",
+            source_table=f"{schema}.traffic",
+            value_expression="SUM(sessions)",
+            compare=ComparisonType.week_over_week,
+            warn_threshold=20.0,
+            drill_down=["session_source"],
+        ),
+        MetricConfig(
+            name=f"{name}_bounce_rate",
+            source_table=f"{schema}.traffic",
+            value_expression="AVG(bounce_rate)",
+            compare=ComparisonType.rolling_7day_avg,
+            warn_threshold=25.0,
+        ),
+        MetricConfig(
+            name=f"{name}_avg_session_duration",
+            source_table=f"{schema}.traffic",
+            value_expression="AVG(average_session_duration)",
+            compare=ComparisonType.rolling_7day_avg,
+            warn_threshold=20.0,
+        ),
+    ]
+
+
+def _csv_metrics(name: str) -> list[MetricConfig]:
+    """CSV metrics: row count (placeholder table)."""
+    schema = f"raw_{name}"
+    return [
+        MetricConfig(
+            name=f"{name}_row_count",
+            source_table=f"{schema}.your_table",
+            value_expression="COUNT(*)",
+            compare=ComparisonType.week_over_week,
+            warn_threshold=10.0,
+        ),
+    ]

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -66,7 +66,7 @@ class ProjectInitializer:
             self.loader.save_config(config)
 
             # Create metrics config
-            self._create_metrics_config(config, force=force)
+            self._create_metrics_config(force=force)
 
             # Create default .gitignore
             self._create_gitignore()
@@ -143,11 +143,12 @@ class ProjectInitializer:
 
         return DangoConfig(project=project, sources=sources)
 
-    def _create_metrics_config(self, config: DangoConfig, *, force: bool = False) -> None:
+    def _create_metrics_config(self, *, force: bool = False) -> None:
         """Create ``.dango/metrics.yml`` with default analysis metrics.
 
         Fresh init creates an empty config.  ``--force`` re-init with existing
-        sources generates templates for configured source types.
+        sources generates templates for configured source types by reading
+        the on-disk ``sources.yml`` (not the wizard config, which is blank).
         """
         try:
             from dango.analysis.config import save_metrics_config
@@ -155,9 +156,11 @@ class ProjectInitializer:
             from dango.analysis.templates import generate_metrics_for_source
 
             all_metrics = []  # type: ignore[var-annotated]
-            if force and config.sources and config.sources.sources:
-                for src in config.sources.sources:
-                    all_metrics.extend(generate_metrics_for_source(src.type, src.name))
+            if force:
+                existing_config = self.loader.load_config()
+                if existing_config.sources and existing_config.sources.sources:
+                    for src in existing_config.sources.sources:
+                        all_metrics.extend(generate_metrics_for_source(src.type, src.name))
 
             metrics_config = MetricsConfig(enabled=True, metrics=all_metrics)
             save_metrics_config(self.project_dir, metrics_config)

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -65,6 +65,9 @@ class ProjectInitializer:
             # Save configuration
             self.loader.save_config(config)
 
+            # Create metrics config
+            self._create_metrics_config(config, force=force)
+
             # Create default .gitignore
             self._create_gitignore()
 
@@ -139,6 +142,27 @@ class ProjectInitializer:
         sources = SourcesConfig()
 
         return DangoConfig(project=project, sources=sources)
+
+    def _create_metrics_config(self, config: DangoConfig, *, force: bool = False) -> None:
+        """Create ``.dango/metrics.yml`` with default analysis metrics.
+
+        Fresh init creates an empty config.  ``--force`` re-init with existing
+        sources generates templates for configured source types.
+        """
+        try:
+            from dango.analysis.config import save_metrics_config
+            from dango.analysis.models import MetricsConfig
+            from dango.analysis.templates import generate_metrics_for_source
+
+            all_metrics = []  # type: ignore[var-annotated]
+            if force and config.sources and config.sources.sources:
+                for src in config.sources.sources:
+                    all_metrics.extend(generate_metrics_for_source(src.type, src.name))
+
+            metrics_config = MetricsConfig(enabled=True, metrics=all_metrics)
+            save_metrics_config(self.project_dir, metrics_config)
+        except Exception:
+            pass  # Non-critical — never block init
 
     def _create_directory_structure(self):
         """Create Dango project directory structure"""

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -205,6 +205,32 @@ class SourceWizard:
             self._save_source(source_config)
             console.print(f"\n[green]✅ Saved '{source_name}' to sources.yml[/green]")
 
+            # Step 10: Offer automatic analysis metrics
+            try:
+                from dango.analysis.templates import generate_metrics_for_source
+
+                templates = generate_metrics_for_source(source_type, source_name)
+                if templates:
+                    if Confirm.ask(
+                        "\n[bold]Enable automatic analysis?[/bold]",
+                        default=True,
+                    ):
+                        from dango.analysis.config import add_metrics_to_config
+
+                        header = None
+                        if source_type == "csv":
+                            header = (
+                                "NOTE: Replace 'your_table' with your actual"
+                                " table name after first sync."
+                            )
+                        add_metrics_to_config(self.project_root, templates, header_comment=header)
+                        console.print(
+                            f"[green]✅ Added {len(templates)} analysis"
+                            f" metric(s) to metrics.yml[/green]"
+                        )
+            except Exception:
+                pass  # Never block source add
+
             # Success messages based on whether secrets were required
             if self.secret_params:
                 console.print(f"\n[green]✅ Source '{source_name}' fully configured![/green]")

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -396,5 +396,13 @@ def _run_pii_scan(project_root: Path, sources: list[str]) -> None:
 def _run_analysis(project_root: Path, sources: list[str]) -> None:
     """Run automated analysis on freshly synced sources.
 
-    Populated by P7-011.
+    Args:
+        project_root: Path to the Dango project root.
+        sources: Names of sources that synced successfully.
     """
+    try:
+        from dango.analysis.metrics import run_analysis
+
+        run_analysis(project_root, source_filter=[f"raw_{s}" for s in sources])
+    except Exception:
+        logger.warning("analysis_hook_error", sources=sources, exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,6 +307,8 @@ module = [
     "tests.unit.test_analysis_comparisons",
     "tests.unit.test_analysis_metrics",
     "tests.unit.test_analysis_drilldown",
+    "tests.unit.test_analysis_templates",
+    "tests.integration.test_analysis_integration",
     "tests.unit.test_notebook_manager",
     "tests.unit.test_notebook_snapshot",
     "tests.unit.test_notebook_locking",

--- a/tests/integration/test_analysis_integration.py
+++ b/tests/integration/test_analysis_integration.py
@@ -1,0 +1,88 @@
+"""tests/integration/test_analysis_integration.py
+
+Integration tests for the analysis hook boundary using real DuckDB and SQLite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from dango.analysis.config import save_metrics_config
+from dango.analysis.models import ComparisonType, MetricConfig, MetricsConfig
+from dango.utils.dango_db import _schema_initialized, connect
+from dango.utils.post_sync import dispatch_post_sync_hooks
+
+
+def _create_test_warehouse(tmp_path: Path) -> Path:
+    """Create a real DuckDB warehouse with test data.
+
+    Returns:
+        Path to the DuckDB file.
+    """
+    db_path = tmp_path / "data" / "warehouse.duckdb"
+    db_path.parent.mkdir(parents=True)
+
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE SCHEMA raw_testshop")
+    conn.execute("""
+        CREATE TABLE raw_testshop.orders (
+            id INTEGER NOT NULL,
+            total DOUBLE,
+            status VARCHAR
+        )
+    """)
+    conn.execute("""
+        INSERT INTO raw_testshop.orders VALUES
+        (1, 10.50, 'succeeded'),
+        (2, 25.00, 'succeeded'),
+        (3, 5.00, 'failed')
+    """)
+    conn.close()
+    return db_path
+
+
+def _clear_schema_cache() -> None:
+    """Clear the dango_db schema initialization cache for test isolation."""
+    _schema_initialized.clear()
+
+
+@pytest.mark.integration
+class TestAnalysisHookIntegration:
+    """Integration tests for the full analysis hook boundary path."""
+
+    def test_dispatch_to_analysis(self, tmp_path: Path) -> None:
+        """dispatch_post_sync_hooks -> _run_analysis -> run_analysis -> SQLite."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+
+        # Create metrics config
+        config = MetricsConfig(
+            enabled=True,
+            metrics=[
+                MetricConfig(
+                    name="testshop_order_total",
+                    source_table="raw_testshop.orders",
+                    value_expression="SUM(total)",
+                    filter="status = 'succeeded'",
+                    compare=ComparisonType.week_over_week,
+                    warn_threshold=20.0,
+                ),
+            ],
+        )
+        save_metrics_config(tmp_path, config)
+
+        # Run via dispatcher (full hook boundary)
+        dispatch_post_sync_hooks(tmp_path, ["testshop"])
+
+        # Verify metric was stored in SQLite
+        with connect(tmp_path) as sqlite_conn:
+            rows = sqlite_conn.execute(
+                "SELECT metric_name, metric_value FROM metric_history "
+                "WHERE metric_name = 'testshop_order_total'"
+            ).fetchall()
+
+        assert len(rows) >= 1
+        assert rows[0][1] == pytest.approx(35.5)  # 10.50 + 25.00

--- a/tests/unit/test_analysis_config.py
+++ b/tests/unit/test_analysis_config.py
@@ -1,14 +1,19 @@
 """tests/unit/test_analysis_config.py
 
-Tests for metrics config loading (dango/analysis/config.py).
+Tests for metrics config loading and saving (dango/analysis/config.py).
 """
 
 from __future__ import annotations
 
 import pytest
 
-from dango.analysis.config import get_metrics_file_path, load_metrics_config
-from dango.analysis.models import ComparisonType
+from dango.analysis.config import (
+    add_metrics_to_config,
+    get_metrics_file_path,
+    load_metrics_config,
+    save_metrics_config,
+)
+from dango.analysis.models import ComparisonType, MetricConfig, MetricsConfig
 from dango.exceptions import AnalysisConfigError
 
 
@@ -110,3 +115,76 @@ metrics:
         cfg = load_metrics_config(tmp_path)
         # MetricsConfig accepts extra keys — metrics defaults to []
         assert cfg.metrics == []
+
+
+def _sample_metric(name: str = "test_metric") -> MetricConfig:
+    """Create a sample MetricConfig for testing."""
+    return MetricConfig(
+        name=name,
+        source_table="raw_test.orders",
+        value_expression="COUNT(*)",
+    )
+
+
+@pytest.mark.unit
+class TestSaveMetricsConfig:
+    """save_metrics_config serialization."""
+
+    def test_round_trip(self, tmp_path):
+        """Save then load returns equivalent config."""
+        original = MetricsConfig(
+            enabled=True,
+            metrics=[_sample_metric()],
+        )
+        save_metrics_config(tmp_path, original)
+        loaded = load_metrics_config(tmp_path)
+        assert loaded.enabled is True
+        assert len(loaded.metrics) == 1
+        assert loaded.metrics[0].name == "test_metric"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        """Creates .dango/ directory if missing."""
+        save_metrics_config(tmp_path, MetricsConfig())
+        assert (tmp_path / ".dango" / "metrics.yml").exists()
+
+    def test_header_comment(self, tmp_path):
+        """Header comment is prepended to the file."""
+        save_metrics_config(
+            tmp_path,
+            MetricsConfig(),
+            header_comment="Replace your_table\nwith real name",
+        )
+        content = (tmp_path / ".dango" / "metrics.yml").read_text()
+        assert "# Replace your_table" in content
+        assert "# with real name" in content
+
+    def test_excludes_none_fields(self, tmp_path):
+        """Fields with None values are excluded from YAML."""
+        save_metrics_config(tmp_path, MetricsConfig(metrics=[_sample_metric()]))
+        content = (tmp_path / ".dango" / "metrics.yml").read_text()
+        assert "filter:" not in content
+        assert "warn_threshold:" not in content
+
+
+@pytest.mark.unit
+class TestAddMetricsToConfig:
+    """add_metrics_to_config dedup and merge."""
+
+    def test_adds_new_metrics(self, tmp_path):
+        """New metrics are appended to empty config."""
+        result = add_metrics_to_config(tmp_path, [_sample_metric()])
+        assert len(result.metrics) == 1
+
+    def test_dedup_by_name(self, tmp_path):
+        """Existing metrics with same name are preserved, not overwritten."""
+        add_metrics_to_config(tmp_path, [_sample_metric("revenue")])
+        result = add_metrics_to_config(tmp_path, [_sample_metric("revenue")])
+        assert len(result.metrics) == 1
+
+    def test_merges_different_names(self, tmp_path):
+        """Metrics with different names are both kept."""
+        add_metrics_to_config(tmp_path, [_sample_metric("alpha")])
+        result = add_metrics_to_config(tmp_path, [_sample_metric("beta")])
+        assert len(result.metrics) == 2
+        names = {m.name for m in result.metrics}
+        assert names == {"alpha", "beta"}

--- a/tests/unit/test_analysis_templates.py
+++ b/tests/unit/test_analysis_templates.py
@@ -1,0 +1,70 @@
+"""tests/unit/test_analysis_templates.py
+
+Tests for pre-built metric templates (dango/analysis/templates.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dango.analysis.templates import generate_metrics_for_source
+
+
+@pytest.mark.unit
+class TestGenerateMetricsForSource:
+    """generate_metrics_for_source returns valid MetricConfig lists."""
+
+    def test_stripe_generates_four_metrics(self) -> None:
+        """Stripe template produces 4 metrics."""
+        metrics = generate_metrics_for_source("stripe", "my_stripe")
+        assert len(metrics) == 4
+
+    def test_stripe_table_prefixes(self) -> None:
+        """All Stripe metrics reference raw_<name>.* tables."""
+        metrics = generate_metrics_for_source("stripe", "payments")
+        for m in metrics:
+            assert m.source_table.startswith("raw_payments.")
+
+    def test_stripe_names_prefixed(self) -> None:
+        """All Stripe metric names are prefixed with source_name."""
+        metrics = generate_metrics_for_source("stripe", "shop")
+        for m in metrics:
+            assert m.name.startswith("shop_")
+
+    def test_google_analytics_generates_three_metrics(self) -> None:
+        """Google Analytics template produces 3 metrics."""
+        metrics = generate_metrics_for_source("google_analytics", "ga")
+        assert len(metrics) == 3
+
+    def test_google_analytics_table_prefixes(self) -> None:
+        """All GA metrics reference raw_<name>.* tables."""
+        metrics = generate_metrics_for_source("google_analytics", "ga")
+        for m in metrics:
+            assert m.source_table.startswith("raw_ga.")
+
+    def test_csv_generates_one_metric(self) -> None:
+        """CSV template produces 1 metric with placeholder table."""
+        metrics = generate_metrics_for_source("csv", "uploads")
+        assert len(metrics) == 1
+        assert "your_table" in metrics[0].source_table
+
+    def test_unknown_source_returns_empty(self) -> None:
+        """Unknown source type returns an empty list."""
+        assert generate_metrics_for_source("unknown_db", "test") == []
+
+    def test_all_templates_unique_names(self) -> None:
+        """All templates produce unique metric names within a source."""
+        for source_type in ("stripe", "google_analytics", "csv"):
+            metrics = generate_metrics_for_source(source_type, "test")
+            names = [m.name for m in metrics]
+            assert len(names) == len(set(names)), f"Duplicate names in {source_type}"
+
+    def test_metrics_are_valid_pydantic(self) -> None:
+        """All generated metrics pass MetricConfig validation."""
+        for source_type in ("stripe", "google_analytics", "csv"):
+            metrics = generate_metrics_for_source(source_type, "test")
+            for m in metrics:
+                # MetricConfig is frozen — accessing fields verifies construction
+                assert m.name
+                assert m.source_table
+                assert m.value_expression

--- a/tests/unit/test_post_sync.py
+++ b/tests/unit/test_post_sync.py
@@ -43,3 +43,15 @@ class TestDispatchPostSyncHooks:
     def test_stubs_are_noop(self, tmp_path: Path):
         """Calling with real stubs does not raise."""
         dispatch_post_sync_hooks(project_root=tmp_path, sources=["test_source"])
+
+    def test_analysis_hook_passes_raw_prefix(self, tmp_path: Path) -> None:
+        """Analysis hook prepends raw_ to source names for source_filter."""
+        with patch(
+            "dango.analysis.metrics.run_analysis",
+            return_value=[],
+        ) as mock_engine:
+            from dango.utils.post_sync import _run_analysis
+
+            _run_analysis(tmp_path, ["stripe", "ga"])
+
+        mock_engine.assert_called_once_with(tmp_path, source_filter=["raw_stripe", "raw_ga"])


### PR DESCRIPTION
## Summary

- Pre-built metric templates for Stripe (4 metrics), Google Analytics (3), CSV (1) via `generate_metrics_for_source()` in `analysis/templates.py`
- Post-sync hook `_run_analysis` populated — triggers `run_analysis()` with `raw_`-prefixed source filter after every successful sync
- Source wizard prompts "Enable automatic analysis?" after saving a source, adds generated metrics to `metrics.yml` with dedup
- `dango init` creates empty `metrics.yml`; `--force` re-init generates templates for existing sources
- `save_metrics_config()` and `add_metrics_to_config()` added to `analysis/config.py` for YAML serialization with header comments and name-based dedup

## Test plan

- [x] 9 unit tests for templates (all source types, validation, uniqueness, unknown type)
- [x] 7 unit tests for config save/merge (round-trip, header comments, dedup, parent dir creation)
- [x] 1 unit test for post-sync hook (raw_ prefix mapping)
- [x] 1 integration test (full hook boundary: dispatch → run_analysis → SQLite writes with real DuckDB)
- [x] Full suite: 2702 passed, 0 failed
- [x] All pre-commit hooks pass (ruff, format, mypy, headers, docstrings, file sizes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)