### PR TITLE
P5-004: Enable Tier 3 Sources (Databases & Infrastructure)

### DIFF
--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -1123,6 +1123,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.BASIC,
         "dlt_package": "inbox",
         "dlt_function": "inbox_source",
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "host",
@@ -1170,6 +1171,8 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.BASIC,
         "dlt_package": "mongodb",
         "dlt_function": "mongodb",
+        "pip_dependencies": [{"pip": "pymongo", "import": "pymongo"}],
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "connection_url_env",
@@ -1269,6 +1272,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "dlt_package": "kafka",
         "dlt_function": "kafka_consumer",
         "pip_dependencies": [{"pip": "confluent-kafka", "import": "confluent_kafka"}],
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "topics",
@@ -1324,6 +1328,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.SERVICE_ACCOUNT,
         "dlt_package": "kinesis",
         "dlt_function": "kinesis_stream",
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "stream_name",


### PR DESCRIPTION
## Summary

Enable the four Tier 3 sources in the dango source wizard:
- **mongodb**: NoSQL database with incremental collection support
- **kafka**: Event streaming platform
- **kinesis**: AWS managed streaming service  
- **inbox**: Email IMAP source

All source metadata was already fully defined in registry.py. This task adds the `wizard_enabled: True` flag to make them available in `dango source add` wizard, plus pymongo pip dependency for mongodb.

## Changes

Modified `dango/ingestion/sources/registry.py`:
- `mongodb`: Add pymongo pip dependency + wizard_enabled
- `kafka`: Add wizard_enabled (already has confluent-kafka dep)
- `kinesis`: Add wizard_enabled (boto3 in core deps)
- `inbox`: Add wizard_enabled (stdlib imaplib, no deps)

## Verification

✅ All 4 sources have correct metadata structure  
✅ ruff check passed  
✅ Pre-commit hooks passed  
✅ No breaking changes to existing sources  

## Test Plan

1. Manual: `dango source add` → verify mongodb, kafka, kinesis, inbox appear in the list
2. Manual: Select each source → verify all required/optional params display correctly
3. CI: Ensure all tests pass

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)