### PR TITLE
TASK-075a: Add agent/AI interface endpoints

### DIFF
--- a/dango/auth/CLAUDE.md
+++ b/dango/auth/CLAUDE.md
@@ -15,7 +15,7 @@ User authentication and access control for Dango. Handles password-based login w
 | `sessions.py` | 289 | High-level session + API key lifecycle | `create_session()`, `validate_session()`, `validate_partial_session()`, `create_api_key()`, `validate_api_key()` |
 | `permissions.py` | 195 | 29 permissions, 3 role mappings | `PERMISSIONS`, `ROLE_PERMISSIONS`, `has_permission()`, `require_permission()` |
 | `lockout.py` | 181 | Brute-force protection (5 attempts / 15-min) | `record_failed_login()`, `check_account_locked()`, `unlock_account()` |
-| `audit.py` | 188 | 22 event types to `.dango/logs/audit.jsonl` | `AuditEvent`, `log_auth_event()`, `query_audit_log()` |
+| `audit.py` | 206 | 23 event types to `.dango/logs/audit.jsonl` | `AuditEvent`, `log_auth_event()`, `query_audit_log()` |
 | `admin.py` | 124 | Bootstrap + path helpers | `ensure_admin()`, `is_auth_enabled()`, `get_auth_db_path()` |
 | `totp.py` | 220 | TOTP 2FA: setup/verify/enable/disable, recovery codes | `generate_totp_secret()`, `verify_totp_code()`, `setup_totp()`, `enable_totp()`, `consume_recovery_code()` |
 | `oauth_login.py` | 307 | OAuth provider ABC + Google/GitHub implementations | `OAuthLoginProvider`, `GoogleOAuthProvider`, `GitHubOAuthProvider`, `get_provider()` |

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -68,6 +68,7 @@ class AuditEvent(str, Enum):
     GOVERNANCE_PII_VIEWED        = "governance_pii_viewed"
     CATALOG_VIEWED               = "catalog_viewed"
     INSIGHTS_VIEWED              = "insights_viewed"
