### PR TITLE
TASK-075d: Auth always-on with local-friendly defaults

### DIFF
--- a/dango/auth/sessions.py
+++ b/dango/auth/sessions.py
@@ -24,11 +24,11 @@ from dango.auth.models import APIKey, Session, User
 # Default timeout constants (overridable per-call)
 # ---------------------------------------------------------------------------
 
-DEFAULT_IDLE_TIMEOUT_MINUTES: int = 60
-"""Idle timeout — invalidate session after this many minutes of inactivity."""
+DEFAULT_IDLE_TIMEOUT_MINUTES: int = 1440
+"""Idle timeout — invalidate session after this many minutes of inactivity (24h for local)."""
 
-DEFAULT_SESSION_MAX_DAYS: int = 30
-"""Absolute timeout — session expires this many days after creation."""
+DEFAULT_SESSION_MAX_DAYS: int = 365
+"""Absolute timeout — session expires this many days after creation (1 year for local)."""
 
 DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES: int = 5
 """Partial session timeout — for 2FA intermediate state."""

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -392,6 +392,28 @@ def _create_admin_and_enable_auth(
     ssh.write_remote_file("/srv/dango/project/.dango/auth.yml", "enabled: true\n", mode=0o644)
     ssh.exec_command("chown dango:dango /srv/dango/project/.dango/auth.yml")
 
+    # Write cloud-specific auth timeouts (30-day session, 60-min idle)
+    timeout_script = (
+        "import sys, os\n"
+        "sys.path.insert(0, '/srv/dango/project')\n"
+        "os.chdir('/srv/dango/project')\n"
+        "from pathlib import Path\n"
+        "import yaml\n"
+        "config_path = Path('.dango/project.yml')\n"
+        "if config_path.exists():\n"
+        "    config_data = yaml.safe_load(config_path.read_text()) or {}\n"
+        "    config_data.setdefault('auth', {})\n"
+        "    config_data['auth']['session_max_days'] = 30\n"
+        "    config_data['auth']['idle_timeout_minutes'] = 60\n"
+        "    config_path.write_text(yaml.dump(config_data, default_flow_style=False, sort_keys=False))\n"
+    )
+    encoded_timeout = base64.b64encode(timeout_script.encode()).decode()
+    ssh.exec_command(
+        f"sudo -u dango /srv/dango/venv/bin/python -c "
+        f"\"import base64; exec(base64.b64decode('{encoded_timeout}'))\"",
+        timeout=15,
+    )
+
     return deploy_token
 
 

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -107,6 +107,12 @@ class ProjectInitializer:
                 console.print("  3. Retry: dango init")
                 raise SystemExit(1)
 
+            # Setup authentication (admin user + auth.yml)
+            # NON-CRITICAL: Can set up later via 'dango auth enable'
+            auth_success = self._setup_auth(skip_wizard=skip_wizard, force=force)
+            if not auth_success:
+                warnings.append("Auth setup skipped (run 'dango auth enable' to set up later)")
+
         except KeyboardInterrupt:
             # User cancelled - rollback
             print_error("\n\n✗ Initialization cancelled by user")
@@ -1002,6 +1008,125 @@ on-run-end:
             console.print("    You can generate docs later with: cd dbt && dbt docs generate")
             return False
 
+    def _setup_auth(self, *, skip_wizard: bool = False, force: bool = False) -> bool:
+        """Set up authentication: create admin user and enable auth.
+
+        Runs database migrations to create auth.db, then either prompts for
+        admin credentials (interactive) or generates a random admin
+        (skip-wizard mode).
+
+        Args:
+            skip_wizard: If True, generate random admin credentials.
+            force: If True, skip admin creation when admins already exist.
+
+        Returns:
+            True if auth was set up successfully, False otherwise.
+        """
+        import os
+        import re
+
+        import click
+
+        from dango.auth.admin import (
+            ensure_admin,
+            format_credentials_panel,
+            get_auth_db_path,
+            set_auth_enabled,
+        )
+        from dango.auth.database import create_user, list_users
+        from dango.auth.models import Role, User
+        from dango.auth.security import check_password_strength, hash_password
+        from dango.migrations import apply_all_pending
+
+        console.print("\nSetting up authentication...")
+
+        try:
+            # Create auth.db via migrations framework
+            apply_all_pending(self.project_dir)
+
+            db_path = get_auth_db_path(self.project_dir)
+
+            # On --force re-init, skip admin creation if admins already exist
+            if force:
+                existing_users = list_users(db_path, active_only=True)
+                existing_admins = [u for u in existing_users if u.role == Role.ADMIN]
+                if existing_admins:
+                    # Just ensure auth.yml is written
+                    set_auth_enabled(self.project_dir, enabled=True)
+                    console.print("[green]✓[/green] Auth already configured (admin exists)")
+                    return True
+
+            if skip_wizard:
+                # Non-interactive: generate random admin
+                result = ensure_admin(db_path)
+                if result is not None:
+                    user, password = result
+                    set_auth_enabled(self.project_dir, enabled=True)
+                    console.print()
+                    console.print(format_credentials_panel(user.email, password))
+                    console.print()
+                else:
+                    set_auth_enabled(self.project_dir, enabled=True)
+                    console.print("[green]✓[/green] Auth enabled (admin already exists)")
+                return True
+
+            # Interactive: prompt for admin credentials
+            email_re = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+
+            console.print("  Create the admin account for your project.\n")
+
+            # Email
+            while True:
+                email = click.prompt("  Admin email", default="admin@localhost")
+                if email_re.match(email):
+                    break
+                console.print("  [red]Invalid email format.[/red]")
+
+            # Password (from env or prompt)
+            env_password = os.environ.get("DANGO_ADMIN_PASSWORD")
+            if env_password:
+                issues = check_password_strength(env_password)
+                if issues:
+                    console.print(f"  [red]DANGO_ADMIN_PASSWORD is weak:[/red] {'; '.join(issues)}")
+                    console.print("  [yellow]Skipping auth setup.[/yellow]")
+                    return False
+                password = env_password
+                console.print("  [dim]Using password from DANGO_ADMIN_PASSWORD env var.[/dim]")
+            else:
+                while True:
+                    password = click.prompt("  Admin password", hide_input=True)
+                    issues = check_password_strength(password)
+                    if issues:
+                        console.print(f"  [red]Weak password:[/red] {'; '.join(issues)}")
+                        continue
+                    confirm = click.prompt("  Confirm password", hide_input=True)
+                    if password != confirm:
+                        console.print("  [red]Passwords don't match.[/red]")
+                        continue
+                    break
+
+            # Create admin user
+            user = User(
+                email=email,
+                password_hash=hash_password(password),
+                role=Role.ADMIN,
+                must_change_password=False,
+            )
+            create_user(db_path, user)
+
+            # Enable auth
+            set_auth_enabled(self.project_dir, enabled=True)
+
+            console.print()
+            console.print(format_credentials_panel(email, password, title="Admin account created"))
+            console.print()
+            return True
+
+        except Exception as e:
+            print_error(f"Auth setup failed: {e}")
+            console.print("  [yellow]You can set up auth later with:[/yellow] dango auth enable")
+            return False
+
     def _rollback_initialization(self):
         """
         Rollback project initialization by removing created files/directories.
@@ -1089,6 +1214,7 @@ on-run-end:
 
         # Add next steps (only if not failed)
         if not failures:
+            message += "[dim]Auth is enabled — log in with your admin credentials on first visit.[/dim]\n\n"
             message += "[bold]Next steps:[/bold]\n\n"
 
             # Check if user is already in the project directory

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -516,9 +516,9 @@ class OAuthProviderConfig(BaseModel):
 class AuthConfig(BaseModel):
     """Authentication configuration."""
 
-    enabled: bool = Field(default=False, description="Enable authentication (required for cloud)")
-    idle_timeout_minutes: int = Field(default=60, description="Session idle timeout in minutes")
-    session_max_days: int = Field(default=30, description="Maximum session lifetime in days")
+    enabled: bool = Field(default=True, description="Enable authentication")
+    idle_timeout_minutes: int = Field(default=1440, description="Session idle timeout in minutes")
+    session_max_days: int = Field(default=365, description="Maximum session lifetime in days")
     require_2fa: bool = Field(default=False, description="Require all users to set up 2FA")
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     lockout: AccountLockoutConfig = Field(default_factory=AccountLockoutConfig)

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -76,7 +76,9 @@ def create_app(project_root: Path | None = None) -> FastAPI:
 
     # Auth middleware (innermost — executes after rate limit in request flow)
     auth_config = _load_auth_config(project_root)
-    idle_timeout = auth_config.idle_timeout_minutes if auth_config else 60
+    idle_timeout = (
+        auth_config.idle_timeout_minutes if auth_config else AuthConfig().idle_timeout_minutes
+    )
     application.add_middleware(
         AuthMiddleware, project_root=project_root, idle_timeout_minutes=idle_timeout
     )

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -300,6 +300,17 @@ async def startup_event() -> None:
     project_root = get_project_root()
     logger.info("api_starting", project_root=str(project_root))
 
+    # Write auth.yml if missing (migration path for pre-075d projects)
+    try:
+        from dango.auth.admin import get_auth_config_path, set_auth_enabled
+
+        auth_config_path = get_auth_config_path(project_root)
+        if not auth_config_path.exists():
+            set_auth_enabled(project_root, enabled=True)
+            logger.info("auth_auto_enabled", reason="auth.yml missing")
+    except Exception:
+        logger.warning("auth_yml_migration_failed", exc_info=True)
+
     # First-run admin creation (non-interactive)
     try:
         import os

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -44,6 +44,7 @@ from dango.auth.security import (
     verify_password,
 )
 from dango.auth.sessions import (
+    DEFAULT_SESSION_MAX_DAYS,
     create_api_key,
     create_session,
     invalidate_all_sessions,
@@ -202,7 +203,7 @@ async def login(request: Request) -> JSONResponse:
     auth_config = _get_auth_config(request)
     max_attempts = 5
     lockout_minutes = 15
-    session_max_days = 30
+    session_max_days = DEFAULT_SESSION_MAX_DAYS
     if auth_config is not None:
         max_attempts = auth_config.lockout.max_attempts
         lockout_minutes = auth_config.lockout.lockout_minutes
@@ -389,7 +390,7 @@ async def change_password(request: Request) -> JSONResponse:
     invalidate_all_sessions(db_path, user.id)
 
     auth_config = _get_auth_config(request)
-    session_max_days = auth_config.session_max_days if auth_config else 30
+    session_max_days = auth_config.session_max_days if auth_config else DEFAULT_SESSION_MAX_DAYS
 
     raw_token, _session = create_session(
         db_path,
@@ -769,7 +770,7 @@ async def _resolve_oauth_user(
     # Success — create session
     reset_failed_logins(db_path, user.email)
     auth_config = _get_auth_config(request)
-    session_max_days = auth_config.session_max_days if auth_config else 30
+    session_max_days = auth_config.session_max_days if auth_config else DEFAULT_SESSION_MAX_DAYS
 
     # 2FA required — create partial session (mirrors password login)
     if user.totp_enabled:

--- a/dango/web/routes/auth_2fa.py
+++ b/dango/web/routes/auth_2fa.py
@@ -22,7 +22,12 @@ from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.database import get_session_by_token, get_user_by_id, update_user
 from dango.auth.models import User, UserResponse, UserUpdate
 from dango.auth.security import generate_recovery_codes, hash_token, verify_password
-from dango.auth.sessions import create_session, invalidate_session, validate_partial_session
+from dango.auth.sessions import (
+    DEFAULT_SESSION_MAX_DAYS,
+    create_session,
+    invalidate_session,
+    validate_partial_session,
+)
 from dango.auth.totp import (
     consume_recovery_code,
     disable_totp,
@@ -239,7 +244,7 @@ async def verify_2fa(request: Request) -> JSONResponse:
 
     # Create full session
     auth_config = _get_auth_config(request)
-    session_max_days = auth_config.session_max_days if auth_config else 30
+    session_max_days = auth_config.session_max_days if auth_config else DEFAULT_SESSION_MAX_DAYS
 
     raw_token, _session = create_session(
         db_path,


### PR DESCRIPTION
## Summary

- **Auth enabled by default**: `AuthConfig.enabled` defaults to `True`, so new and existing projects have auth on out of the box
- **Local-friendly session timeouts**: 365-day session / 24h idle timeout — auth is invisible after initial login for local dev
- **`dango init` prompts for admin credentials**: Interactive password prompt (or `DANGO_ADMIN_PASSWORD` env var for CI). `--skip-wizard` generates random admin with temp password.
- **Migration path for existing projects**: `startup_event()` auto-creates `auth.yml` with `enabled: true` if missing
- **Cloud deployments get stricter timeouts**: Deploy provisioner writes `session_max_days=30` / `idle_timeout_minutes=60` to remote `project.yml`

### Files changed (5 files, +166/-7)

| File | Change |
|------|--------|
| `config/models.py` | `AuthConfig` defaults: `enabled=True`, `idle_timeout_minutes=1440`, `session_max_days=365` |
| `auth/sessions.py` | Session constants match new defaults |
| `cli/init.py` | New `_setup_auth()` method + integration into `initialize()` |
| `web/app.py` | Auto-create `auth.yml` in `startup_event()` for pre-075d projects |
| `cli/commands/deploy_provision.py` | Cloud timeout overrides in remote Python script |

## Test plan

- [x] ruff lint + format: pass
- [x] mypy: pass
- [x] All pre-commit hooks: pass
- [x] Full unit test suite: 2792 passed, 7 skipped, 0 failures
- [ ] Manual: `dango init` in temp dir → prompted for admin password → `.dango/auth.yml` created with `enabled: true`
- [ ] Manual: `dango init --skip-wizard` → random password displayed → same file outcomes
- [ ] Manual: existing project without `auth.yml` → `dango start` → auth auto-enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)