### PR TITLE
P7-012: Add analysis output, insights UI, and metric notifications

### DIFF
--- a/dango/analysis/__init__.py
+++ b/dango/analysis/__init__.py
@@ -8,6 +8,7 @@ from dango.analysis.config import (
     load_metrics_config,
     save_metrics_config,
 )
+from dango.analysis.formatter import categorize_results, format_webhook_summary
 from dango.analysis.metrics import run_analysis
 from dango.analysis.models import DimensionContributor, DrillDownDimension
 from dango.analysis.templates import generate_metrics_for_source
@@ -16,6 +17,8 @@ __all__: list[str] = [
     "DimensionContributor",
     "DrillDownDimension",
     "add_metrics_to_config",
+    "categorize_results",
+    "format_webhook_summary",
     "generate_metrics_for_source",
     "load_metrics_config",
     "run_analysis",

--- a/dango/analysis/formatter.py
+++ b/dango/analysis/formatter.py
@@ -1,0 +1,144 @@
+"""dango/analysis/formatter.py
+
+Pure formatting functions for analysis results.
+
+Converts ``AnalysisResult`` objects into sorted, categorised dicts suitable
+for API responses, CLI rendering, and webhook summaries.  No I/O or
+database access — all functions are deterministic on their inputs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dango.analysis.models import AnalysisResult
+
+
+def categorize_results(results: list[AnalysisResult]) -> list[dict[str, Any]]:
+    """Sort results into dicts with a ``status`` field.
+
+    Status priority: flagged > trending > normal > error.  Within each
+    group, items are sorted by ``abs(change_pct)`` descending.
+
+    Returns:
+        List of dicts suitable for API responses and CLI rendering.
+    """
+    categorized: list[dict[str, Any]] = []
+
+    for r in results:
+        status = _assign_status(r)
+        change_pct = r.comparison.change_pct if r.comparison else None
+
+        drill_down_list: list[dict[str, Any]] = []
+        for dim in r.drill_down:
+            contributors = [
+                {
+                    "group_value": c.group_value,
+                    "current_value": c.current_value,
+                    "previous_value": c.previous_value,
+                    "change_pct": c.change_pct,
+                    "change_abs": c.change_abs,
+                }
+                for c in dim.contributors
+            ]
+            drill_down_list.append({"dimension": dim.dimension, "contributors": contributors})
+
+        categorized.append(
+            {
+                "name": r.metric.metric_name,
+                "status": status,
+                "value": r.metric.value,
+                "change_pct": change_pct,
+                "comparison_type": (r.comparison.comparison_type.value if r.comparison else None),
+                "baseline_value": (r.comparison.baseline_value if r.comparison else None),
+                "exceeds_threshold": (r.comparison.exceeds_threshold if r.comparison else False),
+                "trend_direction": (r.comparison.trend_direction if r.comparison else None),
+                "forecast_threshold_days": (
+                    r.comparison.forecast_threshold_days if r.comparison else None
+                ),
+                "source": r.metric.source,
+                "table_name": r.metric.table_name,
+                "drill_down": drill_down_list,
+                "error": r.metric.error,
+            }
+        )
+
+    # Sort: flagged first, then trending, normal, error
+    # Within each group, sort by abs(change_pct) descending
+    status_order = {"flagged": 0, "trending": 1, "normal": 2, "error": 3}
+    categorized.sort(
+        key=lambda d: (
+            status_order.get(d["status"], 4),
+            -(abs(d["change_pct"]) if d["change_pct"] is not None else 0),
+        )
+    )
+
+    return categorized
+
+
+def format_webhook_summary(
+    results: list[AnalysisResult],
+    flagged: list[AnalysisResult],
+) -> str:
+    """Build a one-line summary for webhook payloads.
+
+    Example: ``"1 flagged (stripe_revenue +25.3%), 1 trending. 3 total."``
+
+    Args:
+        results: All analysis results.
+        flagged: Only the flagged (threshold-exceeded) results.
+
+    Returns:
+        A human-readable one-line summary string.
+    """
+    parts: list[str] = []
+
+    # Flagged details
+    if flagged:
+        flagged_details: list[str] = []
+        for r in flagged[:3]:  # cap at 3 to keep it short
+            pct = r.comparison.change_pct if r.comparison else None
+            if pct is not None:
+                sign = "+" if pct > 0 else ""
+                flagged_details.append(f"{r.metric.metric_name} {sign}{pct:.1f}%")
+            else:
+                flagged_details.append(r.metric.metric_name)
+        parts.append(f"{len(flagged)} flagged ({', '.join(flagged_details)})")
+
+    # Trending count
+    trending_count = sum(
+        bool(
+            r.comparison
+            and r.comparison.trend_direction is not None
+            and r.comparison.trend_direction != "stable"
+            and not (r.comparison and r.comparison.exceeds_threshold)
+        )
+        for r in results
+    )
+    if trending_count:
+        parts.append(f"{trending_count} trending")
+
+    summary = ", ".join(parts) if parts else "No issues"
+    return f"{summary}. {len(results)} total."
+
+
+def _assign_status(result: AnalysisResult) -> str:
+    """Determine the status category for an analysis result.
+
+    Args:
+        result: A single analysis result.
+
+    Returns:
+        One of ``"error"``, ``"flagged"``, ``"trending"``, or ``"normal"``.
+    """
+    if result.metric.error is not None:
+        return "error"
+    if result.comparison and result.comparison.exceeds_threshold:
+        return "flagged"
+    if (
+        result.comparison
+        and result.comparison.trend_direction is not None
+        and result.comparison.trend_direction != "stable"
+    ):
+        return "trending"
+    return "normal"

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -67,6 +67,7 @@ class AuditEvent(str, Enum):
     GOVERNANCE_DRIFT_VIEWED      = "governance_drift_viewed"
     GOVERNANCE_PII_VIEWED        = "governance_pii_viewed"
     CATALOG_VIEWED               = "catalog_viewed"
+    INSIGHTS_VIEWED              = "insights_viewed"
     # fmt: on
 
 

--- a/dango/cli/commands/analyze.py
+++ b/dango/cli/commands/analyze.py
@@ -25,7 +25,10 @@ def analyze(ctx: click.Context, source: str | None) -> None:
 
     source_filter: list[str] | None = None
     if source is not None:
-        source_filter = [f"raw_{source}"]
+        from dango.validation import validate_identifier
+
+        validated = validate_identifier(source)
+        source_filter = [f"raw_{validated}"]
 
     results = run_analysis(project_root, source_filter=source_filter)
 

--- a/dango/cli/commands/analyze.py
+++ b/dango/cli/commands/analyze.py
@@ -1,0 +1,78 @@
+"""dango/cli/commands/analyze.py
+
+CLI command for running metric analysis and displaying results.
+"""
+
+from __future__ import annotations
+
+import click
+
+from dango.cli import console
+
+
+@click.command("analyze")
+@click.option("--source", default=None, help="Filter by source name.")
+@click.pass_context
+def analyze(ctx: click.Context, source: str | None) -> None:
+    """Run metric analysis and display results."""
+    from rich.table import Table
+
+    from dango.analysis.formatter import categorize_results
+    from dango.analysis.metrics import run_analysis
+    from dango.cli.utils import require_project_context
+
+    project_root = require_project_context(ctx)
+
+    source_filter: list[str] | None = None
+    if source is not None:
+        source_filter = [f"raw_{source}"]
+
+    results = run_analysis(project_root, source_filter=source_filter)
+
+    if not results:
+        console.print("[dim]No metrics configured or no data available.[/dim]")
+        return
+
+    categorized = categorize_results(results)
+
+    tbl = Table(title="Metric Analysis")
+    tbl.add_column("Status")
+    tbl.add_column("Metric", style="bold")
+    tbl.add_column("Value", justify="right")
+    tbl.add_column("Change", justify="right")
+    tbl.add_column("Trend")
+
+    status_styles = {
+        "flagged": "[red]flagged[/red]",
+        "trending": "[yellow]trending[/yellow]",
+        "normal": "[green]normal[/green]",
+        "error": "[dim]error[/dim]",
+    }
+
+    for item in categorized:
+        status_label = status_styles.get(item["status"], item["status"])
+        value_str = f"{item['value']:.2f}" if item["value"] is not None else "-"
+        change_str = "-"
+        if item["change_pct"] is not None:
+            sign = "+" if item["change_pct"] > 0 else ""
+            change_str = f"{sign}{item['change_pct']:.1f}%"
+        trend_str = item.get("trend_direction") or "-"
+
+        tbl.add_row(status_label, item["name"], value_str, change_str, trend_str)
+
+    console.print(tbl)
+
+    # Show drill-down details for flagged metrics
+    flagged = [m for m in categorized if m["status"] == "flagged"]
+    for item in flagged:
+        if not item["drill_down"]:
+            continue
+        console.print(f"\n  [red]Drill-down:[/red] {item['name']}")
+        for dim in item["drill_down"]:
+            console.print(f"    [bold]{dim['dimension']}[/bold]")
+            for contrib in dim["contributors"][:5]:
+                group = contrib["group_value"] or "(null)"
+                cpct = (
+                    f"{contrib['change_pct']:+.1f}%" if contrib["change_pct"] is not None else "-"
+                )
+                console.print(f"      {group}: {cpct}")

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -9,6 +9,7 @@ top-level ``cli`` group with version info and project-root discovery.
 import click
 
 from dango import __version__
+from dango.cli.commands.analyze import analyze
 from dango.cli.commands.auth import auth
 from dango.cli.commands.cleanup import cleanup
 from dango.cli.commands.config_cmd import config
@@ -64,6 +65,7 @@ def cli(ctx: click.Context) -> None:
 
 
 # --- Register top-level commands ---
+cli.add_command(analyze)
 cli.add_command(init)
 cli.add_command(rename)
 cli.add_command(info)

--- a/dango/platform/notifications/slack.py
+++ b/dango/platform/notifications/slack.py
@@ -23,6 +23,7 @@ _COLORS: dict[EventType, str] = {
     EventType.SYNC_RETRYING: "#aaaaaa",  # gray
     EventType.SCHEMA_DRIFT_DETECTED: "#e0a514",  # dark amber
     EventType.PII_DETECTED: "#e01e5a",  # red
+    EventType.METRIC_ALERT: "#e0a514",  # dark amber
 }
 
 _HEADERS: dict[EventType, str] = {
@@ -32,6 +33,7 @@ _HEADERS: dict[EventType, str] = {
     EventType.SYNC_RETRYING: "Sync Retrying",
     EventType.SCHEMA_DRIFT_DETECTED: "Schema Drift Detected",
     EventType.PII_DETECTED: "PII Detected",
+    EventType.METRIC_ALERT: "Metric Alert",
 }
 
 
@@ -94,6 +96,13 @@ def _build_body(payload: WebhookPayload) -> str:
     elif payload.event_type == EventType.PII_DETECTED:
         if payload.error:
             lines.append(f"*Details:* {payload.error}")
+
+    elif payload.event_type == EventType.METRIC_ALERT:
+        meta = payload.metadata or {}
+        if meta.get("summary"):
+            lines.append(f"*Summary:* {meta['summary']}")
+        if meta.get("flagged_count") is not None:
+            lines.append(f"*Flagged:* {meta['flagged_count']} of {meta.get('total_count', '?')}")
 
     return "\n".join(lines)
 

--- a/dango/platform/notifications/webhook.py
+++ b/dango/platform/notifications/webhook.py
@@ -52,6 +52,7 @@ class EventType(str, Enum):
     SYNC_RETRYING = "sync_retrying"
     SCHEMA_DRIFT_DETECTED = "schema_drift_detected"
     PII_DETECTED = "pii_detected"
+    METRIC_ALERT = "metric_alert"
 
 
 class EventCategory(str, Enum):
@@ -61,6 +62,7 @@ class EventCategory(str, Enum):
     FAILURE = "failure"
     STALE = "stale"
     GOVERNANCE = "governance"
+    ANALYSIS = "analysis"
 
 
 EVENT_TO_CATEGORY: dict[EventType, EventCategory] = {
@@ -70,6 +72,7 @@ EVENT_TO_CATEGORY: dict[EventType, EventCategory] = {
     EventType.SYNC_RETRYING: EventCategory.FAILURE,
     EventType.SCHEMA_DRIFT_DETECTED: EventCategory.GOVERNANCE,
     EventType.PII_DETECTED: EventCategory.GOVERNANCE,
+    EventType.METRIC_ALERT: EventCategory.ANALYSIS,
 }
 
 # ---------------------------------------------------------------------------
@@ -105,6 +108,7 @@ class NotificationConfig(BaseModel):
     on_success: bool = False
     on_stale: bool = True
     on_governance: bool = True
+    on_analysis: bool = True
     stale_threshold_hours: int = 24
 
 
@@ -129,6 +133,7 @@ class WebhookPayload(BaseModel):
     stale_hours: float | None = None
     attempt_number: int | None = None
     next_retry_at: datetime | None = None
+    metadata: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -367,5 +372,6 @@ class WebhookSender:
             "stale_hours": payload.stale_hours,
             "attempt_number": payload.attempt_number,
             "next_retry_at": (payload.next_retry_at.isoformat() if payload.next_retry_at else None),
+            "metadata": payload.metadata,
         }
         return result

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -404,6 +404,9 @@ def _run_pii_scan(project_root: Path, sources: list[str]) -> None:
 def _run_analysis(project_root: Path, sources: list[str]) -> None:
     """Run automated analysis on freshly synced sources.
 
+    Captures results and dispatches a webhook notification if any metrics
+    exceed their configured threshold.
+
     Args:
         project_root: Path to the Dango project root.
         sources: Names of sources that synced successfully.
@@ -411,6 +414,73 @@ def _run_analysis(project_root: Path, sources: list[str]) -> None:
     try:
         from dango.analysis.metrics import run_analysis
 
-        run_analysis(project_root, source_filter=[f"raw_{s}" for s in sources])
+        results = run_analysis(project_root, source_filter=[f"raw_{s}" for s in sources])
+        flagged = [r for r in results if r.comparison and r.comparison.exceeds_threshold]
+        if flagged:
+            _send_analysis_webhook(project_root, sources, results, flagged)
     except Exception:
         logger.warning("analysis_hook_error", sources=sources, exc_info=True)
+
+
+def _send_analysis_webhook(
+    project_root: Path,
+    sources: list[str],
+    results: list[Any],
+    flagged: list[Any],
+) -> None:
+    """Send webhook for flagged metric alerts.  Never raises."""
+    try:
+        from dango.analysis.formatter import format_webhook_summary
+        from dango.platform.notifications.webhook import (
+            EventType,
+            WebhookPayload,
+            load_notification_config,
+            should_notify,
+        )
+
+        config = load_notification_config(project_root)
+        if config is None or not config.webhooks:
+            return
+        if not should_notify(EventType.METRIC_ALERT, config):
+            return
+
+        summary = format_webhook_summary(results, flagged)
+        payload = WebhookPayload(
+            event_type=EventType.METRIC_ALERT,
+            schedule_name="post_sync",
+            sources=sources,
+            metadata={
+                "summary": summary,
+                "flagged_count": len(flagged),
+                "total_count": len(results),
+            },
+            occurred_at=datetime.now(tz=timezone.utc),
+        )
+
+        import httpx
+
+        for webhook in config.webhooks:
+            try:
+                if webhook.format == "slack":
+                    from dango.platform.notifications.slack import format_slack_message
+
+                    json_payload: dict[str, Any] = format_slack_message(payload)
+                else:
+                    json_payload = {
+                        "event": payload.event_type.value,
+                        "schedule": payload.schedule_name,
+                        "sources": payload.sources,
+                        "metadata": payload.metadata,
+                        "timestamp": payload.occurred_at.isoformat()
+                        if payload.occurred_at
+                        else None,
+                    }
+                with httpx.Client(timeout=10.0) as client:
+                    resp = client.post(webhook.url, json=json_payload)
+                logger.info(
+                    "analysis_webhook_delivered", webhook=webhook.name, status=resp.status_code
+                )
+            except Exception:
+                logger.warning("analysis_webhook_error", webhook=webhook.name, exc_info=True)
+    except Exception:
+        logger.warning("analysis_webhook_outer_error", exc_info=True)

--- a/dango/web/routes/insights.py
+++ b/dango/web/routes/insights.py
@@ -1,10 +1,180 @@
 """dango/web/routes/insights.py
 
 Automated insights API endpoints.
+
+Provides read access to cached analysis results, on-demand analysis execution,
+and metric history queries.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import asyncio
 
-router = APIRouter()
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, ConfigDict
+
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.models import User
+from dango.auth.permissions import require_permission
+from dango.logging import get_logger
+from dango.validation import validate_identifier
+from dango.web.helpers import get_project_root
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["insights"])
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class InsightMetric(BaseModel):
+    """A single metric in the insights response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    status: str
+    value: float | None = None
+    change_pct: float | None = None
+    comparison_type: str | None = None
+    baseline_value: float | None = None
+    exceeds_threshold: bool = False
+    trend_direction: str | None = None
+    forecast_threshold_days: int | None = None
+    source: str | None = None
+    table_name: str | None = None
+    drill_down: list[dict] = []  # type: ignore[type-arg]
+    error: str | None = None
+
+
+class InsightsResponse(BaseModel):
+    """Response for insights endpoints."""
+
+    model_config = ConfigDict(frozen=True)
+
+    metrics: list[InsightMetric]
+    total: int
+    flagged: int
+
+
+class HistoryPoint(BaseModel):
+    """A single data point in metric history."""
+
+    model_config = ConfigDict(frozen=True)
+
+    value: float | None = None
+    recorded_at: str
+
+
+class MetricHistoryResponse(BaseModel):
+    """Response for metric history endpoint."""
+
+    model_config = ConfigDict(frozen=True)
+
+    metric: str
+    days: int
+    data_points: list[HistoryPoint]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_insights_response(categorized: list[dict]) -> InsightsResponse:  # type: ignore[type-arg]
+    """Build an ``InsightsResponse`` from categorised result dicts.
+
+    Args:
+        categorized: Output of ``categorize_results()``.
+
+    Returns:
+        An ``InsightsResponse`` with metric list, total, and flagged count.
+    """
+    metrics = [InsightMetric(**m) for m in categorized]
+    flagged_count = sum(1 for m in metrics if m.status == "flagged")
+    return InsightsResponse(metrics=metrics, total=len(metrics), flagged=flagged_count)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/insights")
+async def get_insights(
+    user: User = Depends(require_permission("governance.view")),
+) -> InsightsResponse:
+    """Read latest cached analysis results.
+
+    Returns categorised metrics from the most recent analysis run.
+    """
+    log_auth_event(AuditEvent.INSIGHTS_VIEWED, user_id=user.id, email=user.email)
+
+    project_root = get_project_root()
+
+    from dango.analysis.formatter import categorize_results
+    from dango.analysis.metrics import run_analysis
+
+    results = await asyncio.to_thread(run_analysis, project_root)
+    categorized = categorize_results(results)
+    return _build_insights_response(categorized)
+
+
+@router.post("/api/insights/run")
+async def run_insights(
+    source: str | None = Query(None, description="Filter by source name"),
+    user: User = Depends(require_permission("governance.view")),
+) -> InsightsResponse:
+    """Execute a fresh analysis run (state-mutating).
+
+    Optionally filter by source name.
+    """
+    log_auth_event(AuditEvent.INSIGHTS_VIEWED, user_id=user.id, email=user.email)
+
+    project_root = get_project_root()
+
+    source_filter: list[str] | None = None
+    if source is not None:
+        source_filter = [f"raw_{source}"]
+
+    from dango.analysis.formatter import categorize_results
+    from dango.analysis.metrics import run_analysis
+
+    results = await asyncio.to_thread(run_analysis, project_root, source_filter=source_filter)
+    categorized = categorize_results(results)
+    return _build_insights_response(categorized)
+
+
+@router.get("/api/insights/history")
+async def get_metric_history(
+    metric: str = Query(..., description="Metric name"),
+    days: int = Query(30, ge=1, le=365, description="Days of history"),
+    user: User = Depends(require_permission("governance.view")),
+) -> MetricHistoryResponse:
+    """Read metric value history for a given metric.
+
+    Returns up to ``days`` worth of historical data points.
+    """
+    log_auth_event(AuditEvent.INSIGHTS_VIEWED, user_id=user.id, email=user.email)
+
+    validated_metric = validate_identifier(metric)
+    project_root = get_project_root()
+
+    from dango.utils.dango_db import connect
+
+    def _query_history() -> list[HistoryPoint]:
+        with connect(project_root) as conn:
+            rows = conn.execute(
+                "SELECT metric_value, recorded_at FROM metric_history "
+                "WHERE metric_name = ? "
+                "AND recorded_at >= datetime('now', '-' || ? || ' days') "
+                "ORDER BY recorded_at DESC",
+                (validated_metric, days),
+            ).fetchall()
+        return [HistoryPoint(value=row[0], recorded_at=row[1]) for row in rows]
+
+    data_points = await asyncio.to_thread(_query_history)
+    return MetricHistoryResponse(metric=validated_metric, days=days, data_points=data_points)

--- a/dango/web/routes/insights.py
+++ b/dango/web/routes/insights.py
@@ -9,6 +9,9 @@ and metric history queries.
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, ConfigDict
@@ -98,6 +101,97 @@ def _build_insights_response(categorized: list[dict]) -> InsightsResponse:  # ty
     return InsightsResponse(metrics=metrics, total=len(metrics), flagged=flagged_count)
 
 
+def _read_cached_results(project_root: Path) -> list[dict[str, Any]]:
+    """Read the most recent analysis results from SQLite cache.
+
+    Queries ``metric_history`` for latest values and ``metric_results`` for
+    latest comparison data per metric.  Returns categorised dicts ready for
+    ``_build_insights_response()``.
+
+    Args:
+        project_root: Path to the Dango project root.
+
+    Returns:
+        List of categorised metric dicts (same shape as
+        ``categorize_results()`` output).
+    """
+    from dango.utils.dango_db import connect
+
+    with connect(project_root) as conn:
+        # Latest value per metric from metric_history
+        history_rows = conn.execute(
+            "SELECT h.metric_name, h.metric_value, h.source, h.table_name "
+            "FROM metric_history h "
+            "INNER JOIN ("
+            "  SELECT metric_name, MAX(recorded_at) AS max_at "
+            "  FROM metric_history GROUP BY metric_name"
+            ") latest ON h.metric_name = latest.metric_name "
+            "AND h.recorded_at = latest.max_at"
+        ).fetchall()
+
+        # Latest comparison per metric from metric_results
+        result_rows = conn.execute(
+            "SELECT r.metric_name, r.result_value "
+            "FROM metric_results r "
+            "INNER JOIN ("
+            "  SELECT metric_name, MAX(computed_at) AS max_at "
+            "  FROM metric_results GROUP BY metric_name"
+            ") latest ON r.metric_name = latest.metric_name "
+            "AND r.computed_at = latest.max_at"
+        ).fetchall()
+
+    # Index comparison results by metric_name
+    comparisons: dict[str, dict[str, Any]] = {}
+    for metric_name, result_value in result_rows:
+        if result_value:
+            try:
+                comparisons[metric_name] = json.loads(result_value)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    categorized: list[dict[str, Any]] = []
+    for metric_name, value, source, table_name in history_rows:
+        comp = comparisons.get(metric_name, {})
+        exceeds = comp.get("exceeds_threshold", False)
+        trend_dir = comp.get("trend_direction")
+
+        # Assign status
+        if exceeds:
+            status = "flagged"
+        elif trend_dir is not None and trend_dir != "stable":
+            status = "trending"
+        else:
+            status = "normal"
+
+        categorized.append(
+            {
+                "name": metric_name,
+                "status": status,
+                "value": value,
+                "change_pct": comp.get("change_pct"),
+                "comparison_type": comp.get("comparison_type"),
+                "baseline_value": comp.get("baseline_value"),
+                "exceeds_threshold": exceeds,
+                "trend_direction": trend_dir,
+                "forecast_threshold_days": comp.get("forecast_threshold_days"),
+                "source": source,
+                "table_name": table_name,
+                "drill_down": [],
+                "error": None,
+            }
+        )
+
+    # Sort: flagged first, then trending, normal
+    status_order = {"flagged": 0, "trending": 1, "normal": 2, "error": 3}
+    categorized.sort(
+        key=lambda d: (
+            status_order.get(d["status"], 4),
+            -(abs(d["change_pct"]) if d["change_pct"] is not None else 0),
+        )
+    )
+    return categorized
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -110,16 +204,12 @@ async def get_insights(
     """Read latest cached analysis results.
 
     Returns categorised metrics from the most recent analysis run.
+    Does not execute new analysis — use ``POST /api/insights/run`` for that.
     """
     log_auth_event(AuditEvent.INSIGHTS_VIEWED, user_id=user.id, email=user.email)
 
     project_root = get_project_root()
-
-    from dango.analysis.formatter import categorize_results
-    from dango.analysis.metrics import run_analysis
-
-    results = await asyncio.to_thread(run_analysis, project_root)
-    categorized = categorize_results(results)
+    categorized = await asyncio.to_thread(_read_cached_results, project_root)
     return _build_insights_response(categorized)
 
 
@@ -138,7 +228,8 @@ async def run_insights(
 
     source_filter: list[str] | None = None
     if source is not None:
-        source_filter = [f"raw_{source}"]
+        validated = validate_identifier(source)
+        source_filter = [f"raw_{validated}"]
 
     from dango.analysis.formatter import categorize_results
     from dango.analysis.metrics import run_analysis
@@ -171,7 +262,8 @@ async def get_metric_history(
                 "SELECT metric_value, recorded_at FROM metric_history "
                 "WHERE metric_name = ? "
                 "AND recorded_at >= datetime('now', '-' || ? || ' days') "
-                "ORDER BY recorded_at DESC",
+                "ORDER BY recorded_at DESC "
+                "LIMIT 1000",
                 (validated_metric, days),
             ).fetchall()
         return [HistoryPoint(value=row[0], recorded_at=row[1]) for row in rows]

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -104,6 +104,28 @@ async def catalog_page(
     )
 
 
+@router.get("/insights")
+async def insights_page(
+    request: Request,
+    user: User = Depends(require_permission("governance.view")),
+) -> HTMLResponse:
+    """Serve the insights page."""
+    log_auth_event(
+        AuditEvent.INSIGHTS_VIEWED,
+        user_id=user.id,
+        email=user.email,
+    )
+    return _render_template(
+        "insights.html",
+        {
+            "request": request,
+            "version": dango.__version__,
+            "current_page": "insights",
+            "subtitle": "Insights",
+        },
+    )
+
+
 @router.get("/api")
 async def api_info() -> dict[str, str]:
     """API information endpoint."""

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -76,6 +76,9 @@
                     <a href="/catalog" class="px-3 py-2 rounded-md text-sm font-medium {% if current_page == 'catalog' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors hidden sm:block">
                         Data Catalog
                     </a>
+                    <a href="/insights" class="px-3 py-2 rounded-md text-sm font-medium {% if current_page == 'insights' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors hidden sm:block">
+                        Insights
+                    </a>
                     <a href="/metabase/question/new" id="nav-query-database" target="_blank" class="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors hidden sm:block">
                         Query Database
                     </a>

--- a/dango/web/templates/insights.html
+++ b/dango/web/templates/insights.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+{% block title %}Insights - Dango{% endblock %}
+{% block content %}
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+    <div x-data="insightsPage()" x-init="init()" x-cloak>
+        <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+            <p class="text-sm text-red-700" x-text="error"></p>
+        </div>
+        <!-- Header -->
+        <div class="flex items-center justify-between mb-6">
+            <div>
+                <h2 class="text-xl font-bold text-gray-900">Insights</h2>
+                <p class="text-sm text-gray-500 mt-1">
+                    <span x-text="metrics.length"></span> metrics<template x-if="flaggedCount > 0">, <span class="text-red-600 font-medium" x-text="flaggedCount + ' flagged'"></span></template>
+                </p>
+            </div>
+            <button @click="runAnalysis()" :disabled="running"
+                    class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors disabled:opacity-50">
+                <span x-show="!running">Run Analysis</span>
+                <span x-show="running" x-cloak>Running...</span>
+            </button>
+        </div>
+        <div x-show="loading" x-cloak class="flex items-center justify-center py-12">
+            <div class="text-gray-400 text-sm">Loading insights...</div>
+        </div>
+        <!-- No data -->
+        <template x-if="!loading && metrics.length === 0">
+            <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
+                No metrics configured or no data available. Configure metrics in <code>.dango/metrics.yml</code>.
+            </div>
+        </template>
+        <!-- Metric cards -->
+        <div x-show="!loading && metrics.length > 0" class="space-y-3">
+            <template x-for="m in metrics" :key="m.name">
+                <div class="bg-white shadow rounded-lg px-5 py-4">
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center space-x-3 min-w-0">
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold"
+                                  :class="statusClass(m.status)" x-text="m.status"></span>
+                            <span class="text-sm font-medium text-gray-900 truncate" x-text="m.name"></span>
+                        </div>
+                        <div class="flex items-center space-x-4 text-sm text-right flex-shrink-0">
+                            <span class="text-gray-900 font-mono" x-text="m.value != null ? m.value.toLocaleString(undefined, {maximumFractionDigits: 2}) : '-'"></span>
+                            <span :class="m.change_pct != null && m.change_pct > 0 ? 'text-red-600' : m.change_pct != null && m.change_pct < 0 ? 'text-green-600' : 'text-gray-400'"
+                                  x-text="formatChange(m.change_pct)"></span>
+                            <span class="text-gray-400 hidden sm:inline" x-text="m.trend_direction || '-'"></span>
+                            <button @click="toggleHistory(m.name)" class="text-blue-600 hover:text-blue-800 text-xs hidden sm:inline">History</button>
+                            <template x-if="m.drill_down && m.drill_down.length > 0">
+                                <button @click="m._expanded = !m._expanded" class="text-blue-600 hover:text-blue-800 text-xs">
+                                    <span x-text="m._expanded ? 'Hide' : 'Drill-down'"></span>
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+                    <div class="flex items-center space-x-3 mt-1 text-xs text-gray-400">
+                        <template x-if="m.source"><a :href="'/catalog'" class="hover:text-blue-600" x-text="m.source + (m.table_name ? '.' + m.table_name : '')"></a></template>
+                        <template x-if="m.comparison_type"><span x-text="m.comparison_type.replace(/_/g, ' ')"></span></template>
+                        <template x-if="m.error"><span class="text-red-500" x-text="m.error"></span></template>
+                    </div>
+                    <!-- Drill-down -->
+                    <div x-show="m._expanded" x-cloak class="mt-3 pl-4 border-l-2 border-gray-200 space-y-2">
+                        <template x-for="dim in m.drill_down" :key="dim.dimension">
+                            <div>
+                                <div class="text-xs font-semibold text-gray-600 mb-1" x-text="dim.dimension"></div>
+                                <template x-for="c in dim.contributors.slice(0, 5)" :key="c.group_value">
+                                    <div class="flex items-center justify-between text-xs text-gray-500">
+                                        <span x-text="c.group_value || '(null)'"></span>
+                                        <span :class="c.change_pct != null && c.change_pct > 0 ? 'text-red-600' : 'text-green-600'"
+                                              x-text="formatChange(c.change_pct)"></span>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+            </template>
+        </div>
+        <!-- History panel -->
+        <div x-show="historyMetric" x-cloak class="mt-6 bg-white shadow rounded-lg p-5">
+            <div class="flex items-center justify-between mb-3">
+                <h3 class="text-sm font-semibold text-gray-900">History: <span x-text="historyMetric"></span></h3>
+                <button @click="historyMetric = null; historyData = []" class="text-xs text-gray-400 hover:text-gray-600">Close</button>
+            </div>
+            <div x-show="historyLoading" class="text-sm text-gray-400 py-4 text-center">Loading...</div>
+            <template x-if="!historyLoading && historyData.length > 0">
+                <div class="overflow-x-auto">
+                    <table class="min-w-full text-xs">
+                        <thead><tr><th class="text-left py-1 text-gray-500">Time</th><th class="text-right py-1 text-gray-500">Value</th></tr></thead>
+                        <tbody>
+                            <template x-for="pt in historyData" :key="pt.recorded_at">
+                                <tr><td class="py-1 text-gray-600" x-text="pt.recorded_at"></td><td class="py-1 text-right font-mono" x-text="pt.value != null ? pt.value.toLocaleString(undefined, {maximumFractionDigits: 2}) : '-'"></td></tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </div>
+            </template>
+            <template x-if="!historyLoading && historyData.length === 0">
+                <div class="text-sm text-gray-400 py-4 text-center">No history available.</div>
+            </template>
+        </div>
+    </div>
+</main>
+{% endblock %}
+{% block scripts %}
+<script>
+function insightsPage() {
+    return {
+        metrics: [], flaggedCount: 0, loading: true, running: false, error: null,
+        historyMetric: null, historyData: [], historyLoading: false,
+        async init() {
+            try {
+                const res = await fetch('/api/insights', {headers: {'X-Requested-With': 'XMLHttpRequest'}});
+                if (res.ok) {
+                    const data = await res.json();
+                    this.metrics = data.metrics.map(m => ({...m, _expanded: false}));
+                    this.flaggedCount = data.flagged;
+                } else { this.error = 'Failed to load insights.'; }
+            } catch (e) { this.error = 'Failed to load insights.'; }
+            finally { this.loading = false; }
+        },
+        async runAnalysis() {
+            this.running = true; this.error = null;
+            try {
+                const res = await fetch('/api/insights/run', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}});
+                if (res.ok) {
+                    const data = await res.json();
+                    this.metrics = data.metrics.map(m => ({...m, _expanded: false}));
+                    this.flaggedCount = data.flagged;
+                } else { this.error = 'Analysis failed.'; }
+            } catch (e) { this.error = 'Analysis failed.'; }
+            finally { this.running = false; }
+        },
+        async toggleHistory(metricName) {
+            if (this.historyMetric === metricName) { this.historyMetric = null; this.historyData = []; return; }
+            this.historyMetric = metricName; this.historyLoading = true; this.historyData = [];
+            try {
+                const res = await fetch('/api/insights/history?metric=' + encodeURIComponent(metricName) + '&days=30', {headers: {'X-Requested-With': 'XMLHttpRequest'}});
+                if (res.ok) { const data = await res.json(); this.historyData = data.data_points; }
+            } catch (e) { /* silent */ }
+            finally { this.historyLoading = false; }
+        },
+        statusClass(status) {
+            return {flagged: 'bg-red-100 text-red-800', trending: 'bg-yellow-100 text-yellow-800', normal: 'bg-green-100 text-green-800', error: 'bg-gray-100 text-gray-600'}[status] || 'bg-gray-100 text-gray-600';
+        },
+        formatChange(pct) {
+            if (pct == null) return '-';
+            const sign = pct > 0 ? '+' : '';
+            return sign + pct.toFixed(1) + '%';
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/tests/unit/test_analysis_formatter.py
+++ b/tests/unit/test_analysis_formatter.py
@@ -1,0 +1,192 @@
+"""tests/unit/test_analysis_formatter.py
+
+Tests for dango/analysis/formatter.py — categorize_results and format_webhook_summary.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dango.analysis.formatter import categorize_results, format_webhook_summary
+from dango.analysis.models import (
+    AnalysisResult,
+    ComparisonResult,
+    ComparisonType,
+    DimensionContributor,
+    DrillDownDimension,
+    MetricValue,
+)
+
+
+def _make_result(
+    name: str = "test_metric",
+    value: float | None = 100.0,
+    error: str | None = None,
+    exceeds_threshold: bool = False,
+    change_pct: float | None = None,
+    trend_direction: str | None = None,
+    source: str | None = "raw_stripe",
+    table_name: str | None = "payments",
+    drill_down: list[DrillDownDimension] | None = None,
+) -> AnalysisResult:
+    """Build an AnalysisResult for testing."""
+    metric = MetricValue(
+        metric_name=name,
+        value=value,
+        error=error,
+        source=source,
+        table_name=table_name,
+    )
+    comparison: ComparisonResult | None = None
+    if error is None:
+        comparison = ComparisonResult(
+            metric_name=name,
+            comparison_type=ComparisonType.week_over_week,
+            current_value=value,
+            baseline_value=80.0,
+            change_pct=change_pct,
+            exceeds_threshold=exceeds_threshold,
+            trend_direction=trend_direction,
+        )
+    return AnalysisResult(
+        metric=metric,
+        comparison=comparison,
+        drill_down=drill_down or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# categorize_results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCategorizeResults:
+    """Tests for categorize_results()."""
+
+    def test_empty_input(self) -> None:
+        """Empty list returns empty list."""
+        assert categorize_results([]) == []
+
+    def test_status_assignment_normal(self) -> None:
+        """Normal result gets status 'normal'."""
+        results = categorize_results([_make_result(change_pct=5.0)])
+        assert results[0]["status"] == "normal"
+
+    def test_status_assignment_flagged(self) -> None:
+        """Flagged result gets status 'flagged'."""
+        results = categorize_results([_make_result(exceeds_threshold=True, change_pct=25.0)])
+        assert results[0]["status"] == "flagged"
+
+    def test_status_assignment_trending(self) -> None:
+        """Trending result gets status 'trending'."""
+        results = categorize_results([_make_result(trend_direction="increasing", change_pct=5.0)])
+        assert results[0]["status"] == "trending"
+
+    def test_status_assignment_error(self) -> None:
+        """Error result gets status 'error'."""
+        results = categorize_results([_make_result(error="SQL error", value=None)])
+        assert results[0]["status"] == "error"
+
+    def test_sort_order(self) -> None:
+        """Results are sorted: flagged > trending > normal > error."""
+        items = [
+            _make_result(name="normal_m", change_pct=1.0),
+            _make_result(name="error_m", error="fail", value=None),
+            _make_result(name="flagged_m", exceeds_threshold=True, change_pct=50.0),
+            _make_result(name="trending_m", trend_direction="decreasing", change_pct=3.0),
+        ]
+        categorized = categorize_results(items)
+        statuses = [c["status"] for c in categorized]
+        assert statuses == ["flagged", "trending", "normal", "error"]
+
+    def test_sort_within_group_by_change_pct(self) -> None:
+        """Within same status, sorted by abs(change_pct) descending."""
+        items = [
+            _make_result(name="small", change_pct=2.0),
+            _make_result(name="big", change_pct=-10.0),
+        ]
+        categorized = categorize_results(items)
+        names = [c["name"] for c in categorized]
+        assert names == ["big", "small"]
+
+    def test_dict_fields_present(self) -> None:
+        """Output dicts have all expected fields."""
+        results = categorize_results([_make_result(change_pct=5.0)])
+        item = results[0]
+        expected_keys = {
+            "name",
+            "status",
+            "value",
+            "change_pct",
+            "comparison_type",
+            "baseline_value",
+            "exceeds_threshold",
+            "trend_direction",
+            "forecast_threshold_days",
+            "source",
+            "table_name",
+            "drill_down",
+            "error",
+        }
+        assert set(item.keys()) == expected_keys
+
+    def test_drill_down_included(self) -> None:
+        """Drill-down data is included in output."""
+        dim = DrillDownDimension(
+            dimension="region",
+            contributors=[
+                DimensionContributor(
+                    group_value="US",
+                    current_value=100.0,
+                    previous_value=80.0,
+                    change_pct=25.0,
+                    change_abs=20.0,
+                ),
+            ],
+        )
+        results = categorize_results([_make_result(change_pct=5.0, drill_down=[dim])])
+        assert len(results[0]["drill_down"]) == 1
+        assert results[0]["drill_down"][0]["dimension"] == "region"
+        assert results[0]["drill_down"][0]["contributors"][0]["group_value"] == "US"
+
+
+# ---------------------------------------------------------------------------
+# format_webhook_summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFormatWebhookSummary:
+    """Tests for format_webhook_summary()."""
+
+    def test_no_flagged(self) -> None:
+        """No flagged results produces 'No issues' summary."""
+        results = [_make_result(name="ok", change_pct=1.0)]
+        summary = format_webhook_summary(results, flagged=[])
+        assert "No issues" in summary
+        assert "1 total" in summary
+
+    def test_with_flagged(self) -> None:
+        """Flagged results appear in summary with metric name and change."""
+        flagged = [_make_result(name="revenue", exceeds_threshold=True, change_pct=25.3)]
+        summary = format_webhook_summary(flagged + [_make_result()], flagged)
+        assert "1 flagged" in summary
+        assert "revenue" in summary
+        assert "+25.3%" in summary
+        assert "2 total" in summary
+
+    def test_with_trending(self) -> None:
+        """Trending count appears in summary."""
+        trending = _make_result(name="growing", trend_direction="increasing", change_pct=3.0)
+        summary = format_webhook_summary([trending], flagged=[])
+        assert "1 trending" in summary
+
+    def test_caps_flagged_details(self) -> None:
+        """Only first 3 flagged details are shown."""
+        flagged = [
+            _make_result(name=f"m{i}", exceeds_threshold=True, change_pct=float(i))
+            for i in range(5)
+        ]
+        summary = format_webhook_summary(flagged, flagged)
+        assert "5 flagged" in summary

--- a/tests/unit/test_cli_analyze.py
+++ b/tests/unit/test_cli_analyze.py
@@ -1,0 +1,96 @@
+"""tests/unit/test_cli_analyze.py
+
+Tests for dango/cli/commands/analyze.py — CLI analyze command.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.main import cli
+
+
+def _make_mock_result(
+    name: str = "revenue",
+    value: float = 100.0,
+    change_pct: float = 5.0,
+    exceeds_threshold: bool = False,
+    trend_direction: str | None = None,
+    error: str | None = None,
+) -> MagicMock:
+    """Build a mock AnalysisResult."""
+    mock = MagicMock()
+    mock.metric.metric_name = name
+    mock.metric.value = value
+    mock.metric.error = error
+    mock.metric.source = "raw_stripe"
+    mock.metric.table_name = "payments"
+    mock.comparison = MagicMock() if error is None else None
+    if mock.comparison:
+        mock.comparison.change_pct = change_pct
+        mock.comparison.comparison_type.value = "week_over_week"
+        mock.comparison.baseline_value = 80.0
+        mock.comparison.exceeds_threshold = exceeds_threshold
+        mock.comparison.trend_direction = trend_direction
+        mock.comparison.trend_slope = None
+        mock.comparison.forecast_threshold_days = None
+        mock.comparison.current_value = value
+    mock.drill_down = []
+    return mock
+
+
+@pytest.mark.unit
+class TestAnalyzeCommand:
+    """Tests for ``dango analyze``."""
+
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.cli.utils.require_project_context")
+    def test_no_results(self, mock_ctx: MagicMock, mock_run: MagicMock) -> None:
+        """Empty results show informational message."""
+        mock_ctx.return_value = Path("/fake/project")
+        mock_run.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze"])
+        assert result.exit_code == 0
+        assert "No metrics" in result.output
+
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.cli.utils.require_project_context")
+    def test_with_results(self, mock_ctx: MagicMock, mock_run: MagicMock) -> None:
+        """Results display in a Rich table."""
+        mock_ctx.return_value = Path("/fake/project")
+        mock_run.return_value = [_make_mock_result()]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze"])
+        assert result.exit_code == 0
+        assert "revenue" in result.output
+
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.cli.utils.require_project_context")
+    def test_source_filter(self, mock_ctx: MagicMock, mock_run: MagicMock) -> None:
+        """--source flag passes source_filter to run_analysis."""
+        mock_ctx.return_value = Path("/fake/project")
+        mock_run.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze", "--source", "stripe"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(Path("/fake/project"), source_filter=["raw_stripe"])
+
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.cli.utils.require_project_context")
+    def test_error_result_displays(self, mock_ctx: MagicMock, mock_run: MagicMock) -> None:
+        """Error results show in table with 'error' status."""
+        mock_ctx.return_value = Path("/fake/project")
+        mock_run.return_value = [_make_mock_result(name="broken", error="SQL error", value=0.0)]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["analyze"])
+        assert result.exit_code == 0
+        assert "broken" in result.output

--- a/tests/unit/test_web_insights.py
+++ b/tests/unit/test_web_insights.py
@@ -5,6 +5,7 @@ Tests for dango/web/routes/insights.py — insights API endpoints.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -113,8 +114,30 @@ def _make_mock_result(
     return mock
 
 
+def _mock_connect_with_cache(
+    history_rows: list[tuple[Any, ...]],
+    result_rows: list[tuple[Any, ...]],
+) -> MagicMock:
+    """Build a mock connect() context manager returning cached data.
+
+    The mock routes two SQL queries: metric_history (first call) and
+    metric_results (second call).
+    """
+    mock_conn = MagicMock()
+    cursor_history = MagicMock()
+    cursor_history.fetchall.return_value = history_rows
+    cursor_results = MagicMock()
+    cursor_results.fetchall.return_value = result_rows
+    mock_conn.execute.side_effect = [cursor_history, cursor_results]
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+    mock_ctx.__exit__ = MagicMock(return_value=False)
+    return mock_ctx
+
+
 # ---------------------------------------------------------------------------
-# GET /api/insights
+# GET /api/insights (reads cached results)
 # ---------------------------------------------------------------------------
 
 
@@ -123,19 +146,32 @@ class TestGetInsights:
     """Tests for GET /api/insights."""
 
     @patch("dango.web.routes.insights.get_project_root")
-    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.utils.dango_db.connect")
     @patch("dango.web.routes.insights.log_auth_event")
-    def test_returns_insights(
+    def test_returns_cached_insights(
         self,
         mock_audit: MagicMock,
-        mock_run: MagicMock,
+        mock_connect: MagicMock,
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """GET /api/insights returns categorised metrics."""
+        """GET /api/insights returns cached metrics from SQLite."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
-        mock_run.return_value = [_make_mock_result()]
+
+        comparison_json = json.dumps(
+            {
+                "comparison_type": "week_over_week",
+                "change_pct": 5.0,
+                "baseline_value": 80.0,
+                "exceeds_threshold": False,
+                "trend_direction": None,
+            }
+        )
+        mock_connect.return_value = _mock_connect_with_cache(
+            history_rows=[("revenue", 100.0, "raw_stripe", "payments")],
+            result_rows=[("revenue", comparison_json)],
+        )
 
         resp = client.get("/api/insights")
         assert resp.status_code == 200
@@ -143,21 +179,23 @@ class TestGetInsights:
         assert "metrics" in data
         assert data["total"] == 1
         assert data["flagged"] == 0
+        assert data["metrics"][0]["name"] == "revenue"
+        assert data["metrics"][0]["status"] == "normal"
 
     @patch("dango.web.routes.insights.get_project_root")
-    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.utils.dango_db.connect")
     @patch("dango.web.routes.insights.log_auth_event")
-    def test_empty_results(
+    def test_empty_cache(
         self,
         mock_audit: MagicMock,
-        mock_run: MagicMock,
+        mock_connect: MagicMock,
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """GET /api/insights with no metrics returns empty list."""
+        """GET /api/insights with empty cache returns empty list."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
-        mock_run.return_value = []
+        mock_connect.return_value = _mock_connect_with_cache(history_rows=[], result_rows=[])
 
         resp = client.get("/api/insights")
         assert resp.status_code == 200
@@ -166,19 +204,53 @@ class TestGetInsights:
         assert data["total"] == 0
 
     @patch("dango.web.routes.insights.get_project_root")
-    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.utils.dango_db.connect")
+    @patch("dango.web.routes.insights.log_auth_event")
+    def test_flagged_metric_in_cache(
+        self,
+        mock_audit: MagicMock,
+        mock_connect: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """GET /api/insights returns flagged count from cached data."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+
+        comparison_json = json.dumps(
+            {
+                "comparison_type": "week_over_week",
+                "change_pct": 25.0,
+                "baseline_value": 80.0,
+                "exceeds_threshold": True,
+                "trend_direction": None,
+            }
+        )
+        mock_connect.return_value = _mock_connect_with_cache(
+            history_rows=[("revenue", 100.0, "raw_stripe", "payments")],
+            result_rows=[("revenue", comparison_json)],
+        )
+
+        resp = client.get("/api/insights")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flagged"] == 1
+        assert data["metrics"][0]["status"] == "flagged"
+
+    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.utils.dango_db.connect")
     @patch("dango.web.routes.insights.log_auth_event")
     def test_audit_logged(
         self,
         mock_audit: MagicMock,
-        mock_run: MagicMock,
+        mock_connect: MagicMock,
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
         """GET /api/insights logs audit event."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
-        mock_run.return_value = []
+        mock_connect.return_value = _mock_connect_with_cache(history_rows=[], result_rows=[])
 
         client.get("/api/insights")
         mock_audit.assert_called_once()

--- a/tests/unit/test_web_insights.py
+++ b/tests/unit/test_web_insights.py
@@ -1,0 +1,282 @@
+"""tests/unit/test_web_insights.py
+
+Tests for dango/web/routes/insights.py — insights API endpoints.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    DangoError,
+    ValidationError,
+)
+from dango.web.routes.insights import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.ADMIN) -> User:
+    """Create a test user."""
+    return User(
+        id="u-test-1",
+        email="test@test.com",
+        password_hash="hashed",
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the insights router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        ValidationError: 400,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(
+        request: Request,
+        exc: DangoError,
+    ) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_client(
+    tmp_path: Path,
+    role: Role = Role.ADMIN,
+) -> tuple[TestClient, Path]:
+    """Create a test client with auth middleware injecting a user."""
+    user = _make_user(role)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+def _make_mock_result(
+    name: str = "revenue",
+    value: float = 100.0,
+    change_pct: float = 5.0,
+    exceeds_threshold: bool = False,
+) -> MagicMock:
+    """Build a mock AnalysisResult."""
+    mock = MagicMock()
+    mock.metric.metric_name = name
+    mock.metric.value = value
+    mock.metric.error = None
+    mock.metric.source = "raw_stripe"
+    mock.metric.table_name = "payments"
+    mock.comparison.change_pct = change_pct
+    mock.comparison.comparison_type.value = "week_over_week"
+    mock.comparison.baseline_value = 80.0
+    mock.comparison.exceeds_threshold = exceeds_threshold
+    mock.comparison.trend_direction = None
+    mock.comparison.trend_slope = None
+    mock.comparison.forecast_threshold_days = None
+    mock.comparison.current_value = value
+    mock.drill_down = []
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# GET /api/insights
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetInsights:
+    """Tests for GET /api/insights."""
+
+    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.web.routes.insights.log_auth_event")
+    def test_returns_insights(
+        self,
+        mock_audit: MagicMock,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """GET /api/insights returns categorised metrics."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_run.return_value = [_make_mock_result()]
+
+        resp = client.get("/api/insights")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "metrics" in data
+        assert data["total"] == 1
+        assert data["flagged"] == 0
+
+    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.web.routes.insights.log_auth_event")
+    def test_empty_results(
+        self,
+        mock_audit: MagicMock,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """GET /api/insights with no metrics returns empty list."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_run.return_value = []
+
+        resp = client.get("/api/insights")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["metrics"] == []
+        assert data["total"] == 0
+
+    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.web.routes.insights.log_auth_event")
+    def test_audit_logged(
+        self,
+        mock_audit: MagicMock,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """GET /api/insights logs audit event."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_run.return_value = []
+
+        client.get("/api/insights")
+        mock_audit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/insights/run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunInsights:
+    """Tests for POST /api/insights/run."""
+
+    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.web.routes.insights.log_auth_event")
+    def test_run_returns_fresh_results(
+        self,
+        mock_audit: MagicMock,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """POST /api/insights/run executes and returns results."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_run.return_value = [
+            _make_mock_result(exceeds_threshold=True),
+        ]
+
+        resp = client.post(
+            "/api/insights/run",
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flagged"] == 1
+
+    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.web.routes.insights.log_auth_event")
+    def test_run_with_source_filter(
+        self,
+        mock_audit: MagicMock,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """POST /api/insights/run?source=stripe passes source filter."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_run.return_value = []
+
+        resp = client.post(
+            "/api/insights/run?source=stripe",
+            headers={"X-Requested-With": "XMLHttpRequest"},
+        )
+        assert resp.status_code == 200
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("source_filter") == ["raw_stripe"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/insights/history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetMetricHistory:
+    """Tests for GET /api/insights/history."""
+
+    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.utils.dango_db.connect")
+    @patch("dango.web.routes.insights.log_auth_event")
+    def test_returns_history(
+        self,
+        mock_audit: MagicMock,
+        mock_connect: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """GET /api/insights/history returns data points."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchall.return_value = [
+            (100.0, "2026-03-10T12:00:00"),
+            (95.0, "2026-03-09T12:00:00"),
+        ]
+
+        resp = client.get("/api/insights/history?metric=test_metric&days=7")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["metric"] == "test_metric"
+        assert data["days"] == 7
+        assert len(data["data_points"]) == 2


### PR DESCRIPTION
## Summary
- Add presentation layer for the analysis engine: CLI `dango analyze` command with Rich table output and drill-down details, web UI insights page with Alpine.js, and webhook notifications when metrics exceed thresholds
- New `METRIC_ALERT` event type with Slack formatting, `on_analysis` config flag, and `metadata` field on webhook payloads
- Three API endpoints: `GET /api/insights` (cached read), `POST /api/insights/run` (fresh analysis), `GET /api/insights/history` (metric history)

## Test plan
- [x] 23 new tests (13 formatter, 4 CLI, 6 web) — all pass
- [x] Full suite: 2782 passed, 0 failures
- [x] ruff lint + format clean
- [x] mypy clean
- [x] File sizes within limits (post_sync.py at 486 lines)
- [ ] Manual: `dango analyze` and `dango analyze --source stripe` from a project directory
- [ ] Manual: Browse `http://localhost:8800/insights`, click Run Analysis, verify drill-down and history

🤖 Generated with [Claude Code](https://claude.com/claude-code)