### PR TITLE
P5-013: Add filesystem source to wizard (Parquet, JSON, JSONL, Excel, Azure)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | `dango/ingestion/dlt_sources/` | Vendored third-party dlt connectors (127 files). Rarely modified. |
 | `dango/web/static/` | Frontend HTML/CSS/JS assets. |
 | `tests/` | Read source module first, then find its tests. |
-| `dango/ingestion/sources/registry.py` | 1615-line metadata registry. Only when adding a new source. |
+| `dango/ingestion/sources/registry.py` | 1621-line metadata registry. Only when adding a new source. |
 | `dango/templates/` | Jinja2 templates. Only when modifying project init or model generation. |
 
 ## Decision Tree
@@ -250,7 +250,7 @@ dango/                          # Python package source
 │   ├── dlt_runner.py           # ⚠ 1796 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # CSV loading with dedup (742 lines)
 │   ├── sources/
-│   │   └── registry.py         # Source metadata (1615 lines, 35 source types)
+│   │   └── registry.py         # Source metadata (1621 lines, 32 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
@@ -330,7 +330,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 1796 | — (exempt, too risky) |
-| `ingestion/sources/registry.py` | 1615 | — (metadata-only) |
+| `ingestion/sources/registry.py` | 1621 | — (metadata-only) |
 | `cli/source_wizard.py` | 1350 | — |
 | `visualization/metabase.py` | 1149 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | `dango/ingestion/dlt_sources/` | Vendored third-party dlt connectors (127 files). Rarely modified. |
 | `dango/web/static/` | Frontend HTML/CSS/JS assets. |
 | `tests/` | Read source module first, then find its tests. |
-| `dango/ingestion/sources/registry.py` | 1466-line metadata registry. Only when adding a new source. |
+| `dango/ingestion/sources/registry.py` | 1615-line metadata registry. Only when adding a new source. |
 | `dango/templates/` | Jinja2 templates. Only when modifying project init or model generation. |
 
 ## Decision Tree
@@ -250,7 +250,7 @@ dango/                          # Python package source
 │   ├── dlt_runner.py           # ⚠ 1796 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # CSV loading with dedup (742 lines)
 │   ├── sources/
-│   │   └── registry.py         # Source metadata (1516 lines, 34 source types)
+│   │   └── registry.py         # Source metadata (1615 lines, 35 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
@@ -330,7 +330,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 1796 | — (exempt, too risky) |
-| `ingestion/sources/registry.py` | 1466 | — (metadata-only) |
+| `ingestion/sources/registry.py` | 1615 | — (metadata-only) |
 | `cli/source_wizard.py` | 1350 | — |
 | `visualization/metabase.py` | 1149 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Loads data into DuckDB from external sources via dlt pipelines and CSV files, with a central registry of 34 supported data sources.
+Loads data into DuckDB from external sources via dlt pipelines and CSV files, with a central registry of 35 supported data sources.
 
 ## Files
 
@@ -12,7 +12,7 @@ Loads data into DuckDB from external sources via dlt pipelines and CSV files, wi
 | `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync` (imports `SyncTimeoutError` from `dango.exceptions`) |
 | `csv_loader.py` | Incremental CSV loading with metadata tracking and 4 dedup strategies | `CSVLoader` (imports `CSVSchemaMismatchError` from `dango.exceptions`) |
 | `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
-| `sources/registry.py` | Central registry of 34 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
+| `sources/registry.py` | Central registry of 35 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
 | `dlt_sources/` | Third-party dlt verified source implementations (27 directories, 105+ files) | DO NOT MODIFY — see "Don't Modify" section |
 
 ## Common Tasks

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Loads data into DuckDB from external sources via dlt pipelines and CSV files, with a central registry of 35 supported data sources.
+Loads data into DuckDB from external sources via dlt pipelines and CSV files, with a central registry of 32 supported data sources.
 
 ## Files
 
@@ -12,7 +12,7 @@ Loads data into DuckDB from external sources via dlt pipelines and CSV files, wi
 | `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync` (imports `SyncTimeoutError` from `dango.exceptions`) |
 | `csv_loader.py` | Incremental CSV loading with metadata tracking and 4 dedup strategies | `CSVLoader` (imports `CSVSchemaMismatchError` from `dango.exceptions`) |
 | `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
-| `sources/registry.py` | Central registry of 35 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
+| `sources/registry.py` | Central registry of 32 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
 | `dlt_sources/` | Third-party dlt verified source implementations (27 directories, 105+ files) | DO NOT MODIFY — see "Don't Modify" section |
 
 ## Common Tasks

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -1,6 +1,6 @@
 """dango/ingestion/sources/registry.py
 
-Metadata registry for all 34 supported data sources (31 dlt verified + CSV + REST API + PostgreSQL).
+Metadata registry for all 35 supported data sources (31 dlt verified + CSV + REST API + PostgreSQL + Filesystem).
 """
 
 from enum import Enum
@@ -114,6 +114,75 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/build-a-pipeline-tutorial",
         "cost_warning": "⚠️  ADVANCED FEATURE - Manual configuration required",
         "popularity": 3,  # Low - for advanced users only
