### PR TITLE
P8 Round 2: Version alignment + Metabase v0.59.1 upgrade

### DIFF
--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -470,10 +470,10 @@ Latest 2 versions of:
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| DuckDB | ~1.4.0 | Embedded analytical database |
-| dbt-core | ~1.10.0 | Data transformation framework |
-| dlt | >=1.17.0, <2.0 | Data ingestion toolkit |
-| Metabase | v0.50.26 | Business intelligence / dashboards |
+| DuckDB | 1.4.4 | Embedded analytical database |
+| dbt-core | 1.10.20 | Data transformation framework |
+| dlt | 1.24.0 | Data ingestion toolkit |
+| Metabase | v0.59.1 | Business intelligence / dashboards |
 
 ## spaCy (Data Governance)
 
@@ -810,8 +810,14 @@ custom_sources/
         plugins_dir = self.project_dir / "metabase-plugins"
         plugins_dir.mkdir(exist_ok=True)
 
-        # Download DuckDB driver (MotherDuck official driver)
-        driver_url = "https://github.com/motherduckdb/metabase_duckdb_driver/releases/download/1.4.1.0/duckdb.metabase-driver.jar"
+        # Download DuckDB driver (MotherDuck official driver, version-matched)
+        from dango.utils.driver import (
+            get_duckdb_driver_url,
+            get_duckdb_version,
+            write_driver_version,
+        )
+
+        driver_url = get_duckdb_driver_url()
         duckdb_driver_path = plugins_dir / "duckdb.metabase-driver.jar"
 
         if not duckdb_driver_path.exists():
@@ -827,6 +833,7 @@ custom_sources/
                         console.print(f"    Retry {attempt}/2...")
                         time.sleep(2)  # Wait before retry
                     urllib.request.urlretrieve(driver_url, duckdb_driver_path)
+                    write_driver_version(plugins_dir, get_duckdb_version())
                     console.print(
                         f"[green]✓[/green] Downloaded DuckDB driver ({duckdb_driver_path.stat().st_size // 1024 // 1024}MB)"
                     )

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -242,6 +242,7 @@ class ProjectInitializer:
 .dango/metabase.yml
 data/warehouse/
 data/uploads/
+metabase-plugins/
 dashboards/  # Old export location (deprecated, use 'dango metabase save' instead)
 *.db
 *.db-shm
@@ -812,15 +813,21 @@ custom_sources/
 
         # Download DuckDB driver (MotherDuck official driver, version-matched)
         from dango.utils.driver import (
+            driver_needs_update,
             get_duckdb_driver_url,
             get_duckdb_version,
             write_driver_version,
         )
 
-        driver_url = get_duckdb_driver_url()
         duckdb_driver_path = plugins_dir / "duckdb.metabase-driver.jar"
+        needs_download = not duckdb_driver_path.exists() or driver_needs_update(plugins_dir)
 
-        if not duckdb_driver_path.exists():
+        if needs_download:
+            # Delete stale driver if version mismatch
+            if duckdb_driver_path.exists():
+                duckdb_driver_path.unlink()
+
+            driver_url = get_duckdb_driver_url()
             console.print("⏳ Downloading DuckDB driver (70MB, this may take a moment)...")
             driver_downloaded = False
 

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -87,11 +87,10 @@ def ensure_dbt_schemas(project_root: Path) -> None:
 
 
 def ensure_duckdb_driver(project_root: Path) -> None:
-    """
-    Ensure Metabase DuckDB driver is downloaded.
+    """Ensure Metabase DuckDB driver is downloaded and version-matched.
 
-    Downloads the driver if not present. Retries 3 times on network failure.
-    No-op if driver already exists.
+    Downloads the driver if not present or if the installed DuckDB version
+    has changed since the last download.  Retries 3 times on network failure.
 
     Args:
         project_root: Project root directory
@@ -102,21 +101,32 @@ def ensure_duckdb_driver(project_root: Path) -> None:
     import time
     import urllib.request
 
-    driver_path = project_root / "metabase-plugins" / "duckdb.metabase-driver.jar"
-    if driver_path.exists():
+    from dango.utils.driver import (
+        driver_needs_update,
+        get_duckdb_driver_url,
+        get_duckdb_version,
+        write_driver_version,
+    )
+
+    plugins_dir = project_root / "metabase-plugins"
+    driver_path = plugins_dir / "duckdb.metabase-driver.jar"
+
+    if driver_path.exists() and not driver_needs_update(plugins_dir):
         return
 
