### PR TITLE
P5-015: Enable Facebook Ads insights via combined source

### DIFF
--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -203,6 +203,9 @@ class FacebookAdsSourceConfig(BaseModel):
     access_token_env: str = Field(
         default="FB_ACCESS_TOKEN", description="Environment variable containing access token"
     )
+    initial_load_past_days: int = Field(
+        default=30, description="Days of historical performance metrics to load on first sync"
+    )
     start_date: datetime | None = Field(
         default=None, description="Start date for data extraction (YYYY-MM-DD)"
     )

--- a/dango/ingestion/dlt_sources/facebook_ads/__init__.py
+++ b/dango/ingestion/dlt_sources/facebook_ads/__init__.py
@@ -212,3 +212,125 @@ def facebook_insights_source(
             start_date = start_date.add(days=time_increment_days)
 
     return facebook_insights
+
+
+@dlt.source(name="facebook_ads")
+def facebook_ads_combined(
+    account_id: str = dlt.config.value,
+    access_token: str = dlt.secrets.value,
+    chunk_size: int = 50,
+    request_timeout: float = 300.0,
+    app_api_version: str = None,
+    initial_load_past_days: int = 30,
+    attribution_window_days_lag: int = 7,
+    time_increment_days: int = 1,
+    breakdowns: TInsightsBreakdownOptions = "ads_insights",
+    level: TInsightsLevels = "ad",
+) -> Sequence[DltResource]:
+    """Combined source: entity tables + daily performance insights.
+
+    Loads campaigns, ads, ad_sets, ad_creatives, leads (replace mode)
+    and facebook_insights with daily metrics (merge/incremental mode).
+
+    Args:
+        account_id: Facebook Ads account ID.
+        access_token: Long-lived access token.
+        chunk_size: Page/batch size for entity requests. Defaults to 50.
+        request_timeout: Connection timeout in seconds. Defaults to 300.0.
+        app_api_version: Facebook API version (e.g., 'v17.0'). Defaults to library default.
+        initial_load_past_days: Days of historical insights to load on first run. Defaults to 30.
+        attribution_window_days_lag: Days to re-fetch for attribution changes. Defaults to 7.
+        time_increment_days: Report aggregation window in days. Defaults to 1.
+        breakdowns: Insight breakdown preset. Defaults to "ads_insights".
+        level: Granularity level for insights. Defaults to "ad".
+
+    Returns:
+        Sequence[DltResource]: campaigns, ads, ad_sets, ad_creatives, leads, facebook_insights
+    """
+    account = get_ads_account(
+        account_id, access_token, request_timeout, app_api_version
+    )
+
+    # --- Entity resources (replace mode) ---
+
+    @dlt.resource(primary_key="id", write_disposition="replace")
+    def campaigns(
+        fields: Sequence[str] = DEFAULT_CAMPAIGN_FIELDS, states: Sequence[str] = None
+    ) -> Iterator[TDataItems]:
+        yield get_data_chunked(account.get_campaigns, fields, states, chunk_size)
+
+    @dlt.resource(primary_key="id", write_disposition="replace")
+    def ads(
+        fields: Sequence[str] = DEFAULT_AD_FIELDS, states: Sequence[str] = None
+    ) -> Iterator[TDataItems]:
+        yield get_data_chunked(account.get_ads, fields, states, chunk_size)
+
+    @dlt.resource(primary_key="id", write_disposition="replace")
+    def ad_sets(
+        fields: Sequence[str] = DEFAULT_ADSET_FIELDS, states: Sequence[str] = None
+    ) -> Iterator[TDataItems]:
+        yield get_data_chunked(account.get_ad_sets, fields, states, chunk_size)
+
+    @dlt.transformer(primary_key="id", write_disposition="replace", selected=True)
+    def leads(
+        items: TDataItems,
+        fields: Sequence[str] = DEFAULT_LEAD_FIELDS,
+        states: Sequence[str] = None,
+    ) -> Iterator[TDataItems]:
+        for item in items:
+            ad = Ad(item["id"])
+            yield get_data_chunked(ad.get_leads, fields, states, chunk_size)
+
+    @dlt.resource(primary_key="id", write_disposition="replace")
+    def ad_creatives(
+        fields: Sequence[str] = DEFAULT_ADCREATIVE_FIELDS, states: Sequence[str] = None
+    ) -> Iterator[TDataItems]:
+        yield get_data_chunked(account.get_ad_creatives, fields, states, chunk_size)
+
+    # --- Insights resource (merge/incremental mode) ---
+
+    initial_load_start_date = pendulum.today().subtract(days=initial_load_past_days)
+    initial_load_start_date_str = initial_load_start_date.isoformat()
+
+    @dlt.resource(
+        primary_key=INSIGHTS_PRIMARY_KEY,
+        write_disposition="merge",
+        columns=INSIGHT_FIELDS_TYPES,
+    )
+    def facebook_insights(
+        date_start: dlt.sources.incremental[str] = dlt.sources.incremental(
+            "date_start", initial_value=initial_load_start_date_str
+        )
+    ) -> Iterator[TDataItems]:
+        start_date = get_start_date(date_start, attribution_window_days_lag)
+        end_date = pendulum.now()
+
+        while start_date <= end_date:
+            query = {
+                "level": level,
+                "action_breakdowns": list(ALL_ACTION_BREAKDOWNS),
+                "breakdowns": list(
+                    INSIGHTS_BREAKDOWNS_OPTIONS[breakdowns]["breakdowns"]
+                ),
+                "limit": chunk_size,
+                "fields": list(
+                    set(DEFAULT_INSIGHT_FIELDS)
+                    .union(INSIGHTS_BREAKDOWNS_OPTIONS[breakdowns]["fields"])
+                    .difference(INVALID_INSIGHTS_FIELDS)
+                ),
+                "time_increment": time_increment_days,
+                "action_attribution_windows": list(ALL_ACTION_ATTRIBUTION_WINDOWS),
+                "time_ranges": [
+                    {
+                        "since": start_date.to_date_string(),
+                        "until": start_date.add(
+                            days=time_increment_days - 1
+                        ).to_date_string(),
+                    }
+                ],
+            }
+            job = execute_job(account.get_insights(params=query, is_async=True))
+            yield list(map(process_report_item, job.get_result()))
+            start_date = start_date.add(days=time_increment_days)
+
+    return campaigns, ads, ad_sets, ad_creatives, ads | leads, facebook_insights

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -306,10 +306,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
     "facebook_ads": {
         "display_name": "Facebook Ads",
         "category": "Marketing & Analytics",
-        "description": "Load ad campaigns, ad sets, ads, creatives, and leads from Facebook Ads",
+        "description": "Load ad campaigns, ads, creatives, leads, and daily performance metrics from Facebook Ads",
         "auth_type": AuthType.OAUTH,
         "dlt_package": "facebook_ads",
-        "dlt_function": "facebook_ads_source",
+        "dlt_function": "facebook_ads_combined",
         "pip_dependencies": [{"pip": "facebook-business", "import": "facebook_business"}],
         "required_params": [
             {
@@ -326,17 +326,23 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                 "help": "Long-lived User Access Token (60 days). Generate via 'dango oauth facebook_ads' or manually at https://developers.facebook.com/tools/accesstoken. Requires 'ads_read' permission.",
             },
         ],
-        "optional_params": [],
+        "optional_params": [
+            {
+                "name": "initial_load_past_days",
+                "type": "integer",
+                "default": 30,
+                "help": "Number of past days of performance metrics to load on first sync",
+            },
+        ],
         "setup_guide": [
             "1. OAuth setup runs automatically during 'dango source add'",
             "2. OR manually run: dango oauth facebook_ads",
             "3. Follow the prompts to exchange short-lived token for long-lived token",
-            "4. IMPORTANT: Access token expires in 60 days",
-            "5. Set a reminder to re-authenticate before expiry",
-            "6. NOTE: This loads entity data (campaigns, ads, ad sets, creatives, leads).",
-            "   For daily performance metrics (reach, impressions, clicks, spend),",
-            "   configure facebook_insights_source separately via dlt_native mode.",
-            "7. Facebook retains insights data for 37 months from the date of the report.",
+            "4. IMPORTANT: Access token expires in 60 days — set reminder to re-authenticate",
+            "5. Loads entity data (campaigns, ads, etc.) AND daily performance metrics",
+            "6. Performance metrics: reach, impressions, clicks, spend, CTR, CPC, CPM",
+            "7. First sync loads 30 days of insights; subsequent syncs are incremental",
+            "8. Facebook retains insights data for 37 months",
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/facebook_ads",
         "cost_warning": "Rate limited: 200 calls/hour per user, 4800/day per app",

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -59,8 +59,8 @@ class TestSourceSupportsDateRange:
     """Tests for _source_supports_date_range() helper."""
 
     def test_facebook_ads_no_date_range(self) -> None:
-        # facebook_ads_source() loads entity data (campaigns, ads, etc.)
-        # and does not accept start_date — insights require separate source
+        # facebook_ads_combined() loads entity data + insights;
+        # insights use initial_load_past_days (not start_date)
         assert _source_supports_date_range("facebook_ads") is False
 
     def test_stripe_supports(self) -> None:


### PR DESCRIPTION
## Summary
- Add `facebook_ads_combined()` source function that loads both entity tables (campaigns, ads, ad_sets, ad_creatives, leads) AND daily performance insights in a single sync
- Entity tables use `replace` disposition; insights use `merge` with incremental loading via `dlt.sources.incremental`
- Update registry entry: `dlt_function` → `facebook_ads_combined`, add `initial_load_past_days` optional param, update setup guide
- Update test comment to reflect combined source

## Changes
- `dango/ingestion/dlt_sources/facebook_ads/__init__.py` — add `facebook_ads_combined()` (~110 lines)
- `dango/ingestion/sources/registry.py` — update facebook_ads entry (function, description, optional_params, setup_guide)
- `tests/unit/test_cli_sync.py` — update comment (assertion unchanged)

## Test plan
- [x] All 2813 tests pass
- [x] ruff lint + format clean
- [x] Pre-commit hooks pass
- [ ] P5-007: Manual test `dango source add` → Facebook Ads → `dango sync` → verify `facebook_insights` table in DuckDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)