### PR TITLE
P8 Round 1: fix 5 bugs from manual testing Session 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ dango/                          # Python package source
 ├── logging.py                  # Level 0 — Structured logging (structlog + stdlib)
 ├── cli/                        # Level 3 — Click CLI (primary user interface)
 │   ├── __init__.py             # Shared Console instance
-│   ├── main.py                 # Slim entry point (~109 lines) — registers commands
+│   ├── main.py                 # Slim entry point (~121 lines) — registers commands
 │   ├── commands/               # Command modules (extracted from main.py by TASK-005)
 │   │   ├── __init__.py         # Package marker
 │   │   ├── auth.py             # auth group (12 subcommands, 538 lines)
@@ -335,7 +335,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2030 | — (metadata-only) |
 | `cli/source_wizard.py` | 2148 | — |
 | `visualization/metabase.py` | 1149 | — |
-| `cli/init.py` | 1282 | — |
+| `cli/init.py` | 1288 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 979 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/dango/auth/admin.py
+++ b/dango/auth/admin.py
@@ -75,7 +75,7 @@ def set_auth_enabled(project_root: Path, *, enabled: bool) -> None:
 
 def ensure_admin(
     db_path: Path,
-    email: str = "admin@localhost",
+    email: str = "admin@dango.local",
 ) -> tuple[User, str] | None:
     """Create an admin user if none exists.
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -8,7 +8,7 @@ Click-based command-line interface for all Dango operations — project init, so
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `main.py` (109 lines) | CLI entry point, registers all commands | `cli` (Click group), `main()` |
+| `main.py` (121 lines) | CLI entry point, registers all commands | `cli` (Click group), `main()` |
 | `__init__.py` (12 lines) | Shared `console` (Rich Console) instance | `console` |
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
@@ -41,7 +41,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1282 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1288 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2148 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -66,7 +66,7 @@ def auth_enable(ctx: click.Context) -> None:
         # enabled with no admin user.
         db_path = get_auth_db_path(project_root)
         if db_path.exists():
-            email = click.prompt("Admin email", default="admin@localhost")
+            email = click.prompt("Admin email")
             result = ensure_admin(db_path, email=email)
             if result is not None:
                 user, password = result

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -66,7 +66,14 @@ def auth_enable(ctx: click.Context) -> None:
         # enabled with no admin user.
         db_path = get_auth_db_path(project_root)
         if db_path.exists():
-            email = click.prompt("Admin email")
+            import re
+
+            email_re = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+            while True:
+                email = click.prompt("Admin email")
+                if email_re.match(email):
+                    break
+                console.print("[red]Invalid email format.[/red]")
             result = ensure_admin(db_path, email=email)
             if result is not None:
                 user, password = result

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1113,7 +1113,7 @@ on-run-end:
                     console.print("  [red]Invalid email format.[/red]")
                     continue
                 confirm_email = click.prompt("  Confirm email")
-                if email != confirm_email:
+                if email.lower() != confirm_email.lower():
                     console.print("  [red]Emails don't match.[/red]")
                     continue
                 break

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -131,7 +131,7 @@ class ProjectInitializer:
             raise
 
         # Print success message
-        self._print_success_message(warnings=warnings, failures=failures)
+        self._print_success_message(warnings=warnings, failures=failures, auth_success=auth_success)
 
         # Exit with error if critical failures
         if failures:
@@ -1210,7 +1210,7 @@ on-run-end:
 
         return __version__
 
-    def _print_success_message(self, warnings=None, failures=None):
+    def _print_success_message(self, warnings=None, failures=None, auth_success=True):
         """Print success message with next steps"""
         warnings = warnings or []
         failures = failures or []
@@ -1250,7 +1250,8 @@ on-run-end:
 
         # Add next steps (only if not failed)
         if not failures:
-            message += "[dim]Auth is enabled — log in with your admin credentials on first visit.[/dim]\n\n"
+            if auth_success:
+                message += "[dim]Auth is enabled — log in with your admin credentials on first visit.[/dim]\n\n"
             message += "[bold]Next steps:[/bold]\n\n"
 
             # Check if user is already in the project directory

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1108,10 +1108,15 @@ on-run-end:
 
             # Email
             while True:
-                email = click.prompt("  Admin email", default="admin@localhost")
-                if email_re.match(email):
-                    break
-                console.print("  [red]Invalid email format.[/red]")
+                email = click.prompt("  Admin email")
+                if not email_re.match(email):
+                    console.print("  [red]Invalid email format.[/red]")
+                    continue
+                confirm_email = click.prompt("  Confirm email")
+                if email != confirm_email:
+                    console.print("  [red]Emails don't match.[/red]")
+                    continue
+                break
 
             # Password (from env or prompt)
             env_password = os.environ.get("DANGO_ADMIN_PASSWORD")

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -53,6 +53,18 @@ def cli(ctx: click.Context) -> None:
     """
     ctx.ensure_object(dict)
 
+    # Warn if the dango binary doesn't match the active venv
+    import os
+    import sys
+
+    venv_prefix = os.environ.get("VIRTUAL_ENV")
+    if venv_prefix and not sys.executable.startswith(venv_prefix):
+        click.echo(
+            "Warning: Running 'dango' from outside the active venv. "
+            "Run 'hash -r' or restart your terminal.",
+            err=True,
+        )
+
     # Try to find project root for commands that need it
     # (init command doesn't need it, but most others do)
     try:

