### PR TITLE
P5-016: Fix 7 registry optional_params mismatches

### DIFF
--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -8,7 +8,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 
 class DeduplicationStrategy(str, Enum):
@@ -261,11 +261,15 @@ class GitHubSourceConfig(BaseModel):
 class SlackSourceConfig(BaseModel):
     """Slack API source configuration"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     token_env: str = Field(
         default="SLACK_TOKEN", description="Environment variable containing Slack bot token"
     )
     selected_channels: list[str] | None = Field(
-        default=None, description="List of channel IDs to sync (None = all channels)"
+        default=None,
+        description="List of channel IDs to sync (None = all channels)",
+        validation_alias=AliasChoices("selected_channels", "channels"),
     )
     start_date: datetime | None = Field(default=None, description="Start date for message history")
 

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -246,7 +246,6 @@ class SalesforceSourceConfig(BaseModel):
         default="SALESFORCE_SECURITY_TOKEN",
         description="Environment variable containing security token",
     )
-    is_sandbox: bool = Field(default=False, description="Whether to use sandbox environment")
 
 
 class GitHubSourceConfig(BaseModel):
@@ -265,7 +264,7 @@ class SlackSourceConfig(BaseModel):
     token_env: str = Field(
         default="SLACK_TOKEN", description="Environment variable containing Slack bot token"
     )
-    channels: list[str] | None = Field(
+    selected_channels: list[str] | None = Field(
         default=None, description="List of channel IDs to sync (None = all channels)"
     )
     start_date: datetime | None = Field(default=None, description="Start date for message history")

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -819,6 +819,11 @@ class DltPipelineRunner:
                     console.print(
                         f"  [dim]Selected resources: {', '.join(selected_resources)}[/dim]"
                     )
+                else:
+                    console.print(
+                        f"  [yellow]⚠ Source does not support .with_resources() "
+                        f"— ignoring resource selection: {', '.join(selected_resources)}[/yellow]"
+                    )
 
             # Apply row limit if specified (dev testing)
             if limit is not None:
@@ -903,6 +908,16 @@ class DltPipelineRunner:
             self._restore_dlt_state(state_backup)
             raise
 
+    # Sources with complex credential objects that need restructuring.
+    # Flat env-resolved params → nested credentials dict for dlt.
+    _CREDENTIAL_RESTRUCTURE: dict[str, dict[str, str]] = {
+        "salesforce": {
+            "username": "user_name",  # SecurityTokenAuth uses user_name
+            "password": "password",
+            "security_token": "security_token",
+        },
+    }
+
     def _build_source_config(
         self,
         source_config: DataSource,
@@ -973,7 +988,6 @@ class DltPipelineRunner:
             "deduplication",  # Dango's deduplication strategy
             "enabled",  # Dango's source enable/disable flag
             "description",  # Dango's source description
-            "resources",  # Applied via .with_resources() after source creation
         }
 
         # Resolve environment variables (fields ending in _env)
@@ -1003,17 +1017,9 @@ class DltPipelineRunner:
 
         # Restructure flat env-resolved params into nested credential objects for dlt
         # e.g., Salesforce: flat username/password/security_token → credentials dict
-        CREDENTIAL_RESTRUCTURE: dict[str, dict[str, str]] = {
-            "salesforce": {
-                "username": "user_name",  # SecurityTokenAuth uses user_name
-                "password": "password",
-                "security_token": "security_token",
-            },
-        }
-
         source_type_str = source_type.value
-        if source_type_str in CREDENTIAL_RESTRUCTURE:
-            field_map = CREDENTIAL_RESTRUCTURE[source_type_str]
+        if source_type_str in self._CREDENTIAL_RESTRUCTURE:
+            field_map = self._CREDENTIAL_RESTRUCTURE[source_type_str]
             credentials: dict[str, Any] = {}
             for flat_key, dlt_key in field_map.items():
                 if flat_key in resolved_config:

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -796,6 +796,9 @@ class DltPipelineRunner:
         # This ensures credentials are passed even if dlt's config resolution misses them
         source_kwargs = self._inject_oauth_credentials(source_type.value, source_kwargs)
 
+        # Pop resources before calling source function — applied via .with_resources() after
+        selected_resources = source_kwargs.pop("resources", None)
+
         # Set DLT_PROJECT_DIR so dlt finds .dlt/ regardless of when import happened
         # This is dlt's official mechanism for specifying project location
         os.environ["DLT_PROJECT_DIR"] = str(self.project_root)
@@ -808,6 +811,14 @@ class DltPipelineRunner:
             # Dynamic import of dlt source
             # dlt resolves dlt.secrets.value parameters at this point
             source = self._load_dlt_source(dlt_package, dlt_function, source_kwargs)
+
+            # Apply resource selection via .with_resources() (e.g., HubSpot, Pipedrive)
+            if selected_resources and isinstance(selected_resources, list):
+                if hasattr(source, "with_resources"):
+                    source = source.with_resources(*selected_resources)
+                    console.print(
+                        f"  [dim]Selected resources: {', '.join(selected_resources)}[/dim]"
+                    )
 
             # Apply row limit if specified (dev testing)
             if limit is not None:
@@ -962,6 +973,7 @@ class DltPipelineRunner:
             "deduplication",  # Dango's deduplication strategy
             "enabled",  # Dango's source enable/disable flag
             "description",  # Dango's source description
+            "resources",  # Applied via .with_resources() after source creation
         }
 
         # Resolve environment variables (fields ending in _env)
@@ -988,6 +1000,26 @@ class DltPipelineRunner:
                     resolved_config[param_name] = env_value
             else:
                 resolved_config[key] = value
+
+        # Restructure flat env-resolved params into nested credential objects for dlt
+        # e.g., Salesforce: flat username/password/security_token → credentials dict
+        CREDENTIAL_RESTRUCTURE: dict[str, dict[str, str]] = {
+            "salesforce": {
+                "username": "user_name",  # SecurityTokenAuth uses user_name
+                "password": "password",
+                "security_token": "security_token",
+            },
+        }
+
+        source_type_str = source_type.value
+        if source_type_str in CREDENTIAL_RESTRUCTURE:
+            field_map = CREDENTIAL_RESTRUCTURE[source_type_str]
+            credentials: dict[str, Any] = {}
+            for flat_key, dlt_key in field_map.items():
+                if flat_key in resolved_config:
+                    credentials[dlt_key] = resolved_config.pop(flat_key)
+            if credentials:
+                resolved_config["credentials"] = credentials
 
         # Override dates if provided
         if start_date:

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -501,14 +501,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                 "help": "Reset at Setup > My Personal Information > Reset Security Token",
             },
         ],
-        "optional_params": [
-            {
-                "name": "is_sandbox",
-                "type": "boolean",
-                "prompt": "Use sandbox environment?",
-                "default": False,
-            },
-        ],
+        "optional_params": [],
         "setup_guide": [
             "1. Get Salesforce username and password",
             "2. Reset security token (Setup > Reset Security Token)",
@@ -669,7 +662,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "optional_params": [
             {
-                "name": "channels",
+                "name": "selected_channels",
                 "type": "list",
                 "prompt": "Channel IDs to sync (empty = all channels)",
                 "default": None,
@@ -1299,13 +1292,6 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                 "prompt": "Database IDs to sync (JSON array, empty = all)",
                 "default": None,
                 "help": 'Format: [{"id": "db_id", "use_name": "my_db"}] - Leave empty to sync all databases',
-            },
-            {
-                "name": "page_ids",
-                "type": "list",
-                "prompt": "Page IDs to sync (comma-separated, empty = all)",
-                "default": None,
-                "help": "Comma-separated list of Notion page IDs",
             },
         ],
         "setup_guide": [

--- a/tests/unit/test_registry_params.py
+++ b/tests/unit/test_registry_params.py
@@ -1,0 +1,75 @@
+"""tests/unit/test_registry_params.py
+
+Regression test verifying that all registry optional_params match the actual
+function signatures of the corresponding dlt source functions. Catches mismatches
+like P5-012 (Facebook Ads start_date) and P5-016 (Salesforce, Slack, Notion, etc.)
+before they become runtime TypeErrors.
+"""
+
+import importlib
+import inspect
+
+import pytest
+
+from dango.ingestion.sources.registry import SOURCE_REGISTRY
+
+# Params intercepted by dlt_runner before reaching source functions.
+# These are valid in optional_params even if the function doesn't accept them.
+INTERCEPTED_PARAMS = {"resources"}
+
+# Sources that use dlt built-in packages (not vendored in dango.ingestion.dlt_sources)
+# These can't be introspected without installing extra dependencies.
+BUILTIN_DLT_PACKAGES = {"filesystem", "rest_api", "sql_database"}
+
+
+def _get_importable_sources() -> list[tuple[str, dict]]:
+    """Return registry entries with vendored dlt source functions."""
+    sources = []
+    for source_key, metadata in SOURCE_REGISTRY.items():
+        dlt_package = metadata.get("dlt_package")
+        dlt_function = metadata.get("dlt_function")
+        if not dlt_package or not dlt_function:
+            continue
+        if dlt_package in BUILTIN_DLT_PACKAGES:
+            continue
+        sources.append((source_key, metadata))
+    return sources
+
+
+@pytest.mark.unit
+class TestRegistryParamsMatchSignatures:
+    """Verify optional_params names match actual dlt source function signatures."""
+
+    @pytest.mark.parametrize(
+        "source_key,metadata",
+        _get_importable_sources(),
+        ids=[s[0] for s in _get_importable_sources()],
+    )
+    def test_optional_params_accepted_by_source_function(
+        self, source_key: str, metadata: dict
+    ) -> None:
+        """Each optional_param must be in the function signature or INTERCEPTED_PARAMS."""
+        dlt_package = metadata["dlt_package"]
+        dlt_function = metadata["dlt_function"]
+
+        module_path = f"dango.ingestion.dlt_sources.{dlt_package}"
+        try:
+            source_module = importlib.import_module(module_path)
+        except ImportError:
+            pytest.skip(f"Cannot import {module_path}")
+            return
+
+        func = getattr(source_module, dlt_function, None)
+        assert func is not None, f"{dlt_function} not found in {module_path}"
+
+        sig = inspect.signature(func)
+        accepted_params = set(sig.parameters.keys())
+
+        optional_params = metadata.get("optional_params", [])
+        for param in optional_params:
+            param_name = param["name"]
+            assert param_name in accepted_params or param_name in INTERCEPTED_PARAMS, (
+                f"Source '{source_key}': optional_param '{param_name}' is not accepted "
+                f"by {dlt_function}() and not in INTERCEPTED_PARAMS. "
+                f"Function accepts: {sorted(accepted_params)}"
+            )

--- a/tests/unit/test_registry_params.py
+++ b/tests/unit/test_registry_params.py
@@ -36,14 +36,17 @@ def _get_importable_sources() -> list[tuple[str, dict]]:
     return sources
 
 
+_IMPORTABLE_SOURCES = _get_importable_sources()
+
+
 @pytest.mark.unit
 class TestRegistryParamsMatchSignatures:
     """Verify optional_params names match actual dlt source function signatures."""
 
     @pytest.mark.parametrize(
         "source_key,metadata",
-        _get_importable_sources(),
-        ids=[s[0] for s in _get_importable_sources()],
+        _IMPORTABLE_SOURCES,
+        ids=[s[0] for s in _IMPORTABLE_SOURCES],
     )
     def test_optional_params_accepted_by_source_function(
         self, source_key: str, metadata: dict


### PR DESCRIPTION
## Summary

Audited all registry entries and fixed 7 optional_params that didn't match their dlt source function signatures — these would cause `TypeError` at runtime.

### Group A: `resources` param (4 sources)
- **HubSpot, Pipedrive, Jira, Asana** — `resources` not accepted by source functions. Added `resources` to `DANGO_ONLY_FIELDS` and wired `.with_resources()` post-creation to apply resource selection correctly.

### Group B: Other mismatches (3 sources)
- **Salesforce** — flat `username`/`password`/`security_token` kwargs restructured into nested `credentials` dict matching `SecurityTokenAuth`. Removed invalid `is_sandbox` param.
- **Slack** — renamed `channels` → `selected_channels` to match `slack_source()` signature.
- **Notion** — removed `page_ids` (belongs to `notion_pages()`, not `notion_databases()`).

### Regression test
New `tests/unit/test_registry_params.py` introspects all vendored source functions and asserts every `optional_params` name is either in the function signature or in `INTERCEPTED_PARAMS`.

## Test plan
- [x] New regression test passes: 18 passed, 9 skipped (uninstalled deps)
- [x] All 2729 unit tests pass
- [x] ruff check + format clean
- [x] mypy clean
- [x] Grep confirms no stale `is_sandbox`, `page_ids`, or `channels` in registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)