### PR TITLE
fix: Metabase SSO auto-bridging, CSRF exemption, 403 handling (BUG-011/014/015)

### DIFF
--- a/dango/auth/metabase_bridge.py
+++ b/dango/auth/metabase_bridge.py
@@ -56,21 +56,56 @@ async def bridge_metabase_login(
     user: User,
     project_root: Path,
     metabase_url: str | None = None,
+    *,
+    db_path: Path | None = None,
 ) -> str | None:
     """Create a Metabase session for *user* using their encrypted password.
 
     Returns the Metabase session ID on success, or ``None`` if bridging
     cannot proceed (no credentials, Metabase down, etc.).
+
+    When *db_path* is provided and the user has no Metabase credentials,
+    attempts a lazy sync (creating the Metabase account on the fly) before
+    giving up.  This handles the case where Metabase was not ready at
+    startup and the initial sync silently failed.
     """
     try:
         if user.metabase_password_enc is None or user.metabase_user_id is None:
-            logger.debug("Metabase bridge skip: no credentials for %s", user.email)
-            return None
+            if db_path is None:
+                logger.debug("Metabase bridge skip: no credentials for %s", user.email)
+                return None
+
+            # Lazy sync: user was never synced to Metabase
+            logger.info("Metabase bridge: attempting lazy sync for %s", user.email)
+            if metabase_url is None:
+                metabase_url = await get_metabase_url(project_root)
+            if metabase_url is None:
+                return None
+
+            from dango.auth.metabase_sync import sync_user_to_metabase
+
+            mb_id = await asyncio.to_thread(
+                sync_user_to_metabase, db_path, user.id, project_root, metabase_url
+            )
+            if mb_id is None:
+                logger.warning("Metabase bridge: lazy sync failed for %s", user.email)
+                return None
+
+            # Reload user to get fresh metabase_password_enc
+            from dango.auth.database import get_user_by_id
+
+            refreshed = await asyncio.to_thread(get_user_by_id, db_path, user.id)
+            if refreshed is None or refreshed.metabase_password_enc is None:
+                return None
+            user = refreshed
 
         if metabase_url is None:
             metabase_url = await get_metabase_url(project_root)
         if metabase_url is None:
             logger.debug("Metabase bridge skip: no URL configured")
+            return None
+
+        if user.metabase_password_enc is None:
             return None
 
         from dango.auth.metabase_sync import decrypt_metabase_password

--- a/dango/web/middleware/auth.py
+++ b/dango/web/middleware/auth.py
@@ -174,9 +174,12 @@ class AuthMiddleware:
             return
 
         # CSRF check (cookie-auth only, state-changing methods)
+        # Metabase proxy routes are exempt: Metabase's own frontend sends
+        # POSTs without Dango CSRF headers, and Metabase has its own CSRF
+        # protection.  Dango auth is still required (not a public route).
         method: str = scope.get("method", "GET")
         if auth_method == "session" and method not in _SAFE_METHODS:
-            if not _has_csrf_header(headers):
+            if not path.startswith("/metabase/") and not _has_csrf_header(headers):
                 response = _make_403_json("CSRF validation failed")
                 await response(scope, receive, send)
                 return

--- a/dango/web/routes/metabase_proxy.py
+++ b/dango/web/routes/metabase_proxy.py
@@ -61,6 +61,23 @@ def _get_user_mb_session(request: Request) -> str | None:
     return request.cookies.get(_MB_SESSION_COOKIE)
 
 
