### PR TITLE
DOC-029: Phase 7 documentation sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,10 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
               │                                          Facebook,         │
               │                    auth/                  Shopify)          │
               │                    (users, sessions,                       │
-              │                     RBAC, 2FA, audit)                      │
+              │                     RBAC, 2FA, audit)   governance/        │
+              │                    notebooks/            (drift, PII)      │
+              │                    (Marimo)              analysis/          │
+              │                                         (metrics)          │
               └──────────┬────────────────┬────────────────────────────────┘
                          │                │
               ┌──────────┴────────────────┴────────────────────────────────┐
@@ -70,7 +73,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 | Level | Role | Modules |
 |-------|------|---------|
 | 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `migrations/`, `templates/`, `logging.py`, `exceptions.py` |
-| 1 (core) | Imports Level 0 only | `oauth/`, `ingestion/`, `transformation/`, `auth/` |
+| 1 (core) | Imports Level 0 only | `oauth/`, `ingestion/`, `transformation/`, `auth/`, `governance/`, `notebooks/`, `analysis/` |
 | 2 (platform) | Imports Level 0-1 | `platform/`, `web/`, `visualization/` |
 | 3 (ui) | Imports any level | `cli/` |
 
@@ -254,6 +257,60 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 **Public API:** `create_session()`, `validate_session()`, `require_permission()`, `has_permission()`, `hash_password()`, `verify_password()`, `AuditEvent`, `log_auth_event()`, `bridge_metabase_login()`, `bridge_metabase_logout()`, `sync_user_to_metabase()`, `Role`, `User`, `Session`, `APIKey`
 
 **Imports from:** `config/` (Level 0), `security/` (Level 0), `logging` (Level 0), `exceptions` (Level 0).
+
+#### `governance/`
+**Responsibility:** Data governance — schema drift detection and PII scanning. Monitors DuckDB warehouse schemas for changes, records drift events, scans string columns for PII, and alerts via webhooks.
+
+| File | Description |
+|------|-------------|
+| `__init__.py` | Re-exports public API |
+| `models.py` | Pydantic V2 response models: `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse` |
+| `schema_drift.py` | Schema drift detection engine (490 lines): `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()` |
+| `pii_detector.py` | PII scanning engine using Presidio + spaCy (454 lines): `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()` |
+
+**Public API:** `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()`, `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`
+
+**Imports from:** `utils/dango_db` (Level 0), `logging` (Level 0), `platform/notifications/` (Level 2 — lazy import for webhooks).
+
+---
+
+#### `notebooks/`
+**Responsibility:** Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking, and HTTP/WebSocket reverse proxy.
+
+| File | Description |
+|------|-------------|
+| `__init__.py` | Re-exports public symbols |
+| `manager.py` | Marimo process lifecycle: start/stop/status (197 lines) |
+| `locking.py` | File-level notebook locking via SQLite `notebook_locks` table (249 lines) |
+| `snapshot.py` | DuckDB snapshot management: create, list, cleanup |
+| `proxy.py` | HTTP + WebSocket reverse proxy to Marimo (186 lines) |
+| `templates/` | Starter templates: explore, quality, blank |
+
+**Public API:** `start_marimo()`, `stop_marimo()`, `get_marimo_status()`, `acquire_lock()`, `release_lock()`, `create_snapshot()`, `proxy_to_marimo()`, `proxy_websocket_to_marimo()`
+
+**Imports from:** `utils/` (Level 0), `config/` (Level 0).
+
+---
+
+#### `analysis/`
+**Responsibility:** Automated metric monitoring and comparison engine. Executes user-defined SQL metrics against DuckDB, stores results in SQLite, and compares values against historical baselines.
+
+| File | Description |
+|------|-------------|
+| `__init__.py` | Public API re-exports |
+| `models.py` | Pydantic V2 models: `MetricConfig`, `ComparisonResult`, `AnalysisResult` |
+| `config.py` | YAML config load/save for `.dango/metrics.yml` |
+| `comparisons.py` | Comparison engine + trend detection |
+| `drilldown.py` | GROUP BY breakdown + contributor ranking |
+| `metrics.py` | Orchestration: execute → store → compare → drill-down |
+| `templates.py` | Pre-built metric templates for common sources |
+| `formatter.py` | Result categorization + display formatting |
+
+**Public API:** `run_analysis()`, `load_metrics_config()`, `save_metrics_config()`, `generate_metrics_for_source()`
+
+**Imports from:** `utils/dango_db` (Level 0), `logging` (Level 0), `exceptions` (Level 0).
+
+---
 
 ### Level 2 — Platform
 