-    driver_url = (
-        "https://github.com/motherduckdb/metabase_duckdb_driver/releases/"
-        "download/1.4.1.0/duckdb.metabase-driver.jar"
-    )
-    driver_path.parent.mkdir(exist_ok=True)
+    # Delete stale driver if version mismatch
+    if driver_path.exists():
+        driver_path.unlink()
+
+    driver_url = get_duckdb_driver_url()
+    plugins_dir.mkdir(exist_ok=True)
 
     for attempt in range(3):
         try:
             if attempt > 0:
                 time.sleep(2)
             urllib.request.urlretrieve(driver_url, driver_path)
+            write_driver_version(plugins_dir, get_duckdb_version())
             return
         except Exception:
             if attempt == 2:
@@ -128,9 +138,10 @@ def ensure_duckdb_driver(project_root: Path) -> None:
                     pass
 
     raise RuntimeError(
-        "Failed to download DuckDB driver after 3 attempts. "
-        "Check your internet connection and try again, or download manually from: "
-        "https://github.com/motherduckdb/metabase_duckdb_driver/releases"
+        f"Failed to download DuckDB driver after 3 attempts. "
+        f"URL: {driver_url} — "
+        f"Check your internet connection and try again, or download manually from: "
+        f"https://github.com/motherduckdb/metabase_duckdb_driver/releases"
     )
 
 

--- a/dango/templates/Dockerfile.metabase
+++ b/dango/templates/Dockerfile.metabase
@@ -4,10 +4,10 @@
 # Note: Standard Metabase images use Alpine Linux which lacks glibc/libstdc++
 # that DuckDB requires. This Dockerfile uses Eclipse Temurin (Debian-based) as base.
 
-FROM eclipse-temurin:11-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
-# Metabase version
-ENV MB_VERSION=v0.50.26
+# Metabase version (requires Java 21 as of v0.52+)
+ENV MB_VERSION=v0.59.1
 
 # Install Metabase
 USER root

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -22,6 +22,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
 | `post_sync.py` (~486 lines) | Post-sync hook dispatcher | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_drift_detection()`, `_run_pii_scan()`, `_run_analysis()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
+| `driver.py` | Metabase DuckDB driver version management | `get_duckdb_driver_url()`, `get_duckdb_version()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()` |
 
 ## Common Tasks
 
@@ -40,7 +41,7 @@ Shared utilities for process management, activity logging, sync history tracking
 ## Dependencies
 
 **Imports from:**
-- `duckdb` — database operations in database.py, db_health.py, data_validation.py
+- `duckdb` — database operations in database.py, db_health.py, data_validation.py; version detection in driver.py
 - `psutil` — process existence checks in dbt_lock.py
 - `rich` — console output in db_health.py, data_validation.py
 - `shutil` — disk usage in db_health.py
@@ -53,7 +54,8 @@ Shared utilities for process management, activity logging, sync history tracking
 - `dango/cli/commands/platform.py` — process (kill_process)
 - `dango/cli/commands/cleanup.py` — db_health, log_rotation
 - `dango/platform/local/watcher_runner.py` — dbt_lock, dbt_status
-- `dango/platform/common/startup.py` — log_rotation
+- `dango/platform/common/startup.py` — log_rotation, driver (ensure_duckdb_driver)
+- `dango/cli/init.py` — driver (DuckDB driver download during init)
 - `dango/transformation/__init__.py` — dbt_status
 - `dango/governance/` — dango_db (connect)
 - `dango/notebooks/` — dango_db (connect)
