### PR TITLE
TEST-030: Phase 7 test audit + P7-008 fixups

### DIFF
--- a/dango/cli/commands/notebook.py
+++ b/dango/cli/commands/notebook.py
@@ -35,16 +35,30 @@ def notebook(ctx: click.Context) -> None:
 
     table = Table(title="Notebooks")
     table.add_column("Name", style="bold")
+    table.add_column("Author")
     table.add_column("Size")
     table.add_column("Last Modified")
 
     from datetime import datetime
 
+    # Query notebook_metadata for author info
+    authors: dict[str, str] = {}
+    try:
+        from dango.utils.dango_db import connect
+
+        with connect(project_root) as conn:
+            rows = conn.execute("SELECT name, created_by FROM notebook_metadata").fetchall()
+            for row in rows:
+                authors[row["name"]] = row["created_by"]
+    except Exception:
+        pass  # DB not initialized yet — show "--" for all
+
     for f in sorted(notebooks_dir.glob("*.py")):
         stat = f.stat()
         size_kb = stat.st_size / 1024
         mtime = datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M")
-        table.add_row(f.stem, f"{size_kb:.1f} KB", mtime)
+        author = authors.get(f.stem, "--")
+        table.add_row(f.stem, author, f"{size_kb:.1f} KB", mtime)
 
     console.print(table)
 

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -64,11 +64,14 @@
                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Available</span>
                                 </template>
                                 <template x-if="nb.lock && nb.lock.locked_by === userEmail">
-                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">Editing</span>
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
+                                        Editing <span class="ml-1 font-normal" x-text="'(' + timeAgo(nb.lock.locked_at) + ')'"></span>
+                                    </span>
                                 </template>
                                 <template x-if="nb.lock && nb.lock.locked_by !== userEmail">
                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-orange-100 text-orange-800">
                                         Locked by <span x-text="nb.lock.locked_by" class="ml-1"></span>
+                                        <span class="ml-1 font-normal" x-text="'(' + timeAgo(nb.lock.locked_at) + ')'"></span>
                                     </span>
                                 </template>
                             </td>

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -298,6 +298,12 @@ exemptions:
     reason: "TASK-045a: 8 test classes covering schedule help, list, status, remove, enable, disable, add wizard (sync, dbt, custom cron, cancelled). Marginally over limit."
     review_by: "v1.1"
 
+  - file: tests/unit/test_web_notebooks.py
+    lines: 506
+    category: exempt
+    reason: "TEST-030: 7 test classes covering page, list, create, delete, lock, heartbeat, release, force-release, copy. Marginally over limit after locked_at test addition."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,6 +317,8 @@ module = [
     "tests.unit.test_pii_detection",
     "tests.integration.test_pii_integration",
     "tests.unit.test_error_messages",
+    "tests.integration.test_post_sync_chain_integration",
+    "tests.integration.test_notebook_lifecycle",
 ]
 ignore_errors = true
 

