### PR TITLE
P5-011: Add capability metadata to source registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | `dango/ingestion/dlt_sources/` | Vendored third-party dlt connectors (127 files). Rarely modified. |
 | `dango/web/static/` | Frontend HTML/CSS/JS assets. |
 | `tests/` | Read source module first, then find its tests. |
-| `dango/ingestion/sources/registry.py` | 1621-line metadata registry. Only when adding a new source. |
+| `dango/ingestion/sources/registry.py` | 1934-line metadata registry. Only when adding a new source. |
 | `dango/templates/` | Jinja2 templates. Only when modifying project init or model generation. |
 
 ## Decision Tree
@@ -250,7 +250,7 @@ dango/                          # Python package source
 │   ├── dlt_runner.py           # ⚠ 1796 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # CSV loading with dedup (742 lines)
 │   ├── sources/
-│   │   └── registry.py         # Source metadata (1621 lines, 32 source types)
+│   │   └── registry.py         # Source metadata (1934 lines, 32 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
@@ -330,7 +330,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 1796 | — (exempt, too risky) |
-| `ingestion/sources/registry.py` | 1745 | — (metadata-only) |
+| `ingestion/sources/registry.py` | 1934 | — (metadata-only) |
 | `cli/source_wizard.py` | 1350 | — |
 | `visualization/metabase.py` | 1149 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | `dango/ingestion/dlt_sources/` | Vendored third-party dlt connectors (127 files). Rarely modified. |
 | `dango/web/static/` | Frontend HTML/CSS/JS assets. |
 | `tests/` | Read source module first, then find its tests. |
-| `dango/ingestion/sources/registry.py` | 1934-line metadata registry. Only when adding a new source. |
+| `dango/ingestion/sources/registry.py` | 1936-line metadata registry. Only when adding a new source. |
 | `dango/templates/` | Jinja2 templates. Only when modifying project init or model generation. |
 
 ## Decision Tree
@@ -250,7 +250,7 @@ dango/                          # Python package source
 │   ├── dlt_runner.py           # ⚠ 1796 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # CSV loading with dedup (742 lines)
 │   ├── sources/