+    },
+    "filesystem": {
+        "display_name": "Files & Cloud Storage (Parquet, JSON, Excel)",
+        "category": "Local & Custom",
+        "description": "Load Parquet, JSON, JSONL, Excel, or CSV files from local disk or cloud storage (S3, GCS, Azure)",
+        "auth_type": AuthType.NONE,
+        "dlt_package": "filesystem",  # Built-in dlt core source
+        "dlt_function": "filesystem",
+        "wizard_enabled": True,
+        "required_params": [
+            {
+                "name": "bucket_url",
+                "type": "path",
+                "prompt": "File path or cloud storage URL",
+                "help": "Local path (e.g., 'data/exports/') or cloud URL (e.g., 's3://my-bucket/data/', 'gs://my-bucket/data/')",
+            },
+            {
+                "name": "file_glob",
+                "type": "string",
+                "prompt": "File pattern (glob)",
+                "default": "**/*.parquet",
+                "help": "Glob pattern to match files (e.g., '*.parquet', '**/*.json', 'reports_*.xlsx')",
+            },
+        ],
+        "optional_params": [
+            {
+                "name": "file_format",
+                "type": "choice",
+                "prompt": "File format",
+                "choices": ["parquet", "jsonl", "json", "csv", "xlsx"],
+                "default": None,  # auto-detect from file extension
+                "help": "Format of files to load. Leave blank to auto-detect from file extension. Use 'jsonl' for newline-delimited JSON.",
+            },
+            {
+                "name": "credentials",
+                "type": "string",
+                "prompt": "Cloud storage credentials key (for S3/GCS only)",
+                "default": None,
+                "help": "For cloud storage: add credentials to .dlt/secrets.toml (see setup guide). Leave blank for local files.",
+            },
+        ],
+        "setup_guide": [
+            "LOCAL FILES:",
+            "1. Place your files in a project directory (e.g., data/exports/)",
+            "2. Set bucket_url to the directory path (e.g., 'data/exports/')",
+            "3. Set file_glob to match your files (e.g., '*.parquet', '**/*.json')",
+            "",
+            "CLOUD STORAGE (S3):",
+            "1. Set bucket_url to your S3 path (e.g., 's3://my-bucket/data/')",
+            "2. Add credentials to .dlt/secrets.toml:",
+            "   [sources.filesystem.credentials]",
+            "   aws_access_key_id = 'your-key'",
+            "   aws_secret_access_key = 'your-secret'",
+            "   region_name = 'us-east-1'",
+            "",
+            "CLOUD STORAGE (GCS):",
+            "1. Set bucket_url to your GCS path (e.g., 'gs://my-bucket/data/')",
+            "2. Add credentials to .dlt/secrets.toml:",
+            "   [sources.filesystem.credentials]",
+            "   project_id = 'your-project'",
+            "   private_key = '...'",
+            "   client_email = '...'",
+            "",
+            "SUPPORTED FORMATS: Parquet, JSON (array or JSONL), Excel (.xlsx), CSV",
+            "dlt handles schema inference automatically for all formats.",
+        ],
+        "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/filesystem",
+        "cost_warning": None,
+        "popularity": 7,
     },
     "rest_api": {
         "display_name": "REST API (Generic)",
@@ -1481,7 +1550,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
 # ============================================================================
 
 CATEGORIES = {
-    "Local & Custom": ["csv", "rest_api"],
+    "Local & Custom": ["csv", "filesystem", "rest_api"],
     "Marketing & Analytics": [
         "facebook_ads",
         "google_ads",

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -1,6 +1,6 @@
 """dango/ingestion/sources/registry.py
 
-Metadata registry for all 35 supported data sources (31 dlt verified + CSV + REST API + PostgreSQL + Filesystem).
+Metadata registry for all 32 supported data sources (27 dlt verified + CSV + dlt_native + REST API + PostgreSQL + Filesystem).
 """
 
 from enum import Enum
@@ -176,6 +176,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
             "   project_id = 'your-project'",
             "   private_key = '...'",
             "   client_email = '...'",
+            "",
+            "CLOUD STORAGE (Azure Blob):",
+            "1. Set bucket_url to your Azure path (e.g., 'az://my-container/data/')",
+            "2. Add credentials to .dlt/secrets.toml:",
+            "   [sources.filesystem.credentials]",
+            "   connection_string = 'DefaultEndpointsProtocol=https;AccountName=...'",
             "",
             "SUPPORTED FORMATS: Parquet, JSON (array or JSONL), Excel (.xlsx), CSV",
             "dlt handles schema inference automatically for all formats.",

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -94,7 +94,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
-    lines: 1466
+    lines: 1621
     category: exempt
     reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary

- Adds `filesystem` as a new source in `SOURCE_REGISTRY` under the "Local & Custom" category
- Supports local files and cloud storage (S3, GCS, Azure Blob) in Parquet, JSON, JSONL, Excel, and CSV formats
- `wizard_enabled: True` — users can configure via `dango add`
- Also corrects a pre-existing source count discrepancy (docstring claimed 34, actual was 31)

## Files changed

- `dango/ingestion/sources/registry.py` — new `filesystem` entry + corrected count (32)
- `dango/ingestion/CLAUDE.md` — updated source count
- `docs/file-exemptions.yml` — updated registry.py line count (1466 → 1621)
- `CLAUDE.md` — updated registry.py line count references

## Review notes

Two-pass review was performed:
1. Initial implementation: registry entry, CATEGORIES, doc counts
2. Independent code review identified and fixed: wrong source count in docstring (35→32, correcting pre-existing error), stale `file-exemptions.yml` line count, missing Azure setup instructions in setup_guide despite Azure being in the description

All pre-commit hooks pass (ruff, mypy, file-size, file-header, docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)