### PR TITLE
P8-003: Add GitHub Actions CI workflow to dango init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2030 | — (metadata-only) |
 | `cli/source_wizard.py` | 1878 | — |
 | `visualization/metabase.py` | 1149 | — |
-| `cli/init.py` | 1125 | — |
+| `cli/init.py` | 1282 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 979 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -41,7 +41,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1125 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1282 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (1878 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -71,6 +71,9 @@ class ProjectInitializer:
             # Create default .gitignore
             self._create_gitignore()
 
+            # Create CI workflow
+            self._create_ci_workflow()
+
             # Create README
             self._create_readme(config)
 
@@ -284,6 +287,34 @@ secrets/
             with open(gitignore_path, "w", encoding="utf-8") as f:
                 f.write(gitignore_content)
             print_success("Created .gitignore")
+
+    def _create_ci_workflow(self):
+        """Create GitHub Actions CI workflow for PR validation."""
+        workflow_content = """\
+name: Dango Validate
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install getdango
+      - run: dango config validate
+      - run: cd dbt && dbt parse --profiles-dir .
+"""
+        workflow_dir = self.project_dir / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True, exist_ok=True)
+
+        workflow_path = workflow_dir / "dango-validate.yml"
+        with open(workflow_path, "w", encoding="utf-8") as f:
+            f.write(workflow_content)
+
+        print_success("Created .github/workflows/dango-validate.yml")
 
     def _create_readme(self, config: DangoConfig):
         """Create README.md"""

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -124,9 +124,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1125
+    lines: 1282
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)

--- a/tests/unit/test_cli_init_ci.py
+++ b/tests/unit/test_cli_init_ci.py
@@ -1,0 +1,51 @@
+"""tests/unit/test_cli_init_ci.py
+
+Tests for CI workflow generation in dango init.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dango.cli.init import ProjectInitializer
+
+
+@pytest.mark.unit
+class TestCreateCiWorkflow:
+    """Tests for ProjectInitializer._create_ci_workflow()."""
+
+    def test_creates_workflow_file(self, tmp_path: Path) -> None:
+        """_create_ci_workflow creates the expected file."""
+        initializer = ProjectInitializer(tmp_path)
+        initializer._create_ci_workflow()
+        wf = tmp_path / ".github" / "workflows" / "dango-validate.yml"
+        assert wf.exists()
+
+    def test_workflow_is_valid_yaml(self, tmp_path: Path) -> None:
+        """Generated workflow parses as valid YAML."""
+        initializer = ProjectInitializer(tmp_path)
+        initializer._create_ci_workflow()
+        wf = tmp_path / ".github" / "workflows" / "dango-validate.yml"
+        data = yaml.safe_load(wf.read_text())
+        assert data is not None
+        assert data["name"] == "Dango Validate"
+        assert "jobs" in data
+
+    def test_workflow_commands(self, tmp_path: Path) -> None:
+        """Workflow uses dango config validate (not full validate) and dbt parse."""
+        initializer = ProjectInitializer(tmp_path)
+        initializer._create_ci_workflow()
+        content = (tmp_path / ".github" / "workflows" / "dango-validate.yml").read_text()
+        assert "dango config validate" in content
+        assert "dbt parse --profiles-dir ." in content
+        assert "pip install getdango" in content
+
+    def test_idempotent_on_existing_directory(self, tmp_path: Path) -> None:
+        """Works when .github/workflows/ already exists."""
+        (tmp_path / ".github" / "workflows").mkdir(parents=True)
+        initializer = ProjectInitializer(tmp_path)
+        initializer._create_ci_workflow()
+        assert (tmp_path / ".github" / "workflows" / "dango-validate.yml").exists()


### PR DESCRIPTION
## Summary
- Adds `_create_ci_workflow()` to `ProjectInitializer` that generates `.github/workflows/dango-validate.yml` during `dango init`
- Workflow runs `dango config validate` + `dbt parse --profiles-dir .` on PRs to `main`, catching config/syntax errors before merge
- Updated `docs/file-exemptions.yml` with correct `init.py` line count (1282)

## Test plan
- [x] `pytest tests/unit/test_cli_init_ci.py -v` — 4 tests pass (file creation, YAML validity, correct commands, idempotency)
- [x] `ruff check` + `ruff format --check` — clean
- [x] All pre-commit hooks pass
- [x] `wc -l` matches file-exemptions.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)