### PR TITLE
P8-R5: Fix 10 Session 2 bugs (BUG-013/017-025)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | `dango/ingestion/dlt_sources/` | Vendored third-party dlt connectors (127 files). Rarely modified. |
 | `dango/web/static/` | Frontend HTML/CSS/JS assets. |
 | `tests/` | Read source module first, then find its tests. |
-| `dango/ingestion/sources/registry.py` | 2030-line metadata registry. Only when adding a new source. |
+| `dango/ingestion/sources/registry.py` | 2008-line metadata registry. Only when adding a new source. |
 | `dango/templates/` | Jinja2 templates. Only when modifying project init or model generation. |
 
 ## Decision Tree
@@ -84,7 +84,7 @@ dango/                          # Python package source
 │   │   ├── model.py            # model group (add/remove)
 │   │   ├── platform.py         # start/stop/status + port helpers (979 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (658 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (686 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
@@ -199,7 +199,7 @@ dango/                          # Python package source
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
-│   ├── metabase.py             # Metabase API (1149 lines)
+│   ├── metabase.py             # Metabase API (1150 lines)
 │   └── dashboard_manager.py    # Dashboard export/import (1113 lines)
 │
 ├── platform/                   # Level 2 — Docker, network, file watcher, scheduling
@@ -249,14 +249,14 @@ dango/                          # Python package source
 │
 ├── ingestion/                  # Level 1 — Data loading
 │   ├── dlt_runner.py           # ⚠ 2284 lines — orchestrates full sync pipeline
-│   ├── csv_loader.py           # Multi-format file loading with dedup (773 lines)
+│   ├── csv_loader.py           # Multi-format file loading with dedup (766 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
 │   ├── __init__.py             # run_dbt_models(), generate_dbt_docs()
-│   └── generator.py            # DbtModelGenerator (577 lines)
+│   └── generator.py            # DbtModelGenerator (581 lines)
 │
 ├── oauth/                      # Level 1 — OAuth flows
 │   ├── __init__.py             # OAuthManager
@@ -332,29 +332,29 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 2276 | — (exempt, too risky) |
-| `ingestion/sources/registry.py` | 2030 | — (metadata-only) |
-| `cli/source_wizard.py` | 2148 | — |
-| `visualization/metabase.py` | 1149 | — |
+| `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
+| `cli/source_wizard.py` | 2097 | — |
+| `visualization/metabase.py` | 1150 | — |
 | `cli/init.py` | 1301 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 983 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 812 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 810 | — (extracted from app.py by TASK-085) |
-| `ingestion/csv_loader.py` | 773 | — |
+| `ingestion/csv_loader.py` | 766 | — |
 | `platform/scheduling/jobs.py` | 732 | — (module-level job functions) |
 | `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
 | `web/routes/upload.py` | 699 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 658 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 686 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 594 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
-| `transformation/generator.py` | 577 | — |
+| `transformation/generator.py` | 581 | — |
 | `web/routes/catalog.py` | 566 | — (data catalog: columns, profiling, lineage, impact) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 704 | — (provisioning orchestration + BYOS) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ dango/                          # Python package source
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
-│   ├── metabase.py             # Metabase API (1150 lines)
+│   ├── metabase.py             # Metabase API (1152 lines)
 │   └── dashboard_manager.py    # Dashboard export/import (1113 lines)
 │
 ├── platform/                   # Level 2 — Docker, network, file watcher, scheduling
@@ -256,7 +256,7 @@ dango/                          # Python package source
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
 │   ├── __init__.py             # run_dbt_models(), generate_dbt_docs()
-│   └── generator.py            # DbtModelGenerator (581 lines)
+│   └── generator.py            # DbtModelGenerator (593 lines)
 │
 ├── oauth/                      # Level 1 — OAuth flows
 │   ├── __init__.py             # OAuthManager