--- a/tests/integration/test_notebook_lifecycle.py
+++ b/tests/integration/test_notebook_lifecycle.py
@@ -1,0 +1,146 @@
+"""tests/integration/test_notebook_lifecycle.py
+
+Integration tests for notebook locking lifecycle with real SQLite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dango.notebooks.locking import (
+    acquire_lock,
+    copy_locked_notebook,
+    force_release_lock,
+    get_lock_info,
+    is_locked,
+    refresh_lock,
+    release_lock,
+)
+from dango.utils.dango_db import _schema_initialized, connect
+
+
+def _clear_schema_cache() -> None:
+    """Clear the dango_db schema initialization cache for test isolation."""
+    _schema_initialized.clear()
+
+
+def _seed_notebook_file(project_root: Path, name: str) -> None:
+    """Create a notebook file on disk and register in metadata."""
+    nb_dir = project_root / "notebooks"
+    nb_dir.mkdir(parents=True, exist_ok=True)
+    (nb_dir / f"{name}.py").write_text(f"# {name}\n")
+
+    with connect(project_root) as conn:
+        conn.execute(
+            "INSERT INTO notebook_metadata (id, name, description, created_by, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))",
+            (name, name, f"Test notebook {name}", "test@test.com"),
+        )
+        conn.commit()
+
+
+@pytest.mark.integration
+class TestNotebookLifecycleIntegration:
+    """Integration tests for multi-step notebook locking flows with real SQLite."""
+
+    def test_full_lifecycle(self, tmp_path: Path) -> None:
+        """acquire -> refresh -> get_lock_info (has locked_at) -> release -> not locked."""
+        _clear_schema_cache()
+        _seed_notebook_file(tmp_path, "nb1")
+
+        # Acquire
+        assert acquire_lock(tmp_path, "nb1", "alice@test.com") is True
+        assert is_locked(tmp_path, "nb1") is True
+
+        # Refresh
+        assert refresh_lock(tmp_path, "nb1", "alice@test.com") is True
+
+        # Lock info includes locked_at
+        info = get_lock_info(tmp_path, "nb1")
+        assert info is not None
+        assert info["locked_by"] == "alice@test.com"
+        assert info["locked_at"] is not None
+
+        # Release
+        assert release_lock(tmp_path, "nb1", "alice@test.com") is True
+        assert is_locked(tmp_path, "nb1") is False
+
+    def test_lock_contention(self, tmp_path: Path) -> None:
+        """alice acquires -> bob fails -> alice releases -> bob succeeds."""
+        _clear_schema_cache()
+        _seed_notebook_file(tmp_path, "nb2")
+
+        assert acquire_lock(tmp_path, "nb2", "alice@test.com") is True
+        assert acquire_lock(tmp_path, "nb2", "bob@test.com") is False
+
+        assert release_lock(tmp_path, "nb2", "alice@test.com") is True
+        assert acquire_lock(tmp_path, "nb2", "bob@test.com") is True
+
+        info = get_lock_info(tmp_path, "nb2")
+        assert info is not None
+        assert info["locked_by"] == "bob@test.com"
+
+    def test_force_release(self, tmp_path: Path) -> None:
+        """alice acquires -> force_release -> not locked -> bob acquires."""
+        _clear_schema_cache()
+        _seed_notebook_file(tmp_path, "nb3")
+
+        assert acquire_lock(tmp_path, "nb3", "alice@test.com") is True
+        assert force_release_lock(tmp_path, "nb3") is True
+        assert is_locked(tmp_path, "nb3") is False
+        assert acquire_lock(tmp_path, "nb3", "bob@test.com") is True
+
+    def test_expired_lock_allows_acquisition(self, tmp_path: Path) -> None:
+        """alice acquires -> manually expire via SQL -> bob acquires."""
+        _clear_schema_cache()
+        _seed_notebook_file(tmp_path, "nb4")
+
+        assert acquire_lock(tmp_path, "nb4", "alice@test.com") is True
+
+        # Manually expire the lock
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "UPDATE notebook_locks "
+                "SET expires_at = datetime('now', '-1 minute') "
+                "WHERE notebook_id = 'nb4'"
+            )
+            conn.commit()
+
+        # Bob can acquire (expired lock gets cleaned)
+        assert acquire_lock(tmp_path, "nb4", "bob@test.com") is True
+
+        info = get_lock_info(tmp_path, "nb4")
+        assert info is not None
+        assert info["locked_by"] == "bob@test.com"
+
+    def test_copy_locked_notebook(self, tmp_path: Path) -> None:
+        """alice locks nb -> bob copies -> copy exists with metadata, original lock unaffected."""
+        _clear_schema_cache()
+        _seed_notebook_file(tmp_path, "nb5")
+
+        assert acquire_lock(tmp_path, "nb5", "alice@test.com") is True
+
+        copy_filename = copy_locked_notebook(tmp_path, "nb5", "bob@test.com")
+        assert copy_filename.startswith("nb5_copy_")
+        assert copy_filename.endswith(".py")
+
+        # Copy file exists on disk
+        copy_path = tmp_path / "notebooks" / copy_filename
+        assert copy_path.exists()
+
+        # Copy has metadata
+        copy_stem = copy_filename.removesuffix(".py")
+        with connect(tmp_path) as conn:
+            row = conn.execute(
+                "SELECT created_by FROM notebook_metadata WHERE name = ?",
+                (copy_stem,),
+            ).fetchone()
+        assert row is not None
+        assert row["created_by"] == "bob@test.com"
+
+        # Original lock unaffected
+        info = get_lock_info(tmp_path, "nb5")
+        assert info is not None
+        assert info["locked_by"] == "alice@test.com"

--- a/tests/integration/test_post_sync_chain_integration.py
+++ b/tests/integration/test_post_sync_chain_integration.py
@@ -1,0 +1,145 @@
+"""tests/integration/test_post_sync_chain_integration.py
+
+Integration tests for the full post-sync hook chain with real DuckDB + SQLite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import duckdb
+import pytest
+
+from dango.utils.dango_db import _schema_initialized, connect
+from dango.utils.post_sync import dispatch_post_sync_hooks
+
+
+def _clear_schema_cache() -> None:
+    """Clear the dango_db schema initialization cache for test isolation."""
+    _schema_initialized.clear()
+
+
+def _create_test_warehouse(tmp_path: Path) -> Path:
+    """Create a real DuckDB warehouse with test data.
+
+    Returns:
+        Path to the DuckDB file.
+    """
+    db_path = tmp_path / "data" / "warehouse.duckdb"
+    db_path.parent.mkdir(parents=True)
+
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE SCHEMA raw_testshop")
+    conn.execute("""
+        CREATE TABLE raw_testshop.orders (
+            id INTEGER NOT NULL,
+            total DOUBLE,
+            status VARCHAR,
+            email VARCHAR
+        )
+    """)
+    conn.execute("""
+        INSERT INTO raw_testshop.orders VALUES
+        (1, 10.50, 'succeeded', 'alice@example.com'),
+        (2, 25.00, 'succeeded', 'bob@example.com'),
+        (3, 5.00, 'failed', 'charlie@example.com')
+    """)
+    conn.close()
+    return db_path
+
+
+@pytest.mark.integration
+class TestPostSyncChainIntegration:
+    """Integration tests for the full 4-hook post-sync chain."""
+
+    def test_profiling_stores_stats(self, tmp_path: Path) -> None:
+        """dispatch_post_sync_hooks stores profiling_stats rows for testshop."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+
+        # Mock PII analyzer to avoid spaCy dependency
+        with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
+            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+
+        with connect(tmp_path) as sqlite_conn:
+            rows = sqlite_conn.execute(
+                "SELECT source, table_name, column_name FROM profiling_stats "
+                "WHERE source = 'testshop'"
+            ).fetchall()
+
+        assert len(rows) > 0
+        sources = {r["source"] for r in rows}
+        assert "testshop" in sources
+
+    def test_drift_baseline_created(self, tmp_path: Path) -> None:
+        """First dispatch creates schema_baselines with no drift_events."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+
+        with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
+            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+
+        with connect(tmp_path) as sqlite_conn:
+            baselines = sqlite_conn.execute(
+                "SELECT source FROM schema_baselines WHERE source = 'testshop'"
+            ).fetchall()
+            drift_events = sqlite_conn.execute(
+                "SELECT source FROM drift_events WHERE source = 'testshop'"
+            ).fetchall()
+
+        assert len(baselines) > 0
+        assert len(drift_events) == 0  # First run = baseline only, no drift
+
+    def test_second_dispatch_detects_drift(self, tmp_path: Path) -> None:
+        """ALTER TABLE between dispatches produces drift_events."""
+        _clear_schema_cache()
+        db_path = _create_test_warehouse(tmp_path)
+
+        with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
+            # First run — establishes baseline
+            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+
+        # ALTER TABLE — add a column
+        conn = duckdb.connect(str(db_path))
+        conn.execute("ALTER TABLE raw_testshop.orders ADD COLUMN notes VARCHAR")
+        conn.close()
+
+        with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
+            # Second run — should detect drift
+            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+
+        with connect(tmp_path) as sqlite_conn:
+            drift_events = sqlite_conn.execute(
+                "SELECT source, table_name, event_type FROM drift_events WHERE source = 'testshop'"
+            ).fetchall()
+
+        assert len(drift_events) > 0
+        event_types = {r["event_type"] for r in drift_events}
+        assert "column_added" in event_types
+
+    def test_hook_failure_does_not_block_chain(self, tmp_path: Path) -> None:
+        """Patch drift engine to raise — profiling still ran, analysis still ran."""
+        _clear_schema_cache()
+        _create_test_warehouse(tmp_path)
+
+        with (
+            patch(
+                "dango.governance.schema_drift.detect_drift_for_sources",
+                side_effect=RuntimeError("drift engine boom"),
+            ),
+            patch("dango.governance.pii_detector._get_analyzer", return_value=None),
+            patch("dango.analysis.metrics.run_analysis", return_value=[]) as mock_analysis,
+        ):
+            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+
+        # Profiling ran before drift (check profiling_stats)
+        with connect(tmp_path) as sqlite_conn:
+            rows = sqlite_conn.execute(
+                "SELECT source FROM profiling_stats WHERE source = 'testshop'"
+            ).fetchall()
+
+        assert len(rows) > 0  # Profiling succeeded despite drift failure
+
+        # Analysis ran after drift
+        mock_analysis.assert_called_once()