@@ -63,7 +65,7 @@ Shared utilities for process management, activity logging, sync history tracking
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_db_health_disk.py tests/unit/test_log_rotation.py`
+- **Unit:** `pytest tests/unit/test_db_health_disk.py tests/unit/test_log_rotation.py tests/unit/test_driver_utils.py`
 - **Integration:** None yet
 - **Manual:** `dango start` exercises database.py; `dango sync` exercises activity_log, sync_history, db_health, dbt_lock; `dango cleanup` exercises log_rotation, db_health
 

--- a/dango/utils/driver.py
+++ b/dango/utils/driver.py
@@ -1,0 +1,70 @@
+"""dango/utils/driver.py
+
+Metabase DuckDB driver version management.
+
+Provides dynamic driver URL generation based on the installed DuckDB version
+and version tracking to detect when the driver needs re-downloading.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DRIVER_VERSION_FILE = ".driver-version"
+"""Filename written to ``metabase-plugins/`` after a successful driver download."""
+
+_DRIVER_URL_TEMPLATE = (
+    "https://github.com/motherduckdb/metabase_duckdb_driver/"
+    "releases/download/{version}.0/duckdb.metabase-driver.jar"
+)
+
+
+def get_duckdb_version() -> str:
+    """Return the installed DuckDB version string (e.g. ``"1.4.4"``)."""
+    import duckdb
+
+    return duckdb.__version__
+
+
+def get_duckdb_driver_url() -> str:
+    """Build the Metabase DuckDB driver download URL for the installed version.
+
+    The MotherDuck driver releases use a four-part version scheme
+    (e.g. ``1.4.4.0``) where the first three parts match ``duckdb.__version__``.
+    """
+    return _DRIVER_URL_TEMPLATE.format(version=get_duckdb_version())
+
+
+def read_driver_version(plugins_dir: Path) -> str | None:
+    """Read the previously downloaded driver version from *plugins_dir*.
+
+    Returns ``None`` if the version file does not exist or cannot be read.
+    """
+    version_file = plugins_dir / DRIVER_VERSION_FILE
+    try:
+        return version_file.read_text().strip() or None
+    except OSError:
+        return None
+
+
+def write_driver_version(plugins_dir: Path, version: str) -> None:
+    """Write *version* to the driver version tracking file in *plugins_dir*."""
+    version_file = plugins_dir / DRIVER_VERSION_FILE
+    version_file.write_text(version + "\n")
+
+
+def driver_needs_update(plugins_dir: Path) -> bool:
+    """Return ``True`` if the driver jar is missing or its version mismatches.
+
+    Checks:
+    1. Driver jar file does not exist → needs update.
+    2. Version tracking file is missing → needs update (legacy install).
+    3. Recorded version differs from ``duckdb.__version__`` → needs update.
+    """
+    driver_jar = plugins_dir / "duckdb.metabase-driver.jar"
+    if not driver_jar.exists():
+        return True
+    recorded = read_driver_version(plugins_dir)
+    if recorded is None:
+        return True
+    return recorded != get_duckdb_version()

--- a/dango/utils/driver.py
+++ b/dango/utils/driver.py
@@ -13,6 +13,10 @@ from pathlib import Path
 DRIVER_VERSION_FILE = ".driver-version"
 """Filename written to ``metabase-plugins/`` after a successful driver download."""
 
+# NOTE: Always appends ".0" to the DuckDB version. The MotherDuck repo also has
+# patch releases (e.g. 1.4.1.1, 1.4.3.1) but we pin DuckDB to an exact version
+# whose .0 driver is verified to exist. When bumping DuckDB, verify the .0
+# release exists at https://github.com/motherduckdb/metabase_duckdb_driver/releases
 _DRIVER_URL_TEMPLATE = (
     "https://github.com/motherduckdb/metabase_duckdb_driver/"
     "releases/download/{version}.0/duckdb.metabase-driver.jar"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,12 @@ classifiers = [
 ]
 
 dependencies = [
-    # Critical dependencies - use compatible release for stability
-    "duckdb~=1.4.0",      # Database - latest stable
-    "dbt-core~=1.10.0",   # Core tool - latest stable (requires protobuf 6.x)
-    "dbt-duckdb~=1.10.0", # Adapter - must match dbt-core
-    "dlt[duckdb]>=1.17.0,<2.0", # ETL tool - allow 1.17+ for Python 3.13/3.14 support
+    # Critical dependencies - pinned exact for version alignment
+    # DuckDB + Metabase driver + Metabase must all match (see Dockerfile.metabase)
+    "duckdb==1.4.4",          # Pinned — Metabase driver must match
+    "dbt-core==1.10.20",      # Pinned — latest 1.10.x (1.11 is breaking)
+    "dbt-duckdb==1.10.1",     # Pinned — must match dbt-core
+    "dlt[duckdb]==1.24.0",    # Pinned — latest stable
 
     # Framework and utilities - flexible versions
     "click>=8.1.7",
@@ -327,6 +328,7 @@ module = [
     "tests.unit.test_web_ai_tools",
     "tests.unit.test_web_imports",
     "tests.unit.test_byos",
+    "tests.unit.test_driver_utils",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_driver_utils.py
+++ b/tests/unit/test_driver_utils.py
@@ -1,0 +1,78 @@
+"""tests/unit/test_driver_utils.py
+
+Tests for dango.utils.driver — Metabase DuckDB driver version management.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from dango.utils.driver import (
+    driver_needs_update,
+    get_duckdb_driver_url,
+    read_driver_version,
+    write_driver_version,
+)
+
+
+@pytest.mark.unit
+class TestGetDuckdbDriverUrl:
+    def test_url_contains_version(self):
+        """URL includes duckdb version with .0 suffix."""
+        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+            url = get_duckdb_driver_url()
+
+        assert "/1.4.4.0/" in url
+        assert url.endswith("duckdb.metabase-driver.jar")
+
+    def test_url_format_different_version(self):
+        """URL adapts to whatever version is installed."""
+        with patch("dango.utils.driver.get_duckdb_version", return_value="1.5.1"):
+            url = get_duckdb_driver_url()
+
+        assert "/1.5.1.0/" in url
+
+
+@pytest.mark.unit
+class TestDriverVersionTracking:
+    def test_read_missing_file(self, tmp_path):
+        """read_driver_version returns None when file does not exist."""
+        assert read_driver_version(tmp_path) is None
+
+    def test_write_then_read(self, tmp_path):
+        """Round-trip: write a version, read it back."""
+        write_driver_version(tmp_path, "1.4.4")
+        assert read_driver_version(tmp_path) == "1.4.4"
+
+    def test_read_empty_file(self, tmp_path):
+        """read_driver_version returns None for an empty file."""
+        (tmp_path / ".driver-version").write_text("")
+        assert read_driver_version(tmp_path) is None
+
+
+@pytest.mark.unit
+class TestDriverNeedsUpdate:
+    def test_no_jar(self, tmp_path):
+        """Needs update when driver jar does not exist."""
+        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+            assert driver_needs_update(tmp_path) is True
+
+    def test_jar_exists_no_version_file(self, tmp_path):
+        """Needs update when jar exists but version file is missing."""
+        (tmp_path / "duckdb.metabase-driver.jar").touch()
+        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+            assert driver_needs_update(tmp_path) is True
+
+    def test_version_mismatch(self, tmp_path):
+        """Needs update when recorded version differs from installed."""
+        (tmp_path / "duckdb.metabase-driver.jar").touch()
+        write_driver_version(tmp_path, "1.3.0")
+        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+            assert driver_needs_update(tmp_path) is True
+
+    def test_up_to_date(self, tmp_path):
+        """No update needed when jar exists and version matches."""
+        (tmp_path / "duckdb.metabase-driver.jar").touch()
+        write_driver_version(tmp_path, "1.4.4")
+        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+            assert driver_needs_update(tmp_path) is False

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -48,14 +48,16 @@ class TestEnsureDbtSchemas:
 
 @pytest.mark.unit
 class TestEnsureDuckdbDriver:
-    def test_no_op_if_driver_exists(self, tmp_path):
-        """ensure_duckdb_driver skips download when driver jar already present."""
-        driver_path = tmp_path / "metabase-plugins" / "duckdb.metabase-driver.jar"
-        driver_path.parent.mkdir(parents=True)
-        driver_path.touch()
+    def test_no_op_if_driver_exists_and_version_matches(self, tmp_path):
+        """ensure_duckdb_driver skips download when jar and version match."""
+        plugins_dir = tmp_path / "metabase-plugins"
+        plugins_dir.mkdir(parents=True)
+        (plugins_dir / "duckdb.metabase-driver.jar").touch()
+        (plugins_dir / ".driver-version").write_text("1.4.4\n")
 
         with patch("urllib.request.urlretrieve") as mock_retrieve:
-            ensure_duckdb_driver(tmp_path)
+            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+                ensure_duckdb_driver(tmp_path)
 
         mock_retrieve.assert_not_called()
 
@@ -67,17 +69,21 @@ class TestEnsureDuckdbDriver:
             Path(dest).touch()
 
         with patch("urllib.request.urlretrieve", side_effect=fake_retrieve):
-            ensure_duckdb_driver(tmp_path)
+            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+                ensure_duckdb_driver(tmp_path)
 
-        driver_path = tmp_path / "metabase-plugins" / "duckdb.metabase-driver.jar"
+        plugins_dir = tmp_path / "metabase-plugins"
+        driver_path = plugins_dir / "duckdb.metabase-driver.jar"
         assert driver_path.exists()
+        assert (plugins_dir / ".driver-version").read_text().strip() == "1.4.4"
 
     def test_raises_runtime_error_after_3_failures(self, tmp_path):
         """ensure_duckdb_driver raises RuntimeError when all 3 attempts fail."""
         with patch("urllib.request.urlretrieve", side_effect=OSError("network error")):
             with patch("time.sleep"):  # Skip retry delays
-                with pytest.raises(RuntimeError, match="3 attempts"):
-                    ensure_duckdb_driver(tmp_path)
+                with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+                    with pytest.raises(RuntimeError, match="3 attempts"):
+                        ensure_duckdb_driver(tmp_path)
 
     def test_retries_on_failure(self, tmp_path):
         """ensure_duckdb_driver retries up to 3 times before giving up."""
@@ -91,10 +97,44 @@ class TestEnsureDuckdbDriver:
 
         with patch("urllib.request.urlretrieve", side_effect=failing_retrieve):
             with patch("time.sleep"):
-                with pytest.raises(RuntimeError):
-                    ensure_duckdb_driver(tmp_path)
+                with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+                    with pytest.raises(RuntimeError):
+                        ensure_duckdb_driver(tmp_path)
 
         assert call_count == 3
+
+    def test_redownloads_on_version_mismatch(self, tmp_path):
+        """ensure_duckdb_driver re-downloads when version file doesn't match."""
+        plugins_dir = tmp_path / "metabase-plugins"
+        plugins_dir.mkdir(parents=True)
+        (plugins_dir / "duckdb.metabase-driver.jar").touch()
+        (plugins_dir / ".driver-version").write_text("1.3.0\n")
+
+        def fake_retrieve(url: str, dest: Path) -> None:
+            Path(dest).touch()
+
+        with patch("urllib.request.urlretrieve", side_effect=fake_retrieve) as mock_ret:
+            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+                ensure_duckdb_driver(tmp_path)
+
+        mock_ret.assert_called_once()
+        assert (plugins_dir / ".driver-version").read_text().strip() == "1.4.4"
+
+    def test_redownloads_when_version_file_missing(self, tmp_path):
+        """ensure_duckdb_driver re-downloads when version file is absent."""
+        plugins_dir = tmp_path / "metabase-plugins"
+        plugins_dir.mkdir(parents=True)
+        (plugins_dir / "duckdb.metabase-driver.jar").touch()
+
+        def fake_retrieve(url: str, dest: Path) -> None:
+            Path(dest).touch()
+
+        with patch("urllib.request.urlretrieve", side_effect=fake_retrieve) as mock_ret:
+            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
+                ensure_duckdb_driver(tmp_path)
+
+        mock_ret.assert_called_once()
+        assert (plugins_dir / ".driver-version").read_text().strip() == "1.4.4"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **Pin exact dependency versions** to prevent version drift: `duckdb==1.4.4`, `dbt-core==1.10.20`, `dbt-duckdb==1.10.1`, `dlt[duckdb]==1.24.0`
- **Upgrade Metabase** from v0.50.26 to v0.59.1 (Java 21 base image, verified API compatibility)
- **Dynamic DuckDB driver URL** derived from `duckdb.__version__` — eliminates hardcoded driver version in `init.py` and `startup.py`
- **Driver version tracking** via `.driver-version` file with automatic re-download on version mismatch

Fixes BUG-009 (three-way version mismatch causing Metabase timeout on fresh installs).

## Test plan

- [x] All 3017 existing tests pass
- [x] 9 new tests for `dango/utils/driver.py` (URL format, version tracking, needs-update logic)
- [x] 6 updated tests for `ensure_duckdb_driver()` (version-aware no-op, mismatch re-download)
- [x] Ruff check + format clean
- [x] All pre-commit hooks pass (including mypy)
- [ ] Manual: `dango init` → verify compat table, driver download, `.driver-version` file
- [ ] Manual: `dango start` → verify Metabase v0.59.1 connects to DuckDB
- [ ] Manual: verify `cat .dango/project.yml | grep auth` shows `auth.enabled: true` (BUG-006 re-verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)