### PR TITLE
P8-002: Enable Shopify source with API key auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | `dango/ingestion/dlt_sources/` | Vendored third-party dlt connectors (127 files). Rarely modified. |
 | `dango/web/static/` | Frontend HTML/CSS/JS assets. |
 | `tests/` | Read source module first, then find its tests. |
-| `dango/ingestion/sources/registry.py` | 2030-line metadata registry. Only when adding a new source. |
+| `dango/ingestion/sources/registry.py` | 2063-line metadata registry. Only when adding a new source. |
 | `dango/templates/` | Jinja2 templates. Only when modifying project init or model generation. |
 
 ## Decision Tree
@@ -330,7 +330,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 2276 | — (exempt, too risky) |
-| `ingestion/sources/registry.py` | 2030 | — (metadata-only) |
+| `ingestion/sources/registry.py` | 2063 | — (metadata-only) |
 | `cli/source_wizard.py` | 2148 | — |
 | `visualization/metabase.py` | 1149 | — |
 | `cli/init.py` | 1282 | — |
@@ -348,7 +348,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/source.py` | 658 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 652 | — (remote group + push/rollback/firewall/domain) |
 | `cli/validate.py` | 651 | — |
-| `config/models.py` | 594 | — (Pydantic config models) |
+| `config/models.py` | 620 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 577 | — |
 | `web/routes/catalog.py` | 566 | — (data catalog: columns, profiling, lineage, impact) |

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -9,7 +9,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports, `__all__` | Re-exports all public symbols |
-| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `LocalFilesSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `CloudConfig` (incl. `provider`, `firewall_id`) |
+| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `LocalFilesSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `ShopifySourceConfig`, `CloudConfig` (incl. `provider`, `firewall_id`) |
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
 | `schedules.py` | Schedule config models, validation, reload | `ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`, `CRON_PRESETS`, `load_schedules_config`, `validate_schedules`, `reload_schedules`, `log_startup_checks` |

--- a/dango/config/__init__.py
+++ b/dango/config/__init__.py
@@ -22,6 +22,7 @@ from .models import (
     GoogleSheetsSourceConfig,
     LocalFilesSourceConfig,
     ProjectContext,
+    ShopifySourceConfig,
     SourcesConfig,
     SourceType,
     SpacesConfig,
@@ -49,6 +50,7 @@ __all__ = [
     "CSVSourceConfig",
     "LocalFilesSourceConfig",
     "GoogleSheetsSourceConfig",
+    "ShopifySourceConfig",
     "StripeSourceConfig",
     # Cloud config models
     "CloudConfig",

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -192,6 +192,27 @@ class StripeSourceConfig(BaseModel):
     end_date: datetime | None = None
 
 
+class ShopifySourceConfig(BaseModel):
+    """Shopify API source configuration"""
+
+    private_app_password_env: str = Field(
+        default="SHOPIFY_ACCESS_TOKEN",
+        description="Environment variable containing Shopify Admin API access token",
+    )
+    shop_url: str = Field(default="", description="Shopify store URL (e.g., mystore.myshopify.com)")
+    api_version: str = Field(default="2023-10", description="Shopify API version")
+    start_date: str | None = Field(
+        default=None, description="Start date for data loading (YYYY-MM-DD)"
+    )
+    end_date: str | None = Field(default=None, description="End date for data loading (YYYY-MM-DD)")
+    order_status: str = Field(
+        default="any", description="Order status filter: any, open, closed, cancelled"
+    )
+    resources: list[str] | None = Field(
+        default=None, description="Resources to sync (orders, customers, products)"
+    )
+
+
 class FacebookAdsSourceConfig(BaseModel):
     """Facebook Ads API source configuration"""
 
@@ -389,6 +410,7 @@ class DataSource(BaseModel):
 
     # E-commerce & Payment
     stripe: StripeSourceConfig | None = None
+    shopify: ShopifySourceConfig | None = None
 
     # Development
     github: GitHubSourceConfig | None = None

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -9,8 +9,7 @@ Loads data into DuckDB from external sources via dlt pipelines and local files, 
 Registry contains 33 sources: 27 dlt verified (vendored in `dlt_sources/`) + CSV
 (custom, hidden) + Local Files (unified, primary wizard entry) + dlt_native
 (passthrough) + filesystem (hidden, cloud storage) + rest_api (dlt core built-in) +
-PostgreSQL (dlt sql_database wrapper). Excluded: generic `sql_database` (too complex
-for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see P5-006).
+PostgreSQL (dlt sql_database wrapper). Excluded: generic `sql_database` (too complex for wizard — use dlt_native).
 
 ## Files
 

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -40,8 +40,6 @@ class AuthType(str, Enum):
 #   - sql_database (generic): Too complex for wizard UI (arbitrary table selectors,
 #     multiple DB dialects). Use dlt_native with dlt's sql_database for advanced
 #     multi-database setups.
-#   - Shopify: wizard_enabled=False pending P5-006 investigation — dlt's shopify_dlt
-#     connector may be incompatible with Shopify's Jan 2026 API deprecation.
 
 # ============================================================================
 # SOURCE REGISTRY
@@ -719,10 +717,24 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "display_name": "Shopify",
         "category": "E-commerce & Payment",
         "description": "Load e-commerce data from Shopify (orders, customers, products, etc.)",
-        "auth_type": AuthType.OAUTH,
-        "dlt_package": "shopify_dlt",  # Note: source name is shopify_dlt
+        "auth_type": AuthType.API_KEY,
+        "dlt_package": "shopify_dlt",
         "dlt_function": "shopify_source",
-        "required_params": [],
+        "required_params": [
+            {
+                "name": "shop_url",
+                "type": "string",
+                "prompt": "Shop URL (e.g., mystore.myshopify.com)",
+                "help": "Your Shopify store domain without https://",
+            },
+            {
+                "name": "private_app_password_env",
+                "type": "secret",
+                "env_var": "SHOPIFY_ACCESS_TOKEN",
+                "prompt": "Shopify Admin API access token",
+                "help": "Find in Shopify Admin > Apps > Develop apps > your app > API credentials",
+            },
+        ],
         "optional_params": [
             {
                 "name": "resources",
@@ -736,20 +748,41 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                 "type": "date",
                 "prompt": "Start date (YYYY-MM-DD)",
                 "default": None,
+                "help": "How far back to load data on first sync. Default: all available data.",
+            },
+            {
+                "name": "end_date",
+                "type": "date",
+                "prompt": "End date (YYYY-MM-DD)",
+                "default": None,
+                "help": "Optional end date to limit data range.",
+            },
+            {
+                "name": "api_version",
+                "type": "string",
+                "prompt": "Shopify API version",
+                "default": "2023-10",
+                "help": "Shopify API version. Default: 2023-10",
+            },
+            {
+                "name": "order_status",
+                "type": "choice",
+                "prompt": "Order status filter",
+                "choices": ["any", "open", "closed", "cancelled"],
+                "default": "any",
+                "help": "Filter orders by status. Default: all statuses.",
             },
         ],
         "setup_guide": [
-            "1. OAuth setup runs automatically during 'dango source add' — follow the prompts",
-            "2. OR manually run: dango oauth shopify",
-            "3. Either way: create a custom app in Shopify Admin > Apps > Develop apps",
-            "4. Configure Admin API scopes (read permissions needed)",
-            "5. Install app and reveal Admin API access token",
-            "6. Enter shop URL (e.g., mystore.myshopify.com) and access token when prompted",
-            "7. Credentials are permanent (stored in .dlt/secrets.toml)",
+            "1. Go to Shopify Admin > Settings > Apps and sales channels > Develop apps",
+            "2. Create a custom app (or use an existing one)",
+            "3. Configure Admin API scopes: read_orders, read_customers, read_products",
+            "4. Install the app and reveal the Admin API access token",
+            "5. Copy the access token (starts with shpat_)",
         ],
         "docs_url": "https://dlthub.com/docs/dlt-ecosystem/verified-sources/shopify",
         "cost_warning": "Included with Shopify plan",
-        "wizard_enabled": False,  # Disabled: OAuth 2.0 rewrite needed
+        "wizard_enabled": True,
         "popularity": 9,
         "capabilities": {
             "performance_metrics": False,

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -100,9 +100,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
-    lines: 2030
+    lines: 2063
     category: exempt
-    reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type. P5-011 added capability metadata (+313 lines). 5c-007 added local_files entry (+70 lines)."
+    reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type. P5-011 added capability metadata (+313 lines). 5c-007 added local_files entry (+70 lines). P8-002 enabled Shopify (+33 lines)."
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py
@@ -207,9 +207,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/config/models.py
-    lines: 594
+    lines: 620
     category: exempt
-    reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
+    reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). P8-002 added ShopifySourceConfig (+25 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py


### PR DESCRIPTION
## Summary
- Fix Shopify auth type from `OAUTH` → `API_KEY` (it uses a private app password, not OAuth 2.0)
- Add `ShopifySourceConfig` Pydantic model with all dlt source params (shop_url, private_app_password_env, api_version, start_date, end_date, order_status, resources)
- Rewrite registry entry with proper required/optional params, setup guide, and `wizard_enabled=True`
- Update docs (ingestion/config CLAUDE.md, file-exemptions.yml, root CLAUDE.md line counts)

## Test plan
- [x] `ruff check` + `ruff format --check` pass
- [x] `mypy dango/config/models.py` passes
- [x] `ShopifySourceConfig` instantiates correctly
- [x] Registry returns `wizard_enabled=True` and `auth_type=api_key`
- [x] `DataSource(type='shopify', shopify=ShopifySourceConfig(...))` works
- [x] `pytest tests/unit/test_config_models.py tests/unit/test_oauth_validation.py` — 96 tests pass
- [x] All pre-commit hooks pass
- [x] `wc -l` matches file-exemptions.yml and root CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)