+def _set_mb_session_cookie(response: Response, session_id: str, request: Request) -> None:
+    """Set the ``metabase.SESSION`` cookie on *response*."""
+    response.set_cookie(
+        key=_MB_SESSION_COOKIE,
+        value=session_id,
+        path="/",
+        httponly=True,
+        samesite="lax",
+        secure=is_secure_request(request.scope),
+    )
+
+
+def _clear_mb_session_cookie(response: Response) -> None:
+    """Delete the ``metabase.SESSION`` cookie (stale session)."""
+    response.delete_cookie(key=_MB_SESSION_COOKIE, path="/")
+
+
 async def _rebridge_if_needed(request: Request, metabase_url: str) -> str | None:
     """Create a fresh Metabase session for the current user.
 
@@ -136,17 +153,14 @@ async def proxy_to_metabase(
             if new_session is not None:
                 response = await _do_proxy(target_url, request.method, headers, body, new_session)
                 if response.status_code not in (401, 403):
-                    # Attach the new session cookie to the response
                     final = _build_response(response)
-                    final.set_cookie(
-                        key=_MB_SESSION_COOKIE,
-                        value=new_session,
-                        path="/",
-                        httponly=True,
-                        samesite="lax",
-                        secure=is_secure_request(request.scope),
-                    )
+                    _set_mb_session_cookie(final, new_session, request)
                     return final
+            # Re-bridge failed or retry still 401/403 — clear stale cookie so
+            # the next request hits the auto-bridge path instead of looping.
+            final = _build_response(response)
+            _clear_mb_session_cookie(final)
+            return final
 
         return _build_response(response)
 
@@ -301,14 +315,7 @@ async def metabase_proxy(request: Request, path: str = "") -> Response:
             if new_session is not None:
                 session_id = new_session
                 response = await proxy_to_metabase(request, target_path, session_id, metabase_url)
-                response.set_cookie(
-                    key=_MB_SESSION_COOKIE,
-                    value=new_session,
-                    path="/",
-                    httponly=True,
-                    samesite="lax",
-                    secure=is_secure_request(request.scope),
-                )
+                _set_mb_session_cookie(response, new_session, request)
                 return response
 
     return await proxy_to_metabase(request, target_path, session_id, metabase_url)

--- a/dango/web/routes/metabase_proxy.py
+++ b/dango/web/routes/metabase_proxy.py
@@ -64,17 +64,21 @@ def _get_user_mb_session(request: Request) -> str | None:
 async def _rebridge_if_needed(request: Request, metabase_url: str) -> str | None:
     """Create a fresh Metabase session for the current user.
 
-    Called when a proxied request gets a 401 from Metabase.  Returns the
-    new Metabase session ID, or ``None`` if re-bridging fails.
+    Called when a proxied request has no session cookie or gets a 401/403
+    from Metabase.  Returns the new Metabase session ID, or ``None`` if
+    re-bridging fails.  Passes ``db_path`` so that the bridge can
+    lazy-sync users who were never synced to Metabase.
     """
     user = getattr(request.state, "user", None)
     if user is None:
         return None
     try:
+        from dango.auth.admin import get_auth_db_path
         from dango.auth.metabase_bridge import bridge_metabase_login
 
         project_root = _get_project_root(request)
-        return await bridge_metabase_login(user, project_root, metabase_url)
+        db_path = get_auth_db_path(project_root)
+        return await bridge_metabase_login(user, project_root, metabase_url, db_path=db_path)
     except Exception:
         logger.warning("metabase_rebridge_failed", exc_info=True)
         return None
@@ -126,12 +130,12 @@ async def proxy_to_metabase(
     try:
         response = await _do_proxy(target_url, request.method, headers, body, session_id)
 
-        # Re-bridge on 401 (session expired)
-        if response.status_code == 401 and session_id is not None:
+        # Re-bridge on 401 (session expired) or 403 (stale/mismatched session)
+        if response.status_code in (401, 403) and session_id is not None:
             new_session = await _rebridge_if_needed(request, metabase_url)
             if new_session is not None:
                 response = await _do_proxy(target_url, request.method, headers, body, new_session)
-                if response.status_code != 401:
+                if response.status_code not in (401, 403):
                     # Attach the new session cookie to the response
                     final = _build_response(response)
                     final.set_cookie(
@@ -181,17 +185,37 @@ async def _do_proxy(
         return await client.request(method=method, url=url, headers=proxy_headers, content=body)
 
 
+_SKIP_HEADERS = frozenset(("content-encoding", "transfer-encoding", "content-length"))
+
+
 def _build_response(proxy_response: httpx.Response) -> Response:
-    """Build a FastAPI Response from an httpx response."""
+    """Build a FastAPI Response from an httpx response.
+
+    Uses ``multi_items()`` so that multiple ``Set-Cookie`` headers from
+    Metabase are preserved (a plain dict would keep only the last one).
+    """
     response_headers: dict[str, str] = {}
-    for key, value in proxy_response.headers.items():
-        if key.lower() not in ("content-encoding", "transfer-encoding", "content-length"):
+    set_cookie_values: list[str] = []
+
+    for key, value in proxy_response.headers.multi_items():
+        lower = key.lower()
+        if lower in _SKIP_HEADERS:
+            continue
+        if lower == "set-cookie":
+            set_cookie_values.append(value)
+        else:
             response_headers[key] = value
-    return Response(
+
+    response = Response(
         content=proxy_response.content,
         status_code=proxy_response.status_code,
         headers=response_headers,
     )
+
+    for cookie_value in set_cookie_values:
+        response.headers.append("set-cookie", cookie_value)
+
+    return response
 
 
 # ==============================================================================
@@ -256,13 +280,35 @@ async def metabase_proxy(request: Request, path: str = "") -> Response:
     """Reverse proxy for Metabase with per-user session bridging.
 
     Routes all requests to the configured Metabase URL and uses the