+    AI_CATALOG_VIEWED            = "ai_catalog_viewed"
     # fmt: on
 
 

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -45,6 +45,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact (~566 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
 | `routes/insights.py` | Metric results, run trigger, history (~272 lines) | `router` |
+| `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~497 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -45,7 +45,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact (~566 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
 | `routes/insights.py` | Metric results, run trigger, history (~272 lines) | `router` |
-| `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~497 lines) | `router` |
+| `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~496 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -328,6 +328,7 @@ async def unhandled_error_handler(request: Request, exc: Exception) -> Response:
 # ---------------------------------------------------------------------------
 # Register routers — Dango API routes first, then proxy routes (catch-all last)
 # ---------------------------------------------------------------------------
+from dango.web.routes.ai import router as ai_router  # noqa: E402
 from dango.web.routes.auth import router as auth_router  # noqa: E402
 from dango.web.routes.auth_2fa import router as auth_2fa_router  # noqa: E402
 from dango.web.routes.catalog import router as catalog_router  # noqa: E402
@@ -368,6 +369,7 @@ app.include_router(schedules_router)
 app.include_router(catalog_router)
 app.include_router(governance_router)
 app.include_router(insights_router)
+app.include_router(ai_router)
 app.include_router(notebooks_router)
 app.include_router(websocket_router)
 app.include_router(ui_router)

--- a/dango/web/routes/ai.py
+++ b/dango/web/routes/ai.py
@@ -1,0 +1,497 @@
+"""dango/web/routes/ai.py
+
+Agent/AI interface endpoints for metadata discovery and tool descriptions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import duckdb
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from dango.auth.audit import AuditEvent, log_auth_event
+from dango.auth.models import User
+from dango.auth.permissions import has_permission, require_permission
+from dango.logging import get_logger
+from dango.web.helpers import (
+    get_dbt_models,
+    get_duckdb_path,
+    get_project_root,
+    get_source_freshness,
+    get_source_tables_info,
+    load_sources_config,
+    load_sync_history,
+)
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["ai"])
+
+
+# ---------------------------------------------------------------------------
+# Response models (scoped to AI endpoints)
+# ---------------------------------------------------------------------------
+
+
+class ColumnSummary(BaseModel):
+    """Column metadata for agent consumption."""
+
+    name: str
+    type: str
+    nullable: bool
+
+
+class TableSummary(BaseModel):
+    """Table metadata including column schema."""
+
+    name: str
+    source: str
+    row_count: int | None
+    columns: list[ColumnSummary]
+
+
+class QualitySignals(BaseModel):
+    """Data quality signals from governance subsystem."""
+
+    drift_event_count: int = 0
+    pii_column_count: int = 0
+
+
+class SourceSummary(BaseModel):
+    """Source metadata with tables and quality signals."""
+
+    name: str
+    type: str
+    enabled: bool
+    status: str
+    last_sync_time: str | None
+    row_count: int | None
+    freshness: dict[str, Any] | None
+    tables: list[TableSummary]
+    quality: QualitySignals
+
+
+class DbtModelSummary(BaseModel):
+    """dbt model metadata for agent consumption."""
+
+    name: str
+    unique_id: str
+    path: str
+    materialization: str | None
+    schema_name: str | None
+    description: str
+    depends_on: list[str]
+    tags: list[str]
+    row_count: int | None
+    last_run: str | None
+    status: str | None
+
+
+class CatalogSummaryResponse(BaseModel):
+    """Full catalog summary combining sources and dbt models."""
+
+    description: str
+    generated_at: str
+    sources: list[SourceSummary]
+    dbt_models: list[DbtModelSummary]
+    totals: dict[str, int]
+
+
+class ToolParameter(BaseModel):
+    """Parameter description for a tool endpoint."""
+
+    name: str
+    type: str
+    required: bool
+    description: str
+    enum: list[str] | None = None
+
+
+class ToolDescription(BaseModel):
+    """Describes an available API tool for agent use."""
+
+    name: str
+    description: str
+    endpoint: str
+    method: str
+    parameters: list[ToolParameter]
+    permissions_required: list[str]
+    is_read_only: bool
+    is_safe_to_retry: bool
+
+
+class ToolsResponse(BaseModel):
+    """List of available tools with user role context."""
+
+    description: str
+    tools: list[ToolDescription]
+    user_role: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_column_schema(
+    db_path: str,
+    source: str,
+    table: str,
+) -> list[dict[str, Any]]:
+    """Query DuckDB information_schema for column metadata.
+
+    Uses read-only connection. Returns empty list on any error.
+    """
+    schema = f"raw_{source}"
+    try:
+        conn = duckdb.connect(db_path, read_only=True)
+        try:
+            rows = conn.execute(
+                "SELECT column_name, data_type, is_nullable "
+                "FROM information_schema.columns "
+                f"WHERE table_schema = '{schema}' AND table_name = '{table}' "
+                "ORDER BY ordinal_position"
+            ).fetchall()
+            return [{"name": r[0], "type": r[1], "nullable": r[2] == "YES"} for r in rows]
+        finally:
+            conn.close()
+    except Exception:
+        return []
+
+
+async def _build_source_summary(
+    source_cfg: dict[str, Any],
+    db_path_str: str,
+    has_governance: bool,
+    project_root: Any,
+) -> SourceSummary:
+    """Build a SourceSummary for a single source.
+
+    Fetches freshness, tables, sync history, and optionally quality signals
+    concurrently via asyncio.to_thread.
+    """
+    name = source_cfg.get("name", "")
+    source_type = source_cfg.get("type", "unknown")
+    enabled = source_cfg.get("enabled", True)
+
+    freshness_data, tables_info, sync_history = await asyncio.gather(
+        asyncio.to_thread(get_source_freshness, name),
+        asyncio.to_thread(get_source_tables_info, name),
+        asyncio.to_thread(load_sync_history, name, 1),
+    )
+
+    status = freshness_data.get("status", "unknown") if freshness_data else "unknown"
+    last_sync_time = freshness_data.get("last_sync_time") if freshness_data else None
+
+    # Build table summaries with column schema
+    table_summaries: list[TableSummary] = []
+    total_rows: int | None = None
+    if tables_info is not None:
+        total_rows = tables_info.get("total_rows")
+        for tbl in tables_info.get("tables", []):
+            cols = await asyncio.to_thread(
+                _get_column_schema,
+                db_path_str,
+                name,
+                tbl["name"],
+            )
+            table_summaries.append(
+                TableSummary(
+                    name=tbl["name"],
+                    source=name,
+                    row_count=tbl.get("row_count"),
+                    columns=[ColumnSummary(**c) for c in cols],
+                )
+            )
+
+    # Freshness dict for response
+    freshness: dict[str, Any] | None = None
+    if freshness_data:
+        freshness = {
+            "status": freshness_data.get("status"),
+            "hours_since_sync": freshness_data.get("hours_since_sync"),
+            "last_sync_status": freshness_data.get("last_sync_status"),
+        }
+
+    # Quality signals
+    quality = QualitySignals()
+    if has_governance:
+        try:
+            from dango.governance.schema_drift import get_drift_history
+
+            drift_events = await asyncio.to_thread(get_drift_history, project_root, source=name)
+            quality.drift_event_count = len(drift_events)
+        except Exception:
+            pass
+
+        try:
+            from dango.governance.pii_detector import get_pii_findings
+
+            pii_findings = await asyncio.to_thread(get_pii_findings, project_root, source=name)
+            quality.pii_column_count = len(pii_findings)
+        except Exception:
+            pass
+
+    return SourceSummary(
+        name=name,
+        type=source_type,
+        enabled=enabled,
+        status=status,
+        last_sync_time=last_sync_time,
+        row_count=total_rows,
+        freshness=freshness,
+        tables=table_summaries,
+        quality=quality,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/catalog/summary
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/catalog/summary")
+async def get_catalog_summary(
+    user: User = Depends(require_permission("source.view")),
+) -> CatalogSummaryResponse:
+    """Return a machine-readable summary of all data sources and dbt models.
+
+    Designed for LLM/agent consumption. Includes table schemas, freshness,
+    row counts, and quality signals (drift + PII) when the user has
+    governance.view permission.
+    """
+    log_auth_event(
+        AuditEvent.AI_CATALOG_VIEWED,
+        user_id=user.id,
+        email=user.email,
+    )
+
+    project_root = get_project_root()
+    has_governance = has_permission(user, "governance.view")
+
+    # Fetch sources config and dbt models concurrently
+    sources_config, dbt_models_raw = await asyncio.gather(
+        asyncio.to_thread(load_sources_config),
+        asyncio.to_thread(get_dbt_models),
+    )
+
+    # Build source summaries concurrently
+    db_path = get_duckdb_path()
+    db_path_str = str(db_path) if db_path.exists() else ""
+
+    source_summaries = await asyncio.gather(
+        *[
+            _build_source_summary(src, db_path_str, has_governance, project_root)
+            for src in sources_config
+        ]
+    )
+
+    # Build dbt model summaries
+    dbt_models = [
+        DbtModelSummary(
+            name=m.get("name", ""),
+            unique_id=m.get("unique_id", ""),
+            path=m.get("path", ""),
+            materialization=m.get("materialization"),
+            schema_name=m.get("schema"),
+            description=m.get("description", ""),
+            depends_on=m.get("depends_on", []),
+            tags=m.get("tags", []),
+            row_count=m.get("row_count"),
+            last_run=m.get("last_run"),
+            status=m.get("status"),
+        )
+        for m in dbt_models_raw
+    ]
+
+    total_tables = sum(len(s.tables) for s in source_summaries)
+
+    return CatalogSummaryResponse(
+        description=(
+            "Dango data catalog summary. Contains all configured data sources "
+            "with table schemas, freshness, and quality signals, plus dbt "
+            "transformation models."
+        ),
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        sources=list(source_summaries),
+        dbt_models=dbt_models,
+        totals={
+            "source_count": len(source_summaries),
+            "table_count": total_tables,
+            "model_count": len(dbt_models),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tools
+# ---------------------------------------------------------------------------
+
+# fmt: off
+_TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "list_sources",
+        "description": "List all configured data sources with sync status and row counts.",
+        "endpoint": "/api/sources",
+        "method": "GET",
+        "parameters": [],
+        "permissions_required": ["source.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "get_source_details",
+        "description": "Get detailed information for a specific data source including tables, freshness, and sync history.",
+        "endpoint": "/api/sources/{source_name}/details",
+        "method": "GET",
+        "parameters": [
+            {"name": "source_name", "type": "string", "required": True, "description": "Name of the data source.", "enum": None},
+        ],
+        "permissions_required": ["source.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "get_catalog_summary",
+        "description": "Get a machine-readable summary of all data sources, tables, columns, and dbt models with quality signals.",
+        "endpoint": "/api/catalog/summary",
+        "method": "GET",
+        "parameters": [],
+        "permissions_required": ["source.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "get_table_schema",
+        "description": "Get column schema and profiling statistics for a specific table.",
+        "endpoint": "/api/catalog/{source}/{table}/columns",
+        "method": "GET",
+        "parameters": [
+            {"name": "source", "type": "string", "required": True, "description": "Source name.", "enum": None},
+            {"name": "table", "type": "string", "required": True, "description": "Table name.", "enum": None},
+        ],
+        "permissions_required": ["governance.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "check_freshness",
+        "description": "Check data freshness for a specific source (last sync time, hours since sync).",
+        "endpoint": "/api/sources/{source_name}/details",
+        "method": "GET",
+        "parameters": [
+            {"name": "source_name", "type": "string", "required": True, "description": "Name of the data source.", "enum": None},
+        ],
+        "permissions_required": ["source.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "get_schema_drift",
+        "description": "Get schema drift events showing column additions, removals, and type changes.",
+        "endpoint": "/api/governance/schema-drift",
+        "method": "GET",
+        "parameters": [
+            {"name": "source", "type": "string", "required": False, "description": "Filter by source name.", "enum": None},
+            {"name": "table", "type": "string", "required": False, "description": "Filter by table name.", "enum": None},
+            {"name": "limit", "type": "integer", "required": False, "description": "Max events to return (default 100).", "enum": None},
+        ],
+        "permissions_required": ["governance.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "get_pii_findings",
+        "description": "Get PII detection findings showing columns containing personally identifiable information.",
+        "endpoint": "/api/governance/pii",
+        "method": "GET",
+        "parameters": [
+            {"name": "source", "type": "string", "required": False, "description": "Filter by source name.", "enum": None},
+            {"name": "table", "type": "string", "required": False, "description": "Filter by table name.", "enum": None},
+            {"name": "limit", "type": "integer", "required": False, "description": "Max findings to return (default 100).", "enum": None},
+        ],
+        "permissions_required": ["governance.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "list_dbt_models",
+        "description": "List all dbt transformation models with their status, dependencies, and row counts.",
+        "endpoint": "/api/dbt/models",
+        "method": "GET",
+        "parameters": [],
+        "permissions_required": ["dbt.view"],
+        "is_read_only": True,
+        "is_safe_to_retry": True,
+    },
+    {
+        "name": "sync_source",
+        "description": "Trigger a data sync for a specific source. This ingests fresh data from the external service.",
+        "endpoint": "/api/sources/{source_name}/sync",
+        "method": "POST",
+        "parameters": [
+            {"name": "source_name", "type": "string", "required": True, "description": "Name of the source to sync.", "enum": None},
+        ],
+        "permissions_required": ["source.sync"],
+        "is_read_only": False,
+        "is_safe_to_retry": False,
+    },
+    {
+        "name": "run_dbt_model",
+        "description": "Run a specific dbt transformation model to refresh derived tables.",
+        "endpoint": "/api/dbt/models/{model_name}/run",
+        "method": "POST",
+        "parameters": [
+            {"name": "model_name", "type": "string", "required": True, "description": "Name of the dbt model to run.", "enum": None},
+        ],
+        "permissions_required": ["dbt.run"],
+        "is_read_only": False,
+        "is_safe_to_retry": False,
+    },
+]
+# fmt: on
+
+
+@router.get("/api/tools")
+async def get_tools(
+    user: User = Depends(require_permission("source.view")),
+) -> ToolsResponse:
+    """Return descriptions of all available API tools for agent use.
+
+    All tools are visible to all authenticated users. Each tool includes
+    permissions_required metadata so agents know which actions they can
+    perform. RBAC enforcement happens at the target endpoint.
+    """
+    log_auth_event(
+        AuditEvent.AI_CATALOG_VIEWED,
+        user_id=user.id,
+        email=user.email,
+        details={"endpoint": "tools"},
+    )
+
+    tools = [
+        ToolDescription(
+            name=t["name"],
+            description=t["description"],
+            endpoint=t["endpoint"],
+            method=t["method"],
+            parameters=[ToolParameter(**p) for p in t["parameters"]],
+            permissions_required=t["permissions_required"],
+            is_read_only=t["is_read_only"],
+            is_safe_to_retry=t["is_safe_to_retry"],
+        )
+        for t in _TOOL_DEFINITIONS
+    ]
+
+    return ToolsResponse(
+        description=(
+            "Available Dango API tools. Each tool maps to an API endpoint. "
+            "Check permissions_required before calling mutating endpoints."
+        ),
+        tools=tools,
+        user_role=user.role.value,
+    )

--- a/dango/web/routes/ai.py
+++ b/dango/web/routes/ai.py
@@ -17,6 +17,7 @@ from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
 from dango.auth.permissions import has_permission, require_permission
 from dango.logging import get_logger
+from dango.validation import validate_identifier, validate_source_name
 from dango.web.helpers import (
     get_dbt_models,
     get_duckdb_path,
@@ -24,7 +25,6 @@ from dango.web.helpers import (
     get_source_freshness,
     get_source_tables_info,
     load_sources_config,
-    load_sync_history,
 )
 
 logger = get_logger(__name__)
@@ -137,23 +137,21 @@ class ToolsResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _get_column_schema(
-    db_path: str,
-    source: str,
-    table: str,
-) -> list[dict[str, Any]]:
+def _get_column_schema(db_path: str, source: str, table: str) -> list[dict[str, Any]]:
     """Query DuckDB information_schema for column metadata.
 
-    Uses read-only connection. Returns empty list on any error.
+    Validates source/table names, uses read-only connection.
+    Returns empty list on any error.
     """
-    schema = f"raw_{source}"
     try:
+        schema = f"raw_{validate_source_name(source)}"
+        safe_table = validate_identifier(table)
         conn = duckdb.connect(db_path, read_only=True)
         try:
             rows = conn.execute(
                 "SELECT column_name, data_type, is_nullable "
                 "FROM information_schema.columns "
-                f"WHERE table_schema = '{schema}' AND table_name = '{table}' "
+                f"WHERE table_schema = '{schema}' AND table_name = '{safe_table}' "
                 "ORDER BY ordinal_position"
             ).fetchall()
             return [{"name": r[0], "type": r[1], "nullable": r[2] == "YES"} for r in rows]
@@ -165,23 +163,22 @@ def _get_column_schema(
 
 async def _build_source_summary(
     source_cfg: dict[str, Any],
-    db_path_str: str,
+    db_path_str: str | None,
     has_governance: bool,
     project_root: Any,
 ) -> SourceSummary:
     """Build a SourceSummary for a single source.
 
-    Fetches freshness, tables, sync history, and optionally quality signals
-    concurrently via asyncio.to_thread.
+    Fetches freshness, tables, and optionally quality signals concurrently
+    via asyncio.to_thread.
     """
     name = source_cfg.get("name", "")
     source_type = source_cfg.get("type", "unknown")
     enabled = source_cfg.get("enabled", True)
 
-    freshness_data, tables_info, sync_history = await asyncio.gather(
+    freshness_data, tables_info = await asyncio.gather(
         asyncio.to_thread(get_source_freshness, name),
         asyncio.to_thread(get_source_tables_info, name),
-        asyncio.to_thread(load_sync_history, name, 1),
     )
 
     status = freshness_data.get("status", "unknown") if freshness_data else "unknown"
@@ -193,12 +190,14 @@ async def _build_source_summary(
     if tables_info is not None:
         total_rows = tables_info.get("total_rows")
         for tbl in tables_info.get("tables", []):
-            cols = await asyncio.to_thread(
-                _get_column_schema,
-                db_path_str,
-                name,
-                tbl["name"],
-            )
+            cols: list[dict[str, Any]] = []
+            if db_path_str is not None:
+                cols = await asyncio.to_thread(
+                    _get_column_schema,
+                    db_path_str,
+                    name,
+                    tbl["name"],
+                )
             table_summaries.append(
                 TableSummary(
                     name=tbl["name"],
@@ -226,7 +225,7 @@ async def _build_source_summary(
             drift_events = await asyncio.to_thread(get_drift_history, project_root, source=name)
             quality.drift_event_count = len(drift_events)
         except Exception:
-            pass
+            logger.debug("Failed to fetch drift history for %s", name, exc_info=True)
 
         try:
             from dango.governance.pii_detector import get_pii_findings
@@ -234,7 +233,7 @@ async def _build_source_summary(
             pii_findings = await asyncio.to_thread(get_pii_findings, project_root, source=name)
             quality.pii_column_count = len(pii_findings)
         except Exception:
-            pass
+            logger.debug("Failed to fetch PII findings for %s", name, exc_info=True)
 
     return SourceSummary(
         name=name,
@@ -281,7 +280,7 @@ async def get_catalog_summary(
 
     # Build source summaries concurrently
     db_path = get_duckdb_path()
-    db_path_str = str(db_path) if db_path.exists() else ""
+    db_path_str: str | None = str(db_path) if db_path.exists() else None
 
     source_summaries = await asyncio.gather(
         *[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,9 @@ module = [
     "tests.unit.test_ingestion_ux",
     "tests.integration.test_post_sync_chain_integration",
     "tests.integration.test_notebook_lifecycle",
+    "tests.unit.test_web_ai",
+    "tests.unit.test_web_ai_tools",
+    "tests.unit.test_web_imports",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_web_ai.py
+++ b/tests/unit/test_web_ai.py
@@ -1,0 +1,432 @@
+"""tests/unit/test_web_ai.py
+
+Tests for dango.web.routes.ai — catalog summary endpoint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    DangoError,
+    ValidationError,
+)
+from dango.web.routes.ai import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.ADMIN) -> User:
+    """Create a test user."""
+    return User(
+        id="u-test-1",
+        email="test@test.com",
+        password_hash="hashed",
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the AI router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        ValidationError: 400,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(
+        request: Request,
+        exc: DangoError,
+    ) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_client(
+    tmp_path: Path,
+    role: Role = Role.ADMIN,
+) -> tuple[TestClient, Path]:
+    """Create a test client with auth middleware injecting a user."""
+    user = _make_user(role)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+def _setup_unauthenticated_client(tmp_path: Path) -> TestClient:
+    """Create a test client with no user set (unauthenticated)."""
+    app = _make_app(tmp_path)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _mock_source_config(name: str = "stripe", source_type: str = "stripe") -> dict[str, Any]:
+    """Build a mock source config dict."""
+    return {"name": name, "type": source_type, "enabled": True}
+
+
+def _mock_freshness() -> dict[str, Any]:
+    """Build a mock freshness dict."""
+    return {
+        "status": "synced",
+        "hours_since_sync": 2.0,
+        "last_sync_time": "2026-03-25T10:00:00",
+        "last_sync_status": "success",
+    }
+
+
+def _mock_tables_info() -> dict[str, Any]:
+    """Build a mock tables info dict."""
+    return {
+        "total_rows": 1500,
+        "tables": [
+            {"name": "payments", "row_count": 1000, "schema": "raw_stripe"},
+            {"name": "customers", "row_count": 500, "schema": "raw_stripe"},
+        ],
+        "has_multiple_tables": True,
+    }
+
+
+def _mock_dbt_model(name: str = "stg_payments") -> dict[str, Any]:
+    """Build a mock dbt model dict."""
+    return {
+        "name": name,
+        "unique_id": f"model.dango.{name}",
+        "path": f"models/staging/{name}.sql",
+        "materialization": "view",
+        "schema": "staging",
+        "database": "warehouse",
+        "depends_on": ["source.dango.stripe.payments"],
+        "description": f"Staged {name} data",
+        "tags": ["staging"],
+        "row_count": 1000,
+        "last_run": "2026-03-25T09:00:00",
+        "status": "success",
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /api/catalog/summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetCatalogSummary:
+    """Tests for GET /api/catalog/summary."""
+
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_empty_project(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_db_path: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Empty project returns 200 with empty lists."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_sources.return_value = []
+        mock_dbt.return_value = []
+        mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
+
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sources"] == []
+        assert data["dbt_models"] == []
+        assert data["totals"]["source_count"] == 0
+        assert data["totals"]["table_count"] == 0
+        assert data["totals"]["model_count"] == 0
+
+    @patch("dango.web.routes.ai._get_column_schema")
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.load_sync_history")
+    @patch("dango.web.routes.ai.get_source_tables_info")
+    @patch("dango.web.routes.ai.get_source_freshness")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_source_with_tables(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_freshness: MagicMock,
+        mock_tables: MagicMock,
+        mock_history: MagicMock,
+        mock_db_path: MagicMock,
+        mock_col_schema: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Source with tables returns correct response shape."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_sources.return_value = [_mock_source_config()]
+        mock_dbt.return_value = []
+        mock_freshness.return_value = _mock_freshness()
+        mock_tables.return_value = _mock_tables_info()
+        mock_history.return_value = []
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db_path.touch()
+        mock_db_path.return_value = db_path
+        mock_col_schema.return_value = [
+            {"name": "id", "type": "INTEGER", "nullable": False},
+            {"name": "amount", "type": "DOUBLE", "nullable": True},
+        ]
+
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["sources"]) == 1
+        src = data["sources"][0]
+        assert src["name"] == "stripe"
+        assert src["type"] == "stripe"
+        assert src["status"] == "synced"
+        assert src["row_count"] == 1500
+        assert len(src["tables"]) == 2
+        assert src["tables"][0]["name"] == "payments"
+        assert len(src["tables"][0]["columns"]) == 2
+        assert src["tables"][0]["columns"][0]["name"] == "id"
+        assert data["totals"]["table_count"] == 2
+
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_dbt_models_included(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_db_path: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """dbt models included with correct fields."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_sources.return_value = []
+        mock_dbt.return_value = [_mock_dbt_model()]
+        mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
+
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["dbt_models"]) == 1
+        model = data["dbt_models"][0]
+        assert model["name"] == "stg_payments"
+        assert model["unique_id"] == "model.dango.stg_payments"
+        assert model["materialization"] == "view"
+        assert model["schema_name"] == "staging"
+        assert model["depends_on"] == ["source.dango.stripe.payments"]
+        assert model["tags"] == ["staging"]
+        assert data["totals"]["model_count"] == 1
+
+    @patch("dango.governance.pii_detector.get_pii_findings")
+    @patch("dango.governance.schema_drift.get_drift_history")
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.load_sync_history")
+    @patch("dango.web.routes.ai.get_source_tables_info")
+    @patch("dango.web.routes.ai.get_source_freshness")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_quality_signals_for_admin(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_freshness: MagicMock,
+        mock_tables: MagicMock,
+        mock_history: MagicMock,
+        mock_db_path: MagicMock,
+        mock_drift: MagicMock,
+        mock_pii: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Admin (has governance.view) gets populated quality signals."""
+        client, project_root = _setup_client(tmp_path, role=Role.ADMIN)
+        mock_root.return_value = project_root
+        mock_sources.return_value = [_mock_source_config()]
+        mock_dbt.return_value = []
+        mock_freshness.return_value = _mock_freshness()
+        mock_tables.return_value = {"total_rows": 100, "tables": [], "has_multiple_tables": False}
+        mock_history.return_value = []
+        mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
+        mock_drift.return_value = [{"id": 1}, {"id": 2}]
+        mock_pii.return_value = [{"id": 1}]
+
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 200
+        quality = resp.json()["sources"][0]["quality"]
+        assert quality["drift_event_count"] == 2
+        assert quality["pii_column_count"] == 1
+
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.load_sync_history")
+    @patch("dango.web.routes.ai.get_source_tables_info")
+    @patch("dango.web.routes.ai.get_source_freshness")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_quality_signals_zeroed_for_editor(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_freshness: MagicMock,
+        mock_tables: MagicMock,
+        mock_history: MagicMock,
+        mock_db_path: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Editor (no governance.view) gets zeroed quality signals."""
+        client, project_root = _setup_client(tmp_path, role=Role.EDITOR)
+        mock_root.return_value = project_root
+        mock_sources.return_value = [_mock_source_config()]
+        mock_dbt.return_value = []
+        mock_freshness.return_value = _mock_freshness()
+        mock_tables.return_value = {"total_rows": 100, "tables": [], "has_multiple_tables": False}
+        mock_history.return_value = []
+        mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
+
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 200
+        quality = resp.json()["sources"][0]["quality"]
+        assert quality["drift_event_count"] == 0
+        assert quality["pii_column_count"] == 0
+
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_audit_event_logged(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_db_path: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Audit event is logged on catalog summary access."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_sources.return_value = []
+        mock_dbt.return_value = []
+        mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
+
+        client.get("/api/catalog/summary")
+        mock_audit.assert_called_once()
+        from dango.auth.audit import AuditEvent
+
+        assert mock_audit.call_args[0][0] == AuditEvent.AI_CATALOG_VIEWED
+
+    def test_unauthenticated_returns_401(self, tmp_path: Path) -> None:
+        """Unauthenticated request returns 401."""
+        client = _setup_unauthenticated_client(tmp_path)
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 401
+
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_has_description_field(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_db_path: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Response has self-describing description field."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_sources.return_value = []
+        mock_dbt.return_value = []
+        mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
+
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "description" in data
+        assert len(data["description"]) > 0
+
+    @patch("dango.web.routes.ai.get_duckdb_path")
+    @patch("dango.web.routes.ai.get_dbt_models")
+    @patch("dango.web.routes.ai.load_sources_config")
+    @patch("dango.web.routes.ai.get_project_root")
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_generated_at_is_iso_timestamp(
+        self,
+        mock_audit: MagicMock,
+        mock_root: MagicMock,
+        mock_sources: MagicMock,
+        mock_dbt: MagicMock,
+        mock_db_path: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """generated_at is a valid ISO timestamp."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+        mock_sources.return_value = []
+        mock_dbt.return_value = []
+        mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
+
+        resp = client.get("/api/catalog/summary")
+        assert resp.status_code == 200
+        from datetime import datetime
+
+        datetime.fromisoformat(resp.json()["generated_at"])

--- a/tests/unit/test_web_ai.py
+++ b/tests/unit/test_web_ai.py
@@ -180,7 +180,6 @@ class TestGetCatalogSummary:
 
     @patch("dango.web.routes.ai._get_column_schema")
     @patch("dango.web.routes.ai.get_duckdb_path")
-    @patch("dango.web.routes.ai.load_sync_history")
     @patch("dango.web.routes.ai.get_source_tables_info")
     @patch("dango.web.routes.ai.get_source_freshness")
     @patch("dango.web.routes.ai.get_dbt_models")
@@ -195,7 +194,6 @@ class TestGetCatalogSummary:
         mock_dbt: MagicMock,
         mock_freshness: MagicMock,
         mock_tables: MagicMock,
-        mock_history: MagicMock,
         mock_db_path: MagicMock,
         mock_col_schema: MagicMock,
         tmp_path: Path,
@@ -207,7 +205,6 @@ class TestGetCatalogSummary:
         mock_dbt.return_value = []
         mock_freshness.return_value = _mock_freshness()
         mock_tables.return_value = _mock_tables_info()
-        mock_history.return_value = []
         db_path = tmp_path / "data" / "warehouse.duckdb"
         db_path.parent.mkdir(parents=True, exist_ok=True)
         db_path.touch()
@@ -269,7 +266,6 @@ class TestGetCatalogSummary:
     @patch("dango.governance.pii_detector.get_pii_findings")
     @patch("dango.governance.schema_drift.get_drift_history")
     @patch("dango.web.routes.ai.get_duckdb_path")
-    @patch("dango.web.routes.ai.load_sync_history")
     @patch("dango.web.routes.ai.get_source_tables_info")
     @patch("dango.web.routes.ai.get_source_freshness")
     @patch("dango.web.routes.ai.get_dbt_models")
@@ -284,7 +280,6 @@ class TestGetCatalogSummary:
         mock_dbt: MagicMock,
         mock_freshness: MagicMock,
         mock_tables: MagicMock,
-        mock_history: MagicMock,
         mock_db_path: MagicMock,
         mock_drift: MagicMock,
         mock_pii: MagicMock,
@@ -297,7 +292,6 @@ class TestGetCatalogSummary:
         mock_dbt.return_value = []
         mock_freshness.return_value = _mock_freshness()
         mock_tables.return_value = {"total_rows": 100, "tables": [], "has_multiple_tables": False}
-        mock_history.return_value = []
         mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
         mock_drift.return_value = [{"id": 1}, {"id": 2}]
         mock_pii.return_value = [{"id": 1}]
@@ -309,7 +303,6 @@ class TestGetCatalogSummary:
         assert quality["pii_column_count"] == 1
 
     @patch("dango.web.routes.ai.get_duckdb_path")
-    @patch("dango.web.routes.ai.load_sync_history")
     @patch("dango.web.routes.ai.get_source_tables_info")
     @patch("dango.web.routes.ai.get_source_freshness")
     @patch("dango.web.routes.ai.get_dbt_models")
@@ -324,7 +317,6 @@ class TestGetCatalogSummary:
         mock_dbt: MagicMock,
         mock_freshness: MagicMock,
         mock_tables: MagicMock,
-        mock_history: MagicMock,
         mock_db_path: MagicMock,
         tmp_path: Path,
     ) -> None:
@@ -335,7 +327,6 @@ class TestGetCatalogSummary:
         mock_dbt.return_value = []
         mock_freshness.return_value = _mock_freshness()
         mock_tables.return_value = {"total_rows": 100, "tables": [], "has_multiple_tables": False}
-        mock_history.return_value = []
         mock_db_path.return_value = tmp_path / "data" / "warehouse.duckdb"
 
         resp = client.get("/api/catalog/summary")

--- a/tests/unit/test_web_ai_tools.py
+++ b/tests/unit/test_web_ai_tools.py
@@ -1,0 +1,230 @@
+"""tests/unit/test_web_ai_tools.py
+
+Tests for dango.web.routes.ai — tools endpoint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    DangoError,
+    ValidationError,
+)
+from dango.web.routes.ai import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.ADMIN) -> User:
+    """Create a test user."""
+    return User(
+        id="u-test-1",
+        email="test@test.com",
+        password_hash="hashed",
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the AI router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        ValidationError: 400,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(
+        request: Request,
+        exc: DangoError,
+    ) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_client(
+    tmp_path: Path,
+    role: Role = Role.ADMIN,
+) -> tuple[TestClient, Path]:
+    """Create a test client with auth middleware injecting a user."""
+    user = _make_user(role)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+def _setup_unauthenticated_client(tmp_path: Path) -> TestClient:
+    """Create a test client with no user set (unauthenticated)."""
+    app = _make_app(tmp_path)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetTools:
+    """Tests for GET /api/tools."""
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_returns_tool_list(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Returns non-empty tool list for admin."""
+        client, _ = _setup_client(tmp_path)
+        resp = client.get("/api/tools")
+        assert resp.status_code == 200
+        assert len(resp.json()["tools"]) > 0
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_tool_has_required_fields(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Each tool has all required fields."""
+        client, _ = _setup_client(tmp_path)
+        resp = client.get("/api/tools")
+        data = resp.json()
+
+        required_fields = {
+            "name",
+            "description",
+            "endpoint",
+            "method",
+            "parameters",
+            "permissions_required",
+            "is_read_only",
+            "is_safe_to_retry",
+        }
+        for tool in data["tools"]:
+            assert required_fields.issubset(tool.keys()), (
+                f"Tool {tool.get('name')} missing: {required_fields - tool.keys()}"
+            )
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_mutating_tools_flagged(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """sync_source and run_dbt_model are not read-only."""
+        client, _ = _setup_client(tmp_path)
+        resp = client.get("/api/tools")
+        mutating = {t["name"] for t in resp.json()["tools"] if not t["is_read_only"]}
+        assert "sync_source" in mutating
+        assert "run_dbt_model" in mutating
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_all_roles_see_all_tools(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Viewer, editor, and admin all see the same tools."""
+        tool_counts = []
+        for role in [Role.VIEWER, Role.EDITOR, Role.ADMIN]:
+            client, _ = _setup_client(tmp_path, role=role)
+            resp = client.get("/api/tools")
+            assert resp.status_code == 200
+            tool_counts.append(len(resp.json()["tools"]))
+        assert tool_counts[0] == tool_counts[1] == tool_counts[2]
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_mutating_tools_have_permissions(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Mutating tools include correct permissions_required."""
+        client, _ = _setup_client(tmp_path)
+        resp = client.get("/api/tools")
+        tools_by_name = {t["name"]: t for t in resp.json()["tools"]}
+        assert "source.sync" in tools_by_name["sync_source"]["permissions_required"]
+        assert "dbt.run" in tools_by_name["run_dbt_model"]["permissions_required"]
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_audit_event_logged(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Audit event is logged with endpoint detail."""
+        client, _ = _setup_client(tmp_path)
+        client.get("/api/tools")
+        mock_audit.assert_called_once()
+        from dango.auth.audit import AuditEvent
+
+        assert mock_audit.call_args[0][0] == AuditEvent.AI_CATALOG_VIEWED
+        assert mock_audit.call_args[1]["details"] == {"endpoint": "tools"}
+
+    def test_unauthenticated_returns_401(self, tmp_path: Path) -> None:
+        """Unauthenticated request returns 401."""
+        client = _setup_unauthenticated_client(tmp_path)
+        resp = client.get("/api/tools")
+        assert resp.status_code == 401
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_has_description_field(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Response has self-describing description field."""
+        client, _ = _setup_client(tmp_path)
+        resp = client.get("/api/tools")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "description" in data
+        assert len(data["description"]) > 0
+
+    @patch("dango.web.routes.ai.log_auth_event")
+    def test_user_role_included(
+        self,
+        mock_audit: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Response includes user_role field."""
+        client, _ = _setup_client(tmp_path, role=Role.VIEWER)
+        resp = client.get("/api/tools")
+        assert resp.status_code == 200
+        assert resp.json()["user_role"] == "viewer"

--- a/tests/unit/test_web_imports.py
+++ b/tests/unit/test_web_imports.py
@@ -124,6 +124,12 @@ class TestWebImports:
 
         assert router is not None
 
+    def test_import_ai_route(self):
+        """AI route module imports."""
+        from dango.web.routes.ai import router
+
+        assert router is not None
+
     def test_app_has_routes_registered(self):
         """App instance has all routers included (routes are registered)."""
         from dango.web.app import app
@@ -138,6 +144,8 @@ class TestWebImports:
             "/api/sources",
             "/api/logs",
             "/api/dbt/models",
+            "/api/catalog/summary",
+            "/api/tools",
             "/ws",
             "/",
             "/health",


### PR DESCRIPTION
## Summary

- Add `GET /api/catalog/summary` — machine-readable catalog of all data sources, table schemas, freshness, row counts, dbt models, and quality signals (drift + PII)
- Add `GET /api/tools` — describes all available API tools with parameter schemas, permission metadata, and read-only/mutating flags for agent consumption
- New audit event `AI_CATALOG_VIEWED` for both endpoints

## Changes

| File | Change |
|------|--------|
| `dango/web/routes/ai.py` | New route file (497 lines) — both endpoints + Pydantic models |
| `dango/auth/audit.py` | Add `AI_CATALOG_VIEWED` audit event |
| `dango/web/app.py` | Import + register `ai_router` |
| `tests/unit/test_web_ai.py` | Catalog summary tests (9 tests) |
| `tests/unit/test_web_ai_tools.py` | Tools endpoint tests (9 tests) |
| `tests/unit/test_web_imports.py` | Add AI route import test + expected paths |
| `pyproject.toml` | Add mypy overrides for new test files |
| `dango/web/CLAUDE.md` | Add routes/ai.py to files table |
| `dango/auth/CLAUDE.md` | Update audit.py line count + event count |

## Test plan

- [x] 18 new tests pass (`pytest tests/unit/test_web_ai.py tests/unit/test_web_ai_tools.py -v`)
- [x] Import tests pass (`pytest tests/unit/test_web_imports.py -v`)
- [x] Full suite: 2913 passed, 0 failed
- [x] `ruff check dango/` + `ruff format --check dango/` pass
- [x] `mypy dango/` passes
- [x] File headers validated
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)