--- a/tests/unit/test_notebook_cli.py
+++ b/tests/unit/test_notebook_cli.py
@@ -42,6 +42,80 @@ class TestNotebookList:
 
             assert "explore" in result.output
 
+    def test_shows_author_column(self):
+        """Create notebook file + metadata entry and verify Author column appears."""
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            nb_dir = project_root / "notebooks"
+            nb_dir.mkdir()
+            (nb_dir / "my_nb.py").write_text("# notebook")
+            (project_root / ".dango").mkdir()
+
+            from dango.utils.dango_db import _schema_initialized, connect
+
+            _schema_initialized.clear()
+            with connect(project_root) as conn:
+                conn.execute(
+                    "INSERT INTO notebook_metadata (id, name, description, created_by, created_at, updated_at) "
+                    "VALUES ('id1', 'my_nb', 'desc', 'alice@test.com', '2026-01-01', '2026-01-01')"
+                )
+                conn.commit()
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.notebook import notebook
+
+                result = runner.invoke(notebook, [])
+
+            assert "Author" in result.output
+            assert "alice@test.com" in result.output
+
+    def test_shows_dash_for_unknown_author(self):
+        """Notebook on disk with no metadata shows '--' for author."""
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            nb_dir = project_root / "notebooks"
+            nb_dir.mkdir()
+            (nb_dir / "orphan.py").write_text("# notebook")
+            (project_root / ".dango").mkdir()
+
+            from dango.utils.dango_db import _schema_initialized
+
+            _schema_initialized.clear()
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.notebook import notebook
+
+                result = runner.invoke(notebook, [])
+
+            assert "Author" in result.output
+            assert "--" in result.output
+
+    def test_works_without_metadata_db(self):
+        """CLI falls back gracefully when dango.db doesn't exist."""
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            nb_dir = project_root / "notebooks"
+            nb_dir.mkdir()
+            (nb_dir / "solo.py").write_text("# notebook")
+
+            # Patch connect at source to raise (lazy import inside function)
+            with (
+                patch("dango.cli.utils.find_project_root", return_value=project_root),
+                patch(
+                    "dango.utils.dango_db.connect",
+                    side_effect=Exception("no db"),
+                ),
+            ):
+                from dango.cli.commands.notebook import notebook
+
+                result = runner.invoke(notebook, [])
+
+            assert "solo" in result.output
+            assert "--" in result.output
+
 
 @pytest.mark.unit
 class TestNotebookNew:

--- a/tests/unit/test_post_sync.py
+++ b/tests/unit/test_post_sync.py
@@ -55,3 +55,117 @@ class TestDispatchPostSyncHooks:
             _run_analysis(tmp_path, ["stripe", "ga"])
 
         mock_engine.assert_called_once_with(tmp_path, source_filter=["raw_stripe", "raw_ga"])
+
+    def test_profiling_engine_error_isolation(self, tmp_path: Path) -> None:
+        """When profiling engine raises, _run_profiling catches it and drift/pii/analysis still run."""
+        with (
+            patch("dango.utils.post_sync.profile_table", side_effect=RuntimeError("boom")),
+            patch("dango.governance.schema_drift.detect_drift_for_sources") as mock_drift,
+            patch("dango.governance.pii_detector.scan_sources_for_pii") as mock_pii,
+            patch("dango.analysis.metrics.run_analysis", return_value=[]) as mock_analysis,
+        ):
+            # Create minimal warehouse so _run_profiling tries to profile
+            db_path = tmp_path / "data" / "warehouse.duckdb"
+            db_path.parent.mkdir(parents=True)
+
+            import duckdb
+
+            conn = duckdb.connect(str(db_path))
+            conn.execute("CREATE SCHEMA raw_testshop")
+            conn.execute("CREATE TABLE raw_testshop.orders (id INTEGER)")
+            conn.close()
+
+            dispatch_post_sync_hooks(project_root=tmp_path, sources=["testshop"])
+
+        # Drift, PII, and analysis still called despite profiling failure
+        mock_drift.assert_called_once()
+        mock_pii.assert_called_once()
+        mock_analysis.assert_called_once()
+
+    def test_drift_engine_error_isolation(self, tmp_path: Path) -> None:
+        """When drift engine raises, _run_drift_detection catches it and pii/analysis still run."""
+        with (
+            patch("dango.utils.post_sync._run_profiling"),
+            patch(
+                "dango.governance.schema_drift.detect_drift_for_sources",
+                side_effect=RuntimeError("drift boom"),
+            ),
+            patch("dango.governance.pii_detector.scan_sources_for_pii") as mock_pii,
+            patch("dango.analysis.metrics.run_analysis", return_value=[]) as mock_analysis,
+        ):
+            dispatch_post_sync_hooks(project_root=tmp_path, sources=["s1"])
+
+        mock_pii.assert_called_once()
+        mock_analysis.assert_called_once()
+
+    def test_pii_engine_error_isolation(self, tmp_path: Path) -> None:
+        """When PII engine raises, _run_pii_scan catches it and analysis still runs."""
+        with (
+            patch("dango.utils.post_sync._run_profiling"),
+            patch("dango.utils.post_sync._run_drift_detection"),
+            patch(
+                "dango.governance.pii_detector.scan_sources_for_pii",
+                side_effect=RuntimeError("pii boom"),
+            ),
+            patch("dango.analysis.metrics.run_analysis", return_value=[]) as mock_analysis,
+        ):
+            dispatch_post_sync_hooks(project_root=tmp_path, sources=["s1"])
+
+        mock_analysis.assert_called_once()
+
+    def test_hooks_called_in_order(self, tmp_path: Path) -> None:
+        """Hooks are called in order: profiling -> drift -> pii -> analysis."""
+        call_order: list[str] = []
+
+        def _make_side_effect(name: str):
+            def _side_effect(*_args, **_kwargs):
+                call_order.append(name)
+
+            return _side_effect
+
+        with (
+            patch(
+                "dango.utils.post_sync._run_profiling",
+                side_effect=_make_side_effect("profiling"),
+            ),
+            patch(
+                "dango.utils.post_sync._run_drift_detection",
+                side_effect=_make_side_effect("drift"),
+            ),
+            patch(
+                "dango.utils.post_sync._run_pii_scan",
+                side_effect=_make_side_effect("pii"),
+            ),
+            patch(
+                "dango.utils.post_sync._run_analysis",
+                side_effect=_make_side_effect("analysis"),
+            ),
+        ):
+            dispatch_post_sync_hooks(project_root=tmp_path, sources=["s1"])
+
+        assert call_order == ["profiling", "drift", "pii", "analysis"]
+
+    def test_log_start_and_complete(self, tmp_path: Path) -> None:
+        """Verify logger.info called with post_sync_hooks_start and _complete."""
+        with (
+            patch("dango.utils.post_sync._run_profiling"),
+            patch("dango.utils.post_sync._run_drift_detection"),
+            patch("dango.utils.post_sync._run_pii_scan"),
+            patch("dango.utils.post_sync._run_analysis"),
+            patch("dango.utils.post_sync.logger") as mock_logger,
+        ):
+            dispatch_post_sync_hooks(project_root=tmp_path, sources=["s1"])
+
+        info_calls = list(mock_logger.info.call_args_list)
+        events = [c[0][0] for c in info_calls]
+        assert "post_sync_hooks_start" in events
+        assert "post_sync_hooks_complete" in events
+
+    def test_drift_hook_calls_engine(self, tmp_path: Path) -> None:
+        """Call _run_drift_detection directly and verify it calls the engine."""
+        with patch("dango.governance.schema_drift.detect_drift_for_sources") as mock_engine:
+            from dango.utils.post_sync import _run_drift_detection
+
+            _run_drift_detection(tmp_path, ["shopify", "stripe"])
+
+        mock_engine.assert_called_once_with(tmp_path, ["shopify", "stripe"])

