### PR TITLE
P5-010: Parameterize Mux views date range and fix idempotency

### DIFF
--- a/dango/ingestion/dlt_sources/mux/__init__.py
+++ b/dango/ingestion/dlt_sources/mux/__init__.py
@@ -13,15 +13,22 @@ from .settings import API_BASE_URL, DEFAULT_LIMIT
 
 
 @dlt.source
-def mux_source() -> Iterable[DltResource]:
+def mux_source(
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> Iterable[DltResource]:
     """
-    Source function that passes all video assets and every video view from yesterday to be loaded.
+    Source function that loads all video assets and video views for a configurable date range.
+
+    Args:
+        start_date: Start of the date range (ISO 8601 string or datetime). Defaults to 30 days ago.
+        end_date: End of the date range (ISO 8601 string or datetime). Defaults to today.
 
     Yields:
         DltResource: Video assets and video views to be loaded.
     """
     yield assets_resource
-    yield views_resource
+    yield views_resource(start_date=start_date, end_date=end_date)
 
 
 @dlt.resource(write_disposition="merge")
@@ -51,31 +58,45 @@ def assets_resource(
     yield response.json()["data"]
 
 
-@dlt.resource(write_disposition="append")
+@dlt.resource(write_disposition="replace")
 def views_resource(
     mux_api_access_token: str = dlt.secrets.value,
     mux_api_secret_key: str = dlt.secrets.value,
     limit: int = DEFAULT_LIMIT,
-) -> Iterable[DltResource]:
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> Iterable[TDataItem]:
     """
-    Resource function that yields metadata about every video view from yesterday to be loaded.
+    Resource function that yields metadata about video views for a configurable date range.
 
     Args:
-        mux_api_access_token (str): API access token for Mux.
-        mux_api_secret_key (str): API secret key for Mux.
-        limit (int): Limit on the number of video views to retrieve. Defaults to DEFAULT_LIMIT.
+        mux_api_access_token: API access token for Mux.
+        mux_api_secret_key: API secret key for Mux.
+        limit: Limit on the number of video views to retrieve. Defaults to DEFAULT_LIMIT.
+        start_date: Start of the date range (ISO 8601 string or datetime). Defaults to 30 days ago.
+        end_date: End of the date range (ISO 8601 string or datetime). Defaults to today.
 
     Yields:
-        DltResource: Data for each video view from yesterday.
+        TDataItem: Data for each video view in the date range.
     """
     url = f"{API_BASE_URL}/data/v1/video-views"
     page = 1
-    today = pendulum.today()
-    yest_start = today.subtract(days=1).int_timestamp
-    yest_end = today.int_timestamp
+
+    if end_date:
+        end_dt = pendulum.parse(str(end_date)) if not isinstance(end_date, pendulum.DateTime) else end_date
+    else:
+        end_dt = pendulum.today()
+
+    if start_date:
+        start_dt = pendulum.parse(str(start_date)) if not isinstance(start_date, pendulum.DateTime) else start_date
+    else:
+        start_dt = end_dt.subtract(days=30)
+
+    timeframe_start = int(start_dt.timestamp())
+    timeframe_end = int(end_dt.timestamp())
 
     while True:
-        params = {"limit": limit, "page": page, "timeframe[]": [yest_start, yest_end]}
+        params = {"limit": limit, "page": page, "timeframe[]": [timeframe_start, timeframe_end]}
         response = requests.get(
             url,
             params=params,  # type: ignore

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -749,7 +749,14 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                 "help": "Secret key paired with access token",
             },
         ],
-        "optional_params": [],
+        "optional_params": [
+            {
+                "name": "start_date",
+                "type": "string",
+                "prompt": "Start date for video views (YYYY-MM-DD)",
+                "help": "How far back to load views. Defaults to 30 days ago.",
+            },
+        ],
         "setup_guide": [
             "1. Log in to Mux Dashboard",
             "2. Go to Settings > Access Tokens",


### PR DESCRIPTION
## Summary
- Add `start_date`/`end_date` parameters to `mux_source()` and `views_resource()` (default: 30 days ago → today; was hardcoded to yesterday only)
- Switch `views_resource` write disposition from `"append"` to `"replace"` for idempotent re-runs
- Add `start_date` optional param to Mux registry entry in `registry.py`

## Test plan
- [x] `grep "subtract(days=1)"` confirms hardcoded date removed
- [x] `grep "write_disposition"` confirms `"replace"` for views_resource
- [x] All 2813 tests pass (`pytest`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)