### PR TITLE
P8 Round 4: Remove ICU + pin driver 1.5.1.0

### DIFF
--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -139,7 +139,6 @@ def start(ctx: click.Context) -> None:
     from dango.platform.common.startup import (
         ensure_dbt_schemas,
         ensure_duckdb_driver,
-        ensure_icu_extension,
         import_dashboards,
         rotate_logs,
         run_pending_migrations,
@@ -180,9 +179,6 @@ def start(ctx: click.Context) -> None:
                 console.print(f"[red]Migration error:[/red] {migration_exc}")
                 raise click.Abort() from migration_exc
             raise
-
-        # Ensure ICU extension is installed (Metabase timezone support)
-        ensure_icu_extension(project_root)
 
         # Ensure all dbt schemas exist (for Metabase visibility)
         ensure_dbt_schemas(project_root)

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -40,7 +40,6 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
     from dango.platform.common.startup import (
         ensure_dbt_schemas,
         ensure_duckdb_driver,
-        ensure_icu_extension,
         import_dashboards,
         rotate_logs,
         run_pending_migrations,
@@ -77,24 +76,21 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
         print(f"Migration failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
-    # 2. ICU extension (Metabase timezone support)
-    ensure_icu_extension(project_root)
-
-    # 3. dbt schemas
+    # 2. dbt schemas
     try:
         ensure_dbt_schemas(project_root)
     except Exception as exc:
         print(f"Schema setup failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
-    # 4. DuckDB driver
+    # 3. DuckDB driver
     try:
         ensure_duckdb_driver(project_root)
     except Exception as exc:
         print(f"DuckDB driver download failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
-    # 5. Docker services
+    # 4. Docker services
     try:
         start_docker_services(project_root)
     except Exception as exc:
@@ -102,7 +98,7 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
         _stop_docker_quiet(project_root)
         raise SystemExit(1) from exc
 
-    # 6. Metabase setup
+    # 5. Metabase setup
     try:
         setup_metabase_if_needed(project_root, project_name, organization)
     except Exception as exc:
@@ -110,7 +106,7 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
         _stop_docker_quiet(project_root)
         raise SystemExit(1) from exc
 
-    # 7. Dashboard import (non-critical)
+    # 6. Dashboard import (non-critical)
     try:
         import_dashboards(project_root)
     except Exception:

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -206,12 +206,6 @@ class ProjectInitializer:
 
         # Always ensure schemas exist (CREATE IF NOT EXISTS is idempotent)
         conn = duckdb.connect(str(duckdb_path))
-        # Install ICU extension for Metabase timezone compatibility
-        try:
-            conn.execute("INSTALL icu")
-            conn.execute("LOAD icu")
-        except Exception:
-            pass  # Already installed
         conn.execute("CREATE SCHEMA IF NOT EXISTS raw")
         conn.execute("CREATE SCHEMA IF NOT EXISTS staging")
         conn.execute("CREATE SCHEMA IF NOT EXISTS intermediate")
@@ -813,9 +807,9 @@ custom_sources/
 
         # Download DuckDB driver (MotherDuck official driver, version-matched)
         from dango.utils.driver import (
+            METABASE_DUCKDB_DRIVER_VERSION,
             driver_needs_update,
             get_duckdb_driver_url,
-            get_duckdb_version,
             write_driver_version,
         )
 
@@ -840,7 +834,7 @@ custom_sources/
                         console.print(f"    Retry {attempt}/2...")
                         time.sleep(2)  # Wait before retry
                     urllib.request.urlretrieve(driver_url, duckdb_driver_path)
-                    write_driver_version(plugins_dir, get_duckdb_version())
+                    write_driver_version(plugins_dir, METABASE_DUCKDB_DRIVER_VERSION)
                     console.print(
                         f"[green]✓[/green] Downloaded DuckDB driver ({duckdb_driver_path.stat().st_size // 1024 // 1024}MB)"
                     )

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -73,7 +73,7 @@ platform/
 | File | Purpose | Key Symbols |
 |------|---------|-------------|
 | `docker.py` | Docker Compose lifecycle | `DockerManager`, `ServiceStatus` |
-| `common/startup.py` | Shared startup helpers | `run_pending_migrations`, `ensure_icu_extension`, `ensure_dbt_schemas`, `ensure_duckdb_driver`, `start_docker_services`, `setup_metabase_if_needed`, `import_dashboards` |
+| `common/startup.py` | Shared startup helpers | `run_pending_migrations`, `ensure_dbt_schemas`, `ensure_duckdb_driver`, `start_docker_services`, `setup_metabase_if_needed`, `import_dashboards` |
 | `local/network.py` | Shared nginx routing (local dev) | `NetworkConfig`, `NginxManager`, `HostsManager` |
 | `local/watcher.py` | File change detection | `DebouncedFileHandler`, `FileWatcher`, `MultiTargetWatcher`, `SyncTrigger` |
 | `local/watcher_lifecycle.py` | Watcher subprocess lifecycle | `start_file_watcher`, `stop_file_watcher`, `get_watcher_status`, `get_watcher_pid_file_path` |

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -52,27 +52,6 @@ def run_pending_migrations(project_root: Path) -> dict[str, Any]:
     return apply_all_pending(project_root)
 
 
-def ensure_icu_extension(project_root: Path) -> None:
-    """Install ICU extension in DuckDB if not already present.
-
-    ICU is required for Metabase timezone support. No-op if the
-    warehouse database does not exist yet.
-    """
-    import duckdb
-
-    duckdb_path = project_root / "data" / "warehouse.duckdb"
-    if not duckdb_path.exists():
-        return
-    conn = duckdb.connect(str(duckdb_path))
-    try:
-        conn.execute("INSTALL icu")
-        conn.execute("LOAD icu")
-    except Exception:
-        pass  # Already installed
-    finally:
-        conn.close()
-
-
 def ensure_dbt_schemas(project_root: Path) -> None:
     """
     Create DuckDB schemas required for Metabase visibility.
@@ -102,9 +81,9 @@ def ensure_duckdb_driver(project_root: Path) -> None:
     import urllib.request
 
     from dango.utils.driver import (
+        METABASE_DUCKDB_DRIVER_VERSION,
         driver_needs_update,
         get_duckdb_driver_url,
-        get_duckdb_version,
         write_driver_version,
     )
 
@@ -126,7 +105,7 @@ def ensure_duckdb_driver(project_root: Path) -> None:
             if attempt > 0:
                 time.sleep(2)
             urllib.request.urlretrieve(driver_url, driver_path)
-            write_driver_version(plugins_dir, get_duckdb_version())
+            write_driver_version(plugins_dir, METABASE_DUCKDB_DRIVER_VERSION)
             return
         except Exception:
             if attempt == 2:

--- a/dango/templates/docker-compose.yml.j2
+++ b/dango/templates/docker-compose.yml.j2
@@ -10,6 +10,8 @@ services:
       - "{{ metabase_port }}:3000"
     volumes:
       - metabase-data:/metabase-data
+      # No :ro — DuckDB needs to create temp files during reads.
+      # Write protection is handled by read_only: True in the Metabase DB config.
       - ./data:/data
       - ./metabase-plugins:/app/plugins
     environment:

--- a/dango/templates/docker-compose.yml.j2
+++ b/dango/templates/docker-compose.yml.j2
@@ -10,7 +10,7 @@ services:
       - "{{ metabase_port }}:3000"
     volumes:
       - metabase-data:/metabase-data
-      - ./data:/data:ro
+      - ./data:/data
       - ./metabase-plugins:/app/plugins
     environment:
       MB_DB_TYPE: h2

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -22,7 +22,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
 | `post_sync.py` (~486 lines) | Post-sync hook dispatcher | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_drift_detection()`, `_run_pii_scan()`, `_run_analysis()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
-| `driver.py` | Metabase DuckDB driver version management | `get_duckdb_driver_url()`, `get_duckdb_version()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()` |
+| `driver.py` | Metabase DuckDB driver version management (pinned to match Metabase, not DuckDB Python) | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `get_duckdb_version()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()` |
 
 ## Common Tasks
 

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -22,7 +22,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
 | `post_sync.py` (~486 lines) | Post-sync hook dispatcher | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_drift_detection()`, `_run_pii_scan()`, `_run_analysis()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
-| `driver.py` | Metabase DuckDB driver version management (pinned to match Metabase, not DuckDB Python) | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `get_duckdb_version()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()` |
+| `driver.py` | Metabase DuckDB driver version management (pinned to match Metabase, not DuckDB Python) | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()` |
 
 ## Common Tasks
 

--- a/dango/utils/driver.py
+++ b/dango/utils/driver.py
@@ -13,13 +13,18 @@ from pathlib import Path
 DRIVER_VERSION_FILE = ".driver-version"
 """Filename written to ``metabase-plugins/`` after a successful driver download."""
 
-# NOTE: Always appends ".0" to the DuckDB version. The MotherDuck repo also has
-# patch releases (e.g. 1.4.1.1, 1.4.3.1) but we pin DuckDB to an exact version
-# whose .0 driver is verified to exist. When bumping DuckDB, verify the .0
-# release exists at https://github.com/motherduckdb/metabase_duckdb_driver/releases
-_DRIVER_URL_TEMPLATE = (
+# Driver version must match METABASE version, not DuckDB Python version.
+# DuckDB 1.5.x can read files created by DuckDB 1.4.x (backwards compatible).
+# Current alignment: Metabase v0.59.1 → driver 1.5.1.0 → reads DuckDB 1.4.4 files
+#
+# When upgrading: check https://github.com/motherduckdb/metabase_duckdb_driver/releases
+# for the driver that targets your Metabase version. The driver's bundled DuckDB must
+# be >= the Python DuckDB version for backwards-compatible reads.
+METABASE_DUCKDB_DRIVER_VERSION = "1.5.1.0"
+
+METABASE_DUCKDB_DRIVER_URL = (
     "https://github.com/motherduckdb/metabase_duckdb_driver/"
-    "releases/download/{version}.0/duckdb.metabase-driver.jar"
+    f"releases/download/{METABASE_DUCKDB_DRIVER_VERSION}/duckdb.metabase-driver.jar"
 )
 
 
@@ -31,12 +36,8 @@ def get_duckdb_version() -> str:
 
 
 def get_duckdb_driver_url() -> str:
-    """Build the Metabase DuckDB driver download URL for the installed version.
-
-    The MotherDuck driver releases use a four-part version scheme
-    (e.g. ``1.4.4.0``) where the first three parts match ``duckdb.__version__``.
-    """
-    return _DRIVER_URL_TEMPLATE.format(version=get_duckdb_version())
+    """Return the pinned Metabase DuckDB driver download URL."""
+    return METABASE_DUCKDB_DRIVER_URL
 
 
 def read_driver_version(plugins_dir: Path) -> str | None:
@@ -71,4 +72,4 @@ def driver_needs_update(plugins_dir: Path) -> bool:
     recorded = read_driver_version(plugins_dir)
     if recorded is None:
         return True
-    return recorded != get_duckdb_version()
+    return recorded != METABASE_DUCKDB_DRIVER_VERSION

--- a/dango/utils/driver.py
+++ b/dango/utils/driver.py
@@ -2,8 +2,8 @@
 
 Metabase DuckDB driver version management.
 
-Provides dynamic driver URL generation based on the installed DuckDB version
-and version tracking to detect when the driver needs re-downloading.
+Provides pinned driver URL and version tracking to detect when the
+driver needs re-downloading.
 """
 
 from __future__ import annotations
@@ -26,13 +26,6 @@ METABASE_DUCKDB_DRIVER_URL = (
     "https://github.com/motherduckdb/metabase_duckdb_driver/"
     f"releases/download/{METABASE_DUCKDB_DRIVER_VERSION}/duckdb.metabase-driver.jar"
 )
-
-
-def get_duckdb_version() -> str:
-    """Return the installed DuckDB version string (e.g. ``"1.4.4"``)."""
-    import duckdb
-
-    return duckdb.__version__
 
 
 def get_duckdb_driver_url() -> str:
@@ -64,7 +57,7 @@ def driver_needs_update(plugins_dir: Path) -> bool:
     Checks:
     1. Driver jar file does not exist → needs update.
     2. Version tracking file is missing → needs update (legacy install).
-    3. Recorded version differs from ``duckdb.__version__`` → needs update.
+    3. Recorded version differs from ``METABASE_DUCKDB_DRIVER_VERSION`` → needs update.
     """
     driver_jar = plugins_dir / "duckdb.metabase-driver.jar"
     if not driver_jar.exists():

--- a/tests/unit/test_driver_utils.py
+++ b/tests/unit/test_driver_utils.py
@@ -3,11 +3,10 @@
 Tests for dango.utils.driver — Metabase DuckDB driver version management.
 """
 
-from unittest.mock import patch
-
 import pytest
 
 from dango.utils.driver import (
+    METABASE_DUCKDB_DRIVER_VERSION,
     driver_needs_update,
     get_duckdb_driver_url,
     read_driver_version,
@@ -17,20 +16,12 @@ from dango.utils.driver import (
 
 @pytest.mark.unit
 class TestGetDuckdbDriverUrl:
-    def test_url_contains_version(self):
-        """URL includes duckdb version with .0 suffix."""
-        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-            url = get_duckdb_driver_url()
+    def test_url_contains_pinned_version(self):
+        """URL includes the pinned Metabase driver version."""
+        url = get_duckdb_driver_url()
 
-        assert "/1.4.4.0/" in url
+        assert f"/{METABASE_DUCKDB_DRIVER_VERSION}/" in url
         assert url.endswith("duckdb.metabase-driver.jar")
-
-    def test_url_format_different_version(self):
-        """URL adapts to whatever version is installed."""
-        with patch("dango.utils.driver.get_duckdb_version", return_value="1.5.1"):
-            url = get_duckdb_driver_url()
-
-        assert "/1.5.1.0/" in url
 
 
 @pytest.mark.unit
@@ -41,8 +32,8 @@ class TestDriverVersionTracking:
 
     def test_write_then_read(self, tmp_path):
         """Round-trip: write a version, read it back."""
-        write_driver_version(tmp_path, "1.4.4")
-        assert read_driver_version(tmp_path) == "1.4.4"
+        write_driver_version(tmp_path, "1.5.1.0")
+        assert read_driver_version(tmp_path) == "1.5.1.0"
 
     def test_read_empty_file(self, tmp_path):
         """read_driver_version returns None for an empty file."""
@@ -54,25 +45,21 @@ class TestDriverVersionTracking:
 class TestDriverNeedsUpdate:
     def test_no_jar(self, tmp_path):
         """Needs update when driver jar does not exist."""
-        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-            assert driver_needs_update(tmp_path) is True
+        assert driver_needs_update(tmp_path) is True
 
     def test_jar_exists_no_version_file(self, tmp_path):
         """Needs update when jar exists but version file is missing."""
         (tmp_path / "duckdb.metabase-driver.jar").touch()
-        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-            assert driver_needs_update(tmp_path) is True
+        assert driver_needs_update(tmp_path) is True
 
     def test_version_mismatch(self, tmp_path):
-        """Needs update when recorded version differs from installed."""
+        """Needs update when recorded version differs from pinned."""
         (tmp_path / "duckdb.metabase-driver.jar").touch()
         write_driver_version(tmp_path, "1.3.0")
-        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-            assert driver_needs_update(tmp_path) is True
+        assert driver_needs_update(tmp_path) is True
 
     def test_up_to_date(self, tmp_path):
-        """No update needed when jar exists and version matches."""
+        """No update needed when jar exists and version matches pinned."""
         (tmp_path / "duckdb.metabase-driver.jar").touch()
-        write_driver_version(tmp_path, "1.4.4")
-        with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-            assert driver_needs_update(tmp_path) is False
+        write_driver_version(tmp_path, METABASE_DUCKDB_DRIVER_VERSION)
+        assert driver_needs_update(tmp_path) is False

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -11,12 +11,12 @@ import pytest
 from dango.platform.common.startup import (
     ensure_dbt_schemas,
     ensure_duckdb_driver,
-    ensure_icu_extension,
     import_dashboards,
     run_pending_migrations,
     setup_metabase_if_needed,
     start_docker_services,
 )
+from dango.utils.driver import METABASE_DUCKDB_DRIVER_VERSION
 
 
 @pytest.mark.unit
@@ -53,11 +53,10 @@ class TestEnsureDuckdbDriver:
         plugins_dir = tmp_path / "metabase-plugins"
         plugins_dir.mkdir(parents=True)
         (plugins_dir / "duckdb.metabase-driver.jar").touch()
-        (plugins_dir / ".driver-version").write_text("1.4.4\n")
+        (plugins_dir / ".driver-version").write_text(f"{METABASE_DUCKDB_DRIVER_VERSION}\n")
 
         with patch("urllib.request.urlretrieve") as mock_retrieve:
-            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-                ensure_duckdb_driver(tmp_path)
+            ensure_duckdb_driver(tmp_path)
 
         mock_retrieve.assert_not_called()
 
@@ -69,21 +68,21 @@ class TestEnsureDuckdbDriver:
             Path(dest).touch()
 
         with patch("urllib.request.urlretrieve", side_effect=fake_retrieve):
-            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-                ensure_duckdb_driver(tmp_path)
+            ensure_duckdb_driver(tmp_path)
 
         plugins_dir = tmp_path / "metabase-plugins"
         driver_path = plugins_dir / "duckdb.metabase-driver.jar"
         assert driver_path.exists()
-        assert (plugins_dir / ".driver-version").read_text().strip() == "1.4.4"
+        assert (
+            plugins_dir / ".driver-version"
+        ).read_text().strip() == METABASE_DUCKDB_DRIVER_VERSION
 
     def test_raises_runtime_error_after_3_failures(self, tmp_path):
         """ensure_duckdb_driver raises RuntimeError when all 3 attempts fail."""
         with patch("urllib.request.urlretrieve", side_effect=OSError("network error")):
             with patch("time.sleep"):  # Skip retry delays
-                with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-                    with pytest.raises(RuntimeError, match="3 attempts"):
-                        ensure_duckdb_driver(tmp_path)
+                with pytest.raises(RuntimeError, match="3 attempts"):
+                    ensure_duckdb_driver(tmp_path)
 
     def test_retries_on_failure(self, tmp_path):
         """ensure_duckdb_driver retries up to 3 times before giving up."""
@@ -97,9 +96,8 @@ class TestEnsureDuckdbDriver:
 
         with patch("urllib.request.urlretrieve", side_effect=failing_retrieve):
             with patch("time.sleep"):
-                with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-                    with pytest.raises(RuntimeError):
-                        ensure_duckdb_driver(tmp_path)
+                with pytest.raises(RuntimeError):
+                    ensure_duckdb_driver(tmp_path)
 
         assert call_count == 3
 
@@ -114,11 +112,12 @@ class TestEnsureDuckdbDriver:
             Path(dest).touch()
 
         with patch("urllib.request.urlretrieve", side_effect=fake_retrieve) as mock_ret:
-            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-                ensure_duckdb_driver(tmp_path)
+            ensure_duckdb_driver(tmp_path)
 
         mock_ret.assert_called_once()
-        assert (plugins_dir / ".driver-version").read_text().strip() == "1.4.4"
+        assert (
+            plugins_dir / ".driver-version"
+        ).read_text().strip() == METABASE_DUCKDB_DRIVER_VERSION
 
     def test_redownloads_when_version_file_missing(self, tmp_path):
         """ensure_duckdb_driver re-downloads when version file is absent."""
@@ -130,11 +129,12 @@ class TestEnsureDuckdbDriver:
             Path(dest).touch()
 
         with patch("urllib.request.urlretrieve", side_effect=fake_retrieve) as mock_ret:
-            with patch("dango.utils.driver.get_duckdb_version", return_value="1.4.4"):
-                ensure_duckdb_driver(tmp_path)
+            ensure_duckdb_driver(tmp_path)
 
         mock_ret.assert_called_once()
-        assert (plugins_dir / ".driver-version").read_text().strip() == "1.4.4"
+        assert (
+            plugins_dir / ".driver-version"
+        ).read_text().strip() == METABASE_DUCKDB_DRIVER_VERSION
 
 
 @pytest.mark.unit
@@ -262,41 +262,3 @@ class TestImportDashboards:
 
         assert result == expected
         mock_import.assert_called_once_with(tmp_path)
-
-
-@pytest.mark.unit
-class TestEnsureIcuExtension:
-    def test_no_op_when_db_does_not_exist(self, tmp_path):
-        """ensure_icu_extension does nothing when warehouse.duckdb is absent."""
-        with patch("duckdb.connect") as mock_connect:
-            ensure_icu_extension(tmp_path)
-        mock_connect.assert_not_called()
-
-    def test_installs_icu_when_db_exists(self, tmp_path):
-        """ensure_icu_extension runs INSTALL/LOAD icu on existing warehouse."""
-        db_path = tmp_path / "data" / "warehouse.duckdb"
-        db_path.parent.mkdir(parents=True)
-        db_path.touch()
-
-        mock_conn = MagicMock()
-        with patch("duckdb.connect", return_value=mock_conn) as mock_connect:
-            ensure_icu_extension(tmp_path)
-
-        mock_connect.assert_called_once_with(str(db_path))
-        assert mock_conn.execute.call_count == 2
-        mock_conn.execute.assert_any_call("INSTALL icu")
-        mock_conn.execute.assert_any_call("LOAD icu")
-        mock_conn.close.assert_called_once()
-
-    def test_ignores_already_installed_error(self, tmp_path):
-        """ensure_icu_extension swallows exceptions (e.g., already installed)."""
-        db_path = tmp_path / "data" / "warehouse.duckdb"
-        db_path.parent.mkdir(parents=True)
-        db_path.touch()
-
-        mock_conn = MagicMock()
-        mock_conn.execute.side_effect = Exception("already installed")
-        with patch("duckdb.connect", return_value=mock_conn):
-            ensure_icu_extension(tmp_path)  # Should not raise
-
-        mock_conn.close.assert_called_once()


### PR DESCRIPTION
## Summary
- **Remove ICU extension** from `dango init` and startup — ICU metadata in DuckDB files caused Metabase's Java driver to hang on autoload inside Docker (BUG-009 root cause)
- **Pin driver to 1.5.1.0** to match Metabase v0.59.1 instead of dynamically matching `duckdb.__version__` — driver 1.5.1.0 bundles DuckDB 1.5.1 which reads 1.4.4 files (backwards compatible)
- **Remove `:ro` mount** from docker-compose template — `read_only: True` at the DuckDB level handles this; `:ro` can interfere with DuckDB temp files during reads

## Changes
- `dango/utils/driver.py` — `METABASE_DUCKDB_DRIVER_VERSION = "1.5.1.0"` constant, pinned URL
- `dango/cli/init.py` — removed ICU install, use pinned driver version
- `dango/platform/common/startup.py` — removed `ensure_icu_extension()`, use pinned driver version
- `dango/cli/commands/platform.py` — removed ICU import/call
- `dango/cli/commands/serve.py` — removed ICU import/call, renumbered steps
- `dango/templates/docker-compose.yml.j2` — `./data:/data` (was `./data:/data:ro`)
- Tests and CLAUDE.md docs updated

## What's NOT changed
- `csv_loader.py` ICU install — kept for Session 2 testing (check 2.19a)
- DuckDB Python `==1.4.4`, Metabase `v0.59.1`, `read_only: True`

## Test plan
- [x] `pytest tests/unit/test_driver_utils.py tests/unit/test_platform_startup.py -v` — 27/27 pass
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest -m unit` — 2911 passed
- [ ] Manual: `dango init` + `dango start` → Metabase connects → web UI loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)