--- a/tests/unit/test_web_notebooks.py
+++ b/tests/unit/test_web_notebooks.py
@@ -169,6 +169,19 @@ class TestListNotebooks:
         assert data[0]["id"] is None
 
     @patch(f"{_P}.get_project_root")
+    def test_lock_includes_locked_at(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        """When a notebook is locked, the API response includes locked_at."""
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_notebook(tmp_path, "locked_nb")
+        _seed_lock(tmp_path, "locked_nb", locked_by="editor@test.com")
+        data = _client(tmp_path).get("/api/notebooks").json()
+        assert len(data) == 1
+        assert data[0]["lock"] is not None
+        assert data[0]["lock"]["locked_at"] is not None
+        assert isinstance(data[0]["lock"]["locked_at"], str)
+
+    @patch(f"{_P}.get_project_root")
     def test_viewer_can_list(self, mock_root: MagicMock, tmp_path: Path) -> None:
         """Viewer can list notebooks."""
         mock_root.return_value = tmp_path


### PR DESCRIPTION
## Summary
- **P7-008 fixups:** Add `locked_at` time display to lock badges in notebooks.html; add Author column to CLI `dango notebook` list
- **Test gap coverage:** 15 new tests across 5 files — error isolation for post-sync hooks, notebook CLI author column, locked_at API verification, full post-sync chain integration (profiling + drift + PII + analysis), notebook locking lifecycle integration

## Files Changed (9)
| File | Change |
|------|--------|
| `dango/web/templates/notebooks.html` | locked_at display in lock badges |
| `dango/cli/commands/notebook.py` | Author column via notebook_metadata |
| `tests/unit/test_post_sync.py` | +6 tests (57→171 lines) |
| `tests/unit/test_web_notebooks.py` | +1 test (493→506 lines) |
| `tests/unit/test_notebook_cli.py` | +3 tests (150→224 lines) |
| `tests/integration/test_post_sync_chain_integration.py` | **New** — 4 integration tests |
| `tests/integration/test_notebook_lifecycle.py` | **New** — 5 integration tests |
| `pyproject.toml` | +2 mypy exemptions for new test files |
| `docs/file-exemptions.yml` | +1 exemption (test_web_notebooks.py at 506 lines) |

## Test plan
- [x] `pytest -m unit tests/unit/test_post_sync.py` — 10 passed
- [x] `pytest -m unit tests/unit/test_notebook_cli.py` — 10 passed
- [x] `pytest -m unit tests/unit/test_web_notebooks.py` — 32 passed
- [x] `pytest -m integration tests/integration/test_post_sync_chain_integration.py` — 4 passed
- [x] `pytest -m integration tests/integration/test_notebook_lifecycle.py` — 5 passed
- [x] Full suite: 2802 passed, 23 skipped
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy dango/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)