### PR TITLE
P7-004: Catalog lineage graph visualization

### DIFF
--- a/dango/web/static/css/catalog.css
+++ b/dango/web/static/css/catalog.css
@@ -36,3 +36,50 @@
     border-radius: 3px;
     background-color: #f59e0b;
 }
+
+/* Lineage graph */
+.lineage-svg { background: #fafafa; border-radius: 0.5rem; }
+.lineage-arrow-path { fill: #9ca3af; }
+
+/* Node base */
+.lineage-node rect { stroke-width: 1.5; fill: #fef3c7; stroke: #f59e0b; }
+.lineage-node text { font-size: 12px; fill: #1f2937; pointer-events: none; }
+.lineage-node:hover rect { filter: brightness(0.95); }
+
+/* Node type colors */
+.lineage-node.source rect { fill: #dbeafe; stroke: #3b82f6; }
+.lineage-node.staging rect { fill: #d1fae5; stroke: #10b981; }
+.lineage-node.mart rect { fill: #ede9fe; stroke: #8b5cf6; }
+.lineage-node.intermediate rect { fill: #fef3c7; stroke: #f59e0b; }
+
+/* Node states */
+.lineage-node.selected rect { stroke-width: 2.5; filter: drop-shadow(0 1px 3px rgba(0,0,0,0.15)); }
+.lineage-node.dimmed { opacity: 0.2; }
+.lineage-node.highlighted rect { stroke-width: 2.5; filter: drop-shadow(0 1px 3px rgba(0,0,0,0.15)); }
+
+/* Edges */
+.lineage-edge { fill: none; stroke: #9ca3af; stroke-width: 1.5; }
+.lineage-edge.highlighted { stroke: #6366f1; stroke-width: 2.5; }
+.lineage-edge.dimmed { opacity: 0.1; }
+
+/* Lineage container */
+.lineage-wrapper { position: relative; }
+.lineage-controls { position: absolute; top: 0.5rem; right: 0.5rem; display: flex; gap: 0.25rem; z-index: 10; }
+.lineage-controls button {
+    width: 28px; height: 28px; border-radius: 4px;
+    background: white; border: 1px solid #d1d5db; color: #374151;
+    font-size: 14px; cursor: pointer; display: flex; align-items: center; justify-content: center;
+}
+.lineage-controls button:hover { background: #f3f4f6; }
+
+/* Detail panel */
+.lineage-detail {
+    position: absolute; top: 0; right: 0; width: 320px; height: 100%;
+    background: white; border-left: 1px solid #e5e7eb; box-shadow: -2px 0 8px rgba(0,0,0,0.06);
+    overflow-y: auto; z-index: 20; transition: transform 0.2s ease;
+}
+.lineage-detail-header { padding: 1rem; border-bottom: 1px solid #e5e7eb; }
+.lineage-detail-body { padding: 1rem; }
+.lineage-detail-row { display: flex; justify-content: space-between; padding: 0.35rem 0; font-size: 0.875rem; }
+.lineage-detail-label { color: #6b7280; }
+.lineage-detail-value { color: #111827; font-weight: 500; }

--- a/dango/web/static/css/catalog.css
+++ b/dango/web/static/css/catalog.css
@@ -43,7 +43,7 @@
 
 /* Node base */
 .lineage-node rect { stroke-width: 1.5; fill: #fef3c7; stroke: #f59e0b; }
-.lineage-node text { font-size: 12px; fill: #1f2937; pointer-events: none; }
+.lineage-node text { font-size: 12px; fill: #1f2937; font-family: ui-sans-serif, system-ui, sans-serif; pointer-events: none; }
 .lineage-node:hover rect { filter: brightness(0.95); }
 
 /* Node type colors */
@@ -76,7 +76,7 @@
 .lineage-detail {
     position: absolute; top: 0; right: 0; width: 320px; height: 100%;
     background: white; border-left: 1px solid #e5e7eb; box-shadow: -2px 0 8px rgba(0,0,0,0.06);
-    overflow-y: auto; z-index: 20; transition: transform 0.2s ease;
+    overflow-y: auto; z-index: 20;
 }
 .lineage-detail-header { padding: 1rem; border-bottom: 1px solid #e5e7eb; }
 .lineage-detail-body { padding: 1rem; }

--- a/dango/web/static/js/lineage.js
+++ b/dango/web/static/js/lineage.js
@@ -75,7 +75,9 @@
         for (i = 0; i < queue.length; i++) layer[queue[i]] = 0;
 
         var head = 0;
-        while (head < queue.length) {
+        var maxIter = nodes.length * edges.length + nodes.length;
+        var iter = 0;
+        while (head < queue.length && iter++ < maxIter) {
             var cur = queue[head++];
             var ch = children[cur];
             for (var j = 0; j < ch.length; j++) {
@@ -201,7 +203,7 @@
         var w = container.clientWidth || 800;
         var h = container.clientHeight || 600;
 
-        this._svg = d3.select("#" + this._containerId)
+        this._svg = d3.select(container)
             .append("svg")
             .attr("width", w)
             .attr("height", h)
@@ -311,6 +313,14 @@
         });
     };
 
+    /**
+     * Highlight downstream impact nodes/edges.
+     *
+     * Note: matching is by name because the impact API returns names, not
+     * unique_ids.  If a source and model share the same name (valid in dbt),
+     * both will be highlighted.  Acceptable trade-off — the backend resolves
+     * ambiguity by preferring models.
+     */
     DangoLineage.prototype.highlightImpact = function (nodeId, impactData) {
         if (!impactData || !impactData.tree) return;
         var impactNames = new Set();

--- a/dango/web/static/js/lineage.js
+++ b/dango/web/static/js/lineage.js
@@ -1,0 +1,410 @@
+/**
+ * DangoLineage — D3.js DAG visualization for dbt lineage.
+ *
+ * Layered (Sugiyama-style) left-to-right layout with zoom/pan,
+ * click-to-select, and downstream impact highlighting.
+ */
+(function () {
+    "use strict";
+
+    var NODE_W = 140;
+    var NODE_H = 40;
+    var LAYER_GAP = 200;
+    var NODE_GAP = 80;
+    var TRUNC_LEN = 18;
+
+    function classifyNode(node) {
+        if (node.type === "source") return "source";
+        var n = node.name || "";
+        if (n.startsWith("stg_")) return "staging";
+        if (n.startsWith("fct_") || n.startsWith("dim_")) return "mart";
+        return "intermediate";
+    }
+
+    function truncate(s) {
+        if (!s) return "";
+        return s.length > TRUNC_LEN ? s.slice(0, TRUNC_LEN) + "\u2026" : s;
+    }
+
+    function safeDomId(id) {
+        return id.replace(/[^a-zA-Z0-9_-]/g, "-");
+    }
+
+    /** Collect all downstream names from an impact tree recursively. */
+    function collectImpactNames(tree, out) {
+        if (!tree) return;
+        if (tree.name) out.add(tree.name);
+        if (tree.children) {
+            for (var i = 0; i < tree.children.length; i++) {
+                collectImpactNames(tree.children[i], out);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Layout
+    // -----------------------------------------------------------------------
+
+    /** Assign layers via BFS from roots (nodes with no incoming edges). */
+    function assignLayers(nodes, edges) {
+        var idSet = {};
+        for (var i = 0; i < nodes.length; i++) idSet[nodes[i].id] = true;
+
+        var children = {};  // id -> [child ids]
+        var parents = {};   // id -> [parent ids]
+        for (i = 0; i < nodes.length; i++) {
+            children[nodes[i].id] = [];
+            parents[nodes[i].id] = [];
+        }
+        for (i = 0; i < edges.length; i++) {
+            var s = edges[i].source, t = edges[i].target;
+            if (idSet[s] && idSet[t]) {
+                children[s].push(t);
+                parents[t].push(s);
+            }
+        }
+
+        // Roots: no parents
+        var roots = [];
+        for (i = 0; i < nodes.length; i++) {
+            if (parents[nodes[i].id].length === 0) roots.push(nodes[i].id);
+        }
+
+        var layer = {};
+        var queue = roots.slice();
+        for (i = 0; i < queue.length; i++) layer[queue[i]] = 0;
+
+        var head = 0;
+        while (head < queue.length) {
+            var cur = queue[head++];
+            var ch = children[cur];
+            for (var j = 0; j < ch.length; j++) {
+                var cid = ch[j];
+                var newL = layer[cur] + 1;
+                if (layer[cid] === undefined) {
+                    layer[cid] = newL;
+                    queue.push(cid);
+                } else if (newL > layer[cid]) {
+                    layer[cid] = newL;
+                    queue.push(cid);  // re-process to push further
+                }
+            }
+        }
+
+        // Defensive: assign unvisited nodes
+        var maxL = 0;
+        for (var k in layer) { if (layer[k] > maxL) maxL = layer[k]; }
+        for (i = 0; i < nodes.length; i++) {
+            if (layer[nodes[i].id] === undefined) layer[nodes[i].id] = maxL + 1;
+        }
+
+        return { layers: layer, children: children, parents: parents };
+    }
+
+    /** Order nodes within each layer by barycenter of parent positions. */
+    function orderByBarycenter(nodes, layerMap, parentsMap) {
+        // Group by layer
+        var byLayer = {};
+        for (var i = 0; i < nodes.length; i++) {
+            var l = layerMap[nodes[i].id];
+            if (!byLayer[l]) byLayer[l] = [];
+            byLayer[l].push(nodes[i]);
+        }
+
+        var layerNums = Object.keys(byLayer).map(Number).sort(function (a, b) { return a - b; });
+
+        // Assign initial indices within each layer
+        var posInLayer = {};
+        for (i = 0; i < layerNums.length; i++) {
+            var arr = byLayer[layerNums[i]];
+            for (var j = 0; j < arr.length; j++) posInLayer[arr[j].id] = j;
+        }
+
+        // One pass of barycenter ordering
+        for (i = 1; i < layerNums.length; i++) {
+            var layerNodes = byLayer[layerNums[i]];
+            for (j = 0; j < layerNodes.length; j++) {
+                var ps = parentsMap[layerNodes[j].id] || [];
+                if (ps.length > 0) {
+                    var sum = 0;
+                    for (var p = 0; p < ps.length; p++) sum += (posInLayer[ps[p]] || 0);
+                    posInLayer[layerNodes[j].id] = sum / ps.length;
+                }
+            }
+            layerNodes.sort(function (a, b) {
+                return (posInLayer[a.id] || 0) - (posInLayer[b.id] || 0);
+            });
+            for (j = 0; j < layerNodes.length; j++) posInLayer[layerNodes[j].id] = j;
+        }
+
+        return { byLayer: byLayer, layerNums: layerNums };
+    }
+
+    /** Compute x/y positions for each node. */
+    function computePositions(nodes, edges) {
+        var info = assignLayers(nodes, edges);
+        var ordered = orderByBarycenter(nodes, info.layers, info.parents);
+        var positions = {};
+
+        for (var i = 0; i < ordered.layerNums.length; i++) {
+            var ln = ordered.layerNums[i];
+            var arr = ordered.byLayer[ln];
+            var totalH = arr.length * NODE_GAP;
+            var startY = -totalH / 2 + NODE_GAP / 2;
+            for (var j = 0; j < arr.length; j++) {
+                positions[arr[j].id] = {
+                    x: ln * LAYER_GAP,
+                    y: startY + j * NODE_GAP,
+                };
+            }
+        }
+
+        return positions;
+    }
+
+    // -----------------------------------------------------------------------
+    // DangoLineage class
+    // -----------------------------------------------------------------------
+
+    function DangoLineage(containerId) {
+        this._containerId = containerId;
+        this._svg = null;
+        this._g = null;
+        this._zoom = null;
+        this._onNodeClick = null;
+        this._nodes = [];
+        this._edges = [];
+        this._positions = {};
+        this._nodeMap = {};
+        this._resizeHandler = null;
+    }
+
+    DangoLineage.prototype.onNodeClick = function (cb) {
+        this._onNodeClick = cb;
+    };
+
+    DangoLineage.prototype.render = function (nodes, edges) {
+        this.destroy();
+        this._nodes = nodes || [];
+        this._edges = edges || [];
+        if (this._nodes.length === 0) return;
+
+        this._nodeMap = {};
+        for (var i = 0; i < this._nodes.length; i++) {
+            this._nodeMap[this._nodes[i].id] = this._nodes[i];
+        }
+
+        this._positions = computePositions(this._nodes, this._edges);
+
+        var container = document.getElementById(this._containerId);
+        if (!container) return;
+        var w = container.clientWidth || 800;
+        var h = container.clientHeight || 600;
+
+        this._svg = d3.select("#" + this._containerId)
+            .append("svg")
+            .attr("width", w)
+            .attr("height", h)
+            .attr("class", "lineage-svg");
+
+        // Arrow marker
+        this._svg.append("defs").append("marker")
+            .attr("id", "lineage-arrow")
+            .attr("viewBox", "0 0 10 6")
+            .attr("refX", 10)
+            .attr("refY", 3)
+            .attr("markerWidth", 8)
+            .attr("markerHeight", 6)
+            .attr("orient", "auto")
+            .append("path")
+            .attr("d", "M0,0 L10,3 L0,6 Z")
+            .attr("class", "lineage-arrow-path");
+
+        this._g = this._svg.append("g").attr("class", "lineage-root");
+
+        // Zoom/pan
+        var self = this;
+        this._zoom = d3.zoom()
+            .scaleExtent([0.2, 3])
+            .on("zoom", function (event) {
+                self._g.attr("transform", event.transform);
+            });
+        this._svg.call(this._zoom);
+
+        this._drawEdges();
+        this._drawNodes();
+        this.fitAll();
+
+        // Debounced resize handler
+        var timer = null;
+        this._resizeHandler = function () {
+            clearTimeout(timer);
+            timer = setTimeout(function () { self.fitAll(); }, 200);
+        };
+        window.addEventListener("resize", this._resizeHandler);
+    };
+
+    DangoLineage.prototype._drawEdges = function () {
+        var self = this;
+        var linkGen = d3.linkHorizontal()
+            .source(function (d) {
+                var p = self._positions[d.source];
+                return p ? [p.x + NODE_W, p.y + NODE_H / 2] : [0, 0];
+            })
+            .target(function (d) {
+                var p = self._positions[d.target];
+                return p ? [p.x, p.y + NODE_H / 2] : [0, 0];
+            });
+
+        // Filter edges to only those with both endpoints present
+        var validEdges = this._edges.filter(function (e) {
+            return self._positions[e.source] && self._positions[e.target];
+        });
+
+        this._g.selectAll(".lineage-edge")
+            .data(validEdges)
+            .join("path")
+            .attr("class", "lineage-edge")
+            .attr("d", linkGen)
+            .attr("data-source", function (d) { return safeDomId(d.source); })
+            .attr("data-target", function (d) { return safeDomId(d.target); })
+            .attr("marker-end", "url(#lineage-arrow)");
+    };
+
+    DangoLineage.prototype._drawNodes = function () {
+        var self = this;
+
+        var nodeGroups = this._g.selectAll(".lineage-node")
+            .data(this._nodes.filter(function (n) { return self._positions[n.id]; }))
+            .join("g")
+            .attr("class", function (d) { return "lineage-node " + classifyNode(d); })
+            .attr("data-id", function (d) { return safeDomId(d.id); })
+            .attr("transform", function (d) {
+                var p = self._positions[d.id];
+                return "translate(" + p.x + "," + p.y + ")";
+            })
+            .style("cursor", "pointer")
+            .on("click", function (event, d) {
+                event.stopPropagation();
+                // Toggle selection styling
+                self._g.selectAll(".lineage-node").classed("selected", false);
+                d3.select(this).classed("selected", true);
+                if (self._onNodeClick) self._onNodeClick(d);
+            });
+
+        nodeGroups.append("rect")
+            .attr("width", NODE_W)
+            .attr("height", NODE_H)
+            .attr("rx", 6)
+            .attr("ry", 6);
+
+        nodeGroups.append("text")
+            .attr("x", NODE_W / 2)
+            .attr("y", NODE_H / 2)
+            .attr("text-anchor", "middle")
+            .attr("dominant-baseline", "central")
+            .text(function (d) { return truncate(d.name); });
+
+        // Deselect on background click
+        this._svg.on("click", function () {
+            self._g.selectAll(".lineage-node").classed("selected", false);
+        });
+    };
+
+    DangoLineage.prototype.highlightImpact = function (nodeId, impactData) {
+        if (!impactData || !impactData.tree) return;
+        var impactNames = new Set();
+        collectImpactNames(impactData.tree, impactNames);
+
+        // Also add the root node name
+        var rootNode = this._nodeMap[nodeId];
+        if (rootNode) impactNames.add(rootNode.name);
+
+        var self = this;
+        this._g.selectAll(".lineage-node")
+            .classed("highlighted", function (d) { return impactNames.has(d.name); })
+            .classed("dimmed", function (d) { return !impactNames.has(d.name); });
+
+        this._g.selectAll(".lineage-edge")
+            .classed("highlighted", function (d) {
+                var sn = self._nodeMap[d.source];
+                var tn = self._nodeMap[d.target];
+                return sn && tn && impactNames.has(sn.name) && impactNames.has(tn.name);
+            })
+            .classed("dimmed", function (d) {
+                var sn = self._nodeMap[d.source];
+                var tn = self._nodeMap[d.target];
+                return !(sn && tn && impactNames.has(sn.name) && impactNames.has(tn.name));
+            });
+    };
+
+    DangoLineage.prototype.clearHighlight = function () {
+        this._g.selectAll(".lineage-node").classed("highlighted", false).classed("dimmed", false);
+        this._g.selectAll(".lineage-edge").classed("highlighted", false).classed("dimmed", false);
+    };
+
+    DangoLineage.prototype.zoomIn = function () {
+        if (this._svg && this._zoom) {
+            this._svg.transition().duration(300).call(this._zoom.scaleBy, 1.3);
+        }
+    };
+
+    DangoLineage.prototype.zoomOut = function () {
+        if (this._svg && this._zoom) {
+            this._svg.transition().duration(300).call(this._zoom.scaleBy, 0.7);
+        }
+    };
+
+    DangoLineage.prototype.fitAll = function () {
+        if (!this._svg || !this._g || this._nodes.length === 0) return;
+        var container = document.getElementById(this._containerId);
+        if (!container) return;
+        var w = container.clientWidth || 800;
+        var h = container.clientHeight || 600;
+
+        // Update SVG size in case container resized
+        this._svg.attr("width", w).attr("height", h);
+
+        // Compute bounding box from positions
+        var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        for (var id in this._positions) {
+            var p = this._positions[id];
+            if (p.x < minX) minX = p.x;
+            if (p.y < minY) minY = p.y;
+            if (p.x + NODE_W > maxX) maxX = p.x + NODE_W;
+            if (p.y + NODE_H > maxY) maxY = p.y + NODE_H;
+        }
+
+        var bw = maxX - minX;
+        var bh = maxY - minY;
+        if (bw <= 0 || bh <= 0) return;
+
+        var padding = 40;
+        var scale = Math.min((w - padding * 2) / bw, (h - padding * 2) / bh, 1.5);
+        scale = Math.max(0.2, Math.min(scale, 3));
+        var tx = (w - bw * scale) / 2 - minX * scale;
+        var ty = (h - bh * scale) / 2 - minY * scale;
+
+        var transform = d3.zoomIdentity.translate(tx, ty).scale(scale);
+        this._svg.transition().duration(400).call(this._zoom.transform, transform);
+    };
+
+    DangoLineage.prototype.destroy = function () {
+        if (this._resizeHandler) {
+            window.removeEventListener("resize", this._resizeHandler);
+            this._resizeHandler = null;
+        }
+        var container = document.getElementById(this._containerId);
+        if (container) {
+            var svg = container.querySelector("svg");
+            if (svg) svg.remove();
+        }
+        this._svg = null;
+        this._g = null;
+        this._zoom = null;
+        this._nodeMap = {};
+        this._positions = {};
+    };
+
+    window.DangoLineage = DangoLineage;
+})();

--- a/dango/web/static/js/lineage.js
+++ b/dango/web/static/js/lineage.js
@@ -174,6 +174,7 @@
         this._g = null;
         this._zoom = null;
         this._onNodeClick = null;
+        this._onBackgroundClick = null;
         this._nodes = [];
         this._edges = [];
         this._positions = {};
@@ -183,6 +184,10 @@
 
     DangoLineage.prototype.onNodeClick = function (cb) {
         this._onNodeClick = cb;
+    };
+
+    DangoLineage.prototype.onBackgroundClick = function (cb) {
+        this._onBackgroundClick = cb;
     };
 
     DangoLineage.prototype.render = function (nodes, edges) {
@@ -310,6 +315,7 @@
         // Deselect on background click
         this._svg.on("click", function () {
             self._g.selectAll(".lineage-node").classed("selected", false);
+            if (self._onBackgroundClick) self._onBackgroundClick();
         });
     };
 
@@ -349,6 +355,7 @@
     };
 
     DangoLineage.prototype.clearHighlight = function () {
+        if (!this._g) return;
         this._g.selectAll(".lineage-node").classed("highlighted", false).classed("dimmed", false);
         this._g.selectAll(".lineage-edge").classed("highlighted", false).classed("dimmed", false);
     };

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -7,22 +7,29 @@
         <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
             <p class="text-sm text-red-700" x-text="error"></p>
         </div>
-        <!-- Breadcrumb -->
-        <nav class="mb-4 text-sm text-gray-500">
-            <button @click="goToSources()" class="hover:text-gray-700"
-                    :class="view === 'sources' ? 'font-semibold text-gray-900' : ''">Sources</button>
-            <template x-if="selectedSource">
-                <span>
-                    <span class="mx-1">/</span>
-                    <button @click="goToTables()" class="hover:text-gray-700"
-                            :class="view === 'tables' ? 'font-semibold text-gray-900' : ''"
-                            x-text="selectedSource"></button>
-                </span>
-            </template>
-            <template x-if="selectedTable">
-                <span><span class="mx-1">/</span><span class="font-semibold text-gray-900" x-text="selectedTable"></span></span>
-            </template>
-        </nav>
+        <!-- Breadcrumb + Lineage toggle -->
+        <div class="flex items-center justify-between mb-4">
+            <nav class="text-sm text-gray-500">
+                <button @click="goToSources()" class="hover:text-gray-700"
+                        :class="view === 'sources' ? 'font-semibold text-gray-900' : ''">Sources</button>
+                <template x-if="selectedSource">
+                    <span>
+                        <span class="mx-1">/</span>
+                        <button @click="goToTables()" class="hover:text-gray-700"
+                                :class="view === 'tables' ? 'font-semibold text-gray-900' : ''"
+                                x-text="selectedSource"></button>
+                    </span>
+                </template>
+                <template x-if="selectedTable">
+                    <span><span class="mx-1">/</span><span class="font-semibold text-gray-900" x-text="selectedTable"></span></span>
+                </template>
+            </nav>
+            <button x-show="hasLineage" @click="toggleLineageView()"
+                    class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors"
+                    :class="view === 'lineage' ? 'bg-indigo-100 text-indigo-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'">
+                <span x-text="view === 'lineage' ? 'Table View' : 'Lineage'"></span>
+            </button>
+        </div>
         <div x-show="loading" x-cloak class="flex items-center justify-center py-12">
             <div class="text-gray-400 text-sm">Loading catalog...</div>
         </div>
@@ -230,6 +237,69 @@
                 </div>
             </template>
         </div>
+        <!-- View 4: Lineage graph -->
+        <div x-show="!loading && view === 'lineage'">
+            <h2 class="text-xl font-bold text-gray-900 mb-4">Data Lineage</h2>
+            <template x-if="lineageNodes.length === 0">
+                <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
+                    No lineage data available. Run dbt to generate lineage.
+                </div>
+            </template>
+            <template x-if="lineageNodes.length > 0">
+                <div class="lineage-wrapper bg-white shadow rounded-lg overflow-hidden" style="height:600px">
+                    <div id="lineage-container" style="width:100%;height:100%"></div>
+                    <div class="lineage-controls">
+                        <button @click="lineageZoomIn()" title="Zoom in">+</button>
+                        <button @click="lineageZoomOut()" title="Zoom out">&minus;</button>
+                        <button @click="lineageFitAll()" title="Fit all">&#8694;</button>
+                    </div>
+                    <!-- Detail panel -->
+                    <div class="lineage-detail" x-show="selectedNode" x-cloak x-transition.opacity>
+                        <div class="lineage-detail-header">
+                            <div class="flex items-center justify-between">
+                                <h3 class="font-semibold text-gray-900 text-sm truncate" x-text="selectedNode ? selectedNode.name : ''"></h3>
+                                <button @click="selectedNode = null" class="text-gray-400 hover:text-gray-600 text-lg">&times;</button>
+                            </div>
+                        </div>
+                        <div class="lineage-detail-body" x-show="selectedNode">
+                            <div class="lineage-detail-row">
+                                <span class="lineage-detail-label">Type</span>
+                                <span class="lineage-detail-value" x-text="selectedNode ? selectedNode.type : ''"></span>
+                            </div>
+                            <div class="lineage-detail-row" x-show="selectedNode && selectedNode.materialization">
+                                <span class="lineage-detail-label">Materialization</span>
+                                <span class="lineage-detail-value" x-text="selectedNode ? selectedNode.materialization : ''"></span>
+                            </div>
+                            <div class="lineage-detail-row">
+                                <span class="lineage-detail-label">Description</span>
+                                <span class="lineage-detail-value text-xs" x-text="selectedNode && selectedNode.description ? selectedNode.description : 'None'"></span>
+                            </div>
+                            <div class="lineage-detail-row">
+                                <span class="lineage-detail-label">Tests</span>
+                                <span class="lineage-detail-value" x-text="selectedNode ? selectedNode.test_count : 0"></span>
+                            </div>
+                            <div class="lineage-detail-row">
+                                <span class="lineage-detail-label">Doc coverage</span>
+                                <span class="lineage-detail-value" x-text="selectedNode ? (selectedNode.columns_documented + '/' + selectedNode.columns_total) : ''"></span>
+                            </div>
+                            <div class="mt-4 space-y-2">
+                                <button @click="showDownstream()" :disabled="impactHighlighted"
+                                        class="w-full px-3 py-1.5 text-sm font-medium bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:opacity-50">
+                                    Show Downstream
+                                </button>
+                                <div x-show="impactHighlighted" class="text-sm text-center text-indigo-600">
+                                    <span x-text="impactCount"></span> downstream model<span x-show="impactCount !== 1">s</span>
+                                </div>
+                                <button x-show="impactHighlighted" @click="lineageClearHighlight()"
+                                        class="w-full px-3 py-1.5 text-sm font-medium bg-gray-100 text-gray-600 rounded-md hover:bg-gray-200">
+                                    Clear Highlight
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </div>
     </div>
 </main>
 {% endblock %}
@@ -239,7 +309,8 @@ function catalogPage() {
     return {
         view: 'sources', selectedSource: null, selectedTable: null,
         sources: [], sourceDetail: null, tablesList: [], columnData: null,
-        lineageNodes: [], driftEvents: [], piiFindings: [],
+        lineageNodes: [], lineageEdges: [], driftEvents: [], piiFindings: [],
+        selectedNode: null, impactHighlighted: false, impactCount: 0, _lineage: null,
         loading: true, tablesLoading: false, columnsLoading: false,
         profilingLoading: false, error: null, hasLineage: false,
 
@@ -254,6 +325,7 @@ function catalogPage() {
                 if (lineageRes.status === 'fulfilled' && lineageRes.value.ok) {
                     const dag = await lineageRes.value.json();
                     this.lineageNodes = dag.nodes || [];
+                    this.lineageEdges = dag.edges || [];
                     this.hasLineage = true;
                 }
             } catch (e) { this.error = 'Failed to load catalog data.'; }
@@ -363,7 +435,49 @@ function catalogPage() {
             if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
             return Math.floor(diff / 86400) + 'd ago';
         },
+        toggleLineageView() {
+            if (this.view === 'lineage') {
+                this.goToSources();
+            } else {
+                this.view = 'lineage'; this.selectedNode = null;
+                this.impactHighlighted = false; this.impactCount = 0;
+                this.$nextTick(() => this.renderLineage());
+            }
+        },
+        renderLineage() {
+            if (this._lineage) this._lineage.destroy();
+            this._lineage = new DangoLineage('lineage-container');
+            const self = this;
+            this._lineage.onNodeClick(function (node) {
+                self.selectedNode = node;
+                self.impactHighlighted = false;
+                self.impactCount = 0;
+            });
+            this._lineage.render(this.lineageNodes, this.lineageEdges);
+        },
+        async showDownstream() {
+            if (!this.selectedNode || !this._lineage) return;
+            try {
+                const res = await fetch('/api/catalog/impact/' + encodeURIComponent(this.selectedNode.name),
+                    { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+                if (res.ok) {
+                    const data = await res.json();
+                    this._lineage.highlightImpact(this.selectedNode.id, data);
+                    this.impactHighlighted = true;
+                    this.impactCount = data.total_downstream_count || 0;
+                }
+            } catch (_) { /* silent */ }
+        },
+        lineageZoomIn() { if (this._lineage) this._lineage.zoomIn(); },
+        lineageZoomOut() { if (this._lineage) this._lineage.zoomOut(); },
+        lineageFitAll() { if (this._lineage) this._lineage.fitAll(); },
+        lineageClearHighlight() {
+            if (this._lineage) this._lineage.clearHighlight();
+            this.impactHighlighted = false; this.impactCount = 0;
+        },
     };
 }
 </script>
+<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+<script src="/static/js/lineage.js?v=1741700000"></script>
 {% endblock %}

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -337,6 +337,8 @@ function catalogPage() {
             this.view = 'sources'; this.selectedSource = null; this.selectedTable = null;
             this.sourceDetail = null; this.columnData = null; this.driftEvents = []; this.tablesList = [];
         },
+        // No lineage cleanup needed — breadcrumb is hidden in lineage view,
+        // so goToTables() is only reachable from tables/columns views.
         goToTables() {
             this.view = 'tables'; this.selectedTable = null; this.columnData = null; this.driftEvents = [];
         },
@@ -455,6 +457,11 @@ function catalogPage() {
             const self = this;
             this._lineage.onNodeClick(function (node) {
                 self.selectedNode = node;
+                self.impactHighlighted = false;
+                self.impactCount = 0;
+            });
+            this._lineage.onBackgroundClick(function () {
+                self.selectedNode = null;
                 self.impactHighlighted = false;
                 self.impactCount = 0;
             });

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -258,7 +258,7 @@
                         <div class="lineage-detail-header">
                             <div class="flex items-center justify-between">
                                 <h3 class="font-semibold text-gray-900 text-sm truncate" x-text="selectedNode ? selectedNode.name : ''"></h3>
-                                <button @click="selectedNode = null" class="text-gray-400 hover:text-gray-600 text-lg">&times;</button>
+                                <button @click="selectedNode = null; lineageClearHighlight()" class="text-gray-400 hover:text-gray-600 text-lg">&times;</button>
                             </div>
                         </div>
                         <div class="lineage-detail-body" x-show="selectedNode">
@@ -332,6 +332,8 @@ function catalogPage() {
             finally { this.loading = false; }
         },
         goToSources() {
+            if (this._lineage) { this._lineage.destroy(); this._lineage = null; }
+            this.selectedNode = null; this.impactHighlighted = false; this.impactCount = 0;
             this.view = 'sources'; this.selectedSource = null; this.selectedTable = null;
             this.sourceDetail = null; this.columnData = null; this.driftEvents = []; this.tablesList = [];
         },
@@ -445,6 +447,9 @@ function catalogPage() {
             }
         },
         renderLineage() {
+            if (typeof DangoLineage === 'undefined') {
+                this.error = 'Lineage visualization failed to load.'; return;
+            }
             if (this._lineage) this._lineage.destroy();
             this._lineage = new DangoLineage('lineage-container');
             const self = this;


### PR DESCRIPTION
## Summary
- Add interactive D3.js DAG visualization as a 4th view on the catalog page
- Layered left-to-right (Sugiyama-style) layout with BFS layer assignment and barycenter ordering
- Node color coding by type: sources (blue), staging (green), marts (purple), intermediate (yellow)
- Click-to-select detail panel (320px side drawer) showing name, type, materialization, description, tests, doc coverage
- "Show Downstream" button fetches impact API and highlights downstream nodes/edges
- Zoom/pan controls (mouse wheel + drag + buttons) with debounced resize handler

## Files changed
- **`web/static/js/lineage.js`** (new, 410 lines) — `DangoLineage` class with layout algorithm, SVG rendering, impact highlighting
- **`web/static/css/catalog.css`** (39 → 85 lines) — node colors, states, edge styles, detail panel, zoom controls
- **`web/templates/catalog.html`** (369 → 483 lines) — View 4 lineage container, Alpine.js methods, D3 script tags

## Test plan
- [ ] `dango web dev` in a project with dbt models — verify DAG renders left-to-right
- [ ] Node colors match type classification (source/staging/mart/intermediate)
- [ ] Click node → detail panel opens with correct metadata
- [ ] "Show Downstream" → downstream highlighted, others dimmed, count shown
- [ ] Zoom in/out/fit buttons + mouse wheel zoom + click-drag pan
- [ ] Toggle to table view and back — graph re-renders
- [ ] Empty state (no dbt manifest) — placeholder text, no JS errors
- [ ] No backend changes — existing `test_catalog_lineage.py` (16 tests) covers API

🤖 Generated with [Claude Code](https://claude.com/claude-code)