--- a/dango/migrations/CLAUDE.md
+++ b/dango/migrations/CLAUDE.md
@@ -54,7 +54,7 @@ Rules:
 - `upgrade(conn)` receives an active connection inside a runner-managed transaction
 - No `downgrade()` function
 - `__init__.py` files are ignored during discovery
-- Subdirectories are NOT Python packages
+- Subdirectories have `__init__.py` for packaging (so setuptools includes them); the runner skips these files
 
 ## Common Tasks
 

--- a/dango/migrations/auth/__init__.py
+++ b/dango/migrations/auth/__init__.py
@@ -1,0 +1,8 @@
+"""dango/migrations/auth/__init__.py
+
+Auth database migration scripts.
+
+This file exists for packaging purposes (so setuptools includes the
+directory in wheel/sdist builds). The migration runner discovers
+migration files by filesystem iteration and explicitly skips __init__.py.
+"""

--- a/dango/migrations/scheduler/__init__.py
+++ b/dango/migrations/scheduler/__init__.py
@@ -1,0 +1,8 @@
+"""dango/migrations/scheduler/__init__.py
+
+Scheduler database migration scripts.
+
+This file exists for packaging purposes (so setuptools includes the
+directory in wheel/sdist builds). The migration runner discovers
+migration files by filesystem iteration and explicitly skips __init__.py.
+"""

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -76,7 +76,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         db_path = get_auth_db_path(project_root)
         if db_path.exists():
-            email = os.environ.get("DANGO_ADMIN_EMAIL", "admin@localhost")
+            email = os.environ.get("DANGO_ADMIN_EMAIL", "admin@dango.local")
             result = ensure_admin(db_path, email=email)
             if result is not None:
                 user, password = result

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -136,7 +136,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1282
+    lines: 1288
     category: exempt
     reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation."
     review_by: "v1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ packages = [
     "dango.visualization",
     "dango.web",
     "dango.web.routes",
+    "dango.web.middleware",
     "dango.auth",       # Authentication & authorization
     "dango.oauth",      # OAuth management
     "dango.security",   # Token encryption

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,8 @@ packages = [
     "dango.oauth",      # OAuth management
     "dango.security",   # Token encryption
     "dango.migrations",
+    "dango.migrations.auth",
+    "dango.migrations.scheduler",
     "dango.cli.commands",
     "dango.cli.helpers",
     "dango.governance",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,8 @@ packages = [
     "dango.web",
     "dango.web.routes",
     "dango.web.middleware",
-    "dango.auth",       # Authentication & authorization
-    "dango.oauth",      # OAuth management
-    "dango.security",   # Token encryption
+    "dango.oauth",
+    "dango.security",
     "dango.migrations",
     "dango.migrations.auth",
     "dango.migrations.scheduler",

--- a/tests/unit/test_auth_admin.py
+++ b/tests/unit/test_auth_admin.py
@@ -152,7 +152,7 @@ class TestEnsureAdmin:
         result = ensure_admin(db_path)
         assert result is not None
         user, _ = result
-        assert user.email == "admin@localhost"
+        assert user.email == "admin@dango.local"
 
     def test_email_normalized(self, tmp_path: Path) -> None:
         db_path = _make_db(tmp_path)

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -83,7 +83,7 @@ class TestAuthEnable:
         project_root = _setup_project(tmp_path)
         runner = CliRunner()
         with patch("dango.cli.utils.find_project_root", return_value=project_root):
-            result = runner.invoke(cli, ["auth", "enable"], input="admin@localhost\n")
+            result = runner.invoke(cli, ["auth", "enable"], input="admin@test.com\n")
         assert result.exit_code == 0
         assert "enabled" in result.output.lower()
 
@@ -110,7 +110,7 @@ class TestAuthEnable:
         _add_user(project_root, email="admin@test.com", role=Role.ADMIN)
         runner = CliRunner()
         with patch("dango.cli.utils.find_project_root", return_value=project_root):
-            result = runner.invoke(cli, ["auth", "enable"], input="admin@localhost\n")
+            result = runner.invoke(cli, ["auth", "enable"], input="admin@test.com\n")
         assert result.exit_code == 0
         assert "already exists" in result.output.lower()
 


### PR DESCRIPTION
## Summary

Fixes 5 bugs found during Phase 8 manual testing (Session 1: Fresh Install & First Project):

- **BUG-007** (critical): `dango.web.middleware` missing from `pyproject.toml` packages list → ImportError on non-editable installs
- **BUG-004** (critical): Migration subdirs (`auth/`, `scheduler/`) not included in package → auth.db never initialized → `create_user()` crash during `dango init`
- **BUG-006** (downstream of BUG-004): Auth config not written to `project.yml` — resolved by BUG-004 fix
- **BUG-003** (medium): `admin@localhost` default email in prompts — removed default, added email confirmation step
- **BUG-005** (medium): "Log in with admin credentials" shown even when auth setup failed — now conditional on `auth_success`
- **BUG-001** (medium): Stale `dango` binary after venv install — added venv mismatch detection warning to stderr

## Test plan

- [x] `pytest` — 3003 passed, 30 skipped
- [ ] Manual: `pip install -e ".[dev]"` then `python -c "from dango.web.middleware import AuthMiddleware"` (BUG-007)
- [ ] Manual: `python -c "import dango.migrations.auth"` (BUG-004)
- [ ] Manual: `mkdir /tmp/test-dango && cd /tmp/test-dango && dango init` — verify email prompt (no default), confirm email, auth succeeds, project.yml has auth config, completion message shows auth line
- [ ] Manual: verify `dango start` loads web UI without middleware import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)