### PR TITLE
P5-007 PR1: Fix 20+ source bugs and disable 6 broken sources

### DIFF
--- a/dango/cli/commands/oauth.py
+++ b/dango/cli/commands/oauth.py
@@ -4,6 +4,7 @@ OAuth authentication commands.
 """
 
 import click
+from rich.markup import escape
 
 from dango.cli import console
 
@@ -82,7 +83,7 @@ def oauth_list(ctx: click.Context) -> None:
         console.print("[dim]To remove: dango oauth remove <source_type>[/dim]\n")
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -148,7 +149,7 @@ def oauth_status(ctx: click.Context) -> None:
                 )
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -205,7 +206,7 @@ def oauth_remove(ctx: click.Context, source_type: str) -> None:
             raise click.Abort()
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -282,7 +283,7 @@ def oauth_refresh(ctx: click.Context, oauth_name: str) -> None:
         console.print(f"[dim]  New credential: {new_oauth_name}[/dim]\n")
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -325,7 +326,7 @@ def oauth_facebook_ads(ctx: click.Context) -> None:
             raise click.Abort()
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -367,7 +368,7 @@ def oauth_google_sheets(ctx: click.Context) -> None:
         console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -409,7 +410,7 @@ def oauth_google_analytics(ctx: click.Context) -> None:
         console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -451,7 +452,7 @@ def oauth_google_ads(ctx: click.Context) -> None:
         console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -622,7 +623,7 @@ def oauth_check(ctx: click.Context) -> None:
         console.print("")
 
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():
@@ -805,7 +806,7 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
         console.print("\n[yellow]Setup cancelled[/yellow]")
         raise click.Abort() from None
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
         from dango.exceptions import is_debug_mode
 
         if is_debug_mode():

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -1070,7 +1070,7 @@ class SourceWizard:
         elif param_type == "number" and value and isinstance(value, str):
             try:
                 num = float(value)
-                value = int(num) if num == int(num) else num
+                value = int(num) if num.is_integer() else num
             except ValueError:
                 console.print(f"[red]Invalid number: {value}[/red]")
                 return None

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -220,8 +220,9 @@ class SourceWizard:
                         header = None
                         if source_type == "csv":
                             header = (
-                                "NOTE: Replace 'your_table' with your actual"
-                                " table name after first sync."
+                                f"NOTE: Tables will be created in the raw_{source_name}"
+                                f" schema. Replace 'your_table' with your actual"
+                                f" table name after first sync."
                             )
                         add_metrics_to_config(self.project_root, templates, header_comment=header)
                         console.print(
@@ -703,7 +704,7 @@ class SourceWizard:
         # Source-specific credential parameters that are collected during OAuth
         # These are stored in .dlt/secrets.toml by the OAuth provider
         oauth_collected_params = {
-            "facebook_ads": ["account_id"],  # Facebook OAuth collects account_id
+            "facebook_ads": [],  # account_id is a required wizard param, not OAuth-collected
             "google_ads": ["customer_id"],  # Google Ads OAuth collects customer_id
             "shopify": ["shop_url"],  # Shopify OAuth collects shop_url
         }
@@ -1068,7 +1069,8 @@ class SourceWizard:
                 return None
         elif param_type == "number" and value and isinstance(value, str):
             try:
-                value = float(value)
+                num = float(value)
+                value = int(num) if num == int(num) else num
             except ValueError:
                 console.print(f"[red]Invalid number: {value}[/red]")
                 return None

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -241,14 +241,16 @@ class SalesforceSourceConfig(BaseModel):
     """Salesforce API source configuration"""
 
     username_env: str = Field(
-        default="SALESFORCE_USERNAME", description="Environment variable containing username"
+        default="",
+        description="(Deprecated) Environment variable containing username. Use OAuth 2.0 via secrets.toml instead.",
     )
     password_env: str = Field(
-        default="SALESFORCE_PASSWORD", description="Environment variable containing password"
+        default="",
+        description="(Deprecated) Environment variable containing password. Use OAuth 2.0 via secrets.toml instead.",
     )
     security_token_env: str = Field(
-        default="SALESFORCE_SECURITY_TOKEN",
-        description="Environment variable containing security token",
+        default="",
+        description="(Deprecated) Environment variable containing security token. Use OAuth 2.0 via secrets.toml instead.",
     )
 
 
@@ -268,8 +270,10 @@ class SlackSourceConfig(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    token_env: str = Field(
-        default="SLACK_TOKEN", description="Environment variable containing Slack bot token"
+    access_token_env: str = Field(
+        default="SLACK_ACCESS_TOKEN",
+        description="Environment variable containing Slack bot token",
+        validation_alias=AliasChoices("access_token_env", "token_env"),
     )
     selected_channels: list[str] | None = Field(
         default=None,

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -201,28 +201,69 @@ class DltPipelineRunner:
                     f"\n[green]✓ Added to requirements.txt: {', '.join(new_deps)}[/green]"
                 )
 
-            # Show error and instructions
-            error_message = (
-                f"Missing required dependencies: {', '.join(d['pip'] for d in missing_deps)}"
-            )
-            console.print(f"\n[red]❌ {error_message}[/red]")
-            console.print("\n[bold]To fix, run:[/bold]")
-            console.print("  [cyan]pip install -r requirements.txt[/cyan]")
-            console.print(f"\nThen retry: [cyan]dango sync --source {source_name}[/cyan]\n")
+            # Try auto-installing missing deps
+            import subprocess
+            import sys
 
-            log_activity(
-                project_root=self.project_root,
-                level="error",
-                source=source_name,
-                message=f"Sync blocked: {error_message}",
-            )
+            pip_packages = [d["pip"] for d in missing_deps]
+            console.print(f"\n[yellow]⚠ Missing dependencies: {', '.join(pip_packages)}[/yellow]")
+            console.print("[dim]Attempting automatic install...[/dim]")
 
-            return {
-                "status": "failed",
-                "source": source_name,
-                "error": error_message,
-                "rows_loaded": 0,
-            }
+            try:
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", *pip_packages],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                )
+                console.print(f"[green]✓ Installed: {', '.join(pip_packages)}[/green]")
+                # Re-check deps after install
+                deps_ok, _ = self._check_dependencies(source_type.value)
+                if deps_ok:
+                    console.print("[green]✓ All dependencies satisfied[/green]")
+                    # Fall through to continue sync
+                else:
+                    error_message = (
+                        f"Dependencies still missing after install: "
+                        f"{', '.join(d['pip'] for d in missing_deps)}"
+                    )
+                    console.print(f"\n[red]❌ {error_message}[/red]")
+                    console.print("\n[bold]To fix manually, run:[/bold]")
+                    console.print("  [cyan]pip install -r requirements.txt[/cyan]")
+                    console.print(f"\nThen retry: [cyan]dango sync --source {source_name}[/cyan]\n")
+
+                    log_activity(
+                        project_root=self.project_root,
+                        level="error",
+                        source=source_name,
+                        message=f"Sync blocked: {error_message}",
+                    )
+
+                    return {
+                        "status": "failed",
+                        "source": source_name,
+                        "error": error_message,
+                        "rows_loaded": 0,
+                    }
+            except subprocess.CalledProcessError:
+                error_message = f"Missing required dependencies: {', '.join(pip_packages)}"
+                console.print(f"\n[red]❌ Auto-install failed: {error_message}[/red]")
+                console.print("\n[bold]To fix manually, run:[/bold]")
+                console.print("  [cyan]pip install -r requirements.txt[/cyan]")
+                console.print(f"\nThen retry: [cyan]dango sync --source {source_name}[/cyan]\n")
+
+                log_activity(
+                    project_root=self.project_root,
+                    level="error",
+                    source=source_name,
+                    message=f"Sync blocked: {error_message}",
+                )
+
+                return {
+                    "status": "failed",
+                    "source": source_name,
+                    "error": error_message,
+                    "rows_loaded": 0,
+                }
 
         # Check disk space before starting sync
         try:
@@ -796,6 +837,10 @@ class DltPipelineRunner:
         # This ensures credentials are passed even if dlt's config resolution misses them
         source_kwargs = self._inject_oauth_credentials(source_type.value, source_kwargs)
 
+        # REST API: assemble RESTAPIConfig dict from flat source_kwargs
+        if source_type == SourceType.REST_API:
+            source_kwargs = self._build_rest_api_config(source_kwargs)
+
         # Pop resources before calling source function — applied via .with_resources() after
         selected_resources = source_kwargs.pop("resources", None)
 
@@ -904,6 +949,18 @@ class DltPipelineRunner:
         except Exception as e:
             # Pipeline failed - restore previous state
             console.print(f"  ❌ Pipeline failed: {e}")
+
+            # Per-resource error guidance
+            error_str = str(e).lower()
+            if any(kw in error_str for kw in ("403", "forbidden", "not found", "404")):
+                console.print(
+                    "\n  [yellow]💡 Tip: Some resources may require higher API permissions.[/yellow]"
+                )
+                console.print(
+                    "  [yellow]   Edit .dango/sources.yml to remove failing resources "
+                    "and retry.[/yellow]"
+                )
+
             console.print("  🔄 Restoring previous state...")
             self._restore_dlt_state(state_backup)
             raise
@@ -1024,8 +1081,26 @@ class DltPipelineRunner:
             for flat_key, dlt_key in field_map.items():
                 if flat_key in resolved_config:
                     credentials[dlt_key] = resolved_config.pop(flat_key)
-            if credentials:
+            if credentials and all(v for v in credentials.values()):
                 resolved_config["credentials"] = credentials
+
+        # Convert date strings to pendulum DateTime for sources that expect it
+        _DATETIME_SOURCES = {"workable"}
+        if source_type_str in _DATETIME_SOURCES:
+            for date_key in ("start_date", "end_date"):
+                date_val = resolved_config.get(date_key)
+                if isinstance(date_val, str) and date_val:
+                    try:
+                        import pendulum
+
+                        resolved_config[date_key] = pendulum.parse(date_val)
+                    except Exception:
+                        try:
+                            from datetime import datetime as dt
+
+                            resolved_config[date_key] = dt.fromisoformat(date_val)
+                        except Exception:
+                            pass  # Leave as string — dlt may handle it
 
         # Override dates if provided
         if start_date:
@@ -1034,6 +1109,49 @@ class DltPipelineRunner:
             resolved_config["end_date"] = end_date
 
         return resolved_config
+
+    def _build_rest_api_config(self, source_kwargs: dict[str, Any]) -> dict[str, Any]:
+        """
+        Transform flat REST API source_kwargs into RESTAPIConfig dict format.
+
+        rest_api_source() expects: config={"client": {...}, "resources": [...]}
+        Wizard collects: base_url, endpoints, auth_type, auth_token
+
+        Returns:
+            Dict with single "config" key containing RESTAPIConfig dict
+        """
+        base_url = source_kwargs.pop("base_url", "")
+        endpoints = source_kwargs.pop("endpoints", [])
+        auth_type = source_kwargs.pop("auth_type", None)
+        auth_token = source_kwargs.pop("auth_token", None)
+
+        # Build client config
+        client: dict[str, Any] = {"base_url": base_url}
+
+        # Build auth config based on type
+        if auth_type and auth_type != "none" and auth_token:
+            if auth_type == "bearer":
+                client["auth"] = {"type": "bearer", "token": auth_token}
+            elif auth_type == "api_key":
+                client["auth"] = {
+                    "type": "api_key",
+                    "name": "Authorization",
+                    "api_key": auth_token,
+                    "location": "header",
+                }
+            elif auth_type == "basic":
+                # Basic auth expects "user:password" format in token
+                client["auth"] = {"type": "http_basic", "username": auth_token, "password": ""}
+
+        # Build resources from endpoints
+        resources: list[dict[str, Any] | str] = []
+        for ep in endpoints:
+            if isinstance(ep, str):
+                resources.append({"name": ep, "endpoint": {"path": ep}})
+            elif isinstance(ep, dict):
+                resources.append(ep)
+
+        return {"config": {"client": client, "resources": resources}}
 
     def _check_oauth_token_expiry(
         self, source_type: str, source_name: str

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -7,6 +7,8 @@ import importlib
 import os
 import platform
 import signal
+import subprocess
+import sys
 import time
 from datetime import datetime
 from pathlib import Path
@@ -202,12 +204,10 @@ class DltPipelineRunner:
                 )
 
             # Try auto-installing missing deps
-            import subprocess
-            import sys
-
             pip_packages = [d["pip"] for d in missing_deps]
             console.print(f"\n[yellow]⚠ Missing dependencies: {', '.join(pip_packages)}[/yellow]")
-            console.print("[dim]Attempting automatic install...[/dim]")
+            install_cmd = f"pip install {' '.join(pip_packages)}"
+            console.print(f"[dim]Installing automatically: {install_cmd}[/dim]")
 
             try:
                 subprocess.check_call(
@@ -1081,10 +1081,11 @@ class DltPipelineRunner:
             for flat_key, dlt_key in field_map.items():
                 if flat_key in resolved_config:
                     credentials[dlt_key] = resolved_config.pop(flat_key)
-            if credentials and all(v for v in credentials.values()):
+            if credentials and any(v for v in credentials.values()):
                 resolved_config["credentials"] = credentials
 
         # Convert date strings to pendulum DateTime for sources that expect it
+        # Only Workable — its dlt source types start_date as Optional[DateTime]
         _DATETIME_SOURCES = {"workable"}
         if source_type_str in _DATETIME_SOURCES:
             for date_key in ("start_date", "end_date"):
@@ -1093,13 +1094,14 @@ class DltPipelineRunner:
                     try:
                         import pendulum
 
-                        resolved_config[date_key] = pendulum.parse(date_val)
+                        parsed = pendulum.parse(date_val, strict=True)
+                        # Only accept DateTime results (reject Time, Duration)
+                        if isinstance(parsed, pendulum.DateTime):
+                            resolved_config[date_key] = parsed
                     except Exception:
                         try:
-                            from datetime import datetime as dt
-
-                            resolved_config[date_key] = dt.fromisoformat(date_val)
-                        except Exception:
+                            resolved_config[date_key] = datetime.fromisoformat(date_val)
+                        except ValueError:
                             pass  # Leave as string — dlt may handle it
 
         # Override dates if provided
@@ -1140,8 +1142,13 @@ class DltPipelineRunner:
                     "location": "header",
                 }
             elif auth_type == "basic":
-                # Basic auth expects "user:password" format in token
-                client["auth"] = {"type": "http_basic", "username": auth_token, "password": ""}
+                # Basic auth: split "user:password" format
+                parts = auth_token.split(":", 1) if auth_token else ["", ""]
+                client["auth"] = {
+                    "type": "http_basic",
+                    "username": parts[0],
+                    "password": parts[1] if len(parts) > 1 else "",
+                }
 
         # Build resources from endpoints
         resources: list[dict[str, Any] | str] = []

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -173,23 +173,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                 "help": "Glob pattern to match files (e.g., '*.parquet', '**/*.json', 'reports_*.xlsx')",
             },
         ],
-        "optional_params": [
-            {
-                "name": "file_format",
-                "type": "choice",
-                "prompt": "File format",
-                "choices": ["parquet", "jsonl", "json", "csv", "xlsx"],
-                "default": None,  # auto-detect from file extension
-                "help": "Format of files to load. Leave blank to auto-detect from file extension. Use 'jsonl' for newline-delimited JSON.",
-            },
-            {
-                "name": "credentials",
-                "type": "string",
-                "prompt": "Cloud storage credentials key (for S3/GCS only)",
-                "default": None,
-                "help": "For cloud storage: add credentials to .dlt/secrets.toml (see setup guide). Leave blank for local files.",
-            },
-        ],
+        "optional_params": [],
         "setup_guide": [
             "LOCAL FILES:",
             "1. Place your files in a project directory (e.g., data/exports/)",
@@ -406,9 +390,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "optional_params": [
             {
                 "name": "start_date",
-                "type": "date",
-                "prompt": "Start date (YYYY-MM-DD)",
-                "default": None,
+                "type": "string",
+                "prompt": "Start date (YYYY-MM-DD or relative like '90daysAgo')",
+                "default": "90daysAgo",
+                "help": "GA4 accepts relative dates (e.g., '90daysAgo', '30daysAgo') or absolute dates (YYYY-MM-DD). Defaults to 90daysAgo for first sync.",
             },
         ],
         # Default queries based on industry best practices (Calibrate Analytics)
@@ -530,37 +515,22 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "display_name": "Salesforce",
         "category": "Business & CRM",
         "description": "Load data from Salesforce CRM (accounts, contacts, opportunities, etc.)",
-        "auth_type": AuthType.BASIC,
+        "auth_type": AuthType.SERVICE_ACCOUNT,
         "dlt_package": "salesforce",
         "dlt_function": "salesforce_source",
+        "pip_dependencies": [{"pip": "simple-salesforce", "import": "simple_salesforce"}],
         "wizard_enabled": True,
-        "required_params": [
-            {
-                "name": "username_env",
-                "type": "secret",
-                "env_var": "SALESFORCE_USERNAME",
-                "prompt": "Salesforce username",
-            },
-            {
-                "name": "password_env",
-                "type": "secret",
-                "env_var": "SALESFORCE_PASSWORD",
-                "prompt": "Salesforce password",
-            },
-            {
-                "name": "security_token_env",
-                "type": "secret",
-                "env_var": "SALESFORCE_SECURITY_TOKEN",
-                "prompt": "Salesforce security token",
-                "help": "Reset at Setup > My Personal Information > Reset Security Token",
-            },
-        ],
+        "required_params": [],
         "optional_params": [],
         "setup_guide": [
-            "1. Get Salesforce username and password",
-            "2. Reset security token (Setup > Reset Security Token)",
-            "3. Check email for security token",
-            "4. Add credentials to .env file",
+            "1. Create a Connected App in Salesforce Setup > App Manager",
+            "2. Enable OAuth 2.0 (Client Credentials flow)",
+            "3. Add credentials to .dlt/secrets.toml:",
+            "   [sources.salesforce.credentials]",
+            "   user_name = 'your_username'",
+            "   password = 'your_password'",
+            "   security_token = 'your_security_token'",
+            "4. Or use OAuth 2.0 Client Credentials — see Salesforce docs",
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/salesforce",
         "cost_warning": "Salesforce API limits depend on edition (check your limits)",
@@ -666,7 +636,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/shopify",
         "cost_warning": "Included with Shopify plan",
-        "wizard_enabled": True,  # Enabled: uses Custom App access token via X-Shopify-Access-Token header
+        "wizard_enabled": False,  # Disabled: OAuth 2.0 rewrite needed
         "popularity": 9,
         "capabilities": {
             "performance_metrics": False,
@@ -737,9 +707,9 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "wizard_enabled": True,
         "required_params": [
             {
-                "name": "token_env",
+                "name": "access_token_env",
                 "type": "secret",
-                "env_var": "SLACK_TOKEN",
+                "env_var": "SLACK_ACCESS_TOKEN",
                 "prompt": "Slack Bot User OAuth Token (starts with xoxb-)",
                 "help": "Bot User OAuth Token (starts with 'xoxb-'). Create at https://api.slack.com/apps > Your App > OAuth & Permissions. Required scopes: channels:history, channels:read, users:read. Must invite bot to channels you want to sync.",
             },
@@ -765,7 +735,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
             "3. Add Bot Token Scopes: channels:history, channels:read, users:read",
             "4. Install app to workspace",
             "5. Copy Bot User OAuth Token",
-            "6. Add to .env as SLACK_TOKEN",
+            "6. Add to .env as SLACK_ACCESS_TOKEN",
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/slack",
         "cost_warning": "Subject to Slack API rate limits",
@@ -785,27 +755,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "dlt_package": "zendesk",
         "dlt_function": "zendesk_support",
         "wizard_enabled": True,
-        "required_params": [
-            {
-                "name": "subdomain",
-                "type": "string",
-                "prompt": "Zendesk subdomain (e.g., mycompany from mycompany.zendesk.com)",
-                "help": "Your Zendesk subdomain",
-            },
-            {
-                "name": "email_env",
-                "type": "secret",
-                "env_var": "ZENDESK_EMAIL",
-                "prompt": "Zendesk email",
-            },
-            {
-                "name": "token_env",
-                "type": "secret",
-                "env_var": "ZENDESK_TOKEN",
-                "prompt": "Zendesk API token",
-                "help": "Generate at Admin > Channels > API",
-            },
-        ],
+        "required_params": [],
         "optional_params": [
             {
                 "name": "start_date",
@@ -817,10 +767,12 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "setup_guide": [
             "1. Log in to Zendesk as admin",
             "2. Go to Admin > Channels > API",
-            "3. Enable Token Access",
-            "4. Click '+' to add new API token",
-            "5. Copy token and add to .env as ZENDESK_TOKEN",
-            "6. Add your Zendesk email to .env as ZENDESK_EMAIL",
+            "3. Enable Token Access and create an API token",
+            "4. Add credentials to .dlt/secrets.toml:",
+            "   [sources.zendesk.credentials]",
+            "   subdomain = 'yourcompany'",
+            "   email = 'you@company.com'",
+            "   token = 'your_api_token'",
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/zendesk",
         "cost_warning": "Subject to Zendesk API rate limits",
@@ -947,8 +899,6 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                         "ad_group.id, "
                         "ad_group.name, "
                         "search_term_view.search_term, "
-                        "ad_group_criterion.keyword.text, "
-                        "ad_group_criterion.keyword.match_type, "
                         "search_term_view.status, "
                         "metrics.impressions, "
                         "metrics.clicks, "
@@ -991,7 +941,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.API_KEY,
         "dlt_package": "matomo",
         "dlt_function": "matomo_reports",
-        "wizard_enabled": True,
+        "wizard_enabled": False,  # Disabled: token passed via GET param (security risk)
         "required_params": [
             {
                 "name": "url",
@@ -1014,6 +964,28 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
             },
         ],
         "optional_params": [],
+        "default_config": {
+            "queries": [
+                {
+                    "resource_name": "visits_summary",
+                    "methods": ["VisitsSummary.get"],
+                    "date": "today",
+                    "period": "month",
+                },
+                {
+                    "resource_name": "referrers",
+                    "methods": ["Referrers.getAll"],
+                    "date": "today",
+                    "period": "month",
+                },
+                {
+                    "resource_name": "pages",
+                    "methods": ["Actions.getPageUrls"],
+                    "date": "today",
+                    "period": "month",
+                },
+            ],
+        },
         "setup_guide": [
             "1. Log in to Matomo",
             "2. Go to Settings > Platform > API",
@@ -1249,7 +1221,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.BASIC,
         "dlt_package": "jira",
         "dlt_function": "jira",
-        "wizard_enabled": True,
+        "wizard_enabled": False,  # Disabled: wrong endpoint in dlt source
         "required_params": [
             {
                 "name": "subdomain",
@@ -1365,7 +1337,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.API_KEY,
         "dlt_package": "asana_dlt",  # Note: source name is asana_dlt
         "dlt_function": "asana_source",
-        "wizard_enabled": True,
+        "wizard_enabled": False,  # Disabled: Asana SDK removed from dlt source
         "required_params": [],
         "optional_params": [
             {
@@ -1387,7 +1359,8 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "setup_guide": [
             "1. Create a Personal Access Token at https://app.asana.com/0/developer-console",
-            "2. Add to .dlt/secrets.toml:",
+            "2. Note: The Asana SDK has been removed from the dlt source.",
+            "   Credentials must be added to .dlt/secrets.toml:",
             "   [sources.asana_dlt]",
             "   access_token = 'your_token_here'",
         ],
@@ -1769,7 +1742,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.API_KEY,
         "dlt_package": "strapi",
         "dlt_function": "strapi_source",
-        "wizard_enabled": True,
+        "wizard_enabled": False,  # Disabled: untested, requires Docker Strapi instance
         "required_params": [
             {
                 "name": "domain",
@@ -1814,7 +1787,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_type": AuthType.API_KEY,
         "dlt_package": "personio",
         "dlt_function": "personio_source",
-        "wizard_enabled": True,
+        "wizard_enabled": False,  # Disabled: enterprise-only API
         "required_params": [
             {
                 "name": "client_id_env",


### PR DESCRIPTION
## Summary
- Fix 20+ Tier 1/2 bugs found during P5-007 end-to-end source testing across 5 files
- Disable 6 broken source wizards (shopify, jira, matomo, asana, strapi, personio)
- Add auto-install for missing pip dependencies and REST API config assembly

## Changes by file

**registry.py (12 changes):**
- Rename Slack `token_env` → `access_token_env` (matches dlt function param)
- Remove Zendesk `required_params` → credentials via `secrets.toml`
- Update Asana setup_guide (SDK removed)
- Remove invalid filesystem `optional_params` (`file_format`, `credentials`)
- Fix Google Ads `search_term_stats` query (remove `ad_group_criterion` fields)
- Add Matomo default queries
- GA4 `start_date` default: `"90daysAgo"` (relative date support)
- Add Salesforce `pip_dependencies` (`simple-salesforce`)
- Change Salesforce `auth_type` to `SERVICE_ACCOUNT`, rewrite setup guide
- Disable 6 broken wizards with reasons

**dlt_runner.py (5 changes):**
- REST API config assembly (`_build_rest_api_config`) — transforms flat kwargs to `RESTAPIConfig` dict
- Workable date conversion (source-specific pendulum DateTime)
- Salesforce credential conditional — skip when env vars are empty
- Auto-install missing pip deps before sync (with fallback to manual instructions)
- Per-resource 403/404 error guidance

**models.py (2 changes):**
- SlackSourceConfig: `token_env` → `access_token_env` with `AliasChoices` backward compat
- SalesforceSourceConfig: make env fields optional (`default=""`)

**source_wizard.py (3 changes):**
- Float→int cast for number params (e.g., `site_id: 1` not `1.0`)
- Facebook Ads `account_id` no longer skipped as OAuth-collected param
- CSV metric placeholder uses `raw_{source_name}` schema reference

**oauth.py (1 change):**
- Escape Rich markup in 10 error message instances (prevents `[bracket]` crashes)

## Test plan
- [x] `ruff check` — all 5 files pass
- [x] `ruff format --check` — all 5 files pass
- [x] `mypy` — all 5 files pass
- [x] `pytest tests/unit/ -x` — 2735 passed, 9 skipped
- [x] Backward compat: `SlackSourceConfig(token_env="X")` still works via alias
- [x] Backward compat: `SalesforceSourceConfig()` defaults to empty strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)