### PR TITLE
P8 Round 3: Fix Metabase DuckDB connection (read_only + :ro mount)

### DIFF
--- a/dango/templates/docker-compose.yml.j2
+++ b/dango/templates/docker-compose.yml.j2
@@ -10,7 +10,7 @@ services:
       - "{{ metabase_port }}:3000"
     volumes:
       - metabase-data:/metabase-data
-      - ./data:/data
+      - ./data:/data:ro
       - ./metabase-plugins:/app/plugins
     environment:
       MB_DB_TYPE: h2

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -722,7 +722,7 @@ def setup_metabase(
             "details": {
                 "database_file": docker_duckdb_path,
                 "old_implicit_casting": True,
-                "read_only": False,
+                "read_only": True,
                 # Note: DuckDB driver doesn't support schema-filters-type/patterns
                 # Users will see all schemas (raw_*, main, staging)
                 # This is a limitation of the DuckDB Metabase driver


### PR DESCRIPTION
## Summary

- Set `read_only: True` in Metabase DuckDB connection config (`metabase.py:725`)
- Add `:ro` suffix to data volume mount in docker-compose template

**Root cause:** DuckDB file locking (`fcntl`/`flock`) does not work reliably over Docker Desktop's bind mount FUSE layer on macOS. With `read_only: False`, the DuckDB driver hangs trying to acquire a write lock until timeout (10s), causing `dango start` to fail with "Cannot connect Metabase to DuckDB".

**Why read_only is correct:** Metabase is a BI tool that only reads data. All writes go through dlt (sync) and dbt (transform) on the host. The `:ro` mount is defense-in-depth.

## Test plan

- [x] `pytest` — 3017 passed
- [ ] Manual: `dango init test-project && cd test-project && dango start` → Metabase connects without timeout → web UI loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)