### PR TITLE
P5-009: Rewrite Google Ads connector for performance metrics

### DIFF
--- a/dango/ingestion/dlt_sources/google_ads/__init__.py
+++ b/dango/ingestion/dlt_sources/google_ads/__init__.py
@@ -17,7 +17,7 @@ from .settings import DEFAULT_LOOKBACK_DAYS, DEFAULT_QUERIES
 try:
     from google.ads.googleads.client import GoogleAdsClient  # type: ignore
 except ImportError:
-    raise MissingDependencyException("Requests-OAuthlib", ["google-ads"])
+    raise MissingDependencyException("Google Ads", ["google-ads"])
 
 
 def get_client(

--- a/dango/ingestion/dlt_sources/google_ads/__init__.py
+++ b/dango/ingestion/dlt_sources/google_ads/__init__.py
@@ -1,18 +1,18 @@
-"""
-Preliminary implementation of Google Ads pipeline.
-"""
+"""Google Ads dlt source — query-driven performance metrics."""
 
-from typing import Iterator, List, Union
+from typing import Iterator, Union
+from datetime import date, timedelta
+
 import dlt
+import json
 import tempfile
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.typing import TDataItem
 from dlt.sources import DltResource
 from dlt.sources.credentials import GcpOAuthCredentials, GcpServiceAccountCredentials
-import json
-from .helpers.data_processing import to_dict
 
-from apiclient.discovery import Resource
+from .helpers.data_processing import to_dict, flatten_row
+from .settings import DEFAULT_LOOKBACK_DAYS, DEFAULT_QUERIES
 
 try:
     from google.ads.googleads.client import GoogleAdsClient  # type: ignore
@@ -20,26 +20,12 @@ except ImportError:
     raise MissingDependencyException("Requests-OAuthlib", ["google-ads"])
 
 
-DIMENSION_TABLES = [
-    "accounts",
-    "ad_group",
-    "ad_group_ad",
-    "ad_group_ad_label",
-    "ad_group_label",
-    "campaign_label",
-    "click_view",
-    "customer",
-    "keyword_view",
-    "geographic_view",
-]
-
-
 def get_client(
     credentials: Union[GcpOAuthCredentials, GcpServiceAccountCredentials],
     dev_token: str,
-    impersonated_email: str,
+    impersonated_email: str | None = None,
 ) -> GoogleAdsClient:
-    # generate access token for credentials if we are using OAuth2.0
+    """Creates a GoogleAdsClient from OAuth or service account credentials."""
     if isinstance(credentials, GcpOAuthCredentials):
         credentials.auth("https://www.googleapis.com/auth/adwords")
         conf = {
@@ -48,9 +34,7 @@ def get_client(
             **json.loads(credentials.to_native_representation()),
         }
         return GoogleAdsClient.load_from_dict(config_dict=conf)
-    # use service account to authenticate if not using OAuth2.0
     else:
-        # google ads client requires the key to be in a file on the disc..
         with tempfile.NamedTemporaryFile() as f:
             f.write(credentials.to_native_representation().encode())
             f.seek(0)
@@ -64,100 +48,89 @@ def get_client(
             )
 
 
-@dlt.source(max_table_nesting=2)
+def _compute_date_range(
+    start_date: str | None, end_date: str | None
+) -> tuple[str, str]:
+    """Returns (effective_start, effective_end) as YYYY-MM-DD strings.
+
+    Defaults: start = DEFAULT_LOOKBACK_DAYS ago, end = yesterday.
+    """
+    if end_date:
+        effective_end = end_date
+    else:
+        effective_end = (date.today() - timedelta(days=1)).isoformat()
+
+    if start_date:
+        effective_start = start_date
+    else:
+        effective_start = (
+            date.today() - timedelta(days=DEFAULT_LOOKBACK_DAYS)
+        ).isoformat()
+
+    return effective_start, effective_end
+
+
+def _execute_query(
+    ga_service: object,
+    customer_id: str,
+    query: str,
+) -> Iterator[TDataItem]:
+    """Runs a GAQL query via search_stream and yields flattened rows."""
+    stream = ga_service.search_stream(customer_id=customer_id, query=query)  # type: ignore[union-attr]
+    for batch in stream:
+        for row in batch.results:
+            row_dict = to_dict(row)
+            yield flatten_row(row_dict)
+
+
+@dlt.source(name="google_ads", max_table_nesting=2)
 def google_ads(
     credentials: Union[
         GcpOAuthCredentials, GcpServiceAccountCredentials
     ] = dlt.secrets.value,
-    impersonated_email: str = dlt.secrets.value,
+    customer_id: str = dlt.secrets.value,
     dev_token: str = dlt.secrets.value,
-) -> List[DltResource]:
-    """
-    Loads default tables for google ads in the database.
-    :param credentials:
-    :param dev_token:
-    :return:
+    queries: list[dict[str, str]] = dlt.config.value,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    impersonated_email: str | None = None,
+) -> list[DltResource]:
+    """Loads Google Ads performance data via configurable GAQL queries.
+
+    Each query in the queries list becomes a separate table. Queries use
+    {start_date}/{end_date} placeholders replaced at runtime.
+
+    Default queries load 5 tables: campaign_stats, ad_group_stats,
+    keyword_stats, ad_stats, search_term_stats.
     """
     client = get_client(
         credentials=credentials,
         dev_token=dev_token,
         impersonated_email=impersonated_email,
     )
-    return [
-        customers(client=client),
-        campaigns(client=client),
-        change_events(client=client),
-        customer_clients(client=client),
-    ]
-
-
-@dlt.resource(write_disposition="replace")
-def customers(
-    client: Resource, customer_id: str = dlt.secrets.value
-) -> Iterator[TDataItem]:
-    """
-    Dlt resource which loads dimensions.
-    :param client:
-    :return:
-    """
-    # Issues a search request using streaming.
     ga_service = client.get_service("GoogleAdsService")
-    query = "SELECT customer.id, customer.descriptive_name FROM customer"
-    stream = ga_service.search_stream(customer_id=customer_id, query=query)
-    for batch in stream:
-        for row in batch.results:
-            yield to_dict(row.customer)
 
+    effective_start, effective_end = _compute_date_range(start_date, end_date)
 
-@dlt.resource(write_disposition="replace")
-def campaigns(
-    client: Resource, customer_id: str = dlt.secrets.value
-) -> Iterator[TDataItem]:
-    """
-    Dlt resource which loads dimensions.
-    :param client:
-    :return:
-    """
-    # Issues a search request using streaming.
-    ga_service = client.get_service("GoogleAdsService")
-    query = "SELECT campaign.id, campaign.labels FROM campaign"
-    stream = ga_service.search_stream(customer_id=customer_id, query=query)
-    for batch in stream:
-        for row in batch.results:
-            yield to_dict(row.campaign)
+    # Fall back to defaults if queries list is empty
+    active_queries = queries if queries else DEFAULT_QUERIES
 
+    resources = []
+    for q in active_queries:
+        resource_name = q["resource_name"]
+        formatted_query = q["query"].format(
+            start_date=effective_start,
+            end_date=effective_end,
+        )
+        resource = dlt.resource(
+            _execute_query,
+            name=resource_name,
+            write_disposition="replace",
+        )(
+            ga_service=ga_service,
+            customer_id=customer_id,
+            query=formatted_query,
+        )
+        resources.append(resource)
 
-@dlt.resource(write_disposition="replace")
-def change_events(
-    client: Resource, customer_id: str = dlt.secrets.value
-) -> Iterator[TDataItem]:
-    """
-    Dlt resource which loads dimensions.
-    :param client:
-    :return:
-    """
-    # Issues a search request using streaming.
-    ga_service = client.get_service("GoogleAdsService")
-    query = "SELECT change_event.change_date_time FROM change_event WHERE change_event.change_date_time during LAST_14_DAYS LIMIT 1000"
-    stream = ga_service.search_stream(customer_id=customer_id, query=query)
-    for batch in stream:
-        for row in batch.results:
-            yield to_dict(row.change_event)
-
-
-@dlt.resource(write_disposition="replace")
-def customer_clients(
-    client: Resource, customer_id: str = dlt.secrets.value
-) -> Iterator[TDataItem]:
-    """
-    Dlt resource which loads dimensions.
-    :param client:
-    :return:
-    """
-    # Issues a search request using streaming.
-    ga_service = client.get_service("GoogleAdsService")
-    query = "SELECT customer_client.status FROM customer_client"
-    stream = ga_service.search_stream(customer_id=customer_id, query=query)
-    for batch in stream:
-        for row in batch.results:
-            yield to_dict(row.customer_client)
+    return resources

--- a/dango/ingestion/dlt_sources/google_ads/helpers/data_processing.py
+++ b/dango/ingestion/dlt_sources/google_ads/helpers/data_processing.py
@@ -1,16 +1,12 @@
-from typing import Any, Iterator
+from typing import Any
 from dlt.common.typing import TDataItem
 import proto
 import json
 
 
-def to_dict(item: Any) -> Iterator[TDataItem]:
-    """
-    Processes a batch result (page of results per dimension) accordingly
-    :param batch:
-    :return:
-    """
-    yield json.loads(
+def to_dict(item: Any) -> TDataItem:
+    """Converts a protobuf message to a Python dict."""
+    return json.loads(
         proto.Message.to_json(
             item,
             preserving_proto_field_name=True,
@@ -18,3 +14,52 @@ def to_dict(item: Any) -> Iterator[TDataItem]:
             including_default_value_fields=False,
         )
     )
+
+
+def flatten_row(row_dict: dict[str, Any]) -> dict[str, Any]:
+    """Flattens a Google Ads API response row into a flat dict.
+
+    - segments.* promoted to top level (e.g. segments.date -> date)
+    - metrics.* flattened, with cost_micros converted to cost (/ 1_000_000)
+    - Entity fields prefix-joined: campaign.id -> campaign_id
+    """
+    result: dict[str, Any] = {}
+
+    # Promote segments to top level
+    if "segments" in row_dict:
+        for key, value in row_dict["segments"].items():
+            result[key] = value
+
+    # Flatten metrics, converting cost_micros -> cost
+    if "metrics" in row_dict:
+        for key, value in row_dict["metrics"].items():
+            if key == "cost_micros":
+                result["cost"] = int(value) / 1_000_000 if value else 0.0
+            else:
+                result[key] = value
+
+    # Flatten entity fields (campaign, ad_group, etc.)
+    for key, value in row_dict.items():
+        if key in ("segments", "metrics"):
+            continue
+        if isinstance(value, dict):
+            _flatten_entity(result, key, value)
+        else:
+            result[key] = value
+
+    return result
+
+
+def _flatten_entity(
+    target: dict[str, Any], prefix: str, obj: dict[str, Any]
+) -> None:
+    """Recursively flattens nested entity dicts with underscore-joined keys.
+
+    Example: {"campaign": {"id": 1, "name": "foo"}} -> campaign_id, campaign_name
+    """
+    for key, value in obj.items():
+        flat_key = f"{prefix}_{key}"
+        if isinstance(value, dict):
+            _flatten_entity(target, flat_key, value)
+        else:
+            target[flat_key] = value

--- a/dango/ingestion/dlt_sources/google_ads/settings.py
+++ b/dango/ingestion/dlt_sources/google_ads/settings.py
@@ -1,0 +1,114 @@
+"""Default settings for Google Ads dlt source."""
+
+DEFAULT_LOOKBACK_DAYS = 90
+
+# Each query becomes a separate dlt resource/table.
+# {start_date} and {end_date} are replaced at runtime (YYYY-MM-DD).
+DEFAULT_QUERIES = [
+    {
+        "resource_name": "campaign_stats",
+        "query": (
+            "SELECT "
+            "segments.date, "
+            "campaign.id, "
+            "campaign.name, "
+            "campaign.status, "
+            "campaign.advertising_channel_type, "
+            "metrics.impressions, "
+            "metrics.clicks, "
+            "metrics.cost_micros, "
+            "metrics.conversions, "
+            "metrics.conversions_value, "
+            "metrics.ctr, "
+            "metrics.average_cpc, "
+            "metrics.average_cpm "
+            "FROM campaign "
+            "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+        ),
+    },
+    {
+        "resource_name": "ad_group_stats",
+        "query": (
+            "SELECT "
+            "segments.date, "
+            "campaign.id, "
+            "campaign.name, "
+            "ad_group.id, "
+            "ad_group.name, "
+            "ad_group.status, "
+            "metrics.impressions, "
+            "metrics.clicks, "
+            "metrics.cost_micros, "
+            "metrics.conversions, "
+            "metrics.conversions_value, "
+            "metrics.ctr, "
+            "metrics.average_cpc "
+            "FROM ad_group "
+            "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+        ),
+    },
+    {
+        "resource_name": "keyword_stats",
+        "query": (
+            "SELECT "
+            "segments.date, "
+            "campaign.id, "
+            "campaign.name, "
+            "ad_group.id, "
+            "ad_group.name, "
+            "ad_group_criterion.keyword.text, "
+            "ad_group_criterion.keyword.match_type, "
+            "metrics.impressions, "
+            "metrics.clicks, "
+            "metrics.cost_micros, "
+            "metrics.conversions, "
+            "metrics.ctr, "
+            "metrics.average_cpc "
+            "FROM keyword_view "
+            "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+        ),
+    },
+    {
+        "resource_name": "ad_stats",
+        "query": (
+            "SELECT "
+            "segments.date, "
+            "campaign.id, "
+            "ad_group.id, "
+            "ad_group_ad.ad.id, "
+            "ad_group_ad.ad.name, "
+            "ad_group_ad.ad.type, "
+            "ad_group_ad.status, "
+            "metrics.impressions, "
+            "metrics.clicks, "
+            "metrics.cost_micros, "
+            "metrics.conversions, "
+            "metrics.ctr "
+            "FROM ad_group_ad "
+            "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+        ),
+    },
+    {
+        "resource_name": "search_term_stats",
+        "query": (
+            "SELECT "
+            "segments.date, "
+            "campaign.id, "
+            "campaign.name, "
+            "ad_group.id, "
+            "ad_group.name, "
+            "search_term_view.search_term, "
+            "ad_group_criterion.keyword.text, "
+            "ad_group_criterion.keyword.match_type, "
+            "search_term_view.status, "
+            "metrics.impressions, "
+            "metrics.clicks, "
+            "metrics.cost_micros, "
+            "metrics.conversions, "
+            "metrics.ctr, "
+            "metrics.average_cpc "
+            "FROM search_term_view "
+            "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+        ),
+    },
+]

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -666,7 +666,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
     "google_ads": {
         "display_name": "Google Ads",
         "category": "Marketing & Analytics",
-        "description": "Load ad campaigns and performance data from Google Ads",
+        "description": "Load daily performance metrics from Google Ads via GAQL queries",
         "auth_type": AuthType.OAUTH,
         "dlt_package": "google_ads",
         "dlt_function": "google_ads",
@@ -674,22 +674,137 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "required_params": [],  # OAuth handles credentials; developer_token and customer_id are collected during auth
         "optional_params": [
             {
-                "name": "resources",
-                "type": "multiselect",
-                "prompt": "Resources to sync",
-                "choices": ["customers", "campaigns", "change_events", "customer_clients"],
-                "default": ["customers", "campaigns"],
+                "name": "start_date",
+                "type": "date",
+                "prompt": "Start date (YYYY-MM-DD)",
+                "default": None,
             },
         ],
+        # Default GAQL queries — each becomes a table. Duplicated from
+        # dlt_sources/google_ads/settings.py (registry must not import from dlt_sources/).
+        "default_config": {
+            "queries": [
+                {
+                    "resource_name": "campaign_stats",
+                    "query": (
+                        "SELECT "
+                        "segments.date, "
+                        "campaign.id, "
+                        "campaign.name, "
+                        "campaign.status, "
+                        "campaign.advertising_channel_type, "
+                        "metrics.impressions, "
+                        "metrics.clicks, "
+                        "metrics.cost_micros, "
+                        "metrics.conversions, "
+                        "metrics.conversions_value, "
+                        "metrics.ctr, "
+                        "metrics.average_cpc, "
+                        "metrics.average_cpm "
+                        "FROM campaign "
+                        "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+                    ),
+                },
+                {
+                    "resource_name": "ad_group_stats",
+                    "query": (
+                        "SELECT "
+                        "segments.date, "
+                        "campaign.id, "
+                        "campaign.name, "
+                        "ad_group.id, "
+                        "ad_group.name, "
+                        "ad_group.status, "
+                        "metrics.impressions, "
+                        "metrics.clicks, "
+                        "metrics.cost_micros, "
+                        "metrics.conversions, "
+                        "metrics.conversions_value, "
+                        "metrics.ctr, "
+                        "metrics.average_cpc "
+                        "FROM ad_group "
+                        "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+                    ),
+                },
+                {
+                    "resource_name": "keyword_stats",
+                    "query": (
+                        "SELECT "
+                        "segments.date, "
+                        "campaign.id, "
+                        "campaign.name, "
+                        "ad_group.id, "
+                        "ad_group.name, "
+                        "ad_group_criterion.keyword.text, "
+                        "ad_group_criterion.keyword.match_type, "
+                        "metrics.impressions, "
+                        "metrics.clicks, "
+                        "metrics.cost_micros, "
+                        "metrics.conversions, "
+                        "metrics.ctr, "
+                        "metrics.average_cpc "
+                        "FROM keyword_view "
+                        "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+                    ),
+                },
+                {
+                    "resource_name": "ad_stats",
+                    "query": (
+                        "SELECT "
+                        "segments.date, "
+                        "campaign.id, "
+                        "ad_group.id, "
+                        "ad_group_ad.ad.id, "
+                        "ad_group_ad.ad.name, "
+                        "ad_group_ad.ad.type, "
+                        "ad_group_ad.status, "
+                        "metrics.impressions, "
+                        "metrics.clicks, "
+                        "metrics.cost_micros, "
+                        "metrics.conversions, "
+                        "metrics.ctr "
+                        "FROM ad_group_ad "
+                        "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+                    ),
+                },
+                {
+                    "resource_name": "search_term_stats",
+                    "query": (
+                        "SELECT "
+                        "segments.date, "
+                        "campaign.id, "
+                        "campaign.name, "
+                        "ad_group.id, "
+                        "ad_group.name, "
+                        "search_term_view.search_term, "
+                        "ad_group_criterion.keyword.text, "
+                        "ad_group_criterion.keyword.match_type, "
+                        "search_term_view.status, "
+                        "metrics.impressions, "
+                        "metrics.clicks, "
+                        "metrics.cost_micros, "
+                        "metrics.conversions, "
+                        "metrics.ctr, "
+                        "metrics.average_cpc "
+                        "FROM search_term_view "
+                        "WHERE segments.date BETWEEN '{start_date}' AND '{end_date}'"
+                    ),
+                },
+            ],
+        },
         "setup_guide": [
             "1. OAuth setup runs automatically during 'dango source add'",
             "2. OR manually run: dango oauth google_ads",
             "3. Follow the browser OAuth flow to authenticate",
             "4. Enter Developer Token from Google Ads API Center",
             "5. Enter Customer ID (find in Google Ads account URL, no hyphens)",
-            "6. Credentials are permanent (refresh token stored in .dlt/secrets.toml)",
+            "6. Default queries load 5 tables: campaign_stats, ad_group_stats,"
+            " keyword_stats, ad_stats, search_term_stats",
+            "7. Edit .dlt/config.toml to customize GAQL queries",
+            "8. Paste queries from Google Ads Query Builder for custom reports",
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/google_ads",
+        "cost_warning": "Subject to Google Ads API rate limits",
         "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 7,
     },


### PR DESCRIPTION
## Summary
- **Rewrites** Google Ads connector from 4 hardcoded metadata resources to a **query-driven pattern** using configurable GAQL queries
- **Loads 5 daily performance tables** by default: `campaign_stats`, `ad_group_stats`, `keyword_stats`, `ad_stats`, `search_term_stats`
- Users can **customize queries via `.dlt/config.toml`** (paste GAQL from Google Ads Query Builder)

## Changes
| File | Change |
|------|--------|
| `dlt_sources/google_ads/settings.py` | **NEW** — `DEFAULT_LOOKBACK_DAYS`, `DEFAULT_QUERIES` (5 GAQL templates) |
| `dlt_sources/google_ads/helpers/data_processing.py` | `to_dict()` returns dict (was generator); add `flatten_row()` + `_flatten_entity()` |
| `dlt_sources/google_ads/__init__.py` | Rewrite: remove 4 hardcoded resources, add `_compute_date_range`, `_execute_query`, query-driven `google_ads()` source |
| `sources/registry.py` | Replace `resources` multiselect with `start_date` date picker, add `default_config.queries` (5 queries) |

## Design Decisions
- **GAQL templates** (not structured dicts) — users paste from Google Ads Query Builder
- **`write_disposition="replace"`** — Google Ads conversions attributed retroactively
- **`cost_micros → cost`** — divided by 1M in `flatten_row()` for readability
- **Queries duplicated** in `registry.py` and `settings.py` — matches GA4 pattern; registry must not import from `dlt_sources/`

## Test plan
- [x] `ruff check` + `ruff format` pass on registry.py
- [x] All pre-commit hooks pass
- [x] Registry verification: `get_source_metadata('google_ads')` returns 5 queries
- [x] 73 existing tests pass (test_cli_commands, test_oauth_web_flow, test_web_oauth_connect, test_web_secrets)
- [ ] End-to-end with real Google Ads account (deferred to P5-007 testing task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)