-    user's ``metabase.SESSION`` cookie for authentication.  On 401,
+    user's ``metabase.SESSION`` cookie for authentication.  On 401/403,
     attempts to re-bridge the session transparently.
+
+    When the user is authenticated to Dango but has no ``metabase.SESSION``
+    cookie, auto-bridges before proxying (instead of waiting for a 401
+    that may never come — Metabase returns its login page as 200).
     """
     project_root = _get_project_root(request)
     metabase_url = _get_metabase_url(project_root)
 
     target_path = f"/{path}" if path else "/"
     session_id = _get_user_mb_session(request)
+
+    # Auto-bridge: user is authenticated but has no Metabase session cookie
+    if session_id is None:
+        user = getattr(request.state, "user", None)
+        if user is not None:
+            new_session = await _rebridge_if_needed(request, metabase_url)
+            if new_session is not None:
+                session_id = new_session
+                response = await proxy_to_metabase(request, target_path, session_id, metabase_url)
+                response.set_cookie(
+                    key=_MB_SESSION_COOKIE,
+                    value=new_session,
+                    path="/",
+                    httponly=True,
+                    samesite="lax",
+                    secure=is_secure_request(request.scope),
+                )
+                return response
 
     return await proxy_to_metabase(request, target_path, session_id, metabase_url)

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -337,6 +337,20 @@ class TestCsrfProtection:
         result = asyncio.run(_collect_response(mw, scope))
         assert result["status"] == 200
 
+    @patch(f"{_M}.is_auth_enabled", return_value=True)
+    @patch(f"{_M}.get_auth_db_path")
+    @patch(f"{_M}.sessions.validate_session")
+    def test_non_metabase_path_still_requires_csrf(
+        self, mock_val: Any, mock_db: Any, _m: Any
+    ) -> None:
+        """POST to /metabase_other/... (similar prefix) still requires CSRF."""
+        mock_val.return_value = _make_user()
+        mock_db.return_value = _db_exists()
+        mw = AuthMiddleware(_noop_app, project_root=_PROJECT_ROOT)
+        scope = _make_scope(path="/metabase_other/api", method="POST", cookie="v")
+        result = asyncio.run(_collect_response(mw, scope))
+        assert result["status"] == 403
+
 
 # ---------------------------------------------------------------------------
 # Auth precedence

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -323,6 +323,20 @@ class TestCsrfProtection:
         mw = AuthMiddleware(_noop_app, project_root=_PROJECT_ROOT)
         assert asyncio.run(_collect_response(mw, _make_scope(cookie="v")))["status"] == 200
 
+    @patch(f"{_M}.is_auth_enabled", return_value=True)
+    @patch(f"{_M}.get_auth_db_path")
+    @patch(f"{_M}.sessions.validate_session")
+    def test_metabase_proxy_post_exempt_from_csrf(
+        self, mock_val: Any, mock_db: Any, _m: Any
+    ) -> None:
+        """Cookie auth + POST to /metabase/... without CSRF header: passes (exempt)."""
+        mock_val.return_value = _make_user()
+        mock_db.return_value = _db_exists()
+        mw = AuthMiddleware(_noop_app, project_root=_PROJECT_ROOT)
+        scope = _make_scope(path="/metabase/api/card", method="POST", cookie="v")
+        result = asyncio.run(_collect_response(mw, scope))
+        assert result["status"] == 200
+
 
 # ---------------------------------------------------------------------------
 # Auth precedence

--- a/tests/unit/test_metabase_bridge.py
+++ b/tests/unit/test_metabase_bridge.py
@@ -315,3 +315,11 @@ class TestBridgeLazySync:
         ):
             result = self._run(bridge_metabase_login(user, root, db_path=db_path))
             assert result is None
+
+    def test_lazy_sync_no_metabase_url(self, tmp_path: Path) -> None:
+        """When no metabase.yml exists, lazy sync returns None (no URL)."""
+        user = _make_user(metabase_password_enc=None, metabase_user_id=None)
+        db_path = tmp_path / ".dango" / "auth.db"
+        # No _mb_yml() call — metabase.yml does not exist
+        result = self._run(bridge_metabase_login(user, tmp_path, db_path=db_path))
+        assert result is None

--- a/tests/unit/test_metabase_bridge.py
+++ b/tests/unit/test_metabase_bridge.py
@@ -259,3 +259,59 @@ class TestEnsureMetabaseSynced:
             self._run(
                 ensure_metabase_synced(tmp_path / "auth.db", "user-1", tmp_path, "http://mb:3000")
             )
+
+
+# ---------------------------------------------------------------------------
+# bridge_metabase_login — lazy sync fallback
+# ---------------------------------------------------------------------------
+
+_GET_USER_TARGET = "dango.auth.database.get_user_by_id"
+
+
+@pytest.mark.unit
+class TestBridgeLazySync:
+    """Tests for lazy sync fallback when user has no Metabase credentials."""
+
+    def _run(self, coro: Any) -> Any:
+        return asyncio.run(coro)
+
+    def test_lazy_sync_on_missing_credentials(self, tmp_path: Path) -> None:
+        """When db_path provided and user has no credentials, lazy sync + bridge."""
+        root = _mb_yml(tmp_path)
+        user_no_creds = _make_user(metabase_password_enc=None, metabase_user_id=None)
+        user_with_creds = _make_user()  # has metabase_password_enc + metabase_user_id
+        db_path = root / ".dango" / "auth.db"
+
+        mock_client = _mock_httpx_client("post", _resp(200, {"id": "lazy-sess-123"}))
+
+        with (
+            patch(_SYNC_TARGET, return_value=42),
+            patch(_GET_USER_TARGET, return_value=user_with_creds),
+            patch(_DECRYPT_TARGET, return_value="mb_pw"),
+            patch(_HTTPX_CLIENT, return_value=mock_client),
+        ):
+            result = self._run(bridge_metabase_login(user_no_creds, root, db_path=db_path))
+            assert result == "lazy-sess-123"
+
+    def test_lazy_sync_failure(self, tmp_path: Path) -> None:
+        """When lazy sync returns None, bridge returns None."""
+        root = _mb_yml(tmp_path)
+        user = _make_user(metabase_password_enc=None, metabase_user_id=None)
+        db_path = root / ".dango" / "auth.db"
+
+        with patch(_SYNC_TARGET, return_value=None):
+            result = self._run(bridge_metabase_login(user, root, db_path=db_path))
+            assert result is None
+
+    def test_lazy_sync_user_reload_fails(self, tmp_path: Path) -> None:
+        """When sync succeeds but user reload returns None, bridge returns None."""
+        root = _mb_yml(tmp_path)
+        user = _make_user(metabase_password_enc=None, metabase_user_id=None)
+        db_path = root / ".dango" / "auth.db"
+
+        with (
+            patch(_SYNC_TARGET, return_value=42),
+            patch(_GET_USER_TARGET, return_value=None),
+        ):
+            result = self._run(bridge_metabase_login(user, root, db_path=db_path))
+            assert result is None

--- a/tests/unit/test_web_metabase_proxy.py
+++ b/tests/unit/test_web_metabase_proxy.py
@@ -294,3 +294,132 @@ class TestProxyRebridge:
         assert resp.status_code == 200
         mock_proxy.assert_called_once()
         mock_rebridge.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Auto-bridge on missing session (BUG-011)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAutobridge:
+    """Tests for auto-bridging when user has no metabase.SESSION cookie."""
+
+    def test_auto_bridge_on_missing_session(self, tmp_path: Path) -> None:
+        """Authenticated user without cookie gets auto-bridged session."""
+        app = _make_proxy_app(tmp_path)
+        client = TestClient(app, raise_server_exceptions=False)
+        # No metabase.SESSION cookie set
+
+        ok_resp = _httpx_response(200, b"dashboard html")
+
+        with (
+            patch(_DO_PROXY, new_callable=AsyncMock, return_value=ok_resp),
+            patch(_REBRIDGE, new_callable=AsyncMock, return_value="auto-sess-new"),
+            patch(_GET_MB_URL, return_value="http://mb:3000"),
+        ):
+            resp = client.get("/metabase/")
+
+        assert resp.status_code == 200
+        assert resp.text == "dashboard html"
+        assert "metabase.SESSION" in resp.cookies
+        assert resp.cookies["metabase.SESSION"] == "auto-sess-new"
+
+    def test_auto_bridge_failure_passes_through(self, tmp_path: Path) -> None:
+        """If auto-bridge fails, request is proxied without session (Metabase login page)."""
+        app = _make_proxy_app(tmp_path)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        login_page = _httpx_response(200, b"<html>Metabase Login</html>")
+
+        with (
+            patch(_DO_PROXY, new_callable=AsyncMock, return_value=login_page),
+            patch(_REBRIDGE, new_callable=AsyncMock, return_value=None),
+            patch(_GET_MB_URL, return_value="http://mb:3000"),
+        ):
+            resp = client.get("/metabase/")
+
+        assert resp.status_code == 200
+        assert b"Metabase Login" in resp.content
+        assert "metabase.SESSION" not in resp.cookies
+
+
+# ---------------------------------------------------------------------------
+# 403 re-bridge (BUG-015)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProxy403Rebridge:
+    """Tests for re-bridging on 403 responses from Metabase."""
+
+    def test_403_rebridge_retry_succeeds(self, tmp_path: Path) -> None:
+        """On 403, proxy re-bridges and retries; new cookie is set."""
+        app = _make_proxy_app(tmp_path)
+        client = TestClient(app, raise_server_exceptions=False)
+        client.cookies.set("metabase.SESSION", "stale-sess")
+
+        first_resp = _httpx_response(403, b"Forbidden")
+        retry_resp = _httpx_response(200, b"dashboard data")
+
+        with (
+            patch(_DO_PROXY, new_callable=AsyncMock, side_effect=[first_resp, retry_resp]),
+            patch(_REBRIDGE, new_callable=AsyncMock, return_value="fresh-sess"),
+            patch(_GET_MB_URL, return_value="http://mb:3000"),
+        ):
+            resp = client.get("/metabase/api/card")
+
+        assert resp.status_code == 200
+        assert resp.text == "dashboard data"
+        assert "metabase.SESSION" in resp.cookies
+        assert resp.cookies["metabase.SESSION"] == "fresh-sess"
+
+    def test_403_rebridge_fails_returns_403(self, tmp_path: Path) -> None:
+        """On 403, if re-bridge fails, original 403 is returned."""
+        app = _make_proxy_app(tmp_path)
+        client = TestClient(app, raise_server_exceptions=False)
+        client.cookies.set("metabase.SESSION", "stale-sess")
+
+        first_resp = _httpx_response(403, b"Forbidden")
+
+        with (
+            patch(_DO_PROXY, new_callable=AsyncMock, return_value=first_resp),
+            patch(_REBRIDGE, new_callable=AsyncMock, return_value=None),
+            patch(_GET_MB_URL, return_value="http://mb:3000"),
+        ):
+            resp = client.get("/metabase/api/card")
+
+        assert resp.status_code == 403
+        assert "metabase.SESSION" not in resp.cookies
+
+
+# ---------------------------------------------------------------------------
+# _build_response multi-header preservation (BUG-014)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildResponse:
+    """Tests for _build_response preserving multi-valued headers."""
+
+    def test_preserves_multi_set_cookie(self) -> None:
+        """Multiple Set-Cookie headers from Metabase are all forwarded."""
+        from dango.web.routes.metabase_proxy import _build_response
+
+        raw_response = httpx.Response(
+            status_code=200,
+            content=b"ok",
+            headers=[
+                ("content-type", "text/html"),
+                ("set-cookie", "cookie1=val1; Path=/"),
+                ("set-cookie", "cookie2=val2; Path=/; HttpOnly"),
+            ],
+        )
+        result = _build_response(raw_response)
+
+        assert result.status_code == 200
+        # Collect all set-cookie headers from the response
+        set_cookies = [v for k, v in result.headers.items() if k.lower() == "set-cookie"]
+        assert len(set_cookies) == 2
+        assert "cookie1=val1" in set_cookies[0]
+        assert "cookie2=val2" in set_cookies[1]


### PR DESCRIPTION
## Summary

- **BUG-011 (SSO bridging):** Auto-bridge Metabase session when user has no `metabase.SESSION` cookie, instead of waiting for a 401 that never comes (Metabase returns login page as 200). Lazy-sync users to Metabase on first proxy access if startup sync failed.
- **BUG-014 (proxy CSRF):** Exempt `/metabase/` proxy routes from Dango CSRF check (Metabase's own frontend sends POSTs without Dango headers). Fix `_build_response()` to preserve multiple `Set-Cookie` headers from Metabase.
- **BUG-015 (permission denied):** Re-bridge on 403 (not just 401) so stale sessions from direct Metabase access at `:3000` are transparently refreshed.

### Files changed
- `dango/auth/metabase_bridge.py` — lazy sync fallback in `bridge_metabase_login()`
- `dango/web/routes/metabase_proxy.py` — auto-bridge on missing session, 403 handling, multi-header fix
- `dango/web/middleware/auth.py` — CSRF exemption for `/metabase/` prefix
- 3 test files — 9 new tests (3 bridge, 5 proxy, 1 middleware)

### Security note
CSRF middleware change is narrowly scoped: only `/metabase/` prefix exempt. Dango auth still required. Metabase has its own CSRF protection. `metabase.SESSION` cookie is HttpOnly + SameSite=Lax.

## Test plan
- [x] 58 targeted tests pass (bridge + proxy + middleware)
- [x] 551 full auth test suite passes — no regressions
- [x] ruff lint + format clean
- [x] mypy clean (all 3 source files)
- [ ] Manual: `dango start` → login → click Metabase link → auto-login (no Metabase login page)
- [ ] Manual: Verify `metabase.SESSION` cookie set in browser after first `/metabase/` access

🤖 Generated with [Claude Code](https://claude.com/claude-code)