@@ -510,6 +567,28 @@ On Metabase proxy 401 (stale session):
   → web/routes/metabase_proxy.py: re-bridge automatically using stored credentials
 ```
 
+### 6.10 Post-Sync Hooks
+
+```
+After each sync completes (in dlt_runner.py run_sync):
+
+ingestion/dlt_runner.py: run_sync()
+  → utils/post_sync.py: dispatch_post_sync_hooks(project_root, sources)
+      → _run_profiling(project_root, sources)
+          → Column stats (row count, null %, distinct count) cached in dango.db
+      → _run_drift_detection(project_root, sources)
+          → governance/schema_drift.py: detect_drift_for_sources()
+          → Drift events stored in dango.db, webhook if configured
+      → _run_pii_scan(project_root, sources)
+          → governance/pii_detector.py: scan_sources_for_pii()
+          → PII findings stored in dango.db, webhook if configured
+      → _run_analysis(project_root, sources)
+          → analysis/metrics.py: run_analysis()
+          → Metric results stored in dango.db
+
+Each hook is wrapped in try/except — failures are logged but never propagate.
+```
+
 ## 7. Database Schemas
 
 ### DuckDB Warehouse (`data/{project}.duckdb`)
@@ -582,6 +661,10 @@ The web module (`web/routes/`) exposes 19 REST endpoints, 1 WebSocket, and a Met
 | Admin | `GET /api/admin/users`, `POST /api/admin/users`, `GET /api/admin/users/{id}`, `PUT /api/admin/users/{id}`, `PUT /api/admin/users/{id}/role`, `POST /api/admin/users/{id}/reset-password`, `POST /api/admin/users/{id}/deactivate`, `POST /api/admin/users/{id}/reactivate`, `DELETE /api/admin/users/{id}`, `POST /api/admin/users/{id}/unlock`, `POST /api/admin/users/{id}/reinvite` |
 | dbt | `GET /api/dbt/models`, `POST /api/dbt/models/{name}/run` |
 | Logs | `GET /api/logs` |
+| Catalog | `GET /api/catalog/sources/{source}/columns`, `GET /api/catalog/sources/{source}/tables/{table}/profile`, `GET /api/catalog/lineage`, `GET /api/catalog/lineage/impact/{node}` |
+| Governance | `GET /api/governance/schema-drift`, `GET /api/governance/pii` |
+| Notebooks | `GET /api/notebooks`, `POST /api/notebooks`, `DELETE /api/notebooks/{id}`, `POST /api/notebooks/{id}/lock`, `POST /api/notebooks/{id}/lock/release`, `POST /api/notebooks/{id}/lock/refresh`, `POST /api/notebooks/{id}/lock/force-release`, `POST /api/notebooks/{id}/copy` |
+| Insights | `GET /api/insights`, `POST /api/insights/run`, `GET /api/insights/history` |
 | Docs | `GET /api/docs` (Swagger), `GET /api/redoc` |
 | Real-time | `WS /ws` (sync progress, errors) |
 | Proxy | `/metabase/*` (reverse proxy with SSO session injection) |
@@ -622,7 +705,7 @@ The web module (`web/routes/`) exposes 19 REST endpoints, 1 WebSocket, and a Met
 |------|-------|-----------------|
 | ~~`cli/main.py`~~ | ~~3927~~ | ~~TASK-005~~ — **Done:** split into `cli/commands/`, main.py is now ~88 lines |
 | ~~`web/app.py`~~ | ~~2900~~ | ~~TASK-085~~ — **Done:** split into `web/routes/`, app.py is now ~202 lines |
-| `ingestion/dlt_runner.py` | 1759 | Phase 3 (extract orchestration) |
+| `ingestion/dlt_runner.py` | 1796 | Phase 3 (extract orchestration) |
 
 ### Runtime Architecture
 
@@ -642,7 +725,10 @@ my-project/
 ├── .dango/              # Dango state and config
 │   ├── project.yml      # Project metadata
 │   ├── sources.yml      # Source definitions
-│   └── metabase.yml     # Auto-generated Metabase credentials (gitignored)
+│   ├── metrics.yml      # Metric analysis config (auto-generated)
+│   ├── metabase.yml     # Auto-generated Metabase credentials (gitignored)
+│   ├── dango.db         # SQLite: notebook locks, profiling cache, drift/PII/metric results
+│   └── snapshots/       # DuckDB read-only snapshots for notebooks
 ├── .dlt/                # dlt credentials
 │   └── secrets.toml     # OAuth tokens (gitignored)
 ├── .env                 # API keys (gitignored)
@@ -660,6 +746,7 @@ my-project/
 │   ├── macros/          # get_custom_schema.sql
 │   ├── tests/
 │   └── seeds/
+├── notebooks/           # Marimo notebook files (.py)
 ├── metabase/            # Dashboard export/import (YAML)
 ├── docker-compose.yml
 ├── Dockerfile.metabase

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -647,7 +647,7 @@ Three-tier storage:
 
 ## 10. API Design Principles
 
-The web module (`web/routes/`) exposes 19 REST endpoints, 1 WebSocket, and a Metabase reverse proxy.
+The web module (`web/routes/`) exposes REST endpoints across 18 route files, 1 WebSocket, and a Metabase reverse proxy.
 
 **Current endpoints (all under `/api/`):**
 
@@ -661,9 +661,9 @@ The web module (`web/routes/`) exposes 19 REST endpoints, 1 WebSocket, and a Met
 | Admin | `GET /api/admin/users`, `POST /api/admin/users`, `GET /api/admin/users/{id}`, `PUT /api/admin/users/{id}`, `PUT /api/admin/users/{id}/role`, `POST /api/admin/users/{id}/reset-password`, `POST /api/admin/users/{id}/deactivate`, `POST /api/admin/users/{id}/reactivate`, `DELETE /api/admin/users/{id}`, `POST /api/admin/users/{id}/unlock`, `POST /api/admin/users/{id}/reinvite` |
 | dbt | `GET /api/dbt/models`, `POST /api/dbt/models/{name}/run` |
 | Logs | `GET /api/logs` |
-| Catalog | `GET /api/catalog/sources/{source}/columns`, `GET /api/catalog/sources/{source}/tables/{table}/profile`, `GET /api/catalog/lineage`, `GET /api/catalog/lineage/impact/{node}` |
+| Catalog | `GET /api/catalog/{source}/{table}/columns`, `POST /api/catalog/{source}/{table}/profile`, `GET /api/catalog/lineage`, `GET /api/catalog/impact/{model_name}` |
 | Governance | `GET /api/governance/schema-drift`, `GET /api/governance/pii` |
-| Notebooks | `GET /api/notebooks`, `POST /api/notebooks`, `DELETE /api/notebooks/{id}`, `POST /api/notebooks/{id}/lock`, `POST /api/notebooks/{id}/lock/release`, `POST /api/notebooks/{id}/lock/refresh`, `POST /api/notebooks/{id}/lock/force-release`, `POST /api/notebooks/{id}/copy` |
+| Notebooks | `GET /api/notebooks`, `POST /api/notebooks`, `DELETE /api/notebooks/{name}`, `POST /api/notebooks/{name}/lock`, `POST /api/notebooks/{name}/heartbeat`, `POST /api/notebooks/{name}/release`, `DELETE /api/notebooks/{name}/lock`, `POST /api/notebooks/{name}/copy` |
 | Insights | `GET /api/insights`, `POST /api/insights/run`, `GET /api/insights/history` |
 | Docs | `GET /api/docs` (Swagger), `GET /api/redoc` |
 | Real-time | `WS /ws` (sync progress, errors) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,7 +194,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 | File | Description |
 |------|-------------|
 | `__init__.py` | Re-exports `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY` |
-| `dlt_runner.py` | `DltPipelineRunner` — orchestrates sync: load data, generate staging models, run dbt, refresh Metabase (1759 lines). Contains lazy imports from Level 1-2 modules. |
+| `dlt_runner.py` | `DltPipelineRunner` — orchestrates sync: load data, generate staging models, run dbt, refresh Metabase (1796 lines). Contains lazy imports from Level 1-2 modules. |
 | `csv_loader.py` | `CSVLoader` — incremental CSV loading with 4 dedup strategies, file metadata tracking |
 | `sources/registry.py` | `SOURCE_REGISTRY` — metadata dict for all 33 sources (auth type, params, setup guide, cost warnings) |
 | `dlt_sources/` | 29 vendored dlt source integrations (third-party code, rarely modified) |
@@ -352,7 +352,7 @@ This document describes the **target v1 architecture**. Not-yet-implemented feat
 
 | File | Description |
 |------|-------------|
-| `main.py` | Slim entry point (~88 lines) — registers command groups from `commands/` subpackage |
+| `main.py` | Slim entry point (~109 lines) — registers command groups from `commands/` subpackage |
 | `commands/` | Command modules extracted from main.py by TASK-005: `platform.py` (start/stop/status), `source.py` (add/list/remove/sync), `oauth.py` (OAuth credential management), `auth.py` (user auth placeholder, Phase 2), `project.py` (init/rename/info), `transform.py` (run/docs/generate), etc. |
 | `init.py` | Project initialization wizard — creates directory structure, config files, Docker setup |
 | `wizard.py` | Interactive setup wizards |
@@ -703,7 +703,7 @@ The web module (`web/routes/`) exposes REST endpoints across 18 route files, 1 W
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| ~~`cli/main.py`~~ | ~~3927~~ | ~~TASK-005~~ — **Done:** split into `cli/commands/`, main.py is now ~88 lines |
+| ~~`cli/main.py`~~ | ~~3927~~ | ~~TASK-005~~ — **Done:** split into `cli/commands/`, main.py is now ~109 lines |
 | ~~`web/app.py`~~ | ~~2900~~ | ~~TASK-085~~ — **Done:** split into `web/routes/`, app.py is now ~202 lines |
 | `ingestion/dlt_runner.py` | 1796 | Phase 3 (extract orchestration) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,9 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | Notifications / webhooks | `dango/platform/notifications/` | [`dango/platform/notifications/CLAUDE.md`](dango/platform/notifications/CLAUDE.md) |
 | Jinja2 templates / Dockerfiles | `dango/templates/` | [`dango/templates/CLAUDE.md`](dango/templates/CLAUDE.md) |
 | Auth / users / sessions | `dango/auth/` | [`dango/auth/CLAUDE.md`](dango/auth/CLAUDE.md) |
-| Notebooks | `dango/notebooks/` | Not yet created (Phase 6) |
-| Data governance | `dango/governance/` | Not yet created (Phase 7) |
+| Notebooks | `dango/notebooks/` | [`dango/notebooks/CLAUDE.md`](dango/notebooks/CLAUDE.md) |
+| Data governance | `dango/governance/` | [`dango/governance/CLAUDE.md`](dango/governance/CLAUDE.md) |
+| Metric analysis / insights | `dango/analysis/` | [`dango/analysis/CLAUDE.md`](dango/analysis/CLAUDE.md) |
 
 ## Don't Read First
 
@@ -52,6 +53,9 @@ When unsure which module to look at:
   - Token encryption (keychain) → `security/`
   - Config file format (`.dango/*.yml`) → `config/`
 - **Shared utility** (locking, logging, DB helpers) → `utils/`
+- **HOW schema drift / PII is detected** → `governance/`
+- **HOW metrics are tracked / compared** → `analysis/`
+- **Marimo notebooks** → `notebooks/`
 - **Docker containers / file watching** → `platform/`
 - **HOW scheduled jobs run** → `platform/scheduling/`
 - **HOW notifications are sent** → `platform/notifications/`
@@ -67,7 +71,7 @@ dango/                          # Python package source
 ├── logging.py                  # Level 0 — Structured logging (structlog + stdlib)
 ├── cli/                        # Level 3 — Click CLI (primary user interface)
 │   ├── __init__.py             # Shared Console instance
-│   ├── main.py                 # Slim entry point (~88 lines) — registers commands
+│   ├── main.py                 # Slim entry point (~109 lines) — registers commands
 │   ├── commands/               # Command modules (extracted from main.py by TASK-005)
 │   │   ├── __init__.py         # Package marker
 │   │   ├── auth.py             # auth group (12 subcommands, 538 lines)
@@ -94,7 +98,10 @@ dango/                          # Python package source
 │   │   ├── remote_ops.py       # remote upgrade/resize/migrate
 │   │   ├── remote_backup.py    # remote backup subgroup
 │   │   ├── remote_mgmt.py      # remote status/logs/ssh/query
-│   │   └── schedule.py         # schedule group (add/list/remove/status/enable/disable/webhook)
+│   │   ├── schedule.py         # schedule group (add/list/remove/status/enable/disable/webhook)
+│   │   ├── governance.py       # governance group (drift-report/pii-report)
+│   │   ├── notebook.py         # notebook group (new/open) + snapshot
+│   │   └── analyze.py          # analyze top-level command
 │   ├── init.py                 # Project initialization wizard
 │   ├── wizard.py               # Interactive setup wizards
 │   ├── source_wizard.py        # Source configuration wizard
@@ -125,6 +132,30 @@ dango/                          # Python package source
 │   ├── metabase_sync.py        # Sync users/roles to Metabase (498 lines)
 │   └── metabase_bridge.py      # Async SSO session bridging
 │
+├── governance/                 # Level 1 — Data governance (schema drift + PII scanning)
+│   ├── __init__.py             # Re-exports public API
+│   ├── models.py               # Pydantic V2 response models
+│   ├── schema_drift.py         # Schema drift detection engine (490 lines)
+│   └── pii_detector.py         # PII scanning engine (454 lines)
+│
+├── notebooks/                  # Level 1 — Marimo notebook management
+│   ├── __init__.py             # Re-exports public symbols
+│   ├── manager.py              # Marimo process lifecycle (197 lines)
+│   ├── locking.py              # File-level notebook locking (249 lines)
+│   ├── snapshot.py             # DuckDB snapshot management
+│   ├── proxy.py                # HTTP + WebSocket reverse proxy (186 lines)
+│   └── templates/              # Marimo starter templates (explore, quality, blank)
+│
+├── analysis/                   # Level 1 — Metric monitoring + comparison engine
+│   ├── __init__.py             # Public API re-exports
+│   ├── models.py               # Pydantic V2 models (MetricConfig, ComparisonResult, etc.)
+│   ├── config.py               # YAML config load/save
+│   ├── comparisons.py          # Comparison engine + trend detection
+│   ├── drilldown.py            # Drill-down engine
+│   ├── metrics.py              # Orchestration: execute → store → compare
+│   ├── templates.py            # Pre-built metric templates for common sources
+│   └── formatter.py            # Result categorization + display formatting
+│
 ├── web/                        # Level 2 — FastAPI web server
 │   ├── app.py                  # Entry point (~301 lines) — routers, middleware, admin bootstrap
 │   ├── models.py               # Pydantic request/response DTOs (incl. auth DTOs)
@@ -149,6 +180,10 @@ dango/                          # Python package source
 │   │   ├── metabase_proxy.py   # Metabase reverse proxy + SSO session
 │   │   ├── secrets.py          # Secrets + OAuth credential management (admin-only)
 │   │   ├── oauth_connect.py    # Web-based OAuth connect/callback
+│   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact (566 lines)
+│   │   ├── governance.py       # Schema drift + PII results API
+│   │   ├── insights.py         # Metric results, run trigger, history
+│   │   ├── notebooks.py        # Notebook management API + page route
 │   │   └── initial_sync.py     # Initial data sync after first deploy
 │   ├── templates/              # Auth page templates
 │   │   ├── login.html          # Alpine.js two-step login (credentials → totp)
@@ -156,7 +191,11 @@ dango/                          # Python package source
 │   │   ├── admin_users.html    # Admin user management
 │   │   ├── account.html        # User account settings
 │   │   ├── invite.html         # Invite acceptance page
-│   │   └── secrets.html        # Secrets management page
+│   │   ├── secrets.html        # Secrets management page
+│   │   ├── schedules.html      # Schedule management page
+│   │   ├── notebooks.html      # Notebook management page
+│   │   ├── catalog.html        # Data catalog page (495 lines)
+│   │   └── insights.html       # Insights/analysis page
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
@@ -243,7 +282,9 @@ dango/                          # Python package source
 │   ├── dbt_status.py           # dbt model status tracking
 │   ├── log_rotation.py         # JSONL log rotation with gzip compression
 │   ├── data_validation.py      # Data validation utilities
-│   └── env_file.py             # .env file parsing and serialization
+│   ├── env_file.py             # .env file parsing and serialization
+│   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
+│   └── post_sync.py            # Post-sync hook dispatcher (~486 lines)
 │
 ├── migrations/                 # Level 0 — Database migration framework
 │   ├── __init__.py             # Public API: apply_all_pending(), get_all_status()
@@ -271,7 +312,7 @@ tests/
 | Level | Role | Modules |
 |-------|------|---------|
 | 0 (base) | No dango imports | `config/`, `utils/`, `security/`, `migrations/`, `templates/`, `logging.py` |
-| 1 (core) | Imports Level 0 only | `auth/`, `oauth/`, `ingestion/`, `transformation/` |
+| 1 (core) | Imports Level 0 only | `auth/`, `oauth/`, `ingestion/`, `transformation/`, `governance/`, `notebooks/`, `analysis/` |
 | 2 (platform) | Imports Level 0–1 | `platform/`, `web/`, `visualization/` |
 | 3 (ui) | Imports any level | `cli/` |
 
@@ -288,12 +329,12 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `ingestion/dlt_runner.py` | 1784 | — (exempt, too risky) |
+| `ingestion/dlt_runner.py` | 1796 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 1466 | — (metadata-only) |
-| `cli/source_wizard.py` | 1324 | — |
+| `cli/source_wizard.py` | 1350 | — |
 | `visualization/metabase.py` | 1149 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/init.py` | 1098 | — |
+| `cli/init.py` | 1125 | — |
 | `cli/commands/platform.py` | 964 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | ~854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 815 | — (renamed from auth.py by TASK-093) |
@@ -309,13 +350,14 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/validate.py` | 651 | — |
 | `cli/commands/deploy_wizard.py` | 579 | — (interactive deploy wizard) |
 | `transformation/generator.py` | 577 | — |
+| `web/routes/catalog.py` | 566 | — (data catalog: columns, profiling, lineage, impact) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
-| `config/models.py` | 548 | — (Pydantic config models) |
+| `config/models.py` | 553 | — (Pydantic config models) |
 | `cli/commands/deploy_provision.py` | 543 | — (provisioning orchestration) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
 | `cli/commands/auth.py` | 538 | — (12 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |
-| `web/routes/users.py` | 527 | — (admin user CRUD) |
+| `web/routes/users.py` | 527 | — (admin user CRUD + invite) |
 | `cli/model_wizard.py` | 507 | — |
 | `platform/local/watcher.py` | 506 | — |
 | `platform/cloud/scheduled_backup.py` | 505 | — (server-side scheduled backup) |
@@ -342,10 +384,9 @@ Module CLAUDE.md files provide per-module navigation, public API, and patterns.
 - [`dango/platform/CLAUDE.md`](dango/platform/CLAUDE.md)
 - [`dango/platform/scheduling/CLAUDE.md`](dango/platform/scheduling/CLAUDE.md)
 - [`dango/platform/notifications/CLAUDE.md`](dango/platform/notifications/CLAUDE.md)
-
-**Planned later phases:**
-- `dango/notebooks/CLAUDE.md` (Phase 6)
-- `dango/governance/CLAUDE.md` (Phase 7)
+- [`dango/notebooks/CLAUDE.md`](dango/notebooks/CLAUDE.md)
+- [`dango/governance/CLAUDE.md`](dango/governance/CLAUDE.md)
+- [`dango/analysis/CLAUDE.md`](dango/analysis/CLAUDE.md)
 
 ## Development Setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ dango/                          # Python package source
 │   │   ├── insights.py         # Metric results, run trigger, history
 │   │   ├── notebooks.py        # Notebook management API + page route
 │   │   └── initial_sync.py     # Initial data sync after first deploy
-│   ├── templates/              # Auth page templates
+│   ├── templates/              # Jinja2 page templates
 │   │   ├── login.html          # Alpine.js two-step login (credentials → totp)
 │   │   ├── change_password.html # First-login password change
 │   │   ├── admin_users.html    # Admin user management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ dango/                          # Python package source
 │   └── watcher_runner.py       # → local/watcher_runner.py
 │
 ├── ingestion/                  # Level 1 — Data loading
-│   ├── dlt_runner.py           # ⚠ 1784 lines — orchestrates full sync pipeline
+│   ├── dlt_runner.py           # ⚠ 1796 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # CSV loading with dedup (742 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (1466 lines, 33 source types)

--- a/dango/CLAUDE.md
+++ b/dango/CLAUDE.md
@@ -27,7 +27,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 
 **Used by:**
 - `dango/cli/main.py`, `dango/cli/init.py`, `dango/cli/wizard.py` — import `__version__`
-- `dango.logging` — `get_logger()` used by `web/routes/`, `web/middleware/`, `web/app.py`, `platform/scheduling/`, `platform/notifications/`, `oauth/web_flow.py`, `utils/log_rotation.py`, `cli/commands/schedule.py`, `cli/commands/remote_env.py`; `configure_logging()` called by entry points
+- `dango.logging` — `get_logger()` used by `web/routes/`, `web/middleware/`, `web/app.py`, `platform/scheduling/`, `platform/notifications/`, `oauth/web_flow.py`, `utils/log_rotation.py`, `utils/post_sync.py`, `cli/commands/schedule.py`, `cli/commands/remote_env.py`, `governance/`, `notebooks/`, `analysis/`; `configure_logging()` called by entry points
 - `pyproject.toml` defines `getdango` as the installable package
 - Entry point: `dango.cli.main:cli` (configured in `pyproject.toml`)
 

--- a/dango/CLAUDE.md
+++ b/dango/CLAUDE.md
@@ -27,7 +27,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 
 **Used by:**
 - `dango/cli/main.py`, `dango/cli/init.py`, `dango/cli/wizard.py` — import `__version__`
-- `dango.logging` — `get_logger()` used by `web/routes/`, `web/middleware/`, `web/app.py`, `platform/scheduling/`, `platform/notifications/`, `oauth/web_flow.py`, `utils/log_rotation.py`, `utils/post_sync.py`, `cli/commands/schedule.py`, `cli/commands/remote_env.py`, `governance/`, `notebooks/`, `analysis/`; `configure_logging()` called by entry points
+- `dango.logging` — `get_logger()` used by `web/routes/`, `web/middleware/`, `web/app.py`, `platform/scheduling/`, `platform/notifications/`, `oauth/web_flow.py`, `utils/log_rotation.py`, `utils/post_sync.py`, `cli/commands/schedule.py`, `cli/commands/remote_env.py`, `governance/`, `analysis/`; `configure_logging()` called by entry points. Note: `notebooks/` uses stdlib `logging` directly, not `dango.logging`.
 - `pyproject.toml` defines `getdango` as the installable package
 - Entry point: `dango.cli.main:cli` (configured in `pyproject.toml`)
 

--- a/dango/analysis/CLAUDE.md
+++ b/dango/analysis/CLAUDE.md
@@ -15,6 +15,7 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 | `drilldown.py` | Drill-down engine: GROUP BY breakdown + contributor ranking | `run_drill_down()` |
 | `metrics.py` | Orchestration: execute → store → compare → drill-down | `run_analysis()` |
 | `templates.py` | Pre-built metric templates for common sources | `generate_metrics_for_source()` |
+| `formatter.py` (144 lines) | Result categorization + display formatting | `categorize_results()`, status labels, trend direction |
 
 ## Common Tasks
 
@@ -43,8 +44,8 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 - `utils/post_sync.py` — `_run_analysis()` calls `run_analysis` with `raw_`-prefixed source filter
 - `cli/source_wizard.py` — `generate_metrics_for_source()` + `add_metrics_to_config()` on source add
 - `cli/init.py` — `save_metrics_config()` + `generate_metrics_for_source()` on project init
-- `web/routes/insights.py` — planned (P7-012)
-- `cli/commands/analyze.py` — planned (P7-012)
+- `web/routes/insights.py` — GET /api/insights, POST /api/insights/run, GET /api/insights/history
+- `cli/commands/analyze.py` — `dango analyze` command
 
 ## Testing
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -8,7 +8,7 @@ Click-based command-line interface for all Dango operations — project init, so
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `main.py` (86 lines) | CLI entry point, registers all commands | `cli` (Click group), `main()` |
+| `main.py` (109 lines) | CLI entry point, registers all commands | `cli` (Click group), `main()` |
 | `__init__.py` (12 lines) | Shared `console` (Rich Console) instance | `console` |
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
@@ -36,11 +36,14 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query` | `remote_status()`, `remote_logs()` |
 | `commands/schedule.py` (499 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
+| `commands/governance.py` (125 lines) | `governance` group (drift-report, pii-report) | `governance`, `drift_report()`, `pii_report()` |
+| `commands/notebook.py` (179 lines) | `notebook` group (new, open) + `snapshot` top-level | `notebook`, `notebook_new()`, `notebook_open()`, `snapshot()` |
+| `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1098 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1125 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
-| `source_wizard.py` (1324 lines) | Source configuration wizard | `add_source()` |
+| `source_wizard.py` (1350 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |
 | `utils.py` (129 lines) | Display helpers + project context | `require_project_context()` |
@@ -104,6 +107,12 @@ dango (top-level group)
 ├── deploy (group)              ← commands/deploy.py
 │   ├── (default)  interactive wizard → commands/deploy_wizard.py + deploy_provision.py
 │   └── destroy    tear down cloud infrastructure
+├── analyze                     ← commands/analyze.py
+├── snapshot                    ← commands/notebook.py
+├── governance (group)          ← commands/governance.py
+│   ├── drift-report, pii-report
+├── notebook (group)            ← commands/notebook.py
+│   ├── new, open              (default invocation lists notebooks)
 └── metabase (group)            ← commands/metabase_cmd.py
     ├── save, load, refresh
 ```

--- a/dango/governance/CLAUDE.md
+++ b/dango/governance/CLAUDE.md
@@ -11,7 +11,7 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 | `__init__.py` | Re-exports public API | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse`, `detect_drift_for_sources`, `detect_table_drift`, `get_drift_history`, `scan_sources_for_pii`, `scan_table_for_pii`, `get_pii_findings` |
 | `models.py` (~60 lines) | Pydantic V2 response models | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse` |
 | `schema_drift.py` (~490 lines) | Schema drift detection engine | `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()`, `_send_drift_webhook()` |
-| `pii_detector.py` (~280 lines) | PII scanning engine (Presidio + spaCy) | `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`, `_send_pii_webhook()` |
+| `pii_detector.py` (~454 lines) | PII scanning engine (Presidio + spaCy) | `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`, `_send_pii_webhook()` |
 
 ## Common Tasks
 

--- a/dango/notebooks/CLAUDE.md
+++ b/dango/notebooks/CLAUDE.md
@@ -9,10 +9,10 @@ Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking
 | File | Lines | Purpose | Key Exports |
 |------|-------|---------|-------------|
 | `__init__.py` | ~45 | Re-exports public symbols | All public API |
-| `manager.py` | ~165 | Marimo process lifecycle (PID file, start/stop/status) | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()` |
+| `manager.py` | ~197 | Marimo process lifecycle (PID file, start/stop/status) | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()` |
 | `snapshot.py` | ~130 | DuckDB snapshot management | `create_snapshot()`, `list_snapshots()`, `cleanup_snapshots()` |
-| `locking.py` | ~225 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
-| `proxy.py` | ~165 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |
+| `locking.py` | ~249 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
+| `proxy.py` | ~186 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |
 | `templates/__init__.py` | ~5 | Package marker | — |
 | `templates/explore.py` | ~30 | Data exploration starter template | `app` (marimo.App) |
 | `templates/quality.py` | ~40 | Data quality starter template | `app` (marimo.App) |

--- a/dango/notebooks/CLAUDE.md
+++ b/dango/notebooks/CLAUDE.md
@@ -10,7 +10,7 @@ Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking
 |------|-------|---------|-------------|
 | `__init__.py` | ~45 | Re-exports public symbols | All public API |
 | `manager.py` | ~197 | Marimo process lifecycle (PID file, start/stop/status) | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()` |
-| `snapshot.py` | ~130 | DuckDB snapshot management | `create_snapshot()`, `list_snapshots()`, `cleanup_snapshots()` |
+| `snapshot.py` | ~143 | DuckDB snapshot management | `create_snapshot()`, `list_snapshots()`, `cleanup_snapshots()` |
 | `locking.py` | ~249 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
 | `proxy.py` | ~186 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |
 | `templates/__init__.py` | ~5 | Package marker | — |

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -19,6 +19,8 @@ Shared utilities for process management, activity logging, sync history tracking
 | `dbt_status.py` | Persistent dbt model status from run_results.json | `update_model_status()`, `get_model_statuses()` |
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
+| `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
+| `post_sync.py` (~486 lines) | Post-sync hook dispatcher | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_drift_detection()`, `_run_pii_scan()`, `_run_analysis()` |
 
 ## Common Tasks
 
@@ -46,12 +48,15 @@ Shared utilities for process management, activity logging, sync history tracking
 **Used by:**
 - `dango/web/helpers.py` — db_health, sync_history, activity_log, dbt_status
 - `dango/web/routes/sync.py` — dbt_lock
-- `dango/ingestion/dlt_runner.py` — activity_log, sync_history, db_health
+- `dango/ingestion/dlt_runner.py` — activity_log, sync_history, db_health, post_sync (dispatch_post_sync_hooks)
 - `dango/cli/commands/platform.py` — process (kill_process)
 - `dango/cli/commands/cleanup.py` — db_health, log_rotation
 - `dango/platform/local/watcher_runner.py` — dbt_lock, dbt_status
 - `dango/platform/common/startup.py` — log_rotation
 - `dango/transformation/__init__.py` — dbt_status
+- `dango/governance/` — dango_db (connect)
+- `dango/notebooks/` — dango_db (connect)
+- `dango/analysis/` — dango_db (connect)
 
 **Not yet imported:** `data_validation.py` (prepared utility, not integrated into any module)
 

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -41,7 +41,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, `/schedules` page (~720 lines) | `router` |
-| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~491 lines) | `router` |
+| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~490 lines) | `router` |
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact (~566 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
 | `routes/insights.py` | Metric results, run trigger, history (~272 lines) | `router` |

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -41,10 +41,15 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, `/schedules` page (~720 lines) | `router` |
-| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~490 lines) | `router` |
+| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~491 lines) | `router` |
+| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact (~566 lines) | `router` |
+| `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
+| `routes/insights.py` | Metric results, run trigger, history (~272 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |
+| `templates/catalog.html` | Data catalog page (extends `base.html`) — source/table browser, profiling, lineage (495 lines) | Alpine.js `catalogPage()` component |
+| `templates/insights.html` | Insights/analysis page (extends `base.html`) — metric results, trends (~153 lines) | Alpine.js `insightsPage()` component |
 | `static/` | CSS and JS assets (`css/main.css`, `js/app.js`, `js/logs.js`) | — |
 
 ## Architecture
@@ -175,6 +180,8 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 - `dango.oauth/` — `OAuthStorage` (for OAuth token health in `/api/health/platform`)
 - `dango.platform/` — `platform.watcher_lifecycle.get_watcher_status` (for watcher status endpoint)
 - `dango.notebooks/` — locking, manager, snapshot (notebook management endpoints)
+- `dango.governance/` — drift history, PII findings (governance API endpoints)
+- `dango.analysis/` — metric results, run analysis (insights API endpoints)
 
 **Used by:**
 - `dango/cli/commands/web.py` — imports `from dango.web import app` to run uvicorn

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -1,6 +1,6 @@
 # Exemption registry for files exceeding the 500-line soft limit (STANDARDS.md §2).
 # Consumed by scripts/check_file_sizes.py for CI and pre-commit checks.
-# Line counts refreshed 2026-03-06 (DOC-028) — informational, not enforced by script.
+# Line counts refreshed 2026-03-12 (DOC-029) — informational, not enforced by script.
 #
 # Categories:
 #   refactor — planned for refactoring in v1 (linked to a task)
@@ -37,7 +37,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/users.py
-    lines: 525
+    lines: 527
     category: exempt
     reason: "TASK-100 added invite-based user creation and reinvite endpoint (+77 lines over base)."
     review_by: "v1.1"
@@ -88,9 +88,9 @@ exemptions:
 
   # --- Exempt (stable, not modified in v1) ---
   - file: dango/ingestion/dlt_runner.py
-    lines: 1784
+    lines: 1796
     category: exempt
-    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage."
+    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000."
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
@@ -100,9 +100,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py
-    lines: 1324
+    lines: 1350
     category: exempt
-    reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting."
+    reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting. P7-011 added metrics generation."
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
@@ -118,9 +118,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1098
+    lines: 1125
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines)."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)
@@ -201,7 +201,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/config/models.py
-    lines: 548
+    lines: 553
     category: exempt
     reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ packages = [
     "dango.cli.helpers",
     "dango.governance",
     "dango.notebooks",
+    "dango.notebooks.templates",
     "dango.analysis",
 ]
 include-package-data = true


### PR DESCRIPTION
## Summary
- Update all CLAUDE.md files and ARCHITECTURE.md to reflect Phase 7 (Experience) additions
- Add `governance/`, `notebooks/`, `analysis/` to routing tables, decision trees, structure trees, module hierarchy tables, and documentation indexes across root CLAUDE.md and ARCHITECTURE.md
- Fix stale "planned (P7-012)" references in analysis/CLAUDE.md
- Update line counts in governance, notebooks, cli CLAUDE.md files and file-exemptions.yml
- Add missing Phase 7 CLI commands (`analyze`, `governance`, `notebook`, `snapshot`), web routes (`catalog.py`, `governance.py`, `insights.py`), and templates (`catalog.html`, `insights.html`) to module docs
- Add `dango_db.py` and `post_sync.py` to utils/CLAUDE.md
- Add `dango.notebooks.templates` to pyproject.toml packages list (fixes sdist install)
- Add post-sync hooks workflow (§6.10) to ARCHITECTURE.md
- Refresh file-exemptions.yml line counts (dlt_runner 1796, source_wizard 1350, init 1125, config/models 553, users 527)

## Test plan
- [x] `grep -rn "planned (P7" dango/` returns zero results
- [x] `grep -rn "Not yet created" CLAUDE.md` returns zero results
- [x] `python -c "import dango.notebooks.templates"` succeeds
- [x] `ruff check dango/` + `ruff format --check dango/` pass
- [x] Pre-commit hooks pass
- [x] Monolithic files table is line-count-descending sorted
- [x] All referenced test files exist on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)