### PR TITLE
TASK-075e: Add BYOS (Bring Your Own Server) deploy path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,8 @@ dango/                          # Python package source
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
-│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (838 lines)
-│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (703 lines)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (839 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (704 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (652 lines)
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
@@ -349,11 +349,11 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/remote.py` | 652 | — (remote group + push/rollback/firewall/domain) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 594 | — (Pydantic config models) |
-| `cli/commands/deploy_wizard.py` | 838 | — (interactive deploy wizard + BYOS) |
+| `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 577 | — |
 | `web/routes/catalog.py` | 566 | — (data catalog: columns, profiling, lineage, impact) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
-| `cli/commands/deploy_provision.py` | 703 | — (provisioning orchestration + BYOS) |
+| `cli/commands/deploy_provision.py` | 704 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
 | `cli/commands/auth.py` | 538 | — (12 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,9 @@ dango/                          # Python package source
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
-│   │   ├── deploy.py           # deploy group (wizard default, destroy)
-│   │   ├── deploy_wizard.py    # Interactive deploy wizard (579 lines)
-│   │   ├── deploy_provision.py # Provisioning orchestration (543 lines)
+│   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (838 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (703 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (652 lines)
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
@@ -349,11 +349,11 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/remote.py` | 652 | — (remote group + push/rollback/firewall/domain) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 594 | — (Pydantic config models) |
-| `cli/commands/deploy_wizard.py` | 579 | — (interactive deploy wizard) |
+| `cli/commands/deploy_wizard.py` | 838 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 577 | — |
 | `web/routes/catalog.py` | 566 | — (data catalog: columns, profiling, lineage, impact) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
-| `cli/commands/deploy_provision.py` | 543 | — (provisioning orchestration) |
+| `cli/commands/deploy_provision.py` | 703 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
 | `cli/commands/auth.py` | 538 | — (12 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -28,9 +28,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote.py` (652 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~152 lines) | `serve` production foreground server | `serve()` |
-| `commands/deploy.py` (~460 lines) | `deploy` group (wizard default, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (~800 lines) | Interactive wizard steps 1-9 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
-| `commands/deploy_provision.py` (~660 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
+| `commands/deploy.py` (689 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
+| `commands/deploy_wizard.py` (839 lines) | Interactive wizard steps 1-9 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
+| `commands/deploy_provision.py` (704 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -29,8 +29,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~152 lines) | `serve` production foreground server | `serve()` |
 | `commands/deploy.py` (~460 lines) | `deploy` group (wizard default, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (~579 lines) | Interactive wizard steps 1-9 + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig` |
-| `commands/deploy_provision.py` (~543 lines) | Provisioning orchestration + cleanup | `run_provisioning()`, `ProvisionResult`, `_ResourceTracker` |
+| `commands/deploy_wizard.py` (~800 lines) | Interactive wizard steps 1-9 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
+| `commands/deploy_provision.py` (~660 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |
@@ -105,8 +105,9 @@ dango (top-level group)
 ├── schedule (group)            ← commands/schedule.py
 │   ├── add, list, remove, status, enable, disable, webhook
 ├── deploy (group)              ← commands/deploy.py
-│   ├── (default)  interactive wizard → commands/deploy_wizard.py + deploy_provision.py
-│   └── destroy    tear down cloud infrastructure
+│   ├── (default)  interactive wizard (DO or BYOS) → deploy_wizard.py + deploy_provision.py
+│   ├── --byos     deploy to existing server (any provider)
+│   └── destroy    tear down cloud infrastructure (DO resources or BYOS config)
 ├── analyze                     ← commands/analyze.py
 ├── snapshot                    ← commands/notebook.py
 ├── governance (group)          ← commands/governance.py

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -381,6 +381,11 @@ def deploy_destroy(
     cloud_cfg, project_root = _load_deploy_config(ctx)
 
     if cloud_cfg.provider == "byos":
+        if keep_spaces or keep_ssh_key:
+            console.print(
+                "[yellow]Note:[/yellow] --keep-spaces and --keep-ssh-key are "
+                "DigitalOcean-only options and have no effect for BYOS deployments."
+            )
         _destroy_byos(cloud_cfg, project_root, force)
     else:
         _destroy_do(cloud_cfg, project_root, force, keep_spaces, keep_ssh_key)

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -4,9 +4,10 @@ Deploy group and destroy command for Dango cloud deployments.
 
 Command hierarchy::
 
-    dango deploy             — Interactive deployment wizard (default)
-    dango deploy --reconnect — Reconnect to existing server
-    dango deploy destroy     — Tear down cloud infrastructure
+    dango deploy                        — Interactive deployment wizard (default)
+    dango deploy --reconnect            — Reconnect to existing server
+    dango deploy --byos --server-ip X   — Deploy to your own server
+    dango deploy destroy                — Tear down cloud infrastructure
 """
 
 from __future__ import annotations
@@ -37,6 +38,10 @@ from dango.cli import console
 )
 @click.option("--skip-backups", is_flag=True, help="Skip automated backup setup.")
 @click.option("--skip-initial-sync", is_flag=True, help="Skip initial data sync.")
+@click.option("--byos", is_flag=True, help="Deploy to an existing server (any provider).")
+@click.option("--server-ip", type=str, default=None, help="Server IP/hostname for --byos.")
+@click.option("--ssh-user", type=str, default="root", help="SSH user for --byos.")
+@click.option("--ssh-key", type=str, default=None, help="SSH key path for --byos.")
 @click.pass_context
 def deploy(  # noqa: PLR0913
     ctx: click.Context,
@@ -50,6 +55,10 @@ def deploy(  # noqa: PLR0913
     admin_password: str | None,
     skip_backups: bool,
     skip_initial_sync: bool,
+    byos: bool,
+    server_ip: str | None,
+    ssh_user: str,
+    ssh_key: str | None,
 ) -> None:
     """Deploy and manage Dango cloud infrastructure.
 
@@ -57,10 +66,11 @@ def deploy(  # noqa: PLR0913
 
     \b
     Examples:
-      dango deploy                     Interactive wizard
-      dango deploy --non-interactive   All params via flags/env
-      dango deploy --reconnect --ip X  Reconnect to existing server
-      dango deploy destroy             Tear down cloud infrastructure
+      dango deploy                              Interactive wizard
+      dango deploy --non-interactive            All params via flags/env (DO)
+      dango deploy --reconnect --ip X           Reconnect to existing server
+      dango deploy --byos --server-ip X         Deploy to your own server
+      dango deploy destroy                      Tear down cloud infrastructure
     """
     ctx.ensure_object(dict)
 
@@ -77,7 +87,7 @@ def deploy(  # noqa: PLR0913
 
         loader = ConfigLoader(project_root)
         cloud_cfg = loader.load_cloud_config()
-        if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+        if cloud_cfg is not None and cloud_cfg.droplet_ip is not None:
             console.print(
                 "[yellow]A cloud deployment already exists.[/yellow] "
                 "Did you mean [bold]dango remote push[/bold]?"
@@ -90,12 +100,23 @@ def deploy(  # noqa: PLR0913
         _handle_reconnect(project_root, ip)
         return
 
-    # --- Wizard or non-interactive ---
-    from dango.cli.commands.deploy_provision import run_provisioning
-    from dango.cli.commands.deploy_wizard import run_non_interactive, run_wizard
+    # --- BYOS non-interactive mode ---
+    if byos:
+        _handle_byos(
+            project_root,
+            server_ip=server_ip,
+            ssh_user=ssh_user,
+            ssh_key=ssh_key,
+            domain=domain,
+            admin_email=admin_email,
+            admin_password=admin_password,
+            skip_initial_sync=skip_initial_sync,
+        )
+        return
 
+    # --- Non-interactive DO mode ---
     if non_interactive:
-        config = run_non_interactive(
+        _handle_do_deploy(
             project_root,
             region=region,
             size=size,
@@ -105,26 +126,31 @@ def deploy(  # noqa: PLR0913
             skip_backups=skip_backups,
             skip_initial_sync=skip_initial_sync,
         )
+        return
+
+    # --- Interactive mode: provider selection ---
+    console.print("\n[bold]Select deployment provider:[/bold]\n")
+    console.print("  1. DigitalOcean (automated provisioning)")
+    console.print("  2. I already have a server (any cloud provider)\n")
+
+    choice = click.prompt("  Choice", default="1", show_default=True)
+
+    if choice == "2":
+        from dango.cli.commands.deploy_provision import run_byos_setup
+        from dango.cli.commands.deploy_wizard import run_byos_wizard
+
+        byos_config = run_byos_wizard(project_root)
+        try:
+            byos_result = run_byos_setup(project_root, byos_config)
+        except Exception:
+            raise SystemExit(1) from None
+
+        _print_byos_success(byos_result, byos_config)
     else:
-        config = run_wizard(project_root)
+        from dango.cli.commands.deploy_wizard import run_wizard
 
-    try:
-        result = run_provisioning(project_root, config)
-    except Exception:
-        # run_provisioning already prints error details and cleans up resources
-        raise SystemExit(1) from None
-
-    # --- Success output ---
-    console.print("\n[bold green]Deployment complete![/bold green]")
-    console.print(f"  URL:    {result.url}")
-    console.print(f"  IP:     {result.droplet_ip}")
-    console.print(f"  Admin:  {config.admin_email}")
-    if result.warnings:
-        for w in result.warnings:
-            console.print(f"  [yellow]Warning:[/yellow] {w}")
-    console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
-    if not config.skip_initial_sync:
-        console.print("  Initial data sync is running in the background.")
+        wizard_config = run_wizard(project_root)
+        _handle_do_deploy_with_config(project_root, wizard_config)
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +198,102 @@ def _handle_reconnect(project_root: Path, ip: str | None) -> None:
     console.print("  Run [bold]dango remote status[/bold] for details.")
 
 
+def _handle_byos(
+    project_root: Path,
+    *,
+    server_ip: str | None,
+    ssh_user: str,
+    ssh_key: str | None,
+    domain: str | None,
+    admin_email: str | None,
+    admin_password: str | None,
+    skip_initial_sync: bool,
+) -> None:
+    """Run BYOS deployment (non-interactive via --byos flag)."""
+    from dango.cli.commands.deploy_provision import run_byos_setup
+    from dango.cli.commands.deploy_wizard import run_byos_non_interactive
+
+    config = run_byos_non_interactive(
+        project_root,
+        server_ip=server_ip,
+        ssh_user=ssh_user,
+        ssh_key_path=ssh_key,
+        domain=domain,
+        admin_email=admin_email,
+        admin_password=admin_password,
+        skip_initial_sync=skip_initial_sync,
+    )
+
+    try:
+        result = run_byos_setup(project_root, config)
+    except Exception:
+        raise SystemExit(1) from None
+
+    _print_byos_success(result, config)
+
+
+def _handle_do_deploy(
+    project_root: Path,
+    *,
+    region: str | None,
+    size: str | None,
+    domain: str | None,
+    admin_email: str | None,
+    admin_password: str | None,
+    skip_backups: bool,
+    skip_initial_sync: bool,
+) -> None:
+    """Run DO deployment (non-interactive mode)."""
+    from dango.cli.commands.deploy_wizard import run_non_interactive
+
+    config = run_non_interactive(
+        project_root,
+        region=region,
+        size=size,
+        domain=domain,
+        admin_email=admin_email,
+        admin_password=admin_password,
+        skip_backups=skip_backups,
+        skip_initial_sync=skip_initial_sync,
+    )
+    _handle_do_deploy_with_config(project_root, config)
+
+
+def _handle_do_deploy_with_config(project_root: Path, config: Any) -> None:
+    """Execute DO provisioning with a completed WizardConfig."""
+    from dango.cli.commands.deploy_provision import run_provisioning
+
+    try:
+        result = run_provisioning(project_root, config)
+    except Exception:
+        raise SystemExit(1) from None
+
+    console.print("\n[bold green]Deployment complete![/bold green]")
+    console.print(f"  URL:    {result.url}")
+    console.print(f"  IP:     {result.droplet_ip}")
+    console.print(f"  Admin:  {config.admin_email}")
+    if result.warnings:
+        for w in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {w}")
+    console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
+    if not config.skip_initial_sync:
+        console.print("  Initial data sync is running in the background.")
+
+
+def _print_byos_success(result: Any, config: Any) -> None:
+    """Print BYOS deployment success output."""
+    console.print("\n[bold green]Deployment complete![/bold green]")
+    console.print(f"  URL:    {result.url}")
+    console.print(f"  IP:     {result.server_ip}")
+    console.print(f"  Admin:  {config.admin_email}")
+    if result.warnings:
+        for w in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {w}")
+    console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
+    if not config.skip_initial_sync:
+        console.print("  Initial data sync is running in the background.")
+
+
 def _load_deploy_config(ctx: click.Context) -> tuple[Any, Path]:
     """Load CloudConfig for deploy commands, return (config, project_root).
 
@@ -185,7 +307,7 @@ def _load_deploy_config(ctx: click.Context) -> tuple[Any, Path]:
     loader = ConfigLoader(project_root)
     cloud_cfg = loader.load_cloud_config()
 
-    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
         console.print("[red]Error:[/red] No cloud deployment found. Nothing to destroy.")
         raise SystemExit(1)
 
@@ -229,7 +351,8 @@ def deploy_destroy(
 ) -> None:
     """Tear down all cloud infrastructure for this project.
 
-    Deletes the Droplet, firewall, SSH key (from DO), and Spaces bucket.
+    For DigitalOcean: deletes the Droplet, firewall, SSH key (from DO), and Spaces bucket.
+    For BYOS: optionally stops remote services and removes local cloud.yml.
     Local SSH keys and project files are never deleted.
 
     Use --force to skip confirmation prompts.  Use --keep-spaces or
@@ -240,9 +363,94 @@ def deploy_destroy(
       dango deploy destroy --force
       dango deploy destroy --keep-spaces --keep-ssh-key
     """
+    cloud_cfg, project_root = _load_deploy_config(ctx)
+
+    if cloud_cfg.provider == "byos":
+        _destroy_byos(cloud_cfg, project_root, force)
+    else:
+        _destroy_do(cloud_cfg, project_root, force, keep_spaces, keep_ssh_key)
+
+
+def _destroy_byos(cloud_cfg: Any, project_root: Path, force: bool) -> None:
+    """Tear down a BYOS deployment (stop services, remove local config)."""
     from rich.panel import Panel
 
-    cloud_cfg, project_root = _load_deploy_config(ctx)
+    summary_lines = [
+        f"  Server: [bold]{cloud_cfg.droplet_ip}[/bold]",
+        "  Provider: BYOS",
+        "  [dim]The server itself will NOT be deleted.[/dim]",
+    ]
+    if cloud_cfg.domain:
+        summary_lines.append(f"  Domain: {cloud_cfg.domain}")
+
+    console.print(
+        Panel(
+            "\n".join(summary_lines),
+            title="[red]BYOS Destroy Summary[/red]",
+            border_style="red",
+        )
+    )
+
+    # Offer backup download
+    if not force and cloud_cfg.droplet_ip:
+        _offer_backup_download(cloud_cfg, project_root)
+
+    # Confirm
+    if not force:
+        confirm = click.prompt(
+            f"\nType the server IP ({cloud_cfg.droplet_ip}) to confirm",
+            default="",
+            show_default=False,
+        )
+        if confirm != cloud_cfg.droplet_ip:
+            console.print("[yellow]Aborted.[/yellow] Input did not match.")
+            raise SystemExit(1)
+
+    # Optionally stop remote services
+    if click.confirm("\n  Stop Dango services on the remote server?", default=True):
+        from dango.platform.cloud.ssh import SSHManager
+
+        key_path = _resolve_key_path(cloud_cfg, project_root)
+        if key_path.exists():
+            ssh = SSHManager(
+                key_path=key_path,
+                known_hosts_path=key_path.parent / "known_hosts",
+            )
+            try:
+                ssh.connect(cloud_cfg.droplet_ip)
+                ssh.exec_command("systemctl stop dango-web 2>/dev/null || true", timeout=15)
+                ssh.exec_command(
+                    "cd /srv/dango/project && sudo -u dango docker compose down 2>/dev/null || true",
+                    timeout=60,
+                )
+                console.print("[green]Stopped[/green] remote services.")
+            except Exception as exc:
+                console.print(f"[yellow]Warning:[/yellow] Could not stop remote services: {exc}")
+            finally:
+                ssh.disconnect()
+
+    # Remove local config
+    cloud_yml = project_root / ".dango" / "cloud.yml"
+    if cloud_yml.exists():
+        try:
+            cloud_yml.unlink()
+            console.print("[green]Removed[/green] .dango/cloud.yml")
+        except OSError as exc:
+            console.print(f"[yellow]Warning:[/yellow] Could not remove cloud.yml: {exc}")
+
+    console.print("\n[green]BYOS deployment removed.[/green]")
+    console.print("[dim]The server and its data are still intact.[/dim]")
+
+
+def _destroy_do(
+    cloud_cfg: Any,
+    project_root: Path,
+    force: bool,
+    keep_spaces: bool,
+    keep_ssh_key: bool,
+) -> None:
+    """Tear down a DigitalOcean deployment (delete cloud resources)."""
+    from rich.panel import Panel
 
     # --- Show destruction summary ---
     summary_lines = [
@@ -275,7 +483,7 @@ def deploy_destroy(
     if not force:
         ip = cloud_cfg.droplet_ip or str(cloud_cfg.droplet_id)
         confirm = click.prompt(
-            f"\nType the droplet IP ({ip}) to confirm destruction",
+            f"\nType the server IP ({ip}) to confirm destruction",
             default="",
             show_default=False,
         )
@@ -290,12 +498,13 @@ def deploy_destroy(
     errors: list[str] = []
 
     # 1. Delete droplet
-    try:
-        client.delete_droplet(cloud_cfg.droplet_id)
-        console.print("[green]Deleted[/green] droplet.")
-    except Exception as exc:
-        errors.append(f"Droplet: {exc}")
-        console.print(f"[red]Failed[/red] to delete droplet: {exc}")
+    if cloud_cfg.droplet_id:
+        try:
+            client.delete_droplet(cloud_cfg.droplet_id)
+            console.print("[green]Deleted[/green] droplet.")
+        except Exception as exc:
+            errors.append(f"Droplet: {exc}")
+            console.print(f"[red]Failed[/red] to delete droplet: {exc}")
 
     # 2. Delete firewall
     if cloud_cfg.firewall_id:

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -268,29 +268,44 @@ def _handle_do_deploy_with_config(project_root: Path, config: Any) -> None:
     except Exception:
         raise SystemExit(1) from None
 
-    console.print("\n[bold green]Deployment complete![/bold green]")
-    console.print(f"  URL:    {result.url}")
-    console.print(f"  IP:     {result.droplet_ip}")
-    console.print(f"  Admin:  {config.admin_email}")
-    if result.warnings:
-        for w in result.warnings:
-            console.print(f"  [yellow]Warning:[/yellow] {w}")
-    console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
-    if not config.skip_initial_sync:
-        console.print("  Initial data sync is running in the background.")
+    _print_deploy_success(
+        url=result.url,
+        ip=result.droplet_ip,
+        admin_email=config.admin_email,
+        warnings=result.warnings,
+        skip_initial_sync=config.skip_initial_sync,
+    )
 
 
 def _print_byos_success(result: Any, config: Any) -> None:
     """Print BYOS deployment success output."""
+    _print_deploy_success(
+        url=result.url,
+        ip=result.server_ip,
+        admin_email=config.admin_email,
+        warnings=result.warnings,
+        skip_initial_sync=config.skip_initial_sync,
+    )
+
+
+def _print_deploy_success(
+    *,
+    url: str,
+    ip: str,
+    admin_email: str,
+    warnings: list[str],
+    skip_initial_sync: bool,
+) -> None:
+    """Print deployment success output (shared by DO and BYOS paths)."""
     console.print("\n[bold green]Deployment complete![/bold green]")
-    console.print(f"  URL:    {result.url}")
-    console.print(f"  IP:     {result.server_ip}")
-    console.print(f"  Admin:  {config.admin_email}")
-    if result.warnings:
-        for w in result.warnings:
+    console.print(f"  URL:    {url}")
+    console.print(f"  IP:     {ip}")
+    console.print(f"  Admin:  {admin_email}")
+    if warnings:
+        for w in warnings:
             console.print(f"  [yellow]Warning:[/yellow] {w}")
     console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
-    if not config.skip_initial_sync:
+    if not skip_initial_sync:
         console.print("  Initial data sync is running in the background.")
 
 
@@ -407,7 +422,7 @@ def _destroy_byos(cloud_cfg: Any, project_root: Path, force: bool) -> None:
             raise SystemExit(1)
 
     # Optionally stop remote services
-    if click.confirm("\n  Stop Dango services on the remote server?", default=True):
+    if force or click.confirm("\n  Stop Dango services on the remote server?", default=True):
         from dango.platform.cloud.ssh import SSHManager
 
         key_path = _resolve_key_path(cloud_cfg, project_root)

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -409,7 +409,8 @@ def run_byos_setup(
     except Exception as exc:
         console.print(f"\n[red]BYOS setup failed:[/red] {exc}")
         console.print(
-            "[dim]Server setup steps are idempotent — re-run 'dango deploy' to retry.[/dim]"
+            "[dim]Server setup steps are idempotent — "
+            "run 'dango deploy destroy' then 'dango deploy' to retry.[/dim]"
         )
         raise CloudProvisioningError(str(exc)) from exc
 

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from dango.cli import console
-from dango.cli.commands.deploy_wizard import _EMAIL_RE, WizardConfig
+from dango.cli.commands.deploy_wizard import _EMAIL_RE, BYOSConfig, WizardConfig
 from dango.exceptions import CloudProvisioningError
 
 
@@ -79,6 +79,16 @@ class ProvisionResult:
     droplet_id: int
     firewall_id: str
     ssh_key_id: int
+    domain: str | None = None
+    url: str = ""
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BYOSResult:
+    """Result of a successful BYOS setup run."""
+
+    server_ip: str
     domain: str | None = None
     url: str = ""
     warnings: list[str] = field(default_factory=list)
@@ -273,6 +283,134 @@ def run_provisioning(
                 console.print(f"  - {err}")
         else:
             console.print("[green]All resources cleaned up.[/green]")
+        raise CloudProvisioningError(str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# BYOS setup function
+# ---------------------------------------------------------------------------
+
+
+def run_byos_setup(
+    project_root: Path,
+    config: BYOSConfig,
+) -> BYOSResult:
+    """Execute server setup for BYOS deployments (no cloud provisioning).
+
+    Reuses the same server setup, file sync, secrets push, and admin
+    creation logic as DO provisioning — the server setup is cloud-agnostic.
+
+    Args:
+        project_root: Path to the local Dango project root.
+        config: BYOS configuration from the wizard.
+
+    Returns:
+        ``BYOSResult`` with deployment details.
+
+    Raises:
+        CloudProvisioningError: On unrecoverable failure.
+    """
+    from dango.platform.cloud.file_sync import sync_project_files
+    from dango.platform.cloud.server_setup import setup_server
+    from dango.platform.cloud.ssh import SSHManager
+
+    warnings: list[str] = []
+    key_path = Path(config.ssh_key_path).expanduser()
+    ssh = SSHManager(key_path=key_path)
+
+    try:
+        # --- Sub-step 1: Server setup (16 steps + UFW) ---
+        _status("Setting up server (installs Docker, Caddy, Python, etc.)...")
+        ssh.connect(config.server_ip, username=config.ssh_user)
+        try:
+            setup_result = setup_server(
+                ssh,
+                on_progress=_setup_progress,
+                domain=config.domain,
+                setup_ufw=True,
+            )
+            if setup_result.warnings:
+                for w in setup_result.warnings:
+                    console.print(f"  [yellow]Warning:[/yellow] {w}")
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 2: Sync project files ---
+        _status("Syncing project files...")
+        ssh.connect(config.server_ip, username=config.ssh_user)
+        try:
+            sync_project_files(
+                ssh,
+                project_root,
+                remote_host=config.server_ip,
+                on_progress=_setup_progress,
+            )
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 3: Push secrets ---
+        _status("Pushing secrets to server...")
+        ssh.connect(config.server_ip, username=config.ssh_user)
+        try:
+            _push_secrets(ssh, project_root, warnings)
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 4: Create admin + enable auth ---
+        _status("Creating admin account and enabling auth...")
+        ssh.connect(config.server_ip, username=config.ssh_user)
+        try:
+            deploy_token = _create_admin_and_enable_auth(
+                ssh, config.admin_email, config.admin_password
+            )
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 5: Save cloud.yml ---
+        _status("Saving deployment configuration...")
+        from dango.config.loader import ConfigLoader
+        from dango.config.models import CloudConfig
+
+        loader = ConfigLoader(project_root)
+        cloud_cfg = CloudConfig(
+            provider="byos",
+            droplet_ip=config.server_ip,
+            ssh_key_path=str(key_path),
+            domain=config.domain,
+        )
+        loader.save_cloud_config(cloud_cfg)
+
+        # --- Sub-step 6: Start services + health check ---
+        _status("Starting services...")
+        ssh.connect(config.server_ip, username=config.ssh_user)
+        try:
+            _start_services(ssh)
+        finally:
+            ssh.disconnect()
+
+        url = f"https://{config.domain}" if config.domain else f"http://{config.server_ip}"
+        health_ok = _health_check(url)
+        if not health_ok:
+            warnings.append(f"Health check failed. Server may still be starting. Try: {url}")
+
+        # Trigger initial sync
+        if not config.skip_initial_sync and health_ok:
+            _trigger_initial_sync(url, deploy_token)
+
+        return BYOSResult(
+            server_ip=config.server_ip,
+            domain=config.domain,
+            url=url,
+            warnings=warnings,
+        )
+
+    except CloudProvisioningError:
+        raise
+    except Exception as exc:
+        console.print(f"\n[red]BYOS setup failed:[/red] {exc}")
+        console.print(
+            "[dim]Server setup steps are idempotent — re-run 'dango deploy' to retry.[/dim]"
+        )
         raise CloudProvisioningError(str(exc)) from exc
 
 

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -2,8 +2,11 @@
 
 Interactive deployment wizard and non-interactive validation for ``dango deploy``.
 
-Steps 1-9 gather configuration (region, size, domain, admin credentials, etc.)
-before handing off to ``deploy_provision.py`` for the actual provisioning.
+Steps 1-9 gather DigitalOcean configuration (region, size, domain, admin
+credentials, etc.) before handing off to ``deploy_provision.py``.
+
+Also provides a BYOS (Bring Your Own Server) wizard path that skips
+cloud provisioning and goes straight to server setup.
 """
 
 from __future__ import annotations
@@ -42,6 +45,20 @@ class WizardConfig:
     # Backup credentials (only set if enable_backups is True)
     spaces_access_key: str | None = None
     spaces_secret_key: str | None = None
+
+
+@dataclass
+class BYOSConfig:
+    """Configuration collected from the BYOS (Bring Your Own Server) wizard."""
+
+    server_ip: str
+    ssh_user: str
+    ssh_key_path: str
+    domain: str | None
+    admin_email: str
+    admin_password: str
+    skip_oauth: bool
+    skip_initial_sync: bool
 
 
 # ---------------------------------------------------------------------------
@@ -576,4 +593,247 @@ def run_non_interactive(
         enable_backups=not skip_backups,
         skip_initial_sync=skip_initial_sync,
         monthly_cost=monthly_cost,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BYOS (Bring Your Own Server) wizard
+# ---------------------------------------------------------------------------
+
+
+def _step_byos_server(project_root: Path) -> tuple[str, str, str]:
+    """Prompt for server IP, SSH user, and SSH key path.
+
+    Returns:
+        Tuple of (server_ip, ssh_user, ssh_key_path).
+    """
+    console.print("\n[bold]Step 1: Server Connection[/bold]\n")
+
+    server_ip = click.prompt("  Server IP or hostname")
+
+    ssh_user = click.prompt("  SSH user", default="root", show_default=True)
+
+    console.print("\n  SSH key options:")
+    console.print("    1. Use an existing SSH key")
+    console.print("    2. Generate a new key pair\n")
+
+    key_choice = click.prompt("  Choice", default="1", show_default=True)
+
+    if key_choice == "2":
+        from dango.platform.cloud.ssh import SSHManager
+
+        key_path = project_root / ".dango" / "cloud_key"
+        ssh = SSHManager(key_path=key_path)
+        public_key = ssh.generate_key_pair()
+
+        console.print(f"\n  [green]Generated key pair at:[/green] {key_path}")
+        console.print("\n  [bold]Public key (add to server's ~/.ssh/authorized_keys):[/bold]")
+        console.print(f"  {public_key}\n")
+        click.prompt(
+            "  Press Enter once the key is added to your server", default="", show_default=False
+        )
+        return server_ip, ssh_user, str(key_path)
+
+    # Existing key
+    default_key = str(Path.home() / ".ssh" / "id_ed25519")
+    key_path_str = click.prompt("  Path to SSH private key", default=default_key, show_default=True)
+    key_path = Path(key_path_str).expanduser()
+
+    if not key_path.exists():
+        console.print(f"  [red]Error:[/red] SSH key not found: {key_path}")
+        raise SystemExit(1)
+
+    return server_ip, ssh_user, str(key_path)
+
+
+def _validate_ssh_connectivity(
+    server_ip: str,
+    ssh_user: str,
+    ssh_key_path: str,
+) -> None:
+    """Test SSH connectivity and warn if not Ubuntu.
+
+    Raises:
+        SystemExit: If SSH connection fails.
+    """
+    from dango.platform.cloud.ssh import SSHManager
+
+    console.print("\n  Testing SSH connection...")
+    ssh = SSHManager(key_path=Path(ssh_key_path))
+    try:
+        ssh.connect(server_ip, username=ssh_user)
+    except Exception as exc:
+        console.print(f"  [red]Error:[/red] SSH connection failed: {exc}")
+        console.print(
+            "\n  Troubleshooting:"
+            "\n  - Verify the server IP and SSH user are correct"
+            "\n  - Ensure your SSH key is in the server's authorized_keys"
+            "\n  - Check that port 22 is open on the server"
+        )
+        raise SystemExit(1) from exc
+
+    try:
+        # Check if Ubuntu
+        result = ssh.exec_command("cat /etc/os-release 2>/dev/null")
+        if result.success and "ubuntu" not in result.stdout.lower():
+            console.print(
+                "  [yellow]Warning:[/yellow] Server does not appear to be running Ubuntu. "
+                "Dango is tested on Ubuntu 22.04+. Proceed with caution."
+            )
+        else:
+            console.print("  [green]SSH connection successful.[/green]")
+    finally:
+        ssh.disconnect()
+
+
+def run_byos_wizard(project_root: Path) -> BYOSConfig:
+    """Run the BYOS interactive wizard.
+
+    Args:
+        project_root: Path to the Dango project root.
+
+    Returns:
+        Completed ``BYOSConfig`` ready for server setup.
+    """
+    console.print("\n[bold blue]Dango BYOS Deployment Wizard[/bold blue]")
+    console.print("[dim]Deploy to your own server (any cloud provider)[/dim]\n")
+
+    # Check sources.yml exists (skip DO token check)
+    sources_yml = project_root / ".dango" / "sources.yml"
+    if not sources_yml.exists():
+        console.print(
+            "[red]Error:[/red] No sources.yml found. "
+            "Run [bold]dango source add[/bold] to configure data sources first."
+        )
+        raise SystemExit(1)
+    console.print("  [green]Prerequisites OK.[/green]")
+
+    # Step 1: Server connection
+    server_ip, ssh_user, ssh_key_path = _step_byos_server(project_root)
+
+    # Step 2: Validate SSH
+    _validate_ssh_connectivity(server_ip, ssh_user, ssh_key_path)
+
+    # Step 3: Domain
+    domain = _step_domain()
+
+    # Step 4: Admin credentials
+    admin_email, admin_password = _step_admin()
+
+    # Step 5: Sources
+    _step_sources(project_root)
+
+    # Step 6: OAuth
+    skip_oauth = _step_oauth()
+
+    # Confirmation
+    console.print("\n[bold]Deployment Summary[/bold]\n")
+    console.print(f"  Server:    {server_ip} (SSH user: {ssh_user})")
+    console.print(f"  SSH key:   {ssh_key_path}")
+    if domain:
+        console.print(f"  Domain:    {domain}")
+    console.print(f"  Admin:     {admin_email}")
+    console.print()
+
+    if not click.confirm("  Proceed with deployment?", default=True):
+        console.print("[yellow]Aborted.[/yellow]")
+        raise SystemExit(0)
+
+    return BYOSConfig(
+        server_ip=server_ip,
+        ssh_user=ssh_user,
+        ssh_key_path=ssh_key_path,
+        domain=domain,
+        admin_email=admin_email,
+        admin_password=admin_password,
+        skip_oauth=skip_oauth,
+        skip_initial_sync=False,
+    )
+
+
+def run_byos_non_interactive(
+    project_root: Path,
+    *,
+    server_ip: str | None = None,
+    ssh_user: str = "root",
+    ssh_key_path: str | None = None,
+    domain: str | None = None,
+    admin_email: str | None = None,
+    admin_password: str | None = None,
+    skip_initial_sync: bool = False,
+) -> BYOSConfig:
+    """Validate params for non-interactive BYOS deployment.
+
+    Args:
+        project_root: Path to the Dango project root.
+        server_ip: Required server IP or hostname.
+        ssh_user: SSH user. Defaults to root.
+        ssh_key_path: Path to SSH key. Defaults to .dango/cloud_key.
+        domain: Optional custom domain.
+        admin_email: Required admin email.
+        admin_password: Required admin password (or from DANGO_ADMIN_PASSWORD env).
+        skip_initial_sync: Skip initial data sync.
+
+    Returns:
+        Validated ``BYOSConfig``.
+
+    Raises:
+        SystemExit: If required params are missing or invalid.
+    """
+    from dango.auth.security import check_password_strength
+
+    # Check sources.yml exists
+    sources_yml = project_root / ".dango" / "sources.yml"
+    if not sources_yml.exists():
+        console.print(
+            "[red]Error:[/red] No sources.yml found. "
+            "Run [bold]dango source add[/bold] to configure data sources first."
+        )
+        raise SystemExit(1)
+
+    # Server IP
+    if not server_ip:
+        console.print("[red]Error:[/red] --server-ip is required for --byos.")
+        raise SystemExit(1)
+
+    # SSH key path
+    if ssh_key_path is None:
+        ssh_key_path = str(project_root / ".dango" / "cloud_key")
+    if not Path(ssh_key_path).expanduser().exists():
+        console.print(f"[red]Error:[/red] SSH key not found: {ssh_key_path}")
+        raise SystemExit(1)
+
+    # Admin email
+    if not admin_email:
+        console.print("[red]Error:[/red] --admin-email is required for --byos.")
+        raise SystemExit(1)
+    if not _EMAIL_RE.match(admin_email):
+        console.print(f"[red]Error:[/red] Invalid email format: {admin_email}")
+        raise SystemExit(1)
+
+    # Admin password
+    if not admin_password:
+        admin_password = os.environ.get("DANGO_ADMIN_PASSWORD")
+    if not admin_password:
+        console.print(
+            "[red]Error:[/red] --admin-password or DANGO_ADMIN_PASSWORD env required for --byos."
+        )
+        raise SystemExit(1)
+    issues = check_password_strength(admin_password)
+    if issues:
+        console.print(f"[red]Error:[/red] Weak password: {'; '.join(issues)}")
+        raise SystemExit(1)
+
+    # Validate SSH connectivity
+    _validate_ssh_connectivity(server_ip, ssh_user, ssh_key_path)
+
+    return BYOSConfig(
+        server_ip=server_ip,
+        ssh_user=ssh_user,
+        ssh_key_path=ssh_key_path,
+        domain=domain,
+        admin_email=admin_email,
+        admin_password=admin_password,
+        skip_oauth=True,
+        skip_initial_sync=skip_initial_sync,
     )

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -25,7 +25,7 @@ Command hierarchy::
     │   └── remove          — Revert to IP-only HTTP
     └── backup (subgroup)   — See remote_backup.py
 
-All commands require an active cloud deployment (``droplet_id`` set in
+All commands require an active cloud deployment (``droplet_ip`` set in
 ``.dango/cloud.yml``).  Firewall commands additionally require ``firewall_id``.
 
 Management commands (status, logs, ssh, query) are defined in

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -97,7 +97,7 @@ def firewall(ctx: click.Context) -> None:
 def _require_cloud_deployment(ctx: click.Context) -> tuple[Any, Path]:
     """Load CloudConfig and return (config, project_root), or exit with an error.
 
-    Only requires ``droplet_id`` — does NOT check for ``firewall_id``.
+    Only requires ``droplet_ip`` — does NOT check for ``firewall_id``.
 
     Returns:
         Tuple of (CloudConfig, project_root Path).
@@ -112,7 +112,7 @@ def _require_cloud_deployment(ctx: click.Context) -> tuple[Any, Path]:
     loader = ConfigLoader(project_root)
     cloud_cfg = loader.load_cloud_config()
 
-    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
         console.print(
             "[red]Error:[/red] No cloud deployment found. "
             "Run [bold]dango deploy[/bold] to provision a server first."
@@ -125,15 +125,22 @@ def _require_cloud_deployment(ctx: click.Context) -> tuple[Any, Path]:
 def _load_cloud_config_or_fail(ctx: click.Context) -> tuple[Any, str]:
     """Load CloudConfig and return (config, firewall_id), or exit with an error.
 
-    Requires both ``droplet_id`` and ``firewall_id``.
+    Requires both ``droplet_ip`` and ``firewall_id``.
 
     Returns:
         Tuple of (CloudConfig, firewall_id string).
 
     Raises:
-        SystemExit: If no deployment or no firewall is configured.
+        SystemExit: If no deployment, BYOS provider, or no firewall is configured.
     """
     cloud_cfg, _project_root = _require_cloud_deployment(ctx)
+
+    if cloud_cfg.provider == "byos":
+        console.print(
+            "[red]Error:[/red] Firewall management uses UFW for BYOS deployments. "
+            "SSH into the server and use [bold]ufw[/bold] commands directly."
+        )
+        raise SystemExit(1)
 
     if cloud_cfg.firewall_id is None:
         console.print(
@@ -175,7 +182,7 @@ def _ssh_connect_or_fail(ctx: click.Context) -> tuple[Any, Any, Path]:
     loader = ConfigLoader(project_root)
     cloud_cfg = loader.load_cloud_config()
 
-    if cloud_cfg is None or cloud_cfg.droplet_id is None or cloud_cfg.droplet_ip is None:
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
         console.print(
             "[red]Error:[/red] No cloud deployment found. "
             "Run [bold]dango deploy[/bold] to provision a server first."

--- a/dango/cli/commands/remote_backup.py
+++ b/dango/cli/commands/remote_backup.py
@@ -61,19 +61,18 @@ def _load_spaces_client_or_fail(ctx: click.Context) -> tuple[Any, Any]:
         )
         raise SystemExit(1)
 
-    if cloud_cfg.provider == "byos" and cloud_cfg.spaces is None:
-        console.print(
-            "[red]Error:[/red] Spaces backups require DigitalOcean. "
-            "Use [bold]dango remote backup[/bold] (on-demand via SSH) or "
-            "[bold]dango remote backup download[/bold] for BYOS deployments."
-        )
-        raise SystemExit(1)
-
     if cloud_cfg.spaces is None:
-        console.print(
-            "[red]Error:[/red] Spaces not configured. "
-            "Set [bold]spaces.bucket[/bold] in [bold].dango/cloud.yml[/bold]."
-        )
+        if cloud_cfg.provider == "byos":
+            console.print(
+                "[red]Error:[/red] Spaces backups require DigitalOcean. "
+                "Use [bold]dango remote backup[/bold] (on-demand via SSH) or "
+                "[bold]dango remote backup download[/bold] for BYOS deployments."
+            )
+        else:
+            console.print(
+                "[red]Error:[/red] Spaces not configured. "
+                "Set [bold]spaces.bucket[/bold] in [bold].dango/cloud.yml[/bold]."
+            )
         raise SystemExit(1)
 
     region = cloud_cfg.spaces.region or cloud_cfg.region

--- a/dango/cli/commands/remote_backup.py
+++ b/dango/cli/commands/remote_backup.py
@@ -54,10 +54,18 @@ def _load_spaces_client_or_fail(ctx: click.Context) -> tuple[Any, Any]:
     loader = ConfigLoader(project_root)
     cloud_cfg = loader.load_cloud_config()
 
-    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
         console.print(
             "[red]Error:[/red] No cloud deployment found. "
             "Run [bold]dango deploy[/bold] to provision a server first."
+        )
+        raise SystemExit(1)
+
+    if cloud_cfg.provider == "byos" and cloud_cfg.spaces is None:
+        console.print(
+            "[red]Error:[/red] Spaces backups require DigitalOcean. "
+            "Use [bold]dango remote backup[/bold] (on-demand via SSH) or "
+            "[bold]dango remote backup download[/bold] for BYOS deployments."
         )
         raise SystemExit(1)
 

--- a/dango/cli/commands/remote_mgmt.py
+++ b/dango/cli/commands/remote_mgmt.py
@@ -39,18 +39,10 @@ def _load_cloud_config_with_ip(ctx: click.Context) -> tuple[Any, Path]:
     loader = ConfigLoader(project_root)
     cloud_cfg = loader.load_cloud_config()
 
-    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
         console.print(
             "[red]Error:[/red] No cloud deployment found. "
             "Run [bold]dango deploy[/bold] to provision a server first."
-        )
-        raise SystemExit(1)
-
-    if not cloud_cfg.droplet_ip:
-        console.print(
-            "[red]Error:[/red] No droplet IP found in cloud config. "
-            "Re-provision or manually set [bold]droplet_ip[/bold] in "
-            "[bold].dango/cloud.yml[/bold]."
         )
         raise SystemExit(1)
 

--- a/dango/cli/commands/remote_ops.py
+++ b/dango/cli/commands/remote_ops.py
@@ -182,6 +182,13 @@ def remote_resize(ctx: click.Context, size: str | None, yes: bool) -> None:
 
     cloud_cfg, project_root = _require_cloud_deployment(ctx)
 
+    if cloud_cfg.provider == "byos":
+        console.print(
+            "[red]Error:[/red] Resize is not available for BYOS deployments. "
+            "Manage server sizing through your hosting provider."
+        )
+        raise SystemExit(1)
+
     if size is None:
         # Info mode: show current spec and available tiers
         current_tier = get_size_tier(cloud_cfg.size)
@@ -356,6 +363,10 @@ def remote_migrate(
     from dango.platform.cloud.resize import validate_size_slug
 
     cloud_cfg, project_root = _require_cloud_deployment(ctx)
+
+    if cloud_cfg.provider == "byos":
+        console.print("[red]Error:[/red] Migration is not available for BYOS deployments.")
+        raise SystemExit(1)
 
     # Validate size
     try:

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -118,7 +118,7 @@ def load_cloud_config_with_ssh(ctx: click.Context) -> tuple:
     loader = ConfigLoader(project_root)
     cloud_cfg = loader.load_cloud_config()
 
-    if cloud_cfg is None or cloud_cfg.droplet_id is None or cloud_cfg.droplet_ip is None:
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
         console.print(
             "[red]Error:[/red] No cloud deployment found. "
             "Run [bold]dango deploy[/bold] to provision a server first."

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -9,7 +9,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports, `__all__` | Re-exports all public symbols |
-| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `LocalFilesSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `CloudConfig` (incl. `firewall_id`) |
+| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `LocalFilesSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `CloudConfig` (incl. `provider`, `firewall_id`) |
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
 | `schedules.py` | Schedule config models, validation, reload | `ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`, `CRON_PRESETS`, `load_schedules_config`, `validate_schedules`, `reload_schedules`, `log_startup_checks` |

--- a/dango/config/helpers.py
+++ b/dango/config/helpers.py
@@ -81,11 +81,11 @@ def save_config(config: DangoConfig, project_root: Path | None = None) -> None:
 def is_cloud_mode(project_root: Path) -> bool:
     """Check if this project has an active cloud deployment.
 
-    Returns True if ``.dango/cloud.yml`` exists and contains a ``droplet_id``.
+    Returns True if ``.dango/cloud.yml`` exists and contains a ``droplet_ip``.
     """
     loader = ConfigLoader(project_root)
     cloud_cfg: CloudConfig | None = loader.load_cloud_config()
-    return cloud_cfg is not None and cloud_cfg.droplet_id is not None
+    return cloud_cfg is not None and cloud_cfg.droplet_ip is not None
 
 
 def get_cloud_origin(project_root: Path) -> str | None:
@@ -97,13 +97,11 @@ def get_cloud_origin(project_root: Path) -> str | None:
     """
     loader = ConfigLoader(project_root)
     cloud_cfg: CloudConfig | None = loader.load_cloud_config()
-    if cloud_cfg is None or cloud_cfg.droplet_id is None:
+    if cloud_cfg is None or cloud_cfg.droplet_ip is None:
         return None
     if cloud_cfg.domain:
         return f"https://{cloud_cfg.domain}"
-    if cloud_cfg.droplet_ip:
-        return f"http://{cloud_cfg.droplet_ip}"
-    return None
+    return f"http://{cloud_cfg.droplet_ip}"
 
 
 def check_unreferenced_custom_sources(

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -559,6 +559,10 @@ class DbtOverrides(BaseModel):
 class CloudConfig(BaseModel):
     """Cloud deployment configuration stored in .dango/cloud.yml."""
 
+    provider: str = Field(
+        default="digitalocean",
+        description="Deployment provider: 'digitalocean' or 'byos'",
+    )
     droplet_id: int | None = Field(
         default=None, description="DigitalOcean droplet ID (set after provisioning)"
     )

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -6,7 +6,7 @@ Pydantic models for configuration validation.
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
@@ -559,7 +559,7 @@ class DbtOverrides(BaseModel):
 class CloudConfig(BaseModel):
     """Cloud deployment configuration stored in .dango/cloud.yml."""
 
-    provider: str = Field(
+    provider: Literal["digitalocean", "byos"] = Field(
         default="digitalocean",
         description="Deployment provider: 'digitalocean' or 'byos'",
     )

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -384,7 +384,7 @@ def log_startup_checks(
 
         loader = ConfigLoader(project_root)
         cloud_cfg = loader.load_cloud_config()
-        if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+        if cloud_cfg is not None and cloud_cfg.droplet_ip is not None:
             logger.warning(
                 "cloud_schedule_conflict",
                 message=(

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -89,7 +89,7 @@ platform/
 | `cloud/firewall.py` | Firewall lifecycle and IP allowlisting | `create_default_firewall`, `add_allowed_ip`, `restrict_web_to_ips`, `allow_all_web`, `validate_ip_or_cidr`, `save_firewall_metadata` |
 | `cloud/spaces.py` | DigitalOcean Spaces (S3-compatible) client | `SpacesClient` |
 | `cloud/ssh.py` | SSH key management, TOFU known-hosts, command exec, SFTP | `SSHManager`, `CommandResult` |
-| `cloud/server_setup.py` | SSH-based server setup orchestration (16 idempotent steps) | `setup_server`, `SetupResult` |
+| `cloud/server_setup.py` | SSH-based server setup orchestration (16 steps + optional UFW for BYOS) | `setup_server` (`setup_ufw` param), `SetupResult` |
 | `cloud/server_status.py` | Server resource metrics, service status, PyPI version check | `ServerStatus`, `ServiceInfo`, `collect_server_status`, `check_latest_pypi_version`, `get_local_resource_usage` |
 | `cloud/domain.py` | DNS check, domain set/remove for HTTPS via Caddy | `check_dns`, `set_domain`, `remove_domain` |
 | `cloud/backup.py` | SSH-based backup and rollback | `create_backup`, `rollback`, `list_local_backups`, `rotate_local_backups`, `BackupManifest`, `BackupResult`, `RestoreResult` |

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -436,6 +436,38 @@ def _setup_unattended_upgrades(
     _mark(result, on_progress, step, changed)
 
 
+def _setup_ufw(
+    ssh: SSHManager,
+    result: SetupResult,
+    on_progress: Callable[[str, str], None] | None,
+) -> None:
+    """Step 17 (BYOS only): Install and configure UFW firewall."""
+    step = "ufw"
+    _notify(on_progress, step, "running")
+
+    # Idempotent check: if UFW active with our rules, skip
+    check = ssh.exec_command("ufw status 2>/dev/null | grep -q 'Status: active'")
+    if check.success:
+        rules = ssh.exec_command("ufw status | grep '80/tcp' && ufw status | grep '443/tcp'")
+        if rules.success:
+            _mark(result, on_progress, step, changed=False)
+            return
+
+    _run_checked(
+        ssh,
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ufw"
+        " && ufw default deny incoming"
+        " && ufw default allow outgoing"
+        " && ufw allow ssh"
+        " && ufw allow 80/tcp"
+        " && ufw allow 443/tcp"
+        " && echo 'y' | ufw enable",
+        step=step,
+        timeout=60,
+    )
+    _mark(result, on_progress, step, changed=True)
+
+
 # ---------------------------------------------------------------------------
 # Public orchestrator
 # ---------------------------------------------------------------------------
@@ -471,8 +503,9 @@ def setup_server(
     *,
     on_progress: Callable[[str, str], None] | None = None,
     domain: str | None = None,
+    setup_ufw: bool = False,
 ) -> SetupResult:
-    """Run all server setup steps on a connected droplet.
+    """Run all server setup steps on a connected server.
 
     SSH must be established as **root**.  Each step is idempotent.
 
@@ -480,6 +513,8 @@ def setup_server(
         ssh: A connected ``SSHManager`` (as root).
         on_progress: ``(step_name, status)`` callback.
         domain: FQDN for HTTPS (Caddy auto-TLS). ``None`` → HTTP-only.
+        setup_ufw: If ``True``, install and configure UFW firewall
+            (used for BYOS deployments that lack a cloud-managed firewall).
 
     Raises:
         CloudProvisioningError: If any step fails.
@@ -491,5 +526,8 @@ def setup_server(
             _setup_caddyfile(ssh, result, on_progress, domain=domain)
         else:
             step_fn(ssh, result, on_progress)
+
+    if setup_ufw:
+        _setup_ufw(ssh, result, on_progress)
 
     return result

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -409,12 +409,12 @@ class SchedulerService:
 
             loader = ConfigLoader(self._project_root)
             cloud_cfg = loader.load_cloud_config()
-            if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+            if cloud_cfg is not None and cloud_cfg.droplet_ip is not None:
                 logger.warning(
                     "dual_scheduler_warning",
                     message=(
-                        "A cloud deployment is active (droplet_id="
-                        f"{cloud_cfg.droplet_id}). Running a local scheduler "
+                        "A cloud deployment is active (server="
+                        f"{cloud_cfg.droplet_ip}). Running a local scheduler "
                         "alongside the cloud scheduler may cause duplicate job "
                         "execution."
                     ),

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -213,7 +213,7 @@ def _load_rate_limit_config(project_root: Path | None) -> RateLimitConfig | None
         if not rl.trusted_proxies:
             loader = ConfigLoader(root)
             cloud_cfg = loader.load_cloud_config()
-            if cloud_cfg is not None and cloud_cfg.droplet_id is not None:
+            if cloud_cfg is not None and cloud_cfg.droplet_ip is not None:
                 rl = rl.model_copy(update={"trusted_proxies": ["127.0.0.1"]})
 
         return rl

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -249,13 +249,13 @@ async def _get_cloud_health_data() -> dict[str, Any] | None:
     if not cloud_yml.exists():
         return None
 
-    # Check if it has a droplet_id (actual deployment vs empty config)
+    # Check if it has a droplet_ip (actual deployment vs empty config)
     try:
         from dango.config.loader import ConfigLoader
 
         loader = ConfigLoader(project_root)
         cloud_cfg = loader.load_cloud_config()
-        if cloud_cfg is None or cloud_cfg.droplet_id is None:
+        if cloud_cfg is None or cloud_cfg.droplet_ip is None:
             return None
     except Exception:  # noqa: BLE001
         return None

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -50,19 +50,19 @@ exemptions:
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
-    lines: 838
+    lines: 839
     category: exempt
     reason: "TASK-029+075e: Interactive wizard steps 1-9 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy_provision.py
-    lines: 703
+    lines: 704
     category: exempt
     reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy.py
-    lines: 669
+    lines: 689
     category: exempt
     reason: "TASK-029+075e: Deploy group with DO + BYOS routing, destroy command for both providers. Splitting would scatter the provider selection and destroy dispatch logic."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -50,15 +50,21 @@ exemptions:
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
-    lines: 579
+    lines: 838
     category: exempt
-    reason: "TASK-029: Interactive wizard steps 1-9 + non-interactive validation mode. Sequential prompt flow with display logic — splitting would scatter closely coupled wizard steps."
+    reason: "TASK-029+075e: Interactive wizard steps 1-9 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy_provision.py
-    lines: 543
+    lines: 703
     category: exempt
-    reason: "TASK-029: 10-step provisioning orchestration with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
+    reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
+    review_by: "v1.1"
+
+  - file: dango/cli/commands/deploy.py
+    lines: 669
+    category: exempt
+    reason: "TASK-029+075e: Deploy group with DO + BYOS routing, destroy command for both providers. Splitting would scatter the provider selection and destroy dispatch logic."
     review_by: "v1.1"
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
@@ -216,6 +222,12 @@ exemptions:
     lines: 542
     category: exempt
     reason: "TASK-104: Added get_action() and wait_for_action() for resize/migrate action polling. Core DO API client — splitting would fragment related HTTP methods."
+    review_by: "v1.1"
+
+  - file: dango/platform/cloud/server_setup.py
+    lines: 533
+    category: exempt
+    reason: "TASK-075e: Added optional UFW firewall step for BYOS deployments (+35 lines). 17 idempotent setup steps — splitting would scatter sequential orchestration."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/scheduled_backup.py

--- a/docs/guides/deploy-any-server.md
+++ b/docs/guides/deploy-any-server.md
@@ -1,0 +1,117 @@
+# Deploy to Any Server (BYOS)
+
+Dango can be deployed to any Ubuntu 22.04+ server — not just DigitalOcean. This guide covers the "Bring Your Own Server" (BYOS) deployment path.
+
+## Requirements
+
+- **Ubuntu 22.04+** (tested on 22.04 LTS and 24.04 LTS)
+- **Root SSH access** (key-based authentication)
+- **2+ GB RAM** (4 GB recommended)
+- **Ports 22, 80, 443** open in your provider's firewall/security group
+
+## Quick Start
+
+### Interactive
+
+```bash
+dango deploy
+# Select: "I already have a server (any cloud provider)"
+# Follow the wizard prompts
+```
+
+### Non-Interactive
+
+```bash
+dango deploy --byos \
+  --server-ip 203.0.113.10 \
+  --ssh-user root \
+  --ssh-key ~/.ssh/id_ed25519 \
+  --domain dango.example.com \
+  --admin-email admin@example.com \
+  --admin-password "YourSecurePassword123!"
+```
+
+## What Gets Installed
+
+The BYOS deployment runs the same 16-step server setup as DigitalOcean deployments, plus UFW firewall configuration:
+
+1. System packages (Python, curl, fail2ban, unattended-upgrades)
+2. `dango` system user
+3. Docker (via `get.docker.com`)
+4. Caddy reverse proxy (auto-TLS with Let's Encrypt if domain is set)
+5. Python venv with `getdango` installed
+6. SSH hardening (password auth disabled)
+7. systemd service (`dango-web`)
+8. Fail2ban SSH protection
+9. Unattended security upgrades
+10. **UFW firewall** (SSH + HTTP + HTTPS)
+
+All steps are idempotent — safe to re-run if deployment is interrupted.
+
+## Provider-Specific Tips
+
+### AWS EC2
+
+1. Launch an Ubuntu 22.04 LTS instance (t3.small or larger)
+2. Configure Security Group: allow inbound TCP 22, 80, 443
+3. Use the EC2 key pair as your `--ssh-key`
+
+### Google Cloud Compute Engine
+
+1. Create a VM with Ubuntu 22.04 LTS image (e2-medium or larger)
+2. Add VPC firewall rules: allow TCP 22, 80, 443
+3. Add your SSH public key to the VM metadata
+
+### Hetzner / Linode / Vultr / Any VPS
+
+1. Create an Ubuntu 22.04 server (2+ GB RAM)
+2. Add your SSH public key during creation
+3. Most VPS providers have ports open by default — Dango's UFW handles host-level firewall
+
+## SSH Key Options
+
+The wizard offers two choices:
+
+1. **Use an existing key** — Point to any SSH private key (e.g., `~/.ssh/id_ed25519`)
+2. **Generate a new key** — Creates `.dango/cloud_key` and displays the public key for you to add to the server
+
+## Domain & HTTPS
+
+If you configure a domain, Caddy auto-provisions a Let's Encrypt TLS certificate. Point a DNS A record to your server IP before or immediately after deployment.
+
+Without a domain, Dango is accessible at `http://<server-ip>` (HTTP only).
+
+## Post-Deployment
+
+All `dango remote` commands work with BYOS deployments:
+
+```bash
+dango remote push           # Push config/dbt changes
+dango remote status         # Server health + resource usage
+dango remote logs           # View server logs
+dango remote ssh            # SSH into the server
+dango remote env set K=V    # Set environment variables
+dango remote domain set X   # Configure a domain
+dango remote upgrade        # Upgrade Dango version
+dango remote backup         # On-demand backup (SSH-based)
+```
+
+### Commands NOT Available for BYOS
+
+These require DigitalOcean API access:
+
+- `dango remote resize` — Resize through your hosting provider instead
+- `dango remote migrate` — Provision a new server and redeploy manually
+- `dango remote firewall` — Use `ufw` commands via SSH instead
+- `dango remote backup enable/disable` — Spaces-based scheduled backups are DO-only
+
+## Teardown
+
+```bash
+dango deploy destroy
+```
+
+For BYOS, this:
+- Optionally stops Dango services on the remote server
+- Removes the local `.dango/cloud.yml` config
+- Does **NOT** delete the server itself — manage that through your hosting provider

--- a/docs/guides/monitoring.md
+++ b/docs/guides/monitoring.md
@@ -1,0 +1,71 @@
+# Monitoring
+
+Dango exposes a public health endpoint for uptime monitoring integration.
+
+## Health Endpoint
+
+```
+GET /api/health
+```
+
+- **Public** — no authentication required
+- **Minimal response** — returns `{"status": "ok"}` (no sensitive info)
+- **Load-balancer friendly** — returns 200 when the server is healthy
+
+### Example Response
+
+```json
+{
+  "status": "ok"
+}
+```
+
+### Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Server is healthy and responding |
+| 503 | Server is unhealthy or starting up |
+
+## Uptime Monitoring Setup
+
+### UptimeRobot (Free)
+
+1. Create a new monitor at [uptimerobot.com](https://uptimerobot.com)
+2. Type: HTTP(s)
+3. URL: `https://your-domain.com/api/health` (or `http://<ip>/api/health`)
+4. Monitoring interval: 5 minutes
+5. Alert contacts: your email
+
+### Better Uptime
+
+1. Create a new monitor at [betteruptime.com](https://betteruptime.com)
+2. URL: `https://your-domain.com/api/health`
+3. Check period: 3 minutes
+4. Expected status code: 200
+
+### Generic HTTP Monitor
+
+Any monitoring service that supports HTTP checks works. Configure:
+
+- **URL:** `https://your-domain.com/api/health`
+- **Method:** GET
+- **Expected status:** 200
+- **Timeout:** 10 seconds
+- **Interval:** 3–5 minutes
+
+## Platform Health (Authenticated)
+
+For detailed health information (resource usage, service status, backup health), use the authenticated endpoint:
+
+```
+GET /api/health/platform
+```
+
+This requires a valid session or API key and returns detailed metrics including CPU, memory, disk, Docker status, and backup staleness.
+
+Access this via the Dango web UI at `/health` or programmatically with an API key:
+
+```bash
+curl -H "Authorization: Bearer <api-key>" https://your-domain.com/api/health/platform
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,7 @@ module = [
     "tests.unit.test_web_ai",
     "tests.unit.test_web_ai_tools",
     "tests.unit.test_web_imports",
+    "tests.unit.test_byos",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_byos.py
+++ b/tests/unit/test_byos.py
@@ -1,0 +1,396 @@
+"""tests/unit/test_byos.py
+
+Unit tests for BYOS (Bring Your Own Server) deployment path.
+
+Tests cover:
+- BYOSConfig dataclass
+- BYOS wizard validation (SSH connectivity, non-interactive)
+- UFW setup step in server_setup.py
+- BYOS guards on DO-only operations (resize, migrate, firewall)
+- CloudConfig provider field
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. CloudConfig provider field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCloudConfigProvider:
+    def test_default_provider_is_digitalocean(self):
+        """Default provider should be 'digitalocean'."""
+        from dango.config.models import CloudConfig
+
+        config = CloudConfig()
+        assert config.provider == "digitalocean"
+
+    def test_byos_provider(self):
+        """Provider can be set to 'byos'."""
+        from dango.config.models import CloudConfig
+
+        config = CloudConfig(provider="byos", droplet_ip="1.2.3.4")
+        assert config.provider == "byos"
+        assert config.droplet_ip == "1.2.3.4"
+        assert config.droplet_id is None
+
+    def test_backwards_compatible_no_provider(self):
+        """Existing cloud.yml without provider field defaults to digitalocean."""
+        from dango.config.models import CloudConfig
+
+        config = CloudConfig(droplet_id=123, droplet_ip="1.2.3.4")
+        assert config.provider == "digitalocean"
+
+
+# ---------------------------------------------------------------------------
+# 2. BYOSConfig dataclass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBYOSConfig:
+    def test_byos_config_creation(self):
+        """BYOSConfig can be created with required fields."""
+        from dango.cli.commands.deploy_wizard import BYOSConfig
+
+        config = BYOSConfig(
+            server_ip="1.2.3.4",
+            ssh_user="root",
+            ssh_key_path="/home/user/.ssh/id_ed25519",
+            domain="example.com",
+            admin_email="admin@example.com",
+            admin_password="SecurePassword123!",
+            skip_oauth=False,
+            skip_initial_sync=False,
+        )
+        assert config.server_ip == "1.2.3.4"
+        assert config.ssh_user == "root"
+        assert config.domain == "example.com"
+
+    def test_byos_config_no_domain(self):
+        """BYOSConfig works without a domain."""
+        from dango.cli.commands.deploy_wizard import BYOSConfig
+
+        config = BYOSConfig(
+            server_ip="1.2.3.4",
+            ssh_user="root",
+            ssh_key_path="/path/to/key",
+            domain=None,
+            admin_email="admin@example.com",
+            admin_password="SecurePassword123!",
+            skip_oauth=True,
+            skip_initial_sync=True,
+        )
+        assert config.domain is None
+        assert config.skip_oauth is True
+
+
+# ---------------------------------------------------------------------------
+# 3. BYOSResult dataclass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBYOSResult:
+    def test_byos_result_creation(self):
+        """BYOSResult can be created with required fields."""
+        from dango.cli.commands.deploy_provision import BYOSResult
+
+        result = BYOSResult(server_ip="1.2.3.4")
+        assert result.server_ip == "1.2.3.4"
+        assert result.domain is None
+        assert result.url == ""
+        assert result.warnings == []
+
+    def test_byos_result_with_warnings(self):
+        """BYOSResult can carry warnings."""
+        from dango.cli.commands.deploy_provision import BYOSResult
+
+        result = BYOSResult(
+            server_ip="1.2.3.4",
+            domain="example.com",
+            url="https://example.com",
+            warnings=["Health check failed"],
+        )
+        assert len(result.warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. BYOS non-interactive validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBYOSNonInteractive:
+    def test_missing_server_ip_exits(self, tmp_path):
+        """--byos without --server-ip should fail."""
+        from dango.cli.commands.deploy_wizard import run_byos_non_interactive
+
+        # Create sources.yml
+        (tmp_path / ".dango").mkdir(parents=True)
+        (tmp_path / ".dango" / "sources.yml").write_text("sources: []\n")
+
+        with pytest.raises(SystemExit):
+            run_byos_non_interactive(tmp_path, server_ip=None)
+
+    def test_missing_admin_email_exits(self, tmp_path):
+        """--byos without --admin-email should fail."""
+        from dango.cli.commands.deploy_wizard import run_byos_non_interactive
+
+        (tmp_path / ".dango").mkdir(parents=True)
+        (tmp_path / ".dango" / "sources.yml").write_text("sources: []\n")
+
+        with pytest.raises(SystemExit):
+            run_byos_non_interactive(tmp_path, server_ip="1.2.3.4", admin_email=None)
+
+    def test_missing_sources_yml_exits(self, tmp_path):
+        """BYOS should fail without sources.yml."""
+        from dango.cli.commands.deploy_wizard import run_byos_non_interactive
+
+        (tmp_path / ".dango").mkdir(parents=True)
+        # No sources.yml
+
+        with pytest.raises(SystemExit):
+            run_byos_non_interactive(
+                tmp_path,
+                server_ip="1.2.3.4",
+                admin_email="a@b.com",
+                admin_password="SecurePassword123!",
+            )
+
+    def test_missing_ssh_key_exits(self, tmp_path):
+        """BYOS should fail if SSH key doesn't exist."""
+        from dango.cli.commands.deploy_wizard import run_byos_non_interactive
+
+        (tmp_path / ".dango").mkdir(parents=True)
+        (tmp_path / ".dango" / "sources.yml").write_text("sources: []\n")
+
+        with pytest.raises(SystemExit):
+            run_byos_non_interactive(
+                tmp_path,
+                server_ip="1.2.3.4",
+                ssh_key_path="/nonexistent/key",
+                admin_email="a@b.com",
+                admin_password="SecurePassword123!",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. SSH connectivity validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHValidation:
+    def test_ssh_connection_failure_exits(self):
+        """SSH connection failure should raise SystemExit."""
+        from dango.cli.commands.deploy_wizard import _validate_ssh_connectivity
+
+        with patch("dango.platform.cloud.ssh.SSHManager") as MockSSH:
+            mock_ssh = MockSSH.return_value
+            mock_ssh.connect.side_effect = ConnectionError("Connection refused")
+
+            with pytest.raises(SystemExit):
+                _validate_ssh_connectivity("1.2.3.4", "root", "/path/to/key")
+
+    def test_non_ubuntu_warns(self):
+        """Non-Ubuntu OS should warn but not fail."""
+        from dango.cli.commands.deploy_wizard import _validate_ssh_connectivity
+        from dango.platform.cloud.ssh import CommandResult
+
+        with patch("dango.platform.cloud.ssh.SSHManager") as MockSSH:
+            mock_ssh = MockSSH.return_value
+            mock_ssh.connect.return_value = None
+            mock_ssh.exec_command.return_value = CommandResult(
+                stdout='ID=debian\nNAME="Debian"', stderr="", exit_code=0
+            )
+            mock_ssh.disconnect.return_value = None
+
+            # Should not raise — just warns
+            _validate_ssh_connectivity("1.2.3.4", "root", "/path/to/key")
+
+
+# ---------------------------------------------------------------------------
+# 6. UFW setup step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUFWSetup:
+    def _make_ssh_mock(self, *, ufw_active=False, rules_present=False):
+        """Return a mock SSHManager for UFW testing."""
+        from dango.platform.cloud.ssh import CommandResult
+
+        def _exec(command, timeout=None):
+            if "ufw status" in command and "grep -q" in command:
+                return CommandResult(
+                    stdout="",
+                    stderr="",
+                    exit_code=0 if ufw_active else 1,
+                )
+            if "ufw status | grep" in command:
+                return CommandResult(
+                    stdout="80/tcp ALLOW",
+                    stderr="",
+                    exit_code=0 if rules_present else 1,
+                )
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh = MagicMock()
+        ssh.exec_command.side_effect = _exec
+        return ssh
+
+    def test_ufw_installs_when_not_active(self):
+        """UFW step should install and enable when not active."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_ufw
+
+        ssh = self._make_ssh_mock(ufw_active=False)
+        result = SetupResult()
+
+        _setup_ufw(ssh, result, None)
+
+        assert "ufw" in result.steps_completed
+        assert "ufw" not in result.steps_skipped
+
+    def test_ufw_skips_when_active_with_rules(self):
+        """UFW step should skip when already active with rules."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_ufw
+
+        ssh = self._make_ssh_mock(ufw_active=True, rules_present=True)
+        result = SetupResult()
+
+        _setup_ufw(ssh, result, None)
+
+        assert "ufw" in result.steps_skipped
+        assert "ufw" not in result.steps_completed
+
+    def test_setup_server_with_ufw(self):
+        """setup_server(setup_ufw=True) includes the UFW step."""
+        from dango.platform.cloud.server_setup import setup_server
+        from dango.platform.cloud.ssh import CommandResult
+
+        def _exec(command, timeout=None):
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh = MagicMock()
+        ssh.exec_command.side_effect = _exec
+        ssh.write_remote_file = MagicMock()
+
+        result = setup_server(ssh, setup_ufw=True)
+
+        assert "ufw" in result.steps_completed or "ufw" in result.steps_skipped
+
+    def test_setup_server_without_ufw(self):
+        """setup_server(setup_ufw=False) skips the UFW step."""
+        from dango.platform.cloud.server_setup import setup_server
+        from dango.platform.cloud.ssh import CommandResult
+
+        def _exec(command, timeout=None):
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh = MagicMock()
+        ssh.exec_command.side_effect = _exec
+        ssh.write_remote_file = MagicMock()
+
+        result = setup_server(ssh, setup_ufw=False)
+
+        assert "ufw" not in result.steps_completed
+        assert "ufw" not in result.steps_skipped
+
+
+# ---------------------------------------------------------------------------
+# 7. BYOS guards on DO-only operations
+# ---------------------------------------------------------------------------
+
+
+_PATCH_REQUIRE = "dango.cli.commands.remote._require_cloud_deployment"
+_PATCH_LOADER = "dango.config.loader.ConfigLoader"
+_PATCH_REQUIRE_CTX = "dango.cli.utils.require_project_context"
+
+
+def _make_byos_config() -> MagicMock:
+    """Return a mock CloudConfig for BYOS."""
+    cfg = MagicMock()
+    cfg.provider = "byos"
+    cfg.droplet_id = None
+    cfg.droplet_ip = "1.2.3.4"
+    cfg.firewall_id = None
+    cfg.ssh_key_path = ".dango/cloud_key"
+    cfg.region = "nyc1"
+    cfg.size = "s-2vcpu-4gb"
+    cfg.spaces = None
+    return cfg
+
+
+@pytest.mark.unit
+class TestBYOSGuardResize:
+    def test_byos_resize_blocked(self, tmp_path):
+        """Resize should be blocked for BYOS deployments."""
+        from click.testing import CliRunner
+
+        from dango.cli.commands.remote import remote
+
+        cfg = _make_byos_config()
+
+        with (
+            patch(_PATCH_REQUIRE, return_value=(cfg, tmp_path)),
+            patch("dango.cli.utils.find_project_root", return_value=tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                remote, ["resize", "s-4vcpu-8gb"], obj={"project_root": tmp_path}
+            )
+
+        assert result.exit_code == 1
+        assert "not available for BYOS" in result.output
+
+
+@pytest.mark.unit
+class TestBYOSGuardMigrate:
+    def test_byos_migrate_blocked(self, tmp_path):
+        """Migrate should be blocked for BYOS deployments."""
+        from click.testing import CliRunner
+
+        from dango.cli.commands.remote import remote
+
+        cfg = _make_byos_config()
+
+        with (
+            patch(_PATCH_REQUIRE, return_value=(cfg, tmp_path)),
+            patch("dango.cli.utils.find_project_root", return_value=tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                remote,
+                ["migrate", "--size", "s-4vcpu-8gb"],
+                obj={"project_root": tmp_path},
+            )
+
+        assert result.exit_code == 1
+        assert "not available for BYOS" in result.output
+
+
+@pytest.mark.unit
+class TestBYOSGuardFirewall:
+    def test_byos_firewall_blocked(self, tmp_path):
+        """Firewall commands should be blocked for BYOS deployments."""
+        from click.testing import CliRunner
+
+        from dango.cli.commands.remote import remote
+
+        cfg = _make_byos_config()
+
+        with (
+            patch(_PATCH_REQUIRE, return_value=(cfg, tmp_path)),
+            patch("dango.cli.utils.find_project_root", return_value=tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(remote, ["firewall", "list"], obj={"project_root": tmp_path})
+
+        assert result.exit_code == 1
+        assert "ufw" in result.output.lower()

--- a/tests/unit/test_deploy_wizard.py
+++ b/tests/unit/test_deploy_wizard.py
@@ -165,7 +165,7 @@ class TestNonInteractive:
 class TestDeploymentGuard:
     @patch("dango.cli.utils.find_project_root")
     def test_cloud_yml_exists_blocks(self, mock_find, project_root):
-        """Existing cloud.yml with droplet_id blocks new deployment."""
+        """Existing cloud.yml with droplet_ip blocks new deployment."""
         from click.testing import CliRunner
 
         from dango.cli.commands.deploy import deploy
@@ -173,7 +173,7 @@ class TestDeploymentGuard:
         mock_find.return_value = project_root
 
         cloud_yml = project_root / ".dango" / "cloud.yml"
-        cloud_yml.write_text("droplet_id: 12345\ndroplet_ip: 1.2.3.4\n")
+        cloud_yml.write_text("droplet_ip: 1.2.3.4\n")
 
         runner = CliRunner()
         result = runner.invoke(deploy, [], obj={"project_root": project_root})

--- a/tests/unit/test_remote_backup_cli.py
+++ b/tests/unit/test_remote_backup_cli.py
@@ -25,6 +25,7 @@ from dango.cli.commands.remote import remote
 def _make_cloud_config(*, has_spaces: bool = True) -> MagicMock:
     """Return a mock CloudConfig."""
     cfg = MagicMock()
+    cfg.provider = "digitalocean"
     cfg.droplet_id = 42
     cfg.droplet_ip = "1.2.3.4"
     cfg.firewall_id = "fw-abc"

--- a/tests/unit/test_remote_management_cli.py
+++ b/tests/unit/test_remote_management_cli.py
@@ -172,7 +172,7 @@ class TestRemoteStatusCommand:
         assert "No cloud deployment" in result.output
 
     def test_no_droplet_ip_exits_with_error(self, tmp_path):
-        """Exits when droplet_id is set but droplet_ip is missing."""
+        """Exits when droplet_ip is missing (no active deployment)."""
         cloud_cfg = _make_cloud_config(droplet_ip=None)
         mock_loader = _make_loader(cloud_cfg=cloud_cfg)
 
@@ -183,7 +183,7 @@ class TestRemoteStatusCommand:
             result = _run(["status"], tmp_path, catch_exceptions=True)
 
         assert result.exit_code != 0
-        assert "No droplet IP" in result.output
+        assert "No cloud deployment" in result.output
 
     def test_ssh_connection_failure(self, tmp_path):
         """Exits when SSH connection fails."""

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -417,11 +417,11 @@ class TestSchedulerServiceCloudWarning:
     """Test dual-scheduler cloud detection."""
 
     def test_cloud_warning_logged(self, tmp_path):
-        """Warning should be logged if cloud config has a droplet_id."""
+        """Warning should be logged if cloud config has a droplet_ip."""
         svc = _make_service(tmp_path)
 
         cloud_cfg = MagicMock()
-        cloud_cfg.droplet_id = 12345
+        cloud_cfg.droplet_ip = "1.2.3.4"
 
         mock_loader = MagicMock()
         mock_loader.return_value.load_cloud_config.return_value = cloud_cfg
@@ -437,11 +437,11 @@ class TestSchedulerServiceCloudWarning:
         assert call_args[0][0] == "dual_scheduler_warning"
 
     def test_no_cloud_warning_when_no_deployment(self, tmp_path):
-        """No warning when cloud config has no droplet_id."""
+        """No warning when cloud config has no droplet_ip."""
         svc = _make_service(tmp_path)
 
         cloud_cfg = MagicMock()
-        cloud_cfg.droplet_id = None
+        cloud_cfg.droplet_ip = None
 
         mock_loader = MagicMock()
         mock_loader.return_value.load_cloud_config.return_value = cloud_cfg

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -253,7 +253,7 @@ class TestLogStartupChecks:
 
         scheds = [ScheduleConfig(name="s1", cron="daily", sources=["csv"])]
         cloud_cfg = MagicMock()
-        cloud_cfg.droplet_id = 12345
+        cloud_cfg.droplet_ip = "1.2.3.4"
 
         with (
             patch(f"{_MOD}.logger") as mock_logger,

--- a/tests/unit/test_web_health.py
+++ b/tests/unit/test_web_health.py
@@ -165,7 +165,7 @@ class TestDiskWarningDeduplication:
         mock_data.return_value = _base_health_data(disk_status="warning", used_pct=85)
         # Create cloud.yml to simulate cloud deployment
         (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
-        (tmp_path / ".dango" / "cloud.yml").write_text("droplet_id: 123\n")
+        (tmp_path / ".dango" / "cloud.yml").write_text("droplet_ip: 1.2.3.4\n")
         app = _make_app(tmp_path)
         client = TestClient(app)
 


### PR DESCRIPTION
## Summary

- Add "I already have a server" option to `dango deploy` — enables deployment to any Ubuntu 22.04+ server via SSH, not just DigitalOcean
- Add `provider` field to CloudConfig (`"digitalocean"` or `"byos"`) for distinguishing deployment types
- Change all "deployment exists" guards from `droplet_id` to `droplet_ip` (BYOS has no droplet ID)
- Add BYOS wizard (interactive + `--byos` non-interactive), provisioning orchestration, and UFW firewall step
- Add guards on DO-only operations (resize, migrate, firewall) with helpful BYOS-specific messages
- Add BYOS-specific destroy flow (stops services, removes config, does NOT delete the server)
- Add deployment guide (`docs/guides/deploy-any-server.md`) and monitoring guide (`docs/guides/monitoring.md`)
- Add 20 unit tests for BYOS functionality; all 2914 tests pass

## Files changed (30 files, +1362 -98)

**Core implementation:**
- `dango/config/models.py` — `provider` field on CloudConfig
- `dango/cli/commands/deploy.py` — `--byos`, `--server-ip`, `--ssh-user`, `--ssh-key` flags + routing
- `dango/cli/commands/deploy_wizard.py` — `BYOSConfig`, BYOS wizard, non-interactive validation
- `dango/cli/commands/deploy_provision.py` — `BYOSResult`, `run_byos_setup()` orchestration
- `dango/platform/cloud/server_setup.py` — UFW firewall step (`setup_ufw=True`)

**Guard changes (droplet_id → droplet_ip):**
- `dango/config/helpers.py`, `dango/config/schedules.py`, `dango/web/app.py`
- `dango/cli/commands/remote.py`, `dango/cli/commands/remote_backup.py`, `dango/cli/commands/remote_mgmt.py`
- `dango/cli/utils.py`, `dango/web/routes/health.py`, `dango/platform/scheduling/scheduler.py`

**BYOS guards on DO-only ops:**
- `dango/cli/commands/remote_ops.py` — resize, migrate
- `dango/cli/commands/remote.py` — firewall subgroup
- `dango/cli/commands/remote_backup.py` — Spaces backup

## Test plan

- [x] All 2914 existing tests pass (30 skipped)
- [x] 20 new BYOS unit tests pass (`tests/unit/test_byos.py`)
- [x] `ruff check dango/` — clean
- [x] `ruff format --check dango/` — clean
- [x] `mypy` — clean on all changed source files
- [x] Pre-commit hooks pass
- [x] `grep -rn 'droplet_id is' dango/ --include='*.py'` — only DO-specific files remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)