### PR TITLE
P8 Round 2: Fix ICU init, auth config visibility, password UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,9 +335,9 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2030 | — (metadata-only) |
 | `cli/source_wizard.py` | 2148 | — |
 | `visualization/metabase.py` | 1149 | — |
-| `cli/init.py` | 1288 | — |
+| `cli/init.py` | 1301 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/commands/platform.py` | 979 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 983 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 812 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 810 | — (extracted from app.py by TASK-085) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -14,7 +14,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
 | `commands/source.py` (658 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (979 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/platform.py` (983 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (538 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (812 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
@@ -41,7 +41,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1288 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1301 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2148 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -139,6 +139,7 @@ def start(ctx: click.Context) -> None:
     from dango.platform.common.startup import (
         ensure_dbt_schemas,
         ensure_duckdb_driver,
+        ensure_icu_extension,
         import_dashboards,
         rotate_logs,
         run_pending_migrations,
@@ -179,6 +180,9 @@ def start(ctx: click.Context) -> None:
                 console.print(f"[red]Migration error:[/red] {migration_exc}")
                 raise click.Abort() from migration_exc
             raise
+
+        # Ensure ICU extension is installed (Metabase timezone support)
+        ensure_icu_extension(project_root)
 
         # Ensure all dbt schemas exist (for Metabase visibility)
         ensure_dbt_schemas(project_root)

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -40,6 +40,7 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
     from dango.platform.common.startup import (
         ensure_dbt_schemas,
         ensure_duckdb_driver,
+        ensure_icu_extension,
         import_dashboards,
         rotate_logs,
         run_pending_migrations,
@@ -76,21 +77,24 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
         print(f"Migration failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
-    # 2. dbt schemas
+    # 2. ICU extension (Metabase timezone support)
+    ensure_icu_extension(project_root)
+
+    # 3. dbt schemas
     try:
         ensure_dbt_schemas(project_root)
     except Exception as exc:
         print(f"Schema setup failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
-    # 3. DuckDB driver
+    # 4. DuckDB driver
     try:
         ensure_duckdb_driver(project_root)
     except Exception as exc:
         print(f"DuckDB driver download failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
-    # 4. Docker services
+    # 5. Docker services
     try:
         start_docker_services(project_root)
     except Exception as exc:
@@ -98,7 +102,7 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
         _stop_docker_quiet(project_root)
         raise SystemExit(1) from exc
 
-    # 5. Metabase setup
+    # 6. Metabase setup
     try:
         setup_metabase_if_needed(project_root, project_name, organization)
     except Exception as exc:
@@ -106,7 +110,7 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
         _stop_docker_quiet(project_root)
         raise SystemExit(1) from exc
 
-    # 6. Dashboard import (non-critical)
+    # 7. Dashboard import (non-critical)
     try:
         import_dashboards(project_root)
     except Exception:

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -206,6 +206,12 @@ class ProjectInitializer:
 
         # Always ensure schemas exist (CREATE IF NOT EXISTS is idempotent)
         conn = duckdb.connect(str(duckdb_path))
+        # Install ICU extension for Metabase timezone compatibility
+        try:
+            conn.execute("INSTALL icu")
+            conn.execute("LOAD icu")
+        except Exception:
+            pass  # Already installed
         conn.execute("CREATE SCHEMA IF NOT EXISTS raw")
         conn.execute("CREATE SCHEMA IF NOT EXISTS staging")
         conn.execute("CREATE SCHEMA IF NOT EXISTS intermediate")
@@ -1039,6 +1045,14 @@ on-run-end:
             console.print("    You can generate docs later with: cd dbt && dbt docs generate")
             return False
 
+    def _write_auth_to_project_yml(self) -> None:
+        """Write auth.enabled to project.yml for user visibility."""
+        project_yml = self.project_dir / ".dango" / "project.yml"
+        if project_yml.exists():
+            data = self.loader.load_yaml(project_yml)
+            data.setdefault("auth", {})["enabled"] = True
+            self.loader.save_yaml(data, project_yml)
+
     def _setup_auth(self, *, skip_wizard: bool = False, force: bool = False) -> bool:
         """Set up authentication: create admin user and enable auth.
 
@@ -1066,7 +1080,11 @@ on-run-end:
         )
         from dango.auth.database import create_user, list_users
         from dango.auth.models import Role, User
-        from dango.auth.security import check_password_strength, hash_password
+        from dango.auth.security import (
+            check_password_strength,
+            generate_temp_password,
+            hash_password,
+        )
         from dango.migrations import apply_all_pending
 
         console.print("\nSetting up authentication...")
@@ -1084,6 +1102,7 @@ on-run-end:
                 if existing_admins:
                     # Just ensure auth.yml is written
                     set_auth_enabled(self.project_dir, enabled=True)
+                    self._write_auth_to_project_yml()
                     console.print("[green]✓[/green] Auth already configured (admin exists)")
                     return True
 
@@ -1093,11 +1112,13 @@ on-run-end:
                 if result is not None:
                     user, password = result
                     set_auth_enabled(self.project_dir, enabled=True)
+                    self._write_auth_to_project_yml()
                     console.print()
                     console.print(format_credentials_panel(user.email, password))
                     console.print()
                 else:
                     set_auth_enabled(self.project_dir, enabled=True)
+                    self._write_auth_to_project_yml()
                     console.print("[green]✓[/green] Auth enabled (admin already exists)")
                 return True
 
@@ -1129,29 +1150,21 @@ on-run-end:
                 password = env_password
                 console.print("  [dim]Using password from DANGO_ADMIN_PASSWORD env var.[/dim]")
             else:
-                while True:
-                    password = click.prompt("  Admin password", hide_input=True)
-                    issues = check_password_strength(password)
-                    if issues:
-                        console.print(f"  [red]Weak password:[/red] {'; '.join(issues)}")
-                        continue
-                    confirm = click.prompt("  Confirm password", hide_input=True)
-                    if password != confirm:
-                        console.print("  [red]Passwords don't match.[/red]")
-                        continue
-                    break
+                password = generate_temp_password()
 
             # Create admin user
+            must_change_password = env_password is None  # True for auto-gen, False for env var
             user = User(
                 email=email,
                 password_hash=hash_password(password),
                 role=Role.ADMIN,
-                must_change_password=False,
+                must_change_password=must_change_password,
             )
             create_user(db_path, user)
 
             # Enable auth
             set_auth_enabled(self.project_dir, enabled=True)
+            self._write_auth_to_project_yml()
 
             console.print()
             console.print(format_credentials_panel(email, password, title="Admin account created"))

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -73,7 +73,7 @@ platform/
 | File | Purpose | Key Symbols |
 |------|---------|-------------|
 | `docker.py` | Docker Compose lifecycle | `DockerManager`, `ServiceStatus` |
-| `common/startup.py` | Shared startup helpers | `run_pending_migrations`, `ensure_dbt_schemas`, `ensure_duckdb_driver`, `start_docker_services`, `setup_metabase_if_needed`, `import_dashboards` |
+| `common/startup.py` | Shared startup helpers | `run_pending_migrations`, `ensure_icu_extension`, `ensure_dbt_schemas`, `ensure_duckdb_driver`, `start_docker_services`, `setup_metabase_if_needed`, `import_dashboards` |
 | `local/network.py` | Shared nginx routing (local dev) | `NetworkConfig`, `NginxManager`, `HostsManager` |
 | `local/watcher.py` | File change detection | `DebouncedFileHandler`, `FileWatcher`, `MultiTargetWatcher`, `SyncTrigger` |
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -52,6 +52,27 @@ def run_pending_migrations(project_root: Path) -> dict[str, Any]:
     return apply_all_pending(project_root)
 
 
+def ensure_icu_extension(project_root: Path) -> None:
+    """Install ICU extension in DuckDB if not already present.
+
+    ICU is required for Metabase timezone support. No-op if the
+    warehouse database does not exist yet.
+    """
+    import duckdb
+
+    duckdb_path = project_root / "data" / "warehouse.duckdb"
+    if not duckdb_path.exists():
+        return
+    conn = duckdb.connect(str(duckdb_path))
+    try:
+        conn.execute("INSTALL icu")
+        conn.execute("LOAD icu")
+    except Exception:
+        pass  # Already installed
+    finally:
+        conn.close()
+
+
 def ensure_dbt_schemas(project_root: Path) -> None:
     """
     Create DuckDB schemas required for Metabase visibility.

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -69,7 +69,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 979
+    lines: 983
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
@@ -136,9 +136,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1288
+    lines: 1301
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -11,6 +11,7 @@ import pytest
 from dango.platform.common.startup import (
     ensure_dbt_schemas,
     ensure_duckdb_driver,
+    ensure_icu_extension,
     import_dashboards,
     run_pending_migrations,
     setup_metabase_if_needed,
@@ -221,3 +222,41 @@ class TestImportDashboards:
 
         assert result == expected
         mock_import.assert_called_once_with(tmp_path)
+
+
+@pytest.mark.unit
+class TestEnsureIcuExtension:
+    def test_no_op_when_db_does_not_exist(self, tmp_path):
+        """ensure_icu_extension does nothing when warehouse.duckdb is absent."""
+        with patch("duckdb.connect") as mock_connect:
+            ensure_icu_extension(tmp_path)
+        mock_connect.assert_not_called()
+
+    def test_installs_icu_when_db_exists(self, tmp_path):
+        """ensure_icu_extension runs INSTALL/LOAD icu on existing warehouse."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True)
+        db_path.touch()
+
+        mock_conn = MagicMock()
+        with patch("duckdb.connect", return_value=mock_conn) as mock_connect:
+            ensure_icu_extension(tmp_path)
+
+        mock_connect.assert_called_once_with(str(db_path))
+        assert mock_conn.execute.call_count == 2
+        mock_conn.execute.assert_any_call("INSTALL icu")
+        mock_conn.execute.assert_any_call("LOAD icu")
+        mock_conn.close.assert_called_once()
+
+    def test_ignores_already_installed_error(self, tmp_path):
+        """ensure_icu_extension swallows exceptions (e.g., already installed)."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True)
+        db_path.touch()
+
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = Exception("already installed")
+        with patch("duckdb.connect", return_value=mock_conn):
+            ensure_icu_extension(tmp_path)  # Should not raise
+
+        mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes three issues found during Phase 8 manual testing (Session 1):

- **BUG-009 (critical):** Install DuckDB ICU extension during `dango init` so Metabase timezone functions work on fresh projects. Also adds `ensure_icu_extension()` safety net in `dango start` for existing projects.
- **BUG-006 (medium):** Write `auth.enabled: true` to `project.yml` after enabling auth, so the setting is visible when users inspect their config.
- **BUG-008 (UX):** Auto-generate admin password in interactive init instead of prompting. Auto-generated passwords set `must_change_password=True`; env var passwords set `must_change_password=False`.

## Test plan

- [x] 3 new unit tests for `ensure_icu_extension` (DB exists, DB absent, already-installed error)
- [x] All 3006 existing tests pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] Manual: `dango init` in fresh temp dir — no password prompt, auto-gen password displayed
- [ ] Manual: `cat .dango/project.yml | grep -A2 auth` shows `auth: enabled: true`
- [ ] Manual: `dango start` → Metabase connects without ICU error
- [ ] Manual: Login with auto-gen password → forced password change
- [ ] Manual: `DANGO_ADMIN_PASSWORD=TestPass1! dango init` → uses provided password, no forced change

🤖 Generated with [Claude Code](https://claude.com/claude-code)