-│   │   └── registry.py         # Source metadata (1934 lines, 32 source types)
+│   │   └── registry.py         # Source metadata (1936 lines, 32 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
@@ -330,7 +330,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 1796 | — (exempt, too risky) |
-| `ingestion/sources/registry.py` | 1934 | — (metadata-only) |
+| `ingestion/sources/registry.py` | 1936 | — (metadata-only) |
 | `cli/source_wizard.py` | 1350 | — |
 | `visualization/metabase.py` | 1149 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -15,11 +15,11 @@ for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see P5-006).
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `__init__.py` | Public exports | `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
+| `__init__.py` | Public exports | `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata`, `get_source_capabilities` |
 | `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync` (imports `SyncTimeoutError` from `dango.exceptions`) |
 | `csv_loader.py` | Incremental CSV loading with metadata tracking and 4 dedup strategies | `CSVLoader` (imports `CSVSchemaMismatchError` from `dango.exceptions`) |
-| `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata` |
-| `sources/registry.py` | Central registry of 32 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category` |
+| `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata`, `get_source_capabilities` |
+| `sources/registry.py` | Central registry of 32 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category`, `get_source_capabilities` |
 | `dlt_sources/` | Third-party dlt verified source implementations (27 directories, 105+ files) | DO NOT MODIFY — see "Don't Modify" section |
 
 ## Common Tasks

--- a/dango/ingestion/__init__.py
+++ b/dango/ingestion/__init__.py
@@ -6,7 +6,7 @@ Handles data loading from various sources (CSV, APIs, databases).
 
 from .csv_loader import CSVLoader
 from .dlt_runner import DltPipelineRunner, run_sync
-from .sources import CATEGORIES, SOURCE_REGISTRY, get_source_metadata
+from .sources import CATEGORIES, SOURCE_REGISTRY, get_source_capabilities, get_source_metadata
 
 __all__ = [
     "DltPipelineRunner",
@@ -15,4 +15,5 @@ __all__ = [
     "SOURCE_REGISTRY",
     "CATEGORIES",
     "get_source_metadata",
+    "get_source_capabilities",
 ]

--- a/dango/ingestion/sources/__init__.py
+++ b/dango/ingestion/sources/__init__.py
@@ -4,6 +4,6 @@ Dango Source Registry
 Metadata registry for all supported data sources.
 """
 
-from .registry import CATEGORIES, SOURCE_REGISTRY, get_source_metadata
+from .registry import CATEGORIES, SOURCE_REGISTRY, get_source_capabilities, get_source_metadata
 
-__all__ = ["SOURCE_REGISTRY", "CATEGORIES", "get_source_metadata"]
+__all__ = ["SOURCE_REGISTRY", "CATEGORIES", "get_source_metadata", "get_source_capabilities"]

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -4,7 +4,7 @@ Metadata registry for all 32 supported data sources (27 dlt verified + CSV + dlt
 """
 
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 
 class AuthType(str, Enum):
@@ -277,6 +277,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api",
         "cost_warning": "Check API provider's rate limits and pricing",
+        "wizard_enabled": True,
         "popularity": 8,
         "capabilities": {
             "performance_metrics": False,
@@ -284,7 +285,6 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
             "incremental": True,
             "custom_queries": True,
         },
-        "wizard_enabled": True,
     },
     # ========================================
     # MARKETING & ANALYTICS
@@ -1066,6 +1066,8 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": True,
             "date_range": True,
+            # assets use merge (idempotent upsert) but no dlt.sources.incremental()
+            # cursor — re-fetches all assets each run, not true incremental loading
             "incremental": False,
             "custom_queries": False,
         },
@@ -1931,4 +1933,4 @@ def get_source_capabilities(source_type: str) -> dict[str, bool] | None:
     metadata = SOURCE_REGISTRY.get(source_type)
     if metadata is None:
         return None
-    return metadata.get("capabilities")
+    return cast(dict[str, bool] | None, metadata.get("capabilities"))

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -89,6 +89,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "cost_warning": None,
         "popularity": 10,  # 1-10, used for sorting
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "dlt_native": {
         "display_name": "dlt Native Source (Advanced)",
@@ -137,6 +143,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/build-a-pipeline-tutorial",
         "cost_warning": "⚠️  ADVANCED FEATURE - Manual configuration required",
         "popularity": 3,  # Low - for advanced users only
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": False,
+            "custom_queries": True,
+        },
     },
     "filesystem": {
         "display_name": "Files & Cloud Storage (Parquet, JSON, Excel)",
@@ -212,6 +224,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/filesystem",
         "cost_warning": None,
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "rest_api": {
         "display_name": "REST API (Generic)",
@@ -260,6 +278,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api",
         "cost_warning": "Check API provider's rate limits and pricing",
         "popularity": 8,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": True,
+        },
         "wizard_enabled": True,
     },
     # ========================================
@@ -302,6 +326,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "cost_warning": "Subject to Google API quota limits",
         "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 10,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "facebook_ads": {
         "display_name": "Facebook Ads",
@@ -348,6 +378,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "cost_warning": "Rate limited: 200 calls/hour per user, 4800/day per app",
         "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 9,
+        "capabilities": {
+            "performance_metrics": True,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "google_analytics": {
         "display_name": "Google Analytics (GA4)",
@@ -438,6 +474,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "cost_warning": "Subject to Google API quota limits. Data is aggregated (not event-level).",
         "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 9,
+        "capabilities": {
+            "performance_metrics": True,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": True,
+        },
     },
     # ========================================
     # BUSINESS & CRM
@@ -477,6 +519,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/hubspot",
         "cost_warning": "Subject to HubSpot API limits (varies by plan)",
         "popularity": 9,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "salesforce": {
         "display_name": "Salesforce",
@@ -517,6 +565,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/salesforce",
         "cost_warning": "Salesforce API limits depend on edition (check your limits)",
         "popularity": 8,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     # ========================================
     # E-COMMERCE & PAYMENT
@@ -571,6 +625,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/stripe_analytics",
         "cost_warning": "No additional cost (included with Stripe account)",
         "popularity": 10,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "shopify": {
         "display_name": "Shopify",
@@ -608,6 +668,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "cost_warning": "Included with Shopify plan",
         "wizard_enabled": True,  # Enabled: uses Custom App access token via X-Shopify-Access-Token header
         "popularity": 9,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     # ========================================
     # DEVELOPMENT
@@ -645,6 +711,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/github",
         "cost_warning": "Rate limited: 5000 requests/hour (authenticated)",
         "popularity": 8,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     # ========================================
     # OTHER
@@ -692,6 +764,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/slack",
         "cost_warning": "Subject to Slack API rate limits",
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "zendesk": {
         "display_name": "Zendesk",
@@ -741,6 +819,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/zendesk",
         "cost_warning": "Subject to Zendesk API rate limits",
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     # Additional verified sources (skeleton metadata - to be expanded)
     "google_ads": {
@@ -887,6 +971,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "cost_warning": "Subject to Google Ads API rate limits",
         "wizard_enabled": True,  # OAuth implementation complete
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": True,
+            "date_range": True,
+            "incremental": False,
+            "custom_queries": True,
+        },
     },
     "matomo": {
         "display_name": "Matomo Analytics",
@@ -926,6 +1016,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/matomo",
         "popularity": 5,
+        "capabilities": {
+            "performance_metrics": True,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": True,
+        },
     },
     "mux": {
         "display_name": "Mux",
@@ -967,6 +1063,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/mux",
         "popularity": 4,
+        "capabilities": {
+            "performance_metrics": True,
+            "date_range": True,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "airtable": {
         "display_name": "Airtable",
@@ -1010,6 +1112,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/airtable",
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "pipedrive": {
         "display_name": "Pipedrive",
@@ -1069,6 +1177,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/pipedrive",
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "freshdesk": {
         "display_name": "Freshdesk",
@@ -1125,6 +1239,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/freshdesk",
         "popularity": 6,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "jira": {
         "display_name": "Jira",
@@ -1181,6 +1301,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/jira",
         "popularity": 8,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "workable": {
         "display_name": "Workable",
@@ -1229,6 +1355,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/workable",
         "popularity": 5,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "asana": {
         "display_name": "Asana",
@@ -1273,6 +1405,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/asana",
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "notion": {
         "display_name": "Notion",
@@ -1308,6 +1446,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/notion",
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "inbox": {
         "display_name": "Email Inbox (IMAP)",
@@ -1356,6 +1500,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/inbox",
         "popularity": 5,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "mongodb": {
         "display_name": "MongoDB",
@@ -1406,6 +1556,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/mongodb",
         "popularity": 8,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "postgres": {
         "display_name": "PostgreSQL",
@@ -1456,6 +1612,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/sql_database",
         "popularity": 8,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "kafka": {
         "display_name": "Apache Kafka",
@@ -1513,6 +1675,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/kafka",
         "popularity": 7,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "kinesis": {
         "display_name": "Amazon Kinesis",
@@ -1568,6 +1736,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/kinesis",
         "popularity": 6,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
     "chess": {
         "display_name": "Chess.com",
@@ -1593,6 +1767,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/chess",
         "popularity": 3,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": True,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "strapi": {
         "display_name": "Strapi",
@@ -1626,6 +1806,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/strapi",
         "popularity": 5,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": False,
+            "custom_queries": False,
+        },
     },
     "personio": {
         "display_name": "Personio",
@@ -1660,6 +1846,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/personio",
         "popularity": 4,
+        "capabilities": {
+            "performance_metrics": False,
+            "date_range": False,
+            "incremental": True,
+            "custom_queries": False,
+        },
     },
 }
 
@@ -1732,3 +1924,11 @@ def get_popular_sources(limit: int = 10) -> list[str]:
 def is_source_implemented(source_type: str) -> bool:
     """Check if a source has full metadata in registry"""
     return source_type in SOURCE_REGISTRY
+
+
+def get_source_capabilities(source_type: str) -> dict[str, bool] | None:
+    """Get capability flags for a specific source type."""
+    metadata = SOURCE_REGISTRY.get(source_type)
+    if metadata is None:
+        return None
+    return metadata.get("capabilities")

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -94,7 +94,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
-    lines: 1934
+    lines: 1936
     category: exempt
     reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type. P5-011 added capability metadata (+313 lines)."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -94,9 +94,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
-    lines: 1621
+    lines: 1934
     category: exempt
-    reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type."
+    reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type. P5-011 added capability metadata (+313 lines)."
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,6 @@ module = [
     "dango.notebooks.templates.quality",
     "dango.notebooks.templates.blank",
     "dango.ingestion.dlt_runner",
-    "dango.ingestion.sources.registry",
     "dango.ingestion.csv_loader",
     "dango.cli.source_wizard",
     "dango.cli.init",

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -1,0 +1,63 @@
+"""tests/unit/test_source_registry.py
+
+Tests for source registry capabilities metadata (dango/ingestion/sources/registry.py).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dango.ingestion.sources.registry import (
+    SOURCE_REGISTRY,
+    get_source_capabilities,
+)
+
+CAPABILITY_KEYS = {"performance_metrics", "date_range", "incremental", "custom_queries"}
+
+
+@pytest.mark.unit
+class TestSourceCapabilities:
+    """Tests for capability metadata on all registry entries."""
+
+    def test_all_entries_have_capabilities(self) -> None:
+        """Every registry entry must include a capabilities dict."""
+        for source_type, metadata in SOURCE_REGISTRY.items():
+            assert "capabilities" in metadata, f"{source_type} missing capabilities"
+
+    def test_capabilities_have_required_keys(self) -> None:
+        """Every capabilities dict must have exactly the 4 required boolean keys."""
+        for source_type, metadata in SOURCE_REGISTRY.items():
+            caps = metadata["capabilities"]
+            assert set(caps.keys()) == CAPABILITY_KEYS, (
+                f"{source_type} capabilities keys mismatch: {set(caps.keys())}"
+            )
+
+    def test_capabilities_values_are_bool(self) -> None:
+        """All capability values must be booleans."""
+        for source_type, metadata in SOURCE_REGISTRY.items():
+            for key, value in metadata["capabilities"].items():
+                assert isinstance(value, bool), (
+                    f"{source_type}.capabilities.{key} is {type(value).__name__}, expected bool"
+                )
+
+    def test_get_source_capabilities_known_source(self) -> None:
+        """get_source_capabilities returns correct dict for a known source."""
+        caps = get_source_capabilities("google_analytics")
+        assert caps is not None
+        assert caps["performance_metrics"] is True
+        assert caps["date_range"] is True
+        assert caps["incremental"] is True
+        assert caps["custom_queries"] is True
+
+    def test_get_source_capabilities_unknown_source(self) -> None:
+        """get_source_capabilities returns None for an unknown source."""
+        assert get_source_capabilities("nonexistent_source") is None
+
+    def test_get_source_capabilities_csv(self) -> None:
+        """CSV has incremental but no other capabilities."""
+        caps = get_source_capabilities("csv")
+        assert caps is not None
+        assert caps["performance_metrics"] is False
+        assert caps["date_range"] is False
+        assert caps["incremental"] is True
+        assert caps["custom_queries"] is False


### PR DESCRIPTION
## Summary
- Add structured `capabilities` dict to all 32 `SOURCE_REGISTRY` entries with 4 boolean flags: `performance_metrics`, `date_range`, `incremental`, `custom_queries`
- Add `get_source_capabilities()` helper function, exported from `dango.ingestion.sources`
- Remove `registry.py` from mypy exempt list (zero errors after verification)
- Update line counts in `file-exemptions.yml` and `CLAUDE.md` (1621 → 1934 lines)

## Test plan
- [x] `mypy dango/ingestion/sources/registry.py` — zero errors
- [x] `ruff check` + `ruff format --check` — clean
- [x] Import verification: `get_source_capabilities('google_ads')` returns correct dict
- [x] All 32 entries have `capabilities` key (assertion verified)
- [x] Full test suite: 2831 passed, 32 skipped
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)