### PR TITLE
feat(P5-002): enable rest_api in wizard

### DIFF
--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -162,6 +162,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api",
         "cost_warning": "Check API provider's rate limits and pricing",
         "popularity": 8,
+        "wizard_enabled": True,
     },
     # ========================================
     # MARKETING & ANALYTICS


### PR DESCRIPTION
## Summary
- Add `wizard_enabled: True` to the `rest_api` entry in `SOURCE_REGISTRY`, making the generic REST API source visible in `dango source add`

## Test plan
- [x] `ruff check` + `ruff format --check` pass
- [x] `mypy` clean
- [x] Full test suite passes (2813 passed)
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)