### PR TITLE
P8-004: Deployment version control (git guardrails + deploy journal)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ dango/                          # Python package source
 │   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (839 lines)
 │   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (704 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
-│   │   ├── remote.py           # remote group + push/rollback/firewall/domain (652 lines)
+│   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
 │   │   ├── remote_ops.py       # remote upgrade/resize/migrate
 │   │   ├── remote_backup.py    # remote backup subgroup
@@ -234,7 +234,7 @@ dango/                          # Python package source
 │   │   ├── domain.py           # DNS check, domain set/remove
 │   │   ├── backup.py           # Backup + rollback + service lifecycle
 │   │   ├── file_sync.py        # Project file sync (SFTP + rsync)
-│   │   ├── deployer.py         # Push deploy workflow + deploy lock (574 lines)
+│   │   ├── deployer.py         # Push deploy workflow + deploy lock (578 lines)
 │   │   ├── deploy_journal.py   # Append-only JSONL deployment history
 │   │   ├── scheduled_backup.py # Server-side scheduled backup (505 lines)
 │   │   ├── resize.py           # In-place droplet resize
@@ -348,9 +348,9 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
 | `cli/commands/source.py` | 658 | — (extracted from main.py by TASK-005) |
-| `cli/commands/remote.py` | 693 | — (remote group + push/rollback/firewall/domain) |
-| `cli/commands/remote_mgmt.py` | 502 | — (remote status/logs/ssh/query + deployment history) |
-| `platform/cloud/deployer.py` | 574 | — (push deploy workflow + deploy lock + journal) |
+| `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
+| `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
+| `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 594 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ dango/                          # Python package source
 │   │   ├── webhook.py          # Event types, config, async sender
 │   │   └── slack.py            # Slack Block Kit formatter
 │   ├── cloud/                  # Cloud components (TASK-022+)
-│   │   ├── __init__.py         # Re-exports 63 symbols
+│   │   ├── __init__.py         # Re-exports 69 symbols
 │   │   ├── digitalocean.py     # DO REST API v2 client (542 lines)
 │   │   ├── provisioning.py     # Size tiers, regions, provision_droplet()
 │   │   ├── firewall.py         # Firewall lifecycle, IP allowlisting
@@ -234,7 +234,8 @@ dango/                          # Python package source
 │   │   ├── domain.py           # DNS check, domain set/remove
 │   │   ├── backup.py           # Backup + rollback + service lifecycle
 │   │   ├── file_sync.py        # Project file sync (SFTP + rsync)
-│   │   ├── deployer.py         # Push deploy workflow + deploy lock
+│   │   ├── deployer.py         # Push deploy workflow + deploy lock (574 lines)
+│   │   ├── deploy_journal.py   # Append-only JSONL deployment history
 │   │   ├── scheduled_backup.py # Server-side scheduled backup (505 lines)
 │   │   ├── resize.py           # In-place droplet resize
 │   │   ├── migrate.py          # Server migration via Spaces
@@ -284,7 +285,8 @@ dango/                          # Python package source
 │   ├── data_validation.py      # Data validation utilities
 │   ├── env_file.py             # .env file parsing and serialization
 │   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
-│   └── post_sync.py            # Post-sync hook dispatcher (~486 lines)
+│   ├── post_sync.py            # Post-sync hook dispatcher (~486 lines)
+│   └── git_info.py             # Git repository info + deployment guardrails
 │
 ├── migrations/                 # Level 0 — Database migration framework
 │   ├── __init__.py             # Public API: apply_all_pending(), get_all_status()
@@ -346,7 +348,9 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
 | `cli/commands/source.py` | 658 | — (extracted from main.py by TASK-005) |
-| `cli/commands/remote.py` | 652 | — (remote group + push/rollback/firewall/domain) |
+| `cli/commands/remote.py` | 693 | — (remote group + push/rollback/firewall/domain) |
+| `cli/commands/remote_mgmt.py` | 502 | — (remote status/logs/ssh/query + deployment history) |
+| `platform/cloud/deployer.py` | 574 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 594 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |

--- a/dango/auth/CLAUDE.md
+++ b/dango/auth/CLAUDE.md
@@ -15,7 +15,7 @@ User authentication and access control for Dango. Handles password-based login w
 | `sessions.py` | 289 | High-level session + API key lifecycle | `create_session()`, `validate_session()`, `validate_partial_session()`, `create_api_key()`, `validate_api_key()` |
 | `permissions.py` | 195 | 29 permissions, 3 role mappings | `PERMISSIONS`, `ROLE_PERMISSIONS`, `has_permission()`, `require_permission()` |
 | `lockout.py` | 181 | Brute-force protection (5 attempts / 15-min) | `record_failed_login()`, `check_account_locked()`, `unlock_account()` |
-| `audit.py` | 206 | 23 event types to `.dango/logs/audit.jsonl` | `AuditEvent`, `log_auth_event()`, `query_audit_log()` |
+| `audit.py` | 207 | 24 event types to `.dango/logs/audit.jsonl` | `AuditEvent`, `log_auth_event()`, `query_audit_log()` |
 | `admin.py` | 124 | Bootstrap + path helpers | `ensure_admin()`, `is_auth_enabled()`, `get_auth_db_path()` |
 | `totp.py` | 220 | TOTP 2FA: setup/verify/enable/disable, recovery codes | `generate_totp_secret()`, `verify_totp_code()`, `setup_totp()`, `enable_totp()`, `consume_recovery_code()` |
 | `oauth_login.py` | 307 | OAuth provider ABC + Google/GitHub implementations | `OAuthLoginProvider`, `GoogleOAuthProvider`, `GitHubOAuthProvider`, `get_provider()` |

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -69,6 +69,7 @@ class AuditEvent(str, Enum):
     CATALOG_VIEWED               = "catalog_viewed"
     INSIGHTS_VIEWED              = "insights_viewed"
     AI_CATALOG_VIEWED            = "ai_catalog_viewed"
+    DEPLOYMENT_HISTORY_VIEWED    = "deployment_history_viewed"
     # fmt: on
 
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -25,7 +25,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
-| `commands/remote.py` (652 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
+| `commands/remote.py` (698 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~152 lines) | `serve` production foreground server | `serve()` |
 | `commands/deploy.py` (689 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -292,8 +292,17 @@ def remote_rollback(ctx: click.Context, backup: str | None, yes: bool) -> None:
 @click.option("--dry-run", is_flag=True, help="Show changes without applying.")
 @click.option("--force", is_flag=True, help="Override an existing deploy lock.")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+@click.option("--allow-dirty", is_flag=True, help="Allow deployment with uncommitted changes.")
+@click.option("--allow-branch", is_flag=True, help="Allow deployment from any branch.")
 @click.pass_context
-def remote_push(ctx: click.Context, dry_run: bool, force: bool, yes: bool) -> None:
+def remote_push(
+    ctx: click.Context,
+    dry_run: bool,
+    force: bool,
+    yes: bool,
+    allow_dirty: bool,
+    allow_branch: bool,
+) -> None:
     """Push local project files to the remote server and rebuild.
 
     Syncs config and dbt files, creates a pre-deploy backup, runs
@@ -309,12 +318,33 @@ def remote_push(ctx: click.Context, dry_run: bool, force: bool, yes: bool) -> No
     from rich.status import Status
 
     from dango.platform.cloud.deployer import push_deploy
+    from dango.utils.git_info import check_git_guardrails, collect_git_info
 
     cloud_cfg, project_root = _require_cloud_deployment(ctx)
 
     if cloud_cfg.droplet_ip is None:
         console.print("[red]Error:[/red] No droplet IP found in cloud.yml.")
         raise SystemExit(1)
+
+    # Git guard rails
+    git_info = collect_git_info(project_root)
+    if git_info.is_git_repo:
+        guardrails = check_git_guardrails(
+            git_info,
+            expected_branch=cloud_cfg.deploy_branch,
+            allow_dirty=allow_dirty,
+            allow_branch=allow_branch,
+        )
+        for w in guardrails.warnings:
+            console.print(f"  [dim]{w}[/dim]")
+        if not guardrails.passed:
+            for e in guardrails.errors:
+                console.print(f"  [red]Error:[/red] {e}")
+            console.print("\n[dim]Use --allow-dirty or --allow-branch to override.[/dim]")
+            raise SystemExit(1)
+    else:
+        console.print("[dim]Not a git repo — skipping git guard rails.[/dim]")
+        git_info = None  # type: ignore[assignment]
 
     if not dry_run and not yes:
         if not click.confirm(
@@ -354,6 +384,7 @@ def remote_push(ctx: click.Context, dry_run: bool, force: bool, yes: bool) -> No
                 dry_run=dry_run,
                 force=force,
                 on_progress=_on_progress,
+                git_info=git_info,
             )
 
         # --- Summary ---
@@ -374,6 +405,9 @@ def remote_push(ctx: click.Context, dry_run: bool, force: bool, yes: bool) -> No
             console.print("  packages.yml: [yellow]changed[/yellow]")
 
         if not dry_run:
+            if result.git_info and result.git_info.commit_sha:
+                short_sha = result.git_info.commit_sha[:8]
+                console.print(f"  Git: {short_sha} ({result.git_info.branch})")
             if result.dbt_deps_run:
                 console.print("  dbt deps: [green]ran[/green]")
             if result.dbt_compile_success:

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -322,10 +322,6 @@ def remote_push(
 
     cloud_cfg, project_root = _require_cloud_deployment(ctx)
 
-    if cloud_cfg.droplet_ip is None:
-        console.print("[red]Error:[/red] No droplet IP found in cloud.yml.")
-        raise SystemExit(1)
-
     # Git guard rails
     git_info = collect_git_info(project_root)
     if git_info.is_git_repo:
@@ -336,15 +332,24 @@ def remote_push(
             allow_branch=allow_branch,
         )
         for w in guardrails.warnings:
-            console.print(f"  [dim]{w}[/dim]")
+            console.print(f"  [yellow]Warning:[/yellow] {w}")
         if not guardrails.passed:
             for e in guardrails.errors:
                 console.print(f"  [red]Error:[/red] {e}")
-            console.print("\n[dim]Use --allow-dirty or --allow-branch to override.[/dim]")
+            hints: list[str] = []
+            for e in guardrails.errors:
+                if "dirty" in e.lower() or "uncommitted" in e.lower():
+                    hints.append("--allow-dirty")
+                elif "branch" in e.lower():
+                    hints.append("--allow-branch")
+            override_msg = " or ".join(dict.fromkeys(hints))
+            if override_msg:
+                console.print(f"\n[dim]Use {override_msg} to override.[/dim]")
             raise SystemExit(1)
     else:
         console.print("[dim]Not a git repo — skipping git guard rails.[/dim]")
-        git_info = None  # type: ignore[assignment]
+
+    git_info_param = git_info if git_info.is_git_repo else None
 
     if not dry_run and not yes:
         if not click.confirm(
@@ -384,7 +389,7 @@ def remote_push(
                 dry_run=dry_run,
                 force=force,
                 on_progress=_on_progress,
-                git_info=git_info,
+                git_info=git_info_param,
             )
 
         # --- Summary ---

--- a/dango/cli/commands/remote_mgmt.py
+++ b/dango/cli/commands/remote_mgmt.py
@@ -187,6 +187,22 @@ def remote_status(ctx: click.Context) -> None:
             version_lines.append("  [yellow]Update available[/yellow]")
     console.print(Panel("\n".join(version_lines), title="Versions", border_style="blue"))
 
+    # --- Last Deployment ---
+    if status.deployed_git_commit or status.deployed_at:
+        deploy_lines = []
+        if status.deployed_git_commit:
+            deploy_lines.append(f"  Commit: [bold]{status.deployed_git_commit[:8]}[/bold]")
+        if status.deployed_git_branch:
+            deploy_lines.append(f"  Branch: {status.deployed_git_branch}")
+        if status.deployed_by:
+            deploy_lines.append(f"  Deployer: {status.deployed_by}")
+        if status.deployed_at:
+            deploy_lines.append(f"  Time: {status.deployed_at}")
+        if deploy_lines:
+            console.print(
+                Panel("\n".join(deploy_lines), title="Last Deployment", border_style="blue")
+            )
+
     # --- Backup ---
     if status.last_backup:
         console.print(
@@ -196,6 +212,73 @@ def remote_status(ctx: click.Context) -> None:
         console.print(
             Panel("  [yellow]No backups found[/yellow]", title="Backup", border_style="yellow")
         )
+
+
+# ---------------------------------------------------------------------------
+# history command
+# ---------------------------------------------------------------------------
+
+
+@remote.command("history")
+@click.option("--limit", "-n", default=10, type=int, help="Number of entries to show.")
+@click.pass_context
+def remote_history(ctx: click.Context, limit: int) -> None:
+    """Show deployment history.
+
+    Connects to the remote server and retrieves the deployment journal,
+    showing the most recent deployments with commit, branch, deployer,
+    duration, and status.
+
+    Example:
+      dango remote history
+      dango remote history -n 20
+    """
+    from rich.table import Table
+
+    from dango.platform.cloud.deploy_journal import read_remote_journal
+
+    cloud_cfg, project_root = _load_cloud_config_with_ip(ctx)
+    ssh = _make_ssh_manager(cloud_cfg, project_root)
+
+    try:
+        ssh.connect(cloud_cfg.droplet_ip)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Failed to connect to server: {exc}")
+        raise SystemExit(1) from exc
+
+    try:
+        entries = read_remote_journal(ssh, limit=limit)
+    finally:
+        ssh.disconnect()
+
+    if not entries:
+        console.print("[yellow]No deployment history found.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold cyan", box=None)
+    table.add_column("Time", width=20)
+    table.add_column("Commit", width=10)
+    table.add_column("Branch", width=15)
+    table.add_column("Deployer", width=20)
+    table.add_column("Duration", width=10)
+    table.add_column("Status", width=10)
+
+    for entry in entries:
+        commit = entry.get("git_commit", "")
+        short_commit = commit[:8] if commit else "-"
+        branch = entry.get("git_branch") or "-"
+        deployer = entry.get("deployer") or "-"
+        duration = f"{entry.get('duration_seconds', 0)}s"
+        success = entry.get("success", False)
+        status_str = "[green]OK[/green]" if success else "[red]FAIL[/red]"
+        timestamp = entry.get("timestamp", "-")
+        # Truncate timestamp for display
+        if len(timestamp) > 19:
+            timestamp = timestamp[:19]
+
+        table.add_row(timestamp, short_commit, branch, deployer, duration, status_str)
+
+    console.print(table)
 
 
 # ---------------------------------------------------------------------------

--- a/dango/cli/commands/remote_mgmt.py
+++ b/dango/cli/commands/remote_mgmt.py
@@ -237,6 +237,10 @@ def remote_history(ctx: click.Context, limit: int) -> None:
 
     from dango.platform.cloud.deploy_journal import read_remote_journal
 
+    if limit <= 0:
+        console.print("[red]Error:[/red] --limit must be a positive integer.")
+        raise SystemExit(1)
+
     cloud_cfg, project_root = _load_cloud_config_with_ip(ctx)
     ssh = _make_ssh_manager(cloud_cfg, project_root)
 
@@ -247,7 +251,10 @@ def remote_history(ctx: click.Context, limit: int) -> None:
         raise SystemExit(1) from exc
 
     try:
-        entries = read_remote_journal(ssh, limit=limit)
+        entries = read_remote_journal(ssh, limit=limit, raise_on_error=True)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] Failed to read deployment journal: {exc}")
+        raise SystemExit(1) from exc
     finally:
         ssh.disconnect()
 
@@ -256,24 +263,24 @@ def remote_history(ctx: click.Context, limit: int) -> None:
         return
 
     table = Table(show_header=True, header_style="bold cyan", box=None)
-    table.add_column("Time", width=20)
-    table.add_column("Commit", width=10)
+    table.add_column("Time", width=19)
+    table.add_column("Commit", width=8)
     table.add_column("Branch", width=15)
-    table.add_column("Deployer", width=20)
-    table.add_column("Duration", width=10)
-    table.add_column("Status", width=10)
+    table.add_column("Deployer", width=25)
+    table.add_column("Duration", width=8, justify="right")
+    table.add_column("Status", width=8)
 
     for entry in entries:
         commit = entry.get("git_commit", "")
         short_commit = commit[:8] if commit else "-"
         branch = entry.get("git_branch") or "-"
         deployer = entry.get("deployer") or "-"
-        duration = f"{entry.get('duration_seconds', 0)}s"
+        dur = entry.get("duration_seconds", 0)
+        duration = f"{dur:.0f}s" if dur < 60 else f"{dur / 60:.1f}m"
         success = entry.get("success", False)
         status_str = "[green]OK[/green]" if success else "[red]FAIL[/red]"
-        timestamp = entry.get("timestamp", "-")
-        # Truncate timestamp for display
-        if len(timestamp) > 19:
+        timestamp = entry.get("timestamp") or "-"
+        if timestamp != "-" and len(timestamp) > 19:
             timestamp = timestamp[:19]
 
         table.add_row(timestamp, short_commit, branch, deployer, duration, status_str)

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -9,7 +9,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports, `__all__` | Re-exports all public symbols |
-| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `LocalFilesSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `CloudConfig` (incl. `provider`, `firewall_id`) |
+| `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `LocalFilesSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `CloudConfig` (incl. `provider`, `firewall_id`, `deploy_branch`) |
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
 | `schedules.py` | Schedule config models, validation, reload | `ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`, `CRON_PRESETS`, `load_schedules_config`, `validate_schedules`, `reload_schedules`, `log_startup_checks` |

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -583,6 +583,10 @@ class CloudConfig(BaseModel):
     dbt_overrides: DbtOverrides | None = Field(
         default=None, description="Cloud dbt configuration overrides"
     )
+    deploy_branch: str = Field(
+        default="main",
+        description="Expected git branch for deployments (guard rail check)",
+    )
 
 
 class DangoConfig(BaseModel):

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -42,7 +42,7 @@ platform/
 │   └── slack.py         # Slack Block Kit formatter
 │
 ├── cloud/               # Cloud-only components (TASK-022+)
-│   ├── __init__.py      # Re-exports 63 symbols (clients, provisioning, firewall, backup, deploy, etc.)
+│   ├── __init__.py      # Re-exports 69 symbols (clients, provisioning, firewall, backup, deploy, journal, etc.)
 │   ├── digitalocean.py  # DO REST API v2 client (Droplets, SSH Keys, Firewalls)
 │   ├── provisioning.py  # Size tiers, regions, provision_droplet() orchestration (TASK-023)
 │   ├── firewall.py      # Firewall lifecycle, IP allowlisting (TASK-025)
@@ -54,6 +54,7 @@ platform/
 │   ├── backup.py        # SSH-based backup + rollback (TASK-035)
 │   ├── file_sync.py     # Project file sync: SFTP + rsync (TASK-028)
 │   ├── deployer.py      # Push deployment workflow + deploy lock (TASK-030)
+│   ├── deploy_journal.py # Append-only JSONL deployment history (P8-004)
 │   ├── scheduled_backup.py  # Server-side scheduled backup (TASK-103)
 │   ├── resize.py        # In-place resize (power off → resize → power on) (TASK-104)
 │   ├── migrate.py       # Server migration (new droplet via Spaces) (TASK-105)
@@ -95,6 +96,7 @@ platform/
 | `cloud/backup.py` | SSH-based backup and rollback | `create_backup`, `rollback`, `list_local_backups`, `rotate_local_backups`, `BackupManifest`, `BackupResult`, `RestoreResult` |
 | `cloud/file_sync.py` | Project file sync (SFTP + rsync) with change detection | `sync_project_files`, `SyncResult` |
 | `cloud/deployer.py` | Push deployment workflow with deploy lock | `push_deploy`, `DeployLock`, `DeployResult` |
+| `cloud/deploy_journal.py` | Append-only JSONL deployment history | `DeploymentRecord`, `write_local_journal`, `write_remote_journal`, `read_local_journal`, `read_remote_journal`, `get_latest_deployment` |
 | `cloud/scheduled_backup.py` | Server-side scheduled backup to Spaces | `run_scheduled_backup`, `list_spaces_backups`, `restore_from_spaces`, `enable_scheduled_backup`, `disable_scheduled_backup` |
 | `cloud/resize.py` | In-place droplet resize (power off → resize → power on, regenerate dbt profiles) | `resize_droplet`, `ResizeResult`, `validate_size_slug`, `generate_dbt_profiles_yml`, `regenerate_dbt_profiles`, `get_disk_warning` |
 | `cloud/migrate.py` | Server migration via Spaces (new droplet, transfer data, destroy old) | `migrate_server`, `MigrateResult` |
@@ -149,6 +151,10 @@ from dango.platform.cloud.file_sync import SyncResult, sync_project_files  # als
 # Push deploy (TASK-030)
 from dango.platform.cloud import DeployLock, DeployResult, push_deploy
 from dango.platform.cloud.deployer import DeployLock, DeployResult, push_deploy  # also valid
+
+# Deployment journal (P8-004)
+from dango.platform.cloud import DeploymentRecord, write_local_journal, read_remote_journal
+from dango.platform.cloud.deploy_journal import get_latest_deployment  # also valid
 
 # Scheduled backup (TASK-103, runs on server)
 from dango.platform.cloud.scheduled_backup import run_scheduled_backup, list_spaces_backups
@@ -206,7 +212,8 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 | Create pre-deploy backup | `cloud/backup.py` → `create_backup()` | `pytest tests/unit/test_backup.py` |
 | Rollback from backup | `cloud/backup.py` → `rollback()` | `pytest tests/unit/test_backup.py` |
 | Sync files to remote | `cloud/file_sync.py` → `sync_project_files()` | `pytest tests/unit/test_file_sync.py` |
-| Push deploy to remote | `cloud/deployer.py` → `push_deploy()` | `pytest tests/unit/test_deployer.py` |
+| Push deploy to remote | `cloud/deployer.py` → `push_deploy()` | `pytest tests/unit/test_deployer.py tests/unit/test_deployer_push.py` |
+| View deployment history | `cloud/deploy_journal.py` → `read_local_journal()` / `read_remote_journal()` | `pytest tests/unit/test_deploy_journal.py` |
 | Scheduled backup (server-side) | `cloud/scheduled_backup.py` → `run_scheduled_backup()` | `pytest tests/unit/test_scheduled_backup.py` |
 | Resize droplet | `cloud/resize.py` → `resize_droplet()` | `pytest tests/unit/test_resize.py` |
 | Migrate to new server | `cloud/migrate.py` → `migrate_server()` | `pytest tests/unit/test_migrate.py` |
@@ -341,7 +348,7 @@ Post-deployment hardening (not automated by Dango):
 - **Scheduling:** `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_resilience.py tests/unit/test_execution_history.py tests/unit/test_sync_jobs.py tests/unit/test_sync_trigger.py`
 - **Notifications:** `pytest tests/unit/test_webhook.py tests/unit/test_slack_formatter.py`
 - **Local platform:** `pytest tests/unit/test_platform_startup.py tests/unit/test_watcher_lifecycle.py`
-- **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
+- **Cloud modules:** `pytest tests/unit/test_digitalocean_client.py tests/unit/test_spaces_client.py tests/unit/test_ssh_manager.py tests/unit/test_ssh_sftp.py tests/unit/test_provisioning.py tests/unit/test_firewall.py tests/unit/test_server_setup.py tests/unit/test_domain.py tests/unit/test_backup.py tests/unit/test_file_sync.py tests/unit/test_deployer.py tests/unit/test_deployer_push.py tests/unit/test_deploy_journal.py tests/unit/test_scheduled_backup.py tests/unit/test_resize.py tests/unit/test_migrate.py tests/unit/test_upgrade.py`
 - **Manual:** `dango start` (local platform), `dango deploy` (cloud provisioning)
 
 ## Don't Modify
@@ -349,5 +356,6 @@ Post-deployment hardening (not automated by Dango):
 | File | Reason |
 |------|--------|
 | `cloud/__init__.py` export list | Other modules depend on re-exported symbols; changes break downstream imports |
+| `cloud/deploy_journal.py` JSONL format | CLI (`remote history`) and web UI (`/api/deployments/history`) both parse this format |
 | `cloud/_server_templates.py` systemd unit structure | Running servers depend on the exact systemd unit format |
 | `local/` watcher event format | Web UI parses watcher status responses |

--- a/dango/platform/cloud/__init__.py
+++ b/dango/platform/cloud/__init__.py
@@ -18,6 +18,14 @@ from .backup import (
     stop_services,
     verify_health,
 )
+from .deploy_journal import (
+    DeploymentRecord,
+    get_latest_deployment,
+    read_local_journal,
+    read_remote_journal,
+    write_local_journal,
+    write_remote_journal,
+)
 from .deployer import DeployLock, DeployResult, push_deploy
 from .digitalocean import DigitalOceanClient
 from .domain import check_dns, remove_domain, set_domain
@@ -129,6 +137,13 @@ __all__ = [
     "DeployLock",
     "DeployResult",
     "push_deploy",
+    # Deploy journal (P8-004)
+    "DeploymentRecord",
+    "get_latest_deployment",
+    "read_local_journal",
+    "read_remote_journal",
+    "write_local_journal",
+    "write_remote_journal",
     # Resize (TASK-104)
     "ResizeResult",
     "resize_droplet",

--- a/dango/platform/cloud/backup.py
+++ b/dango/platform/cloud/backup.py
@@ -51,6 +51,8 @@ class BackupManifest:
     dango_version: str
     files: list[dict[str, Any]] = field(default_factory=list)
     total_size_bytes: int = 0
+    git_commit: str | None = None
+    git_branch: str | None = None
 
 
 @dataclass
@@ -168,7 +170,13 @@ def _get_metabase_volume_path(ssh: SSHManager) -> str | None:
 
 
 def _create_archive(
-    ssh: SSHManager, timestamp: str, metabase_vol_path: str | None, backup_type: str
+    ssh: SSHManager,
+    timestamp: str,
+    metabase_vol_path: str | None,
+    backup_type: str,
+    *,
+    git_commit: str | None = None,
+    git_branch: str | None = None,
 ) -> tuple[str, BackupManifest]:
     """Create a tar.gz archive in BACKUP_DIR.  Returns (archive_path, manifest)."""
     archive_name = f"backup-{timestamp}"
@@ -221,6 +229,8 @@ def _create_archive(
             dango_version=dango_version,
             files=files,
             total_size_bytes=total_size,
+            git_commit=git_commit,
+            git_branch=git_branch,
         )
         manifest_json = json.dumps(asdict(manifest), indent=2)
         _run_checked(
@@ -261,6 +271,8 @@ def create_backup(
     backup_type: str = "pre-deploy",
     restart_services: bool = True,
     on_progress: Callable[[str, str], None] | None = None,
+    git_commit: str | None = None,
+    git_branch: str | None = None,
 ) -> BackupResult:
     """Create a backup of all project data on the remote server.
 
@@ -302,7 +314,14 @@ def create_backup(
         _notify(on_progress, "get_metabase_volume", "done")
 
         _notify(on_progress, "create_archive", "running")
-        archive_path, manifest = _create_archive(ssh, timestamp, metabase_vol, backup_type)
+        archive_path, manifest = _create_archive(
+            ssh,
+            timestamp,
+            metabase_vol,
+            backup_type,
+            git_commit=git_commit,
+            git_branch=git_branch,
+        )
         _notify(on_progress, "create_archive", "done")
     finally:
         if restart_services:

--- a/dango/platform/cloud/deploy_journal.py
+++ b/dango/platform/cloud/deploy_journal.py
@@ -15,8 +15,12 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from dango.logging import get_logger
+
 if TYPE_CHECKING:
     from dango.platform.cloud.ssh import SSHManager
+
+logger = get_logger(__name__)
 
 
 _REMOTE_JOURNAL = "/srv/dango/project/.dango/state/deployments.jsonl"
@@ -72,7 +76,7 @@ def write_remote_journal(ssh: SSHManager, record: DeploymentRecord) -> None:
         cmd = f"mkdir -p {parent} && echo {shlex.quote(json_str)} >> {_REMOTE_JOURNAL}"
         ssh.exec_command(cmd)
     except Exception:  # noqa: BLE001
-        pass
+        logger.warning("Failed to write remote deployment journal", exc_info=True)
 
 
 def read_local_journal(project_root: Path, limit: int = 20) -> list[dict[str, Any]]:
@@ -80,6 +84,8 @@ def read_local_journal(project_root: Path, limit: int = 20) -> list[dict[str, An
 
     Returns entries newest-first.  Empty list on missing file or errors.
     """
+    if limit <= 0:
+        return []
     journal_path = project_root / ".dango" / "state" / "deployments.jsonl"
     if not journal_path.exists():
         return []
@@ -97,11 +103,20 @@ def read_local_journal(project_root: Path, limit: int = 20) -> list[dict[str, An
         return []
 
 
-def read_remote_journal(ssh: SSHManager, limit: int = 20) -> list[dict[str, Any]]:
+def read_remote_journal(
+    ssh: SSHManager,
+    limit: int = 20,
+    *,
+    raise_on_error: bool = False,
+) -> list[dict[str, Any]]:
     """Read the last *limit* entries from the remote deployment journal.
 
     Returns entries newest-first.  Empty list on missing file or errors.
+    When *raise_on_error* is True, SSH/connection exceptions are re-raised
+    instead of being silently swallowed.
     """
+    if limit <= 0:
+        return []
     try:
         result = ssh.exec_command(f"tail -{limit} {_REMOTE_JOURNAL} 2>/dev/null")
         if not result.success or not result.stdout.strip():
@@ -115,6 +130,8 @@ def read_remote_journal(ssh: SSHManager, limit: int = 20) -> list[dict[str, Any]
         entries.reverse()
         return entries
     except Exception:  # noqa: BLE001
+        if raise_on_error:
+            raise
         return []
 
 
@@ -129,5 +146,5 @@ def get_latest_deployment(ssh: SSHManager) -> dict[str, Any] | None:
             return None
         entry: dict[str, Any] = json.loads(result.stdout.strip())
         return entry
-    except (json.JSONDecodeError, Exception):  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         return None

--- a/dango/platform/cloud/deploy_journal.py
+++ b/dango/platform/cloud/deploy_journal.py
@@ -1,0 +1,133 @@
+"""dango/platform/cloud/deploy_journal.py
+
+Append-only JSONL deployment journal for tracking deployment history.
+
+Records git commit, branch, deployer identity, duration, and file changes
+for every deployment.  All write operations follow the never-fail pattern:
+errors are logged but never raised.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dango.platform.cloud.ssh import SSHManager
+
+
+_REMOTE_JOURNAL = "/srv/dango/project/.dango/state/deployments.jsonl"
+
+
+@dataclass(frozen=True)
+class DeploymentRecord:
+    """Single deployment event."""
+
+    timestamp: str
+    deployer: str
+    success: bool
+    git_commit: str | None = None
+    git_branch: str | None = None
+    git_clean: bool | None = None
+    git_remote_url: str | None = None
+    dango_version: str | None = None
+    files_synced: list[str] = field(default_factory=list)
+    models_changed: list[str] = field(default_factory=list)
+    models_added: list[str] = field(default_factory=list)
+    models_removed: list[str] = field(default_factory=list)
+    duration_seconds: float = 0.0
+    dry_run: bool = False
+    error: str | None = None
+
+
+def write_local_journal(project_root: Path, record: DeploymentRecord) -> None:
+    """Append a deployment record to the local journal.
+
+    Path: ``<project_root>/.dango/state/deployments.jsonl``
+
+    Never raises — errors are printed as warnings.
+    """
+    journal_path = project_root / ".dango" / "state" / "deployments.jsonl"
+    try:
+        journal_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(journal_path, "a") as f:
+            f.write(json.dumps(asdict(record)) + "\n")
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: Failed to write local deployment journal: {exc}")
+
+
+def write_remote_journal(ssh: SSHManager, record: DeploymentRecord) -> None:
+    """Append a deployment record to the remote journal via SSH.
+
+    Path: ``/srv/dango/project/.dango/state/deployments.jsonl``
+
+    Never raises — errors are silently ignored.
+    """
+    try:
+        json_str = json.dumps(asdict(record))
+        parent = str(Path(_REMOTE_JOURNAL).parent)
+        cmd = f"mkdir -p {parent} && echo {shlex.quote(json_str)} >> {_REMOTE_JOURNAL}"
+        ssh.exec_command(cmd)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def read_local_journal(project_root: Path, limit: int = 20) -> list[dict[str, Any]]:
+    """Read the last *limit* entries from the local deployment journal.
+
+    Returns entries newest-first.  Empty list on missing file or errors.
+    """
+    journal_path = project_root / ".dango" / "state" / "deployments.jsonl"
+    if not journal_path.exists():
+        return []
+    try:
+        lines = journal_path.read_text().strip().splitlines()
+        entries: list[dict[str, Any]] = []
+        for line in lines[-limit:]:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        entries.reverse()
+        return entries
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def read_remote_journal(ssh: SSHManager, limit: int = 20) -> list[dict[str, Any]]:
+    """Read the last *limit* entries from the remote deployment journal.
+
+    Returns entries newest-first.  Empty list on missing file or errors.
+    """
+    try:
+        result = ssh.exec_command(f"tail -{limit} {_REMOTE_JOURNAL} 2>/dev/null")
+        if not result.success or not result.stdout.strip():
+            return []
+        entries: list[dict[str, Any]] = []
+        for line in result.stdout.strip().splitlines():
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        entries.reverse()
+        return entries
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def get_latest_deployment(ssh: SSHManager) -> dict[str, Any] | None:
+    """Read the most recent deployment record from the remote journal.
+
+    Returns ``None`` if the journal is empty or unreadable.
+    """
+    try:
+        result = ssh.exec_command(f"tail -1 {_REMOTE_JOURNAL} 2>/dev/null")
+        if not result.success or not result.stdout.strip():
+            return None
+        entry: dict[str, Any] = json.loads(result.stdout.strip())
+        return entry
+    except (json.JSONDecodeError, Exception):  # noqa: BLE001
+        return None

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from dango.platform.cloud.backup import BackupResult
     from dango.platform.cloud.file_sync import SyncResult
     from dango.platform.cloud.ssh import SSHManager
+    from dango.utils.git_info import GitInfo
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -67,7 +68,7 @@ class DeployResult:
     duration_seconds: float = 0.0
     warnings: list[str] = field(default_factory=list)
     dry_run: bool = False
-    git_info: Any = None
+    git_info: GitInfo | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +308,7 @@ def _run_remote_dbt(
 def _write_deploy_journal(
     ssh: SSHManager,
     local_project_root: Path,
-    git_info: Any,
+    git_info: GitInfo | None,
     *,
     sync_result: Any,
     deploy_succeeded: bool,
@@ -368,7 +369,7 @@ def push_deploy(
     dry_run: bool = False,
     force: bool = False,
     on_progress: Callable[[str, str], None] | None = None,
-    git_info: Any = None,
+    git_info: GitInfo | None = None,
 ) -> DeployResult:
     """Execute full push deployment workflow.
 
@@ -550,16 +551,19 @@ def push_deploy(
 
     finally:
         # Write deployment journal (never-fail)
-        if not dry_run and git_info is not None:
-            _write_deploy_journal(
-                ssh,
-                local_project_root,
-                git_info,
-                sync_result=sync_result,
-                deploy_succeeded=deploy_succeeded,
-                deploy_error=deploy_error,
-                duration_seconds=round(time.monotonic() - start_time, 1),
-            )
+        if not dry_run:
+            try:
+                _write_deploy_journal(
+                    ssh,
+                    local_project_root,
+                    git_info,
+                    sync_result=sync_result,
+                    deploy_succeeded=deploy_succeeded,
+                    deploy_error=deploy_error,
+                    duration_seconds=round(time.monotonic() - start_time, 1),
+                )
+            except Exception:  # noqa: BLE001
+                pass
 
     return DeployResult(
         sync_result=sync_result,

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -67,6 +67,7 @@ class DeployResult:
     duration_seconds: float = 0.0
     warnings: list[str] = field(default_factory=list)
     dry_run: bool = False
+    git_info: Any = None
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +300,62 @@ def _run_remote_dbt(
 
 
 # ---------------------------------------------------------------------------
+# Deploy journal helper
+# ---------------------------------------------------------------------------
+
+
+def _write_deploy_journal(
+    ssh: SSHManager,
+    local_project_root: Path,
+    git_info: Any,
+    *,
+    sync_result: Any,
+    deploy_succeeded: bool,
+    deploy_error: str | None,
+    duration_seconds: float,
+) -> None:
+    """Write deployment record to local and remote journals (never-fail)."""
+    from dango.platform.cloud.deploy_journal import (
+        DeploymentRecord,
+        write_local_journal,
+        write_remote_journal,
+    )
+
+    try:
+        import dango
+
+        dango_version = dango.__version__
+    except Exception:  # noqa: BLE001
+        dango_version = None
+
+    record = DeploymentRecord(
+        timestamp=datetime.now(tz=timezone.utc).isoformat(),
+        deployer=_get_deployer_identity(),
+        success=deploy_succeeded,
+        git_commit=git_info.commit_sha if git_info else None,
+        git_branch=git_info.branch if git_info else None,
+        git_clean=git_info.is_clean if git_info else None,
+        git_remote_url=git_info.remote_url if git_info else None,
+        dango_version=dango_version,
+        files_synced=list(sync_result.synced_files) if sync_result else [],
+        models_changed=list(sync_result.changed_models) if sync_result else [],
+        models_added=list(sync_result.added_models) if sync_result else [],
+        models_removed=list(sync_result.removed_models) if sync_result else [],
+        duration_seconds=duration_seconds,
+        dry_run=False,
+        error=deploy_error,
+    )
+    try:
+        write_local_journal(local_project_root, record)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        write_remote_journal(ssh, record)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -311,6 +368,7 @@ def push_deploy(
     dry_run: bool = False,
     force: bool = False,
     on_progress: Callable[[str, str], None] | None = None,
+    git_info: Any = None,
 ) -> DeployResult:
     """Execute full push deployment workflow.
 
@@ -324,6 +382,7 @@ def push_deploy(
         dry_run: If True, show what would change without applying.
         force: Override any existing deploy lock.
         on_progress: Optional ``(step, status)`` callback for UI updates.
+        git_info: Optional ``GitInfo`` from :func:`collect_git_info`.
 
     Returns:
         :class:`DeployResult` with deployment details.
@@ -364,118 +423,143 @@ def push_deploy(
             duration_seconds=round(time.monotonic() - start_time, 1),
             warnings=warnings,
             dry_run=True,
+            git_info=git_info,
         )
 
     # --- Full deploy ---
     lock: DeployLock | None = None
     services_stopped = False
+    deploy_succeeded = False
+    deploy_error: str | None = None
 
     try:
-        # Step 1: Acquire deploy lock
-        _notify(on_progress, "acquire_lock", "running")
-        lock = _acquire_lock(ssh, force=force)
-        _notify(on_progress, "acquire_lock", "done")
+        try:
+            # Step 1: Acquire deploy lock
+            _notify(on_progress, "acquire_lock", "running")
+            lock = _acquire_lock(ssh, force=force)
+            _notify(on_progress, "acquire_lock", "done")
 
-        # Step 2: Stop dango-web BEFORE backup (DuckDB single-writer).
-        # Backup will also stop services (web already stopped = noop,
-        # Metabase stopped for consistent H2 backup).  With
-        # restart_services=False, services remain stopped throughout
-        # the entire sync + dbt workflow.
-        _notify(on_progress, "stop_web", "running")
-        _stop_web_service(ssh)
-        services_stopped = True
-        _notify(on_progress, "stop_web", "done")
+            # Step 2: Stop dango-web BEFORE backup (DuckDB single-writer).
+            # Backup will also stop services (web already stopped = noop,
+            # Metabase stopped for consistent H2 backup).  With
+            # restart_services=False, services remain stopped throughout
+            # the entire sync + dbt workflow.
+            _notify(on_progress, "stop_web", "running")
+            _stop_web_service(ssh)
+            services_stopped = True
+            _notify(on_progress, "stop_web", "done")
 
-        # Step 3: Pre-deploy backup (services stay down after backup)
-        _notify(on_progress, "create_backup", "running")
-        backup_result = create_backup(
-            ssh,
-            backup_type="pre-deploy",
-            restart_services=False,
-            on_progress=on_progress,
-        )
-        if backup_result.warnings:
-            warnings.extend(backup_result.warnings)
-        _notify(on_progress, "create_backup", "done")
-
-        # Step 4: Sync files
-        _notify(on_progress, "sync_files", "running")
-        sync_result = sync_project_files(
-            ssh, local_project_root, remote_host=remote_host, on_progress=on_progress
-        )
-        _notify(on_progress, "sync_files", "done")
-
-        # Step 5: Fix file ownership
-        _notify(on_progress, "fix_ownership", "running")
-        ssh.exec_command(f"chown -R dango:dango {REMOTE_PROJECT_DIR}", timeout=60)
-        _notify(on_progress, "fix_ownership", "done")
-
-        # Step 6: Validate sources
-        _notify(on_progress, "validate_sources", "running")
-        source_errors = _validate_remote_sources(ssh)
-        if source_errors:
-            for err in source_errors:
-                warnings.append(err)
-        _notify(on_progress, "validate_sources", "done")
-
-        # Step 7: dbt deps (if packages.yml changed)
-        if sync_result.packages_changed:
-            _notify(on_progress, "dbt_deps", "running")
-            deps_result = _run_remote_dbt(ssh, "deps")
-            dbt_deps_run = True
-            if not deps_result.success:
-                warnings.append(
-                    f"dbt deps failed: {deps_result.stderr.strip() or deps_result.stdout.strip()}"
-                )
-            _notify(on_progress, "dbt_deps", "done")
-
-        # Step 8: dbt compile
-        _notify(on_progress, "dbt_compile", "running")
-        compile_result = _run_remote_dbt(ssh, "compile")
-        if not compile_result.success:
-            raise CloudProvisioningError(
-                f"dbt compile failed: {compile_result.stderr.strip() or compile_result.stdout.strip()}"
+            # Step 3: Pre-deploy backup (services stay down after backup)
+            _notify(on_progress, "create_backup", "running")
+            backup_result = create_backup(
+                ssh,
+                backup_type="pre-deploy",
+                restart_services=False,
+                on_progress=on_progress,
+                git_commit=git_info.commit_sha if git_info else None,
+                git_branch=git_info.branch if git_info else None,
             )
-        dbt_compile_success = True
-        _notify(on_progress, "dbt_compile", "done")
+            if backup_result.warnings:
+                warnings.extend(backup_result.warnings)
+            _notify(on_progress, "create_backup", "done")
 
-        # Step 9: dbt run
-        # If macros changed, any model could be affected → full rebuild.
-        # If only models changed, selective rebuild by name.
-        all_changed = sync_result.added_models + sync_result.changed_models
-        if sync_result.has_macro_changes:
-            _notify(on_progress, "dbt_run", "running")
-            run_result = _run_remote_dbt(ssh, "run")
-            if run_result.success:
-                models_rebuilt = ["(full rebuild — macros changed)"]
-            else:
+            # Step 4: Sync files
+            _notify(on_progress, "sync_files", "running")
+            sync_result = sync_project_files(
+                ssh, local_project_root, remote_host=remote_host, on_progress=on_progress
+            )
+            _notify(on_progress, "sync_files", "done")
+
+            # Step 5: Fix file ownership
+            _notify(on_progress, "fix_ownership", "running")
+            ssh.exec_command(f"chown -R dango:dango {REMOTE_PROJECT_DIR}", timeout=60)
+            _notify(on_progress, "fix_ownership", "done")
+
+            # Step 6: Validate sources
+            _notify(on_progress, "validate_sources", "running")
+            source_errors = _validate_remote_sources(ssh)
+            if source_errors:
+                for err in source_errors:
+                    warnings.append(err)
+            _notify(on_progress, "validate_sources", "done")
+
+            # Step 7: dbt deps (if packages.yml changed)
+            if sync_result.packages_changed:
+                _notify(on_progress, "dbt_deps", "running")
+                deps_result = _run_remote_dbt(ssh, "deps")
+                dbt_deps_run = True
+                if not deps_result.success:
+                    warnings.append(
+                        f"dbt deps failed: {deps_result.stderr.strip() or deps_result.stdout.strip()}"
+                    )
+                _notify(on_progress, "dbt_deps", "done")
+
+            # Step 8: dbt compile
+            _notify(on_progress, "dbt_compile", "running")
+            compile_result = _run_remote_dbt(ssh, "compile")
+            if not compile_result.success:
                 raise CloudProvisioningError(
-                    f"dbt run failed: {run_result.stderr.strip() or run_result.stdout.strip()}"
+                    f"dbt compile failed: {compile_result.stderr.strip() or compile_result.stdout.strip()}"
                 )
-            _notify(on_progress, "dbt_run", "done")
-        elif all_changed:
-            _validate_model_names(all_changed)
-            _notify(on_progress, "dbt_run", "running")
-            select_arg = " ".join(all_changed)
-            run_result = _run_remote_dbt(ssh, "run", f"--select {select_arg}")
-            if run_result.success:
-                models_rebuilt = list(all_changed)
-            else:
-                raise CloudProvisioningError(
-                    f"dbt run failed for models [{select_arg}]: "
-                    f"{run_result.stderr.strip() or run_result.stdout.strip()}"
-                )
-            _notify(on_progress, "dbt_run", "done")
+            dbt_compile_success = True
+            _notify(on_progress, "dbt_compile", "done")
+
+            # Step 9: dbt run
+            # If macros changed, any model could be affected → full rebuild.
+            # If only models changed, selective rebuild by name.
+            all_changed = sync_result.added_models + sync_result.changed_models
+            if sync_result.has_macro_changes:
+                _notify(on_progress, "dbt_run", "running")
+                run_result = _run_remote_dbt(ssh, "run")
+                if run_result.success:
+                    models_rebuilt = ["(full rebuild — macros changed)"]
+                else:
+                    raise CloudProvisioningError(
+                        f"dbt run failed: {run_result.stderr.strip() or run_result.stdout.strip()}"
+                    )
+                _notify(on_progress, "dbt_run", "done")
+            elif all_changed:
+                _validate_model_names(all_changed)
+                _notify(on_progress, "dbt_run", "running")
+                select_arg = " ".join(all_changed)
+                run_result = _run_remote_dbt(ssh, "run", f"--select {select_arg}")
+                if run_result.success:
+                    models_rebuilt = list(all_changed)
+                else:
+                    raise CloudProvisioningError(
+                        f"dbt run failed for models [{select_arg}]: "
+                        f"{run_result.stderr.strip() or run_result.stdout.strip()}"
+                    )
+                _notify(on_progress, "dbt_run", "done")
+
+            deploy_succeeded = True
+
+        except Exception as exc:
+            deploy_error = str(exc)
+            raise
+
+        finally:
+            # Always restart all services and release lock
+            if services_stopped:
+                _notify(on_progress, "start_services", "running")
+                _start_all_services(ssh)
+                _notify(on_progress, "start_services", "done")
+
+            if lock is not None:
+                _release_lock(ssh)
 
     finally:
-        # Always restart all services and release lock
-        if services_stopped:
-            _notify(on_progress, "start_services", "running")
-            _start_all_services(ssh)
-            _notify(on_progress, "start_services", "done")
-
-        if lock is not None:
-            _release_lock(ssh)
+        # Write deployment journal (never-fail)
+        if not dry_run and git_info is not None:
+            _write_deploy_journal(
+                ssh,
+                local_project_root,
+                git_info,
+                sync_result=sync_result,
+                deploy_succeeded=deploy_succeeded,
+                deploy_error=deploy_error,
+                duration_seconds=round(time.monotonic() - start_time, 1),
+            )
 
     return DeployResult(
         sync_result=sync_result,
@@ -486,4 +570,5 @@ def push_deploy(
         duration_seconds=round(time.monotonic() - start_time, 1),
         warnings=warnings,
         dry_run=False,
+        git_info=git_info,
     )

--- a/dango/platform/cloud/server_status.py
+++ b/dango/platform/cloud/server_status.py
@@ -112,19 +112,17 @@ def collect_server_status(ssh: Any, cloud_config: Any) -> ServerStatus:
 
 def _get_deployment_info(ssh: Any) -> dict[str, str | None]:
     """Read last entry from remote deployments.jsonl for version info."""
-    result = ssh.exec_command(f"tail -1 {_DEPLOY_JOURNAL} 2>/dev/null")
-    if not result.success or not result.stdout.strip():
+    from dango.platform.cloud.deploy_journal import get_latest_deployment
+
+    entry = get_latest_deployment(ssh)
+    if not entry:
         return {}
-    try:
-        entry: dict[str, Any] = json.loads(result.stdout.strip())
-        return {
-            "git_commit": entry.get("git_commit"),
-            "git_branch": entry.get("git_branch"),
-            "deployed_at": entry.get("timestamp"),
-            "deployed_by": entry.get("deployer"),
-        }
-    except (json.JSONDecodeError, TypeError):
-        return {}
+    return {
+        "git_commit": entry.get("git_commit"),
+        "git_branch": entry.get("git_branch"),
+        "deployed_at": entry.get("timestamp"),
+        "deployed_by": entry.get("deployer"),
+    }
 
 
 def _get_cpu_usage(ssh: Any) -> float | None:

--- a/dango/platform/cloud/server_status.py
+++ b/dango/platform/cloud/server_status.py
@@ -56,6 +56,12 @@ class ServerStatus:
     last_backup: str | None = None
     last_sync_per_source: dict[str, str] = field(default_factory=dict)
 
+    # Deployment version info (from deployments.jsonl)
+    deployed_git_commit: str | None = None
+    deployed_git_branch: str | None = None
+    deployed_at: str | None = None
+    deployed_by: str | None = None
+
 
 # ---------------------------------------------------------------------------
 # SSH-based collection
@@ -65,6 +71,7 @@ _DUCKDB_PATH = "/srv/dango/project/data/warehouse.duckdb"
 _VENV_PYTHON = "/srv/dango/venv/bin/python3"
 _SYNC_HISTORY = "/srv/dango/project/.dango/state/sync_history.jsonl"
 _DEPLOY_TIMESTAMP = "/srv/dango/project/.dango/state/deploy_timestamp"
+_DEPLOY_JOURNAL = "/srv/dango/project/.dango/state/deployments.jsonl"
 _BACKUP_DIR = "/srv/dango/backups/deploy"
 _SYNC_HISTORY_TAIL = 50  # Recent lines to read — sufficient for per-source latest timestamps
 
@@ -82,6 +89,7 @@ def collect_server_status(ssh: Any, cloud_config: Any) -> ServerStatus:
     Returns:
         ``ServerStatus`` snapshot with available metrics.
     """
+    deploy_info = _get_deployment_info(ssh)
     return ServerStatus(
         cpu_usage_pct=_get_cpu_usage(ssh),
         ram_total_mb=_get_ram(ssh, "total"),
@@ -95,7 +103,28 @@ def collect_server_status(ssh: Any, cloud_config: Any) -> ServerStatus:
         last_deploy=_get_last_deploy(ssh),
         last_backup=_get_last_backup(ssh),
         last_sync_per_source=_get_sync_history(ssh),
+        deployed_git_commit=deploy_info.get("git_commit"),
+        deployed_git_branch=deploy_info.get("git_branch"),
+        deployed_at=deploy_info.get("deployed_at"),
+        deployed_by=deploy_info.get("deployed_by"),
     )
+
+
+def _get_deployment_info(ssh: Any) -> dict[str, str | None]:
+    """Read last entry from remote deployments.jsonl for version info."""
+    result = ssh.exec_command(f"tail -1 {_DEPLOY_JOURNAL} 2>/dev/null")
+    if not result.success or not result.stdout.strip():
+        return {}
+    try:
+        entry: dict[str, Any] = json.loads(result.stdout.strip())
+        return {
+            "git_commit": entry.get("git_commit"),
+            "git_branch": entry.get("git_branch"),
+            "deployed_at": entry.get("timestamp"),
+            "deployed_by": entry.get("deployer"),
+        }
+    except (json.JSONDecodeError, TypeError):
+        return {}
 
 
 def _get_cpu_usage(ssh: Any) -> float | None:

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -21,6 +21,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
 | `post_sync.py` (~486 lines) | Post-sync hook dispatcher | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_drift_detection()`, `_run_pii_scan()`, `_run_analysis()` |
+| `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 
 ## Common Tasks
 

--- a/dango/utils/git_info.py
+++ b/dango/utils/git_info.py
@@ -1,0 +1,120 @@
+"""dango/utils/git_info.py
+
+Git repository info and deployment guardrails.
+
+Pure utility — subprocess calls to git, no dango dependencies.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GitInfo:
+    """Snapshot of the local git repository state."""
+
+    commit_sha: str | None = None
+    branch: str | None = None
+    is_clean: bool | None = None
+    remote_url: str | None = None
+    is_git_repo: bool = False
+
+
+@dataclass(frozen=True)
+class GitGuardrailResult:
+    """Result of pre-deployment git checks."""
+
+    passed: bool = True
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def _run_git(args: list[str], cwd: Path) -> str | None:
+    """Run a git command, returning stdout or None on failure."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", *args],  # noqa: S607
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def collect_git_info(project_root: Path) -> GitInfo:
+    """Collect current git repository state.
+
+    Returns a GitInfo with is_git_repo=False if not in a git repo
+    or git is not installed.
+    """
+    # Check if we're in a git repo
+    check = _run_git(["rev-parse", "--is-inside-work-tree"], project_root)
+    if check != "true":
+        return GitInfo()
+
+    commit_sha = _run_git(["rev-parse", "HEAD"], project_root)
+    branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], project_root)
+    remote_url = _run_git(["config", "--get", "remote.origin.url"], project_root)
+
+    # Check for uncommitted changes (staged + unstaged + untracked)
+    status = _run_git(["status", "--porcelain"], project_root)
+    is_clean = status == "" if status is not None else None
+
+    return GitInfo(
+        commit_sha=commit_sha,
+        branch=branch,
+        is_clean=is_clean,
+        remote_url=remote_url,
+        is_git_repo=True,
+    )
+
+
+def check_git_guardrails(
+    git_info: GitInfo,
+    *,
+    expected_branch: str = "main",
+    allow_dirty: bool = False,
+    allow_branch: bool = False,
+) -> GitGuardrailResult:
+    """Check git state against deployment requirements.
+
+    Returns a result with passed=True if all checks pass (or are overridden).
+    Warnings are non-blocking; errors are blocking (unless overridden).
+    """
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    if not git_info.is_git_repo:
+        warnings.append("Not a git repository — skipping git checks.")
+        return GitGuardrailResult(passed=True, warnings=warnings)
+
+    # Branch check
+    if git_info.branch and git_info.branch != expected_branch:
+        if allow_branch:
+            warnings.append(f"Deploying from '{git_info.branch}' (expected '{expected_branch}').")
+        else:
+            errors.append(f"On branch '{git_info.branch}', expected '{expected_branch}'.")
+
+    # Dirty working tree check
+    if git_info.is_clean is False:
+        if allow_dirty:
+            warnings.append("Working tree has uncommitted changes.")
+        else:
+            errors.append("Working tree has uncommitted changes.")
+
+    # No upstream warning (non-blocking)
+    if git_info.commit_sha and git_info.branch:
+        # A detached HEAD or missing remote isn't an error
+        if git_info.branch == "HEAD":
+            warnings.append("Detached HEAD — no branch tracking.")
+
+    passed = len(errors) == 0
+    return GitGuardrailResult(passed=passed, warnings=warnings, errors=errors)

--- a/dango/utils/git_info.py
+++ b/dango/utils/git_info.py
@@ -7,8 +7,9 @@ Pure utility — subprocess calls to git, no dango dependencies.
 
 from __future__ import annotations
 
+import re
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -28,8 +29,13 @@ class GitGuardrailResult:
     """Result of pre-deployment git checks."""
 
     passed: bool = True
-    warnings: list[str] = field(default_factory=list)
-    errors: list[str] = field(default_factory=list)
+    warnings: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+def _strip_credentials(url: str) -> str:
+    """Remove embedded credentials from git remote URLs."""
+    return re.sub(r"://[^@]+@", "://", url)
 
 
 def _run_git(args: list[str], cwd: Path) -> str | None:
@@ -62,7 +68,8 @@ def collect_git_info(project_root: Path) -> GitInfo:
 
     commit_sha = _run_git(["rev-parse", "HEAD"], project_root)
     branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], project_root)
-    remote_url = _run_git(["config", "--get", "remote.origin.url"], project_root)
+    raw_url = _run_git(["config", "--get", "remote.origin.url"], project_root)
+    remote_url = _strip_credentials(raw_url) if raw_url else None
 
     # Check for uncommitted changes (staged + unstaged + untracked)
     status = _run_git(["status", "--porcelain"], project_root)
@@ -94,10 +101,12 @@ def check_git_guardrails(
 
     if not git_info.is_git_repo:
         warnings.append("Not a git repository — skipping git checks.")
-        return GitGuardrailResult(passed=True, warnings=warnings)
+        return GitGuardrailResult(passed=True, warnings=tuple(warnings))
 
-    # Branch check
-    if git_info.branch and git_info.branch != expected_branch:
+    # Detached HEAD check (before branch comparison to avoid dual-error)
+    if git_info.branch == "HEAD":
+        warnings.append("Detached HEAD — no branch tracking.")
+    elif git_info.branch and git_info.branch != expected_branch:
         if allow_branch:
             warnings.append(f"Deploying from '{git_info.branch}' (expected '{expected_branch}').")
         else:
@@ -109,12 +118,12 @@ def check_git_guardrails(
             warnings.append("Working tree has uncommitted changes.")
         else:
             errors.append("Working tree has uncommitted changes.")
-
-    # No upstream warning (non-blocking)
-    if git_info.commit_sha and git_info.branch:
-        # A detached HEAD or missing remote isn't an error
-        if git_info.branch == "HEAD":
-            warnings.append("Detached HEAD — no branch tracking.")
+    elif git_info.is_clean is None:
+        warnings.append("Could not determine working tree status.")
 
     passed = len(errors) == 0
-    return GitGuardrailResult(passed=passed, warnings=warnings, errors=errors)
+    return GitGuardrailResult(
+        passed=passed,
+        warnings=tuple(warnings),
+        errors=tuple(errors),
+    )

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -28,7 +28,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/auth.py` | Login/logout, password change, OAuth flows, invite accept, API key CRUD (~854 lines) | `_bridge_metabase_session()`, `_set_session_cookie()` |
 | `routes/auth_2fa.py` | TOTP 2FA setup/verify/disable/recovery (~328 lines) | — |
 | `routes/users.py` | Admin user CRUD: create, edit, deactivate, delete, unlock, invite (525 lines) | — |
-| `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` (incl. OAuth token health, component disk breakdown, cloud resource metrics, backup staleness) | — |
+| `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` (incl. OAuth token health, component disk breakdown, cloud resource metrics, backup staleness, deployment info), `/api/deployments/history` (admin-only) | — |
 | `routes/config.py` | `/api/config`, `/api/metabase-config` | — |
 | `routes/sources.py` | `/api/sources`, `/api/sources/{name}/details` | — |
 | `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + background `run_sync_task()` (~558 lines) | `run_sync_task()` |

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -4,7 +4,6 @@ Health check and platform status endpoints.
 """
 
 import asyncio
-import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -330,32 +329,48 @@ def _check_backup_health() -> dict[str, Any]:
 
 def _get_local_deployment_info(project_root: Path) -> dict[str, Any] | None:
     """Read latest deployment from local journal (runs ON the cloud server)."""
-    journal_path = project_root / ".dango" / "state" / "deployments.jsonl"
-    if not journal_path.exists():
+    from dango.platform.cloud.deploy_journal import read_local_journal
+
+    entries = read_local_journal(project_root, limit=1)
+    if not entries:
         return None
-    try:
-        lines = journal_path.read_text().strip().splitlines()
-        if not lines:
-            return None
-        entry: dict[str, Any] = json.loads(lines[-1])
-        return {
-            "git_commit": entry.get("git_commit"),
-            "git_branch": entry.get("git_branch"),
-            "deployed_by": entry.get("deployer"),
-            "deployed_at": entry.get("timestamp"),
-            "success": entry.get("success"),
-        }
-    except Exception:  # noqa: BLE001
-        return None
+    entry = entries[0]
+    return {
+        "git_commit": entry.get("git_commit"),
+        "git_branch": entry.get("git_branch"),
+        "deployed_by": entry.get("deployer"),
+        "deployed_at": entry.get("timestamp"),
+        "success": entry.get("success"),
+    }
+
+
+_DEPLOYMENT_ALLOWED_FIELDS = {
+    "timestamp",
+    "deployer",
+    "success",
+    "git_commit",
+    "git_branch",
+    "git_clean",
+    "dango_version",
+    "files_synced",
+    "models_changed",
+    "models_added",
+    "models_removed",
+    "duration_seconds",
+    "dry_run",
+    "error",
+}
 
 
 @router.get("/api/deployments/history")
 async def get_deployment_history(
     request: Request,
+    limit: int = 20,
 ) -> JSONResponse:
     """Return deployment history from local journal (admin-only)."""
     from dango.auth.audit import AuditEvent, log_auth_event
     from dango.auth.permissions import require_permission
+    from dango.platform.cloud.deploy_journal import read_local_journal
 
     perm_dep = require_permission("platform.manage")
     user = await perm_dep(request)
@@ -367,22 +382,9 @@ async def get_deployment_history(
     )
 
     project_root = Path(get_project_root())
-    journal_path = project_root / ".dango" / "state" / "deployments.jsonl"
+    limit = max(1, min(limit, 100))
+    entries = read_local_journal(project_root, limit=limit)
 
-    entries: list[dict[str, Any]] = []
-    if journal_path.exists():
-        try:
-            lines = journal_path.read_text().strip().splitlines()
-            for line in lines:
-                try:
-                    entries.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-        except OSError:
-            pass
+    filtered = [{k: v for k, v in e.items() if k in _DEPLOYMENT_ALLOWED_FIELDS} for e in entries]
 
-    # Newest first, limit 20
-    entries.reverse()
-    entries = entries[:20]
-
-    return JSONResponse(content={"deployments": entries})
+    return JSONResponse(content={"deployments": filtered})

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -4,12 +4,14 @@ Health check and platform status endpoints.
 """
 
 import asyncio
+import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
+from starlette.responses import JSONResponse
 
 from dango.oauth.storage import OAuthStorage
 from dango.web.helpers import (
@@ -184,6 +186,12 @@ async def get_platform_health() -> dict[str, Any]:
         elif cloud_data["backup_health"]["status"] == "none":
             warnings.append("No backups configured")
 
+    # Deployment info (cloud only — journal written on the cloud server)
+    if is_cloud:
+        deploy_info = _get_local_deployment_info(project_root)
+        if deploy_info:
+            result["deployment"] = deploy_info
+
     # OAuth token health
     oauth_health: list[dict[str, Any]] = []
     try:
@@ -318,3 +326,63 @@ def _check_backup_health() -> dict[str, Any]:
         "age_hours": round(age_hours, 1),
         "file": latest_name,
     }
+
+
+def _get_local_deployment_info(project_root: Path) -> dict[str, Any] | None:
+    """Read latest deployment from local journal (runs ON the cloud server)."""
+    journal_path = project_root / ".dango" / "state" / "deployments.jsonl"
+    if not journal_path.exists():
+        return None
+    try:
+        lines = journal_path.read_text().strip().splitlines()
+        if not lines:
+            return None
+        entry: dict[str, Any] = json.loads(lines[-1])
+        return {
+            "git_commit": entry.get("git_commit"),
+            "git_branch": entry.get("git_branch"),
+            "deployed_by": entry.get("deployer"),
+            "deployed_at": entry.get("timestamp"),
+            "success": entry.get("success"),
+        }
+    except Exception:  # noqa: BLE001
+        return None
+
+
+@router.get("/api/deployments/history")
+async def get_deployment_history(
+    request: Request,
+) -> JSONResponse:
+    """Return deployment history from local journal (admin-only)."""
+    from dango.auth.audit import AuditEvent, log_auth_event
+    from dango.auth.permissions import require_permission
+
+    perm_dep = require_permission("platform.manage")
+    user = await perm_dep(request)
+
+    log_auth_event(
+        AuditEvent.DEPLOYMENT_HISTORY_VIEWED,
+        user_id=user.id,
+        email=user.email,
+    )
+
+    project_root = Path(get_project_root())
+    journal_path = project_root / ".dango" / "state" / "deployments.jsonl"
+
+    entries: list[dict[str, Any]] = []
+    if journal_path.exists():
+        try:
+            lines = journal_path.read_text().strip().splitlines()
+            for line in lines:
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        except OSError:
+            pass
+
+    # Newest first, limit 20
+    entries.reverse()
+    entries = entries[:20]
+
+    return JSONResponse(content={"deployments": entries})

--- a/dango/web/templates/health.html
+++ b/dango/web/templates/health.html
@@ -81,6 +81,16 @@
                 <div id="dbt-info" class="text-sm text-gray-500 mt-1">-</div>
             </div>
 
+            <!-- Deployment - Cloud only, hidden by default -->
+            <div id="deploy-card" class="bg-white rounded-lg shadow p-6 hidden">
+                <div class="flex items-center justify-between mb-2">
+                    <h3 class="text-sm font-medium text-gray-600">🚀 Deployment</h3>
+                    <span id="deploy-status-badge" class="px-2 py-1 text-xs rounded-full bg-gray-100 text-gray-800">-</span>
+                </div>
+                <div id="deploy-commit" class="text-2xl font-bold text-gray-900 font-mono">-</div>
+                <div id="deploy-detail" class="text-sm text-gray-500 mt-1">-</div>
+            </div>
+
             <!-- Backup Health - Cloud only, hidden by default -->
             <div id="backup-card" class="bg-white rounded-lg shadow p-6 hidden">
                 <div class="flex items-center justify-between mb-2">
@@ -493,6 +503,29 @@
                         `Last: ${dt.toLocaleString()}`;
                 } else {
                     document.getElementById('backup-detail').textContent = 'Not configured';
+                }
+            }
+
+            // Deployment info
+            if (health.deployment) {
+                const dep = health.deployment;
+                document.getElementById('deploy-card').classList.remove('hidden');
+                document.getElementById('deploy-commit').textContent =
+                    dep.git_commit ? dep.git_commit.substring(0, 8) : 'N/A';
+                const details = [];
+                if (dep.git_branch) details.push(dep.git_branch);
+                if (dep.deployed_by) details.push('by ' + escapeHtml(dep.deployed_by));
+                if (dep.deployed_at) details.push(new Date(dep.deployed_at).toLocaleString());
+                document.getElementById('deploy-detail').textContent = details.join(' · ');
+
+                const badge = document.getElementById('deploy-status-badge');
+                badge.className = 'px-2 py-1 text-xs rounded-full ';
+                if (dep.success) {
+                    badge.className += 'bg-green-100 text-green-800';
+                    badge.textContent = 'Success';
+                } else {
+                    badge.className += 'bg-red-100 text-red-800';
+                    badge.textContent = 'Failed';
                 }
             }
 

--- a/dango/web/templates/health.html
+++ b/dango/web/templates/health.html
@@ -520,12 +520,15 @@
 
                 const badge = document.getElementById('deploy-status-badge');
                 badge.className = 'px-2 py-1 text-xs rounded-full ';
-                if (dep.success) {
+                if (dep.success === true) {
                     badge.className += 'bg-green-100 text-green-800';
                     badge.textContent = 'Success';
-                } else {
+                } else if (dep.success === false) {
                     badge.className += 'bg-red-100 text-red-800';
                     badge.textContent = 'Failed';
+                } else {
+                    badge.className += 'bg-gray-100 text-gray-800';
+                    badge.textContent = 'Unknown';
                 }
             }
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -87,19 +87,19 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/remote.py
-    lines: 693
+    lines: 698
     category: exempt
     reason: "Remote server management: push + rollback + firewall subgroup + domain subgroup + registration of management and backup subgroups. P8-004 added git guard rails (--allow-dirty/--allow-branch) to push command."
     review_by: "v1.1"
 
   - file: dango/cli/commands/remote_mgmt.py
-    lines: 502
+    lines: 509
     category: exempt
     reason: "P8-004: Added deployment panel to remote status + remote history command. Marginally over limit."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/deployer.py
-    lines: 574
+    lines: 578
     category: exempt
     reason: "P8-004: Push deployment workflow with deploy lock and journal writing. Added git_info passthrough, nested try/finally for journal write, _write_deploy_journal helper."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -87,9 +87,21 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/remote.py
-    lines: 652
+    lines: 693
     category: exempt
-    reason: "Remote server management: push + rollback + firewall subgroup + domain subgroup + registration of management and backup subgroups. Each subgroup is a thin CLI layer delegating to platform/cloud modules."
+    reason: "Remote server management: push + rollback + firewall subgroup + domain subgroup + registration of management and backup subgroups. P8-004 added git guard rails (--allow-dirty/--allow-branch) to push command."
+    review_by: "v1.1"
+
+  - file: dango/cli/commands/remote_mgmt.py
+    lines: 502
+    category: exempt
+    reason: "P8-004: Added deployment panel to remote status + remote history command. Marginally over limit."
+    review_by: "v1.1"
+
+  - file: dango/platform/cloud/deployer.py
+    lines: 574
+    category: exempt
+    reason: "P8-004: Push deployment workflow with deploy lock and journal writing. Added git_info passthrough, nested try/finally for journal write, _write_deploy_journal helper."
     review_by: "v1.1"
 
   # --- Exempt (stable, not modified in v1) ---

--- a/tests/unit/test_deploy_journal.py
+++ b/tests/unit/test_deploy_journal.py
@@ -164,6 +164,16 @@ class TestLocalJournal:
         assert result[0]["deployer"] == "also-good"
         assert result[1]["deployer"] == "good"
 
+    def test_read_zero_limit(self, tmp_path: Path) -> None:
+        """limit=0 should return empty list."""
+        write_local_journal(tmp_path, _make_record())
+        assert read_local_journal(tmp_path, limit=0) == []
+
+    def test_read_negative_limit(self, tmp_path: Path) -> None:
+        """Negative limit should return empty list."""
+        write_local_journal(tmp_path, _make_record())
+        assert read_local_journal(tmp_path, limit=-1) == []
+
 
 # ---------------------------------------------------------------------------
 # Remote journal

--- a/tests/unit/test_deploy_journal.py
+++ b/tests/unit/test_deploy_journal.py
@@ -221,6 +221,20 @@ class TestRemoteJournal:
         assert len(result) == 1
         assert result[0]["deployer"] == "good"
 
+    def test_read_returns_empty_on_ssh_exception(self) -> None:
+        """SSH exception should return empty list (default behavior)."""
+        ssh = _make_ssh_mock()
+        ssh.exec_command.side_effect = Exception("connection lost")
+        result = read_remote_journal(ssh)
+        assert result == []
+
+    def test_read_raises_on_ssh_exception_when_requested(self) -> None:
+        """SSH exception should re-raise when raise_on_error=True."""
+        ssh = _make_ssh_mock()
+        ssh.exec_command.side_effect = Exception("connection lost")
+        with pytest.raises(Exception, match="connection lost"):
+            read_remote_journal(ssh, raise_on_error=True)
+
 
 # ---------------------------------------------------------------------------
 # get_latest_deployment
@@ -253,5 +267,12 @@ class TestGetLatestDeployment:
         ssh = _make_ssh_mock()
         ssh.exec_command.return_value = CommandResult(stdout="not json", stderr="", exit_code=0)
 
+        result = get_latest_deployment(ssh)
+        assert result is None
+
+    def test_returns_none_on_ssh_exception(self) -> None:
+        """SSH exception should return None."""
+        ssh = _make_ssh_mock()
+        ssh.exec_command.side_effect = Exception("connection lost")
         result = get_latest_deployment(ssh)
         assert result is None

--- a/tests/unit/test_deploy_journal.py
+++ b/tests/unit/test_deploy_journal.py
@@ -1,0 +1,257 @@
+"""tests/unit/test_deploy_journal.py
+
+Unit tests for dango/platform/cloud/deploy_journal.py — deployment journal.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from dango.platform.cloud.deploy_journal import (
+    DeploymentRecord,
+    get_latest_deployment,
+    read_local_journal,
+    read_remote_journal,
+    write_local_journal,
+    write_remote_journal,
+)
+from dango.platform.cloud.ssh import CommandResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_record(**overrides: object) -> DeploymentRecord:
+    """Create a DeploymentRecord with sensible defaults."""
+    defaults = {
+        "timestamp": "2026-03-27T12:00:00+00:00",
+        "deployer": "test@host",
+        "success": True,
+        "git_commit": "a" * 40,
+        "git_branch": "main",
+        "git_clean": True,
+        "dango_version": "1.0.0",
+        "files_synced": ["dbt/models/"],
+        "models_changed": ["stg_orders"],
+        "models_added": [],
+        "models_removed": [],
+        "duration_seconds": 42.5,
+        "dry_run": False,
+        "error": None,
+    }
+    defaults.update(overrides)
+    return DeploymentRecord(**defaults)  # type: ignore[arg-type]
+
+
+def _make_ssh_mock() -> MagicMock:
+    """Return a mock SSHManager."""
+    ssh = MagicMock()
+    ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=0)
+    return ssh
+
+
+# ---------------------------------------------------------------------------
+# DeploymentRecord serialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeploymentRecord:
+    """Test record serialization."""
+
+    def test_to_dict(self) -> None:
+        record = _make_record()
+        d = asdict(record)
+        assert d["timestamp"] == "2026-03-27T12:00:00+00:00"
+        assert d["deployer"] == "test@host"
+        assert d["success"] is True
+        assert d["git_commit"] == "a" * 40
+
+    def test_to_json(self) -> None:
+        record = _make_record()
+        json_str = json.dumps(asdict(record))
+        parsed = json.loads(json_str)
+        assert parsed["git_branch"] == "main"
+        assert parsed["duration_seconds"] == 42.5
+
+    def test_optional_fields_none(self) -> None:
+        record = _make_record(git_commit=None, git_branch=None, error=None)
+        d = asdict(record)
+        assert d["git_commit"] is None
+        assert d["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# Local journal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLocalJournal:
+    """Test local journal write/read."""
+
+    def test_write_creates_file(self, tmp_path: Path) -> None:
+        record = _make_record()
+        write_local_journal(tmp_path, record)
+
+        journal = tmp_path / ".dango" / "state" / "deployments.jsonl"
+        assert journal.exists()
+        lines = journal.read_text().strip().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["deployer"] == "test@host"
+
+    def test_write_appends(self, tmp_path: Path) -> None:
+        write_local_journal(tmp_path, _make_record(deployer="first"))
+        write_local_journal(tmp_path, _make_record(deployer="second"))
+
+        journal = tmp_path / ".dango" / "state" / "deployments.jsonl"
+        lines = journal.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["deployer"] == "first"
+        assert json.loads(lines[1])["deployer"] == "second"
+
+    def test_write_never_raises_on_permission_error(self, tmp_path: Path) -> None:
+        # Make parent read-only
+        state_dir = tmp_path / ".dango" / "state"
+        state_dir.mkdir(parents=True)
+        journal = state_dir / "deployments.jsonl"
+        journal.touch()
+        journal.chmod(0o000)
+
+        # Should not raise
+        write_local_journal(tmp_path, _make_record())
+
+        journal.chmod(0o644)  # Cleanup
+
+    def test_read_empty(self, tmp_path: Path) -> None:
+        result = read_local_journal(tmp_path)
+        assert result == []
+
+    def test_read_returns_newest_first(self, tmp_path: Path) -> None:
+        write_local_journal(tmp_path, _make_record(deployer="first"))
+        write_local_journal(tmp_path, _make_record(deployer="second"))
+
+        result = read_local_journal(tmp_path)
+        assert len(result) == 2
+        assert result[0]["deployer"] == "second"
+        assert result[1]["deployer"] == "first"
+
+    def test_read_respects_limit(self, tmp_path: Path) -> None:
+        for i in range(5):
+            write_local_journal(tmp_path, _make_record(deployer=f"deploy-{i}"))
+
+        result = read_local_journal(tmp_path, limit=2)
+        assert len(result) == 2
+        assert result[0]["deployer"] == "deploy-4"
+
+    def test_read_handles_corrupt_lines(self, tmp_path: Path) -> None:
+        journal = tmp_path / ".dango" / "state" / "deployments.jsonl"
+        journal.parent.mkdir(parents=True)
+        journal.write_text(
+            json.dumps(asdict(_make_record(deployer="good"))) + "\n"
+            "not valid json\n" + json.dumps(asdict(_make_record(deployer="also-good"))) + "\n"
+        )
+
+        result = read_local_journal(tmp_path)
+        assert len(result) == 2
+        assert result[0]["deployer"] == "also-good"
+        assert result[1]["deployer"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# Remote journal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteJournal:
+    """Test remote journal write/read."""
+
+    def test_write_calls_ssh(self) -> None:
+        ssh = _make_ssh_mock()
+        record = _make_record()
+        write_remote_journal(ssh, record)
+
+        ssh.exec_command.assert_called_once()
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "deployments.jsonl" in cmd
+        assert "mkdir -p" in cmd
+
+    def test_write_never_raises(self) -> None:
+        ssh = _make_ssh_mock()
+        ssh.exec_command.side_effect = Exception("SSH failure")
+
+        # Should not raise
+        write_remote_journal(ssh, _make_record())
+
+    def test_read_returns_newest_first(self) -> None:
+        ssh = _make_ssh_mock()
+        line1 = json.dumps(asdict(_make_record(deployer="first")))
+        line2 = json.dumps(asdict(_make_record(deployer="second")))
+        ssh.exec_command.return_value = CommandResult(
+            stdout=f"{line1}\n{line2}\n", stderr="", exit_code=0
+        )
+
+        result = read_remote_journal(ssh)
+        assert len(result) == 2
+        assert result[0]["deployer"] == "second"
+
+    def test_read_empty_journal(self) -> None:
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=1)
+
+        result = read_remote_journal(ssh)
+        assert result == []
+
+    def test_read_handles_corrupt_lines(self) -> None:
+        ssh = _make_ssh_mock()
+        good = json.dumps(asdict(_make_record(deployer="good")))
+        ssh.exec_command.return_value = CommandResult(
+            stdout=f"not json\n{good}\n", stderr="", exit_code=0
+        )
+
+        result = read_remote_journal(ssh)
+        assert len(result) == 1
+        assert result[0]["deployer"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# get_latest_deployment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetLatestDeployment:
+    """Test get_latest_deployment."""
+
+    def test_returns_last_entry(self) -> None:
+        ssh = _make_ssh_mock()
+        entry = asdict(_make_record(deployer="latest"))
+        ssh.exec_command.return_value = CommandResult(
+            stdout=json.dumps(entry) + "\n", stderr="", exit_code=0
+        )
+
+        result = get_latest_deployment(ssh)
+        assert result is not None
+        assert result["deployer"] == "latest"
+
+    def test_returns_none_on_empty(self) -> None:
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(stdout="", stderr="", exit_code=1)
+
+        result = get_latest_deployment(ssh)
+        assert result is None
+
+    def test_returns_none_on_corrupt(self) -> None:
+        ssh = _make_ssh_mock()
+        ssh.exec_command.return_value = CommandResult(stdout="not json", stderr="", exit_code=0)
+
+        result = get_latest_deployment(ssh)
+        assert result is None

--- a/tests/unit/test_deployer_push.py
+++ b/tests/unit/test_deployer_push.py
@@ -275,3 +275,71 @@ class TestPushDeploy:
 
         result = push_deploy(ssh, tmp_path, "10.0.0.1")
         assert any("missing_source" in w for w in result.warnings)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_git_info_passthrough(self, mock_sync, mock_backup, tmp_path):
+        """git_info should be stored in DeployResult."""
+        mock_sync.return_value = _make_sync_result(dry_run=True)
+        ssh = _make_ssh_mock()
+
+        git_info = MagicMock()
+        git_info.commit_sha = "abc12345" * 5
+        git_info.branch = "main"
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1", dry_run=True, git_info=git_info)
+        assert result.git_info is git_info
+        assert result.git_info.commit_sha == "abc12345" * 5
+
+    @patch("dango.platform.cloud.deployer._write_deploy_journal")
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_journal_written_on_success(self, mock_sync, mock_backup, mock_journal, tmp_path):
+        """Journal should be written on successful deploy with git_info."""
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        git_info = MagicMock()
+        git_info.commit_sha = "a" * 40
+        git_info.branch = "main"
+        git_info.is_clean = True
+        git_info.remote_url = "git@github.com:test/test.git"
+
+        push_deploy(ssh, tmp_path, "10.0.0.1", git_info=git_info)
+
+        mock_journal.assert_called_once()
+        call_kwargs = mock_journal.call_args[1]
+        assert call_kwargs["deploy_succeeded"] is True
+        assert call_kwargs["deploy_error"] is None
+
+    @patch("dango.platform.cloud.deployer._write_deploy_journal")
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_journal_not_written_on_dry_run(self, mock_sync, mock_backup, mock_journal, tmp_path):
+        """Journal should NOT be written on dry-run."""
+        mock_sync.return_value = _make_sync_result(dry_run=True)
+        ssh = _make_ssh_mock()
+
+        git_info = MagicMock()
+        git_info.commit_sha = "a" * 40
+        git_info.branch = "main"
+
+        push_deploy(ssh, tmp_path, "10.0.0.1", dry_run=True, git_info=git_info)
+
+        mock_journal.assert_not_called()
+
+    @patch("dango.platform.cloud.deployer._write_deploy_journal")
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_journal_not_written_without_git_info(
+        self, mock_sync, mock_backup, mock_journal, tmp_path
+    ):
+        """Journal should NOT be written when git_info is None."""
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        mock_journal.assert_not_called()

--- a/tests/unit/test_deployer_push.py
+++ b/tests/unit/test_deployer_push.py
@@ -332,14 +332,56 @@ class TestPushDeploy:
     @patch("dango.platform.cloud.deployer._write_deploy_journal")
     @patch("dango.platform.cloud.backup.create_backup")
     @patch("dango.platform.cloud.file_sync.sync_project_files")
-    def test_journal_not_written_without_git_info(
-        self, mock_sync, mock_backup, mock_journal, tmp_path
-    ):
-        """Journal should NOT be written when git_info is None."""
+    def test_journal_written_without_git_info(self, mock_sync, mock_backup, mock_journal, tmp_path):
+        """Journal should be written even when git_info is None."""
         mock_sync.return_value = _make_sync_result()
         mock_backup.return_value = _make_backup_result()
         ssh = _make_ssh_mock()
 
         push_deploy(ssh, tmp_path, "10.0.0.1")
 
-        mock_journal.assert_not_called()
+        mock_journal.assert_called_once()
+        call_args = mock_journal.call_args
+        assert call_args[0][2] is None  # git_info positional arg
+
+    @patch(
+        "dango.platform.cloud.deployer._write_deploy_journal", side_effect=Exception("journal boom")
+    )
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_journal_failure_does_not_break_deploy(
+        self, mock_sync, mock_backup, mock_journal, tmp_path
+    ):
+        """Deploy should succeed even if journal write raises."""
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        result = push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert result.sync_result is not None
+        assert result.dry_run is False
+
+    @patch("dango.platform.cloud.deployer._write_deploy_journal")
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_journal_written_on_failed_deploy(self, mock_sync, mock_backup, mock_journal, tmp_path):
+        """Journal should be written with deploy_succeeded=False on failure."""
+        mock_sync.return_value = _make_sync_result()
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        def _side_effect(cmd: str, **kwargs: object) -> CommandResult:
+            if "dbt compile" in cmd:
+                return CommandResult(stdout="", stderr="fail", exit_code=1)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _side_effect
+
+        with pytest.raises(CloudProvisioningError):
+            push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        mock_journal.assert_called_once()
+        call_kwargs = mock_journal.call_args[1]
+        assert call_kwargs["deploy_succeeded"] is False
+        assert call_kwargs["deploy_error"] is not None

--- a/tests/unit/test_deployer_push.py
+++ b/tests/unit/test_deployer_push.py
@@ -385,3 +385,4 @@ class TestPushDeploy:
         call_kwargs = mock_journal.call_args[1]
         assert call_kwargs["deploy_succeeded"] is False
         assert call_kwargs["deploy_error"] is not None
+        assert "dbt compile failed" in call_kwargs["deploy_error"]

--- a/tests/unit/test_git_info.py
+++ b/tests/unit/test_git_info.py
@@ -155,8 +155,8 @@ class TestCheckGitGuardrails:
         )
         result = check_git_guardrails(info, expected_branch="main")
         assert result.passed is True
-        assert result.errors == []
-        assert result.warnings == []
+        assert result.errors == ()
+        assert result.warnings == ()
 
     def test_wrong_branch_blocked(self) -> None:
         """Wrong branch should fail."""
@@ -234,3 +234,31 @@ class TestCheckGitGuardrails:
         result = check_git_guardrails(info, expected_branch="main", allow_branch=True)
         assert result.passed is True
         assert any("Detached HEAD" in w for w in result.warnings)
+
+    def test_is_clean_none_warning(self) -> None:
+        """is_clean=None should produce a warning about indeterminate status."""
+        info = GitInfo(is_git_repo=True, branch="main", is_clean=None)
+        result = check_git_guardrails(info, expected_branch="main")
+        assert result.passed is True
+        assert any("status" in w.lower() for w in result.warnings)
+
+    def test_detached_head_no_branch_error(self) -> None:
+        """Detached HEAD should NOT also fire branch mismatch error."""
+        info = GitInfo(is_git_repo=True, branch="HEAD", is_clean=True)
+        result = check_git_guardrails(info, expected_branch="main")
+        assert result.passed is True
+        assert any("detached" in w.lower() for w in result.warnings)
+        assert len(result.errors) == 0
+
+    def test_both_allows(self) -> None:
+        """Both allow_dirty and allow_branch should produce 2 warnings, 0 errors."""
+        info = GitInfo(is_git_repo=True, branch="develop", is_clean=False)
+        result = check_git_guardrails(
+            info,
+            expected_branch="main",
+            allow_dirty=True,
+            allow_branch=True,
+        )
+        assert result.passed is True
+        assert len(result.warnings) == 2
+        assert len(result.errors) == 0

--- a/tests/unit/test_git_info.py
+++ b/tests/unit/test_git_info.py
@@ -1,0 +1,236 @@
+"""tests/unit/test_git_info.py
+
+Unit tests for dango/utils/git_info.py — git info collection and guardrails.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dango.utils.git_info import (
+    GitInfo,
+    check_git_guardrails,
+    collect_git_info,
+)
+
+# ---------------------------------------------------------------------------
+# collect_git_info
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCollectGitInfo:
+    """Test collect_git_info against real and mock git repos."""
+
+    def test_real_git_repo(self, tmp_path: Path) -> None:
+        """Create a real git repo and verify info is collected."""
+        subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        # Create initial commit
+        (tmp_path / "file.txt").write_text("hello")
+        subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+
+        info = collect_git_info(tmp_path)
+
+        assert info.is_git_repo is True
+        assert info.commit_sha is not None
+        assert len(info.commit_sha) == 40
+        assert info.is_clean is True
+
+    def test_clean_vs_dirty(self, tmp_path: Path) -> None:
+        """Dirty working tree should be detected."""
+        subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "file.txt").write_text("hello")
+        subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+
+        # Clean state
+        info = collect_git_info(tmp_path)
+        assert info.is_clean is True
+
+        # Make it dirty
+        (tmp_path / "dirty.txt").write_text("uncommitted")
+        info = collect_git_info(tmp_path)
+        assert info.is_clean is False
+
+    def test_non_git_directory(self, tmp_path: Path) -> None:
+        """Non-git directory should return is_git_repo=False."""
+        info = collect_git_info(tmp_path)
+        assert info.is_git_repo is False
+        assert info.commit_sha is None
+        assert info.branch is None
+
+    def test_git_not_installed(self, tmp_path: Path) -> None:
+        """FileNotFoundError from subprocess should return gracefully."""
+        with patch("dango.utils.git_info._run_git", return_value=None):
+            info = collect_git_info(tmp_path)
+            assert info.is_git_repo is False
+
+    def test_branch_detection(self, tmp_path: Path) -> None:
+        """Branch name should be detected."""
+        subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "file.txt").write_text("hello")
+        subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "checkout", "-b", "feature-branch"],
+            check=True,
+            capture_output=True,
+        )
+
+        info = collect_git_info(tmp_path)
+        assert info.branch == "feature-branch"
+
+
+# ---------------------------------------------------------------------------
+# check_git_guardrails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckGitGuardrails:
+    """Test pre-deployment git guardrails."""
+
+    def test_not_a_git_repo(self) -> None:
+        """Non-git repo should pass with warning."""
+        info = GitInfo(is_git_repo=False)
+        result = check_git_guardrails(info)
+        assert result.passed is True
+        assert len(result.warnings) == 1
+        assert "Not a git" in result.warnings[0]
+
+    def test_correct_branch_clean(self) -> None:
+        """Correct branch + clean tree should pass with no issues."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="main",
+            is_clean=True,
+            is_git_repo=True,
+        )
+        result = check_git_guardrails(info, expected_branch="main")
+        assert result.passed is True
+        assert result.errors == []
+        assert result.warnings == []
+
+    def test_wrong_branch_blocked(self) -> None:
+        """Wrong branch should fail."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="develop",
+            is_clean=True,
+            is_git_repo=True,
+        )
+        result = check_git_guardrails(info, expected_branch="main")
+        assert result.passed is False
+        assert len(result.errors) == 1
+        assert "develop" in result.errors[0]
+        assert "main" in result.errors[0]
+
+    def test_wrong_branch_with_allow(self) -> None:
+        """Wrong branch with allow_branch should pass with warning."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="develop",
+            is_clean=True,
+            is_git_repo=True,
+        )
+        result = check_git_guardrails(info, expected_branch="main", allow_branch=True)
+        assert result.passed is True
+        assert len(result.warnings) == 1
+        assert "develop" in result.warnings[0]
+
+    def test_dirty_tree_blocked(self) -> None:
+        """Dirty tree should fail."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="main",
+            is_clean=False,
+            is_git_repo=True,
+        )
+        result = check_git_guardrails(info, expected_branch="main")
+        assert result.passed is False
+        assert len(result.errors) == 1
+        assert "uncommitted" in result.errors[0]
+
+    def test_dirty_tree_with_allow(self) -> None:
+        """Dirty tree with allow_dirty should pass with warning."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="main",
+            is_clean=False,
+            is_git_repo=True,
+        )
+        result = check_git_guardrails(info, expected_branch="main", allow_dirty=True)
+        assert result.passed is True
+        assert len(result.warnings) == 1
+        assert "uncommitted" in result.warnings[0]
+
+    def test_both_wrong_branch_and_dirty(self) -> None:
+        """Both errors should be reported."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="develop",
+            is_clean=False,
+            is_git_repo=True,
+        )
+        result = check_git_guardrails(info, expected_branch="main")
+        assert result.passed is False
+        assert len(result.errors) == 2
+
+    def test_detached_head_warning(self) -> None:
+        """Detached HEAD should produce a warning."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="HEAD",
+            is_clean=True,
+            is_git_repo=True,
+        )
+        result = check_git_guardrails(info, expected_branch="main", allow_branch=True)
+        assert result.passed is True
+        assert any("Detached HEAD" in w for w in result.warnings)

--- a/tests/unit/test_git_info.py
+++ b/tests/unit/test_git_info.py
@@ -13,6 +13,7 @@ import pytest
 
 from dango.utils.git_info import (
     GitInfo,
+    _strip_credentials,
     check_git_guardrails,
     collect_git_info,
 )
@@ -262,3 +263,26 @@ class TestCheckGitGuardrails:
         assert result.passed is True
         assert len(result.warnings) == 2
         assert len(result.errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# _strip_credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStripCredentials:
+    """Test credential stripping from git remote URLs."""
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://user:pass@github.com/org/repo.git", "https://github.com/org/repo.git"),
+            ("https://token@github.com/org/repo.git", "https://github.com/org/repo.git"),
+            ("https://github.com/org/repo.git", "https://github.com/org/repo.git"),
+            ("git@github.com:org/repo.git", "git@github.com:org/repo.git"),
+        ],
+    )
+    def test_strip_credentials(self, url: str, expected: str) -> None:
+        """Credentials should be removed from HTTPS URLs; SSH URLs left intact."""
+        assert _strip_credentials(url) == expected


### PR DESCRIPTION
## Summary
- **Git guardrails** on `dango remote push`: blocks deployment from wrong branch or dirty working tree, overridable with `--allow-dirty` / `--allow-branch`
- **Deployment journal**: every push records git SHA, branch, deployer, outcome, duration to append-only JSONL (local + remote)
- **CLI**: `dango remote status` shows deployed commit info; new `dango remote history` command shows deployment log
- **Web UI**: health page shows deployment card; new `/api/deployments/history` admin endpoint with audit logging
- **Config**: `deploy_branch` field on `CloudConfig` (default: `main`)

## Files changed (22)
**New:** `dango/utils/git_info.py`, `dango/platform/cloud/deploy_journal.py`, `tests/unit/test_git_info.py`, `tests/unit/test_deploy_journal.py`

**Modified:** `deployer.py` (journal writing), `backup.py` (git fields in manifest), `server_status.py` (deployment info), `remote.py` (guardrails), `remote_mgmt.py` (status panel + history cmd), `health.py` + `health.html` (deployment card + API), `config/models.py`, `auth/audit.py`, `cloud/__init__.py`, CLAUDE.md files, `file-exemptions.yml`

## Test plan
- [x] 46 targeted tests pass (test_git_info, test_deploy_journal, test_deployer_push)
- [x] Full suite: 2989 passed, 30 skipped
- [x] Ruff check + format clean
- [x] Mypy clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)