### PR TITLE
P5-005: Enable Tier 4 sources in wizard (Slack, Notion, Salesforce, Zendesk, Jira)

### DIFF
--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -384,6 +384,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.BASIC,
         "dlt_package": "salesforce",
         "dlt_function": "salesforce_source",
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "username_env",
@@ -575,6 +576,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.API_KEY,
         "dlt_package": "slack",
         "dlt_function": "slack_source",
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "token_env",
@@ -618,6 +620,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.BASIC,
         "dlt_package": "zendesk",
         "dlt_function": "zendesk_support",
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "subdomain",
@@ -935,6 +938,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.BASIC,
         "dlt_package": "jira",
         "dlt_function": "jira",
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "subdomain",
@@ -1082,6 +1086,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.API_KEY,
         "dlt_package": "notion",
         "dlt_function": "notion_databases",
+        "wizard_enabled": True,
         "required_params": [
             {
                 "name": "api_key_env",


### PR DESCRIPTION
## Summary

- Adds `wizard_enabled = True` to 5 registry entries in `registry.py`
- Slack, Notion, Salesforce, Zendesk, and Jira now appear in `dango source add`
- Auth types and wizard params were already correct from P5-000–P5-004 (Slack/Notion: API_KEY, others: BASIC)
- No logic changes — metadata flag only

## Changes

Single file: `dango/ingestion/sources/registry.py` (+5 lines)

## Test plan

- [x] `ruff check` + `ruff format` pass
- [x] `pytest -x` — 2813 passed, 0 failed
- [ ] Manual: `dango source add` → all 5 sources selectable in wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)