@@ -334,7 +334,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/dlt_runner.py` | 2276 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2097 | — |
-| `visualization/metabase.py` | 1150 | — |
+| `visualization/metabase.py` | 1152 | — |
 | `cli/init.py` | 1301 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 983 | — (extracted from main.py by TASK-005) |
@@ -354,7 +354,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 594 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
-| `transformation/generator.py` | 581 | — |
+| `transformation/generator.py` | 593 | — |
 | `web/routes/catalog.py` | 566 | — (data catalog: columns, profiling, lineage, impact) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 704 | — (provisioning orchestration + BYOS) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,7 +13,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (658 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/source.py` (686 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
 | `commands/platform.py` (983 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (538 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
@@ -43,7 +43,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | **Wizards** | | |
 | `init.py` (1301 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
-| `source_wizard.py` (2148 lines) | Source configuration wizard | `add_source()` |
+| `source_wizard.py` (2097 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |
 | `utils.py` (129 lines) | Display helpers + project context | `require_project_context()` |

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -167,7 +167,7 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
         # Get last sync times from multiple sources:
         # 1. _dlt_loads table in each raw_{source_name} schema (for dlt-based sources)
         # 2. _dango_file_metadata table in main schema (for CSV sources)
-        last_sync_times: dict[str, object] = {}
+        last_sync_times: dict[str, datetime] = {}
         row_counts: dict[str, int] = {}
         duckdb_path = project_root / "data" / "warehouse.duckdb"
         if duckdb_path.exists():

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -167,7 +167,8 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
         # Get last sync times from multiple sources:
         # 1. _dlt_loads table in each raw_{source_name} schema (for dlt-based sources)
         # 2. _dango_file_metadata table in main schema (for CSV sources)
-        last_sync_times = {}
+        last_sync_times: dict[str, object] = {}
+        row_counts: dict[str, int] = {}
         duckdb_path = project_root / "data" / "warehouse.duckdb"
         if duckdb_path.exists():
             try:
@@ -216,6 +217,31 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
                         ):
                             last_sync_times[source_name] = last_sync
 
+                # Get row counts per source
+                for src in sources:
+                    raw_schema = f"raw_{src.name}"
+                    try:
+                        schema_tables = conn.execute(
+                            """
+                            SELECT table_name FROM information_schema.tables
+                            WHERE table_schema = ?
+                              AND table_name NOT LIKE '\\_dlt\\_%' ESCAPE '\\'
+                              AND table_name NOT LIKE '\\_dango\\_%' ESCAPE '\\'
+                            """,
+                            [raw_schema],
+                        ).fetchall()
+                        total = 0
+                        for (tbl,) in schema_tables:
+                            cnt = conn.execute(
+                                f'SELECT COUNT(*) FROM "{raw_schema}"."{tbl}"'
+                            ).fetchone()
+                            if cnt:
+                                total += cnt[0]
+                        if total > 0:
+                            row_counts[src.name] = total
+                    except Exception:
+                        pass
+
                 conn.close()
             except Exception:
                 # If we can't read metadata, just skip - last_sync will show "never"
@@ -227,6 +253,7 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
         table.add_column("Type", style="dim")
         table.add_column("Status", style="white")
         table.add_column("Last Sync", style="dim")
+        table.add_column("Rows", style="dim", justify="right")
 
         for src in sources:
             # Status indicator
@@ -258,7 +285,8 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
             else:
                 last_sync = "[dim]never[/dim]"
 
-            table.add_row(src.name, src.type.value, status, last_sync)
+            rows_str = f"{row_counts[src.name]:,}" if src.name in row_counts else "[dim]-[/dim]"
+            table.add_row(src.name, src.type.value, status, last_sync, rows_str)
 
         console.print(table)
         console.print()

--- a/dango/cli/db_helpers.py
+++ b/dango/cli/db_helpers.py
@@ -54,6 +54,11 @@ def build_schema_table_mapping(config: DangoConfig) -> tuple[dict[str, set[str]]
                 # No explicit endpoints - schema will be discovered from DB
                 if schema_name not in schema_to_tables:
                     schema_to_tables[schema_name] = set()
+        else:
+            # Source uses generic_config (no typed config model)
+            # Still register the schema so its tables aren't flagged as orphaned
+            if schema_name not in schema_to_tables:
+                schema_to_tables[schema_name] = set()
 
     return schema_to_tables, source_to_schema
 

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -192,10 +192,6 @@ class SourceWizard:
                     if selected is not None:
                         params["resources"] = selected
 
-                    # Step 4c: Dedup options for local_files
-                    if source_type == "local_files":
-                        params = self._collect_dedup_options(params)
-
                     # All inputs collected, break out of state machine
                     break
 
@@ -1453,53 +1449,6 @@ def {module_name}_resource(api_key: str):
                     return "← Back"
                 if value is not None:
                     params[param["name"]] = value
-
-        return params
-
-    def _collect_dedup_options(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Collect deduplication options for local_files sources."""
-        console.print("\n[bold]Deduplication settings[/bold]")
-
-        choices = [
-            ("Keep latest version (recommended)", "latest_only"),
-            ("Append all records", "append_only"),
-            ("Track history (SCD Type 2)", "scd_type2"),
-            ("No deduplication", "none"),
-        ]
-
-        questions = [
-            inquirer.List(
-                "dedup",
-                message="How should duplicate/updated records be handled?",
-                choices=[(label, val) for label, val in choices],
-                default="latest_only",
-            )
-        ]
-        answers = inquirer.prompt(questions, theme=themes.GreenPassion())
-        if answers:
-            strategy = answers["dedup"]
-            params["deduplication_strategy"] = strategy
-
-            # For strategies that benefit from keys, optionally prompt
-            if strategy in ("latest_only", "scd_type2"):
-                console.print(
-                    "\n[dim]Optional: specify a primary key and timestamp column for smarter dedup.[/dim]"
-                )
-                console.print("[dim]Press Enter to skip (Dango will use file-level dedup).[/dim]")
-
-                pk = inquirer.text(
-                    message="Primary key column (optional)",
-                    default="",
-                )
-                if pk is not None and pk.strip():
-                    params["primary_key"] = pk.strip()
-
-                ts = inquirer.text(
-                    message="Timestamp column (optional)",
-                    default="",
-                )
-                if ts is not None and ts.strip():
-                    params["timestamp_column"] = ts.strip()
 
         return params
 

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -22,11 +22,8 @@ SCAN_ENTITIES = [
     "CREDIT_CARD",
     "US_SSN",
     "IP_ADDRESS",
-    "PERSON",
     "IBAN_CODE",
-    "US_PASSPORT",
-    "US_DRIVER_LICENSE",
-    "CRYPTO",
+    "PERSON",
 ]
 
 SCORE_THRESHOLD = 0.5

--- a/dango/ingestion/csv_loader.py
+++ b/dango/ingestion/csv_loader.py
@@ -103,13 +103,6 @@ class CSVLoader:
         # Connect to DuckDB (needed even if no files exist, to process deletions)
         conn = duckdb.connect(str(self.duckdb_path))
 
-        # Setup ICU extension for Metabase compatibility
-        try:
-            conn.execute("INSTALL icu")
-            conn.execute("LOAD icu")
-        except Exception:
-            pass  # Already installed
-
         # Create schema
         conn.execute(f"CREATE SCHEMA IF NOT EXISTS {target_schema}")
 

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -125,28 +125,6 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         ],
         "optional_params": [
             {
-                "name": "deduplication_strategy",
-                "type": "choice",
-                "prompt": "Deduplication strategy",
-                "choices": ["latest_only", "append_only", "scd_type2", "none"],
-                "default": "latest_only",
-                "help": "How to handle duplicate/updated records",
-            },
-            {
-                "name": "primary_key",
-                "type": "string",
-                "prompt": "Primary key column",
-                "default": None,
-                "help": "Column to use as primary key for deduplication (optional)",
-            },
-            {
-                "name": "timestamp_column",
-                "type": "string",
-                "prompt": "Timestamp column",
-                "default": None,
-                "help": "Column to use for ordering in latest_only/scd_type2 strategies (optional)",
-            },
-            {
                 "name": "notes",
                 "type": "text",
                 "prompt": "Notes on how to refresh this data",

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -217,6 +217,8 @@ def setup_metabase_if_needed(
     Raises:
         RuntimeError: If DuckDB connection fails (critical — services must stop)
     """
+    import os
+
     from dango.config.helpers import is_cloud_mode
     from dango.visualization.metabase import setup_metabase
 
@@ -224,8 +226,31 @@ def setup_metabase_if_needed(
     if credentials_file.exists():
         return {"already_configured": True, "success": True}
 
+    # Resolve admin email: env var > auth DB > fallback
+    admin_email = os.environ.get("DANGO_ADMIN_EMAIL", "")
+    if not admin_email:
+        try:
+            from dango.auth.admin import get_auth_db_path
+            from dango.auth.database import list_users
+            from dango.auth.models import Role
+
+            db_path = get_auth_db_path(project_root)
+            if db_path.exists():
+                users = list_users(db_path, active_only=True)
+                admins = [u for u in users if u.role == Role.ADMIN]
+                if admins and admins[0].email != "admin@dango.local":
+                    admin_email = admins[0].email
+        except Exception:
+            pass
+    if not admin_email:
+        admin_email = "admin@dango.local"
+
     setup_result = setup_metabase(
-        project_root, project_name, organization, cloud_mode=is_cloud_mode(project_root)
+        project_root,
+        project_name,
+        organization,
+        cloud_mode=is_cloud_mode(project_root),
+        admin_email=admin_email,
     )
 
     # DuckDB connection failure is critical — caller must roll back Docker

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -115,6 +115,10 @@ class DbtModelGenerator:
             for row in result:
                 column_name, data_type, is_nullable = row
 
+                # Skip internal metadata columns (dlt and dango)
+                if column_name.startswith("_dlt_") or column_name.startswith("_dango_"):
+                    continue
+
                 # Generate tests based on column properties
                 tests = []
                 if is_nullable == "NO":

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -115,10 +115,6 @@ class DbtModelGenerator:
             for row in result:
                 column_name, data_type, is_nullable = row
 
-                # Skip internal metadata columns (dlt and dango)
-                if column_name.startswith("_dlt_") or column_name.startswith("_dango_"):
-                    continue
-
                 # Generate tests based on column properties
                 tests = []
                 if is_nullable == "NO":
@@ -487,8 +483,17 @@ class DbtModelGenerator:
                         )
                         continue
 
+                    # Filter internal metadata columns for staging context
+                    staging_columns = [
+                        c
+                        for c in columns
+                        if not c["name"].startswith("_dlt_") and not c["name"].startswith("_dango_")
+                    ]
+
                     # Infer deduplication strategy
-                    dedup_strategy, dedup_columns = self.infer_dedup_strategy(source, columns)
+                    dedup_strategy, dedup_columns = self.infer_dedup_strategy(
+                        source, staging_columns
+                    )
 
                     # Generate staging model SQL
                     model_sql = self.generate_staging_model(
@@ -507,13 +512,19 @@ class DbtModelGenerator:
                         {
                             "endpoint": endpoint,
                             "model": str(model_file),
-                            "columns": len(columns),
+                            "columns": len(staging_columns),
                             "dedup_strategy": dedup_strategy or "none",
                         }
                     )
 
-                    # Add to sources.yml tables list
-                    tables_for_yml.append({"name": table_name, "columns": columns})
+                    # Add to sources.yml tables list (all columns including internal)
+                    tables_for_yml.append(
+                        {
+                            "name": table_name,
+                            "columns": columns,
+                            "staging_columns": staging_columns,
+                        }
+                    )
 
                 # Generate sources.yml for all tables (documents raw tables)
                 sources_file = None
@@ -525,6 +536,7 @@ class DbtModelGenerator:
                         f.write(sources_yml)
 
                     # Generate staging schema.yml (documents staging models)
+                    # Uses staging_columns (excludes _dlt_*/_dango_* internal columns)
                     staging_models_for_yml = []
                     for table in tables_for_yml:
                         staging_models_for_yml.append(
@@ -532,7 +544,7 @@ class DbtModelGenerator:
                                 "name": f"stg_{source.name}__{table['name']}",
                                 "table_name": table["name"],
                                 "schema_name": schema_name,
-                                "columns": table["columns"],
+                                "columns": table.get("staging_columns", table["columns"]),
                             }
                         )
 

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -550,6 +550,8 @@ def setup_metabase(
         cloud_mode: When True, generate a random admin password instead
             of the default local password. SSO session bridging handles
             user-facing access, so the random password is invisible.
+        admin_email: Email address for the Metabase admin user.
+            Resolved by caller from DANGO_ADMIN_EMAIL env var or auth DB.
 
     Returns:
         Setup summary with credentials

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -535,6 +535,7 @@ def setup_metabase(
     organization: str | None = None,
     metabase_url: str = "http://localhost:3000",
     cloud_mode: bool = False,
+    admin_email: str = "admin@dango.local",
 ) -> dict[str, Any]:
     """
     Auto-setup Metabase on first start
@@ -589,7 +590,6 @@ def setup_metabase(
         properties = response.json()
         setup_token = properties.get("setup-token")
 
-        admin_email = "admin@dango.local"
         if cloud_mode:
             import secrets as _secrets
 
@@ -1057,6 +1057,7 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
                         )
                     elif schema == "main" and table_name.startswith("_dango"):
                         description = "⚙️ **INTERNAL** - Dango metadata (do not use)"
+                        visibility_type = "hidden"
                     else:
                         continue  # Skip tables without clear guidance
 

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -640,6 +640,7 @@ async function apiCall(endpoint, method = 'GET', body = null, timeoutMs = 5000) 
         method,
         headers: {
             'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
         },
         signal: controller.signal,
     };
@@ -1569,7 +1570,10 @@ async function handleFileDelete(sourceName, filePath, filename, safeFilename) {
     try {
         // Call DELETE endpoint
         const response = await fetch(`/api/sources/${sourceName}/csv-files?file_path=${encodeURIComponent(filePath)}`, {
-            method: 'DELETE'
+            method: 'DELETE',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+            }
         });
 
         const result = await response.json();
@@ -1664,6 +1668,9 @@ async function handleCsvUpload() {
             try {
                 const response = await fetch(`/api/sources/${sourceName}/upload-csv`, {
                     method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
                     body: formData
                 });
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -124,7 +124,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
-    lines: 1150
+    lines: 1152
     category: exempt
     reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations."
     review_by: "v1.1"
@@ -162,7 +162,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 581
+    lines: 593
     category: exempt
     reason: "DbtModelGenerator — generates dbt models from source configs. Stable, rarely modified."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -81,7 +81,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 658
+    lines: 686
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"
@@ -112,19 +112,19 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
-    lines: 2030
+    lines: 2008
     category: exempt
     reason: "Source metadata registry. Declarative data (no logic), naturally grows with each new source type. P5-011 added capability metadata (+313 lines). 5c-007 added local_files entry (+70 lines)."
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py
-    lines: 2148
+    lines: 2097
     category: exempt
     reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting. P7-011 added metrics generation. P5c grew +529 lines (credential unification, resource selection, dedup collection). P8-001 added REST API wizard enhancements: headers, query params, endpoint testing, data_selector/primary_key suggestions (+267 lines)."
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
-    lines: 1149
+    lines: 1150
     category: exempt
     reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations."
     review_by: "v1.1"
@@ -150,7 +150,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/csv_loader.py
-    lines: 773
+    lines: 766
     category: exempt
     reason: "Multi-format file loading (CSV, JSON, JSONL, Parquet) with deduplication. Single-purpose module, stable."
     review_by: "v1.1"
@@ -162,7 +162,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 577
+    lines: 581
     category: exempt
     reason: "DbtModelGenerator — generates dbt models from source configs. Stable, rarely modified."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary

- **BUG-025 (Critical):** `dango db clean` no longer drops tables for generic_config sources (chess + ~21 types). Added else branch to register schema in `build_schema_table_mapping()`.
- **BUG-024 (Critical):** Added `X-Requested-With` CSRF header to `apiCall()`, CSV upload, and CSV delete in `app.js`. All dashboard POST/DELETE actions now work with auth middleware.
- **BUG-018/019 (Medium):** Removed dead dedup wizard prompts from local_files source — dedup was prompted twice and config was never read by csv_loader.
- **BUG-023 (Medium):** Strip `_dlt_*` and `_dango_*` columns from staging model schema YAML via `get_table_schema()` filter.
- **BUG-017 (Medium):** Reduced PII scan entity types from 10 to 7 per VAL-008 (removed US_PASSPORT, US_DRIVER_LICENSE, CRYPTO).
- **BUG-021 (Medium):** Made Metabase admin email configurable — resolves from `DANGO_ADMIN_EMAIL` env var or auth DB admin user.
- **BUG-020 (Low):** Removed unnecessary ICU extension install from csv_loader.
- **BUG-022 (Low):** Hidden `_dango` metadata tables in Metabase (`visibility_type = "hidden"`).
- **BUG-013 (Low):** Added row count column to `dango source list`.

## Test plan

- [x] `ruff check` + `ruff format --check` — all pass
- [x] `pytest -x` — 3013 passed, 30 skipped
- [x] Line counts updated in `file-exemptions.yml`, root `CLAUDE.md`, module `CLAUDE.md`
- [ ] Manual: `dango db clean` with chess source configured (BUG-025)
- [ ] Manual: Dashboard CSV upload/delete/sync (BUG-024)
- [ ] Manual: `dango source add` → Local Files, no dedup prompt (BUG-018/019)
- [ ] Manual: `dango source list` shows Rows column (BUG-013)

🤖 Generated with [Claude Code](https://claude.com/claude-code)