### PR TITLE
P5-000: Rename supported_in_v0 to wizard_enabled, fix Slack/Notion auth_type

### DIFF
--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -312,10 +312,10 @@ class SourceWizard:
 
     def _select_source_flat(self) -> str | None:
         """Select source from flat list (no categories)"""
-        # Get all v0-supported sources
+        # Get all wizard-enabled sources
         all_sources = []
         for source_type, source_meta in SOURCE_REGISTRY.items():
-            if source_meta.get("supported_in_v0", False):
+            if source_meta.get("wizard_enabled", False):
                 display_name = source_meta.get("display_name", source_type)
                 all_sources.append((display_name, source_type))
 
@@ -357,15 +357,15 @@ class SourceWizard:
         choices = []
         for category in categories:
             sources_in_category = get_sources_by_category(category)
-            # Filter to only v0-supported sources
+            # Filter to only wizard-enabled sources
             available = [
                 s
                 for s in sources_in_category
-                if s in SOURCE_REGISTRY and SOURCE_REGISTRY[s].get("supported_in_v0", False)
+                if s in SOURCE_REGISTRY and SOURCE_REGISTRY[s].get("wizard_enabled", False)
             ]
             count = len(available)
 
-            # Skip categories with no v0-supported sources
+            # Skip categories with no wizard-enabled sources
             if count == 0:
                 continue
 
@@ -401,11 +401,11 @@ class SourceWizard:
         """Select specific source from category"""
         sources = get_sources_by_category(category)
 
-        # Filter to only v0-supported sources
+        # Filter to only wizard-enabled sources
         available_sources = [
             s
             for s in sources
-            if s in SOURCE_REGISTRY and SOURCE_REGISTRY[s].get("supported_in_v0", False)
+            if s in SOURCE_REGISTRY and SOURCE_REGISTRY[s].get("wizard_enabled", False)
         ]
 
         if not available_sources:

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -32,7 +32,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.NONE,
         "dlt_package": None,  # Custom implementation, not dlt
         "dlt_function": None,
-        "supported_in_v0": True,  # Fully tested for v0.0.1
+        "wizard_enabled": True,  # Fully tested for v0.0.1
         "required_params": [
             {
                 "name": "directory",
@@ -74,7 +74,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.NONE,  # Auth handled by source itself
         "dlt_package": None,  # User specifies
         "dlt_function": None,  # User specifies
-        "supported_in_v0": True,  # Registry bypass implementation complete
+        "wizard_enabled": True,  # Registry bypass implementation complete
         "required_params": [
             {
                 "name": "source_module",
@@ -201,7 +201,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/google_sheets",
         "cost_warning": "Subject to Google API quota limits",
-        "supported_in_v0": True,  # OAuth implementation complete
+        "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 10,
     },
     "facebook_ads": {
@@ -244,7 +244,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/facebook_ads",
         "cost_warning": "Rate limited: 200 calls/hour per user, 4800/day per app",
-        "supported_in_v0": True,  # OAuth implementation complete
+        "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 9,
     },
     "google_analytics": {
@@ -334,7 +334,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/google_analytics",
         "cost_warning": "Subject to Google API quota limits. Data is aggregated (not event-level).",
-        "supported_in_v0": True,  # OAuth implementation complete
+        "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 9,
     },
     # ========================================
@@ -432,7 +432,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "dlt_package": "stripe_analytics",
         "dlt_function": "stripe_source",
         "pip_dependencies": [{"pip": "stripe", "import": "stripe"}],
-        "supported_in_v0": True,  # Fully tested for v0.0.1
+        "wizard_enabled": True,  # Fully tested for v0.0.1
         "required_params": [
             {
                 "name": "stripe_secret_key_env",
@@ -523,7 +523,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/shopify",
         "cost_warning": "Included with Shopify plan",
-        "supported_in_v0": False,  # Blocked: Shopify deprecating legacy auth Jan 2026, awaiting dlt update
+        "wizard_enabled": False,  # Blocked: Shopify deprecating legacy auth Jan 2026, awaiting dlt update
         "popularity": 9,
     },
     # ========================================
@@ -569,7 +569,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "display_name": "Slack",
         "category": "Communication",
         "description": "Load messages, channels, and user data from Slack",
-        "auth_type": AuthType.OAUTH,
+        "auth_type": AuthType.API_KEY,
         "dlt_package": "slack",
         "dlt_function": "slack_source",
         "required_params": [
@@ -684,7 +684,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
             "6. Credentials are permanent (refresh token stored in .dlt/secrets.toml)",
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/google_ads",
-        "supported_in_v0": True,  # OAuth implementation complete
+        "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 7,
     },
     "matomo": {
@@ -1062,7 +1062,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "display_name": "Notion",
         "category": "Files & Storage",
         "description": "Load pages and databases from Notion",
-        "auth_type": AuthType.OAUTH,
+        "auth_type": AuthType.API_KEY,
         "dlt_package": "notion",
         "dlt_function": "notion_databases",
         "required_params": [


### PR DESCRIPTION
## Summary
- Rename `supported_in_v0` → `wizard_enabled` across `registry.py` (8 occurrences) and `source_wizard.py` (3 occurrences + 3 comments) for clearer v1 semantics
- Fix Slack and Notion `auth_type` from `OAUTH` → `API_KEY` — both use API tokens, not OAuth redirect flows

## Test plan
- [x] `grep -rn "supported_in_v0" dango/` returns 0 results
- [x] `grep -rn "wizard_enabled" dango/` shows all 11 renamed locations
- [x] All 2813 tests pass
- [x] All pre-commit hooks pass (ruff, mypy, format, headers, docstrings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)