### PR TITLE
BUG-016: Rebuild data catalog as superset of dbt docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ dango/                          # Python package source
 │   │   ├── metabase_proxy.py   # Metabase reverse proxy + SSO session
 │   │   ├── secrets.py          # Secrets + OAuth credential management (admin-only)
 │   │   ├── oauth_connect.py    # Web-based OAuth connect/callback
-│   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact (566 lines)
+│   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact, models, search (1157 lines)
 │   │   ├── governance.py       # Schema drift + PII results API
 │   │   ├── insights.py         # Metric results, run trigger, history
 │   │   ├── notebooks.py        # Notebook management API + page route
@@ -355,7 +355,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `config/models.py` | 594 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 593 | — |
-| `web/routes/catalog.py` | 566 | — (data catalog: columns, profiling, lineage, impact) |
+| `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 704 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -42,16 +42,16 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, `/schedules` page (~720 lines) | `router` |
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~490 lines) | `router` |
-| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact (~566 lines) | `router` |
+| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1157 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
 | `routes/insights.py` | Metric results, run trigger, history (~272 lines) | `router` |
 | `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~496 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |
-| `templates/catalog.html` | Data catalog page (extends `base.html`) — source/table browser, profiling, lineage (495 lines) | Alpine.js `catalogPage()` component |
+| `templates/catalog.html` | Data catalog page (extends `base.html`) — model browser, search, detail view, code view, profiling, lineage (618 lines) | Alpine.js `catalogPage()` component |
 | `templates/insights.html` | Insights/analysis page (extends `base.html`) — metric results, trends (~153 lines) | Alpine.js `insightsPage()` component |
-| `static/` | CSS and JS assets (`css/main.css`, `js/app.js`, `js/logs.js`) | — |
+| `static/` | CSS and JS assets (`css/main.css`, `css/catalog.css`, `js/app.js`, `js/logs.js`, `js/lineage.js`, `js/catalog.js`) | — |
 
 ## Architecture
 

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -448,16 +448,10 @@ def _build_model_detail(
     if db_columns:
         for col in db_columns:
             manifest_col = manifest_columns.get(col["name"], {})
-            # Map tests to this column by name pattern
-            col_tests = [
-                t
-                for t in model_tests
-                if t["name"]
-                and (
-                    t["name"].endswith(f"_{model_name}_{col['name']}")
-                    or t["name"].endswith(f"_{col['name']}")
-                )
-            ]
+            # Map tests to this column by dbt naming convention:
+            # test names follow {test_type}_{model}_{column} pattern
+            col_suffix = f"_{model_name}_{col['name']}"
+            col_tests = [t for t in model_tests if t["name"] and t["name"].endswith(col_suffix)]
             columns.append(
                 {
                     "name": col["name"],
@@ -697,15 +691,15 @@ async def get_table_columns(
     project_root = get_project_root()
     db_path = await _validate_and_resolve(source, table, project_root)
 
-    columns, cached_stats, row_count, profiled_at = await asyncio.gather(
+    columns, cached_stats, row_count, profiled_at, manifest = await asyncio.gather(
         asyncio.to_thread(_get_column_schema, db_path, source, table),
         asyncio.to_thread(_get_cached_stats, project_root, source, table),
         asyncio.to_thread(_get_row_count, db_path, source, table),
         asyncio.to_thread(_get_profiled_at, project_root, source, table),
+        asyncio.to_thread(get_dbt_manifest),
     )
 
     # Merge column descriptions from manifest if available
-    manifest = await asyncio.to_thread(get_dbt_manifest)
     col_descriptions: dict[str, str] = {}
     if manifest:
         for src in manifest.get("sources", {}).values():
@@ -871,15 +865,21 @@ async def get_catalog_model(
 
     # Get row count if DuckDB is available and table exists
     if db_path.exists() and schema and table and db_columns:
-        try:
-            conn = duckdb.connect(str(db_path), read_only=True)
+
+        def _count_rows() -> int | None:
             try:
-                count = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
-                result["row_count"] = count[0] if count else 0
-            finally:
-                conn.close()
-        except Exception:
-            pass
+                conn = duckdb.connect(str(db_path), read_only=True)
+                try:
+                    row = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
+                    return row[0] if row else 0
+                finally:
+                    conn.close()
+            except Exception:
+                return None
+
+        row_count = await asyncio.to_thread(_count_rows)
+        if row_count is not None:
+            result["row_count"] = row_count
 
     return result
 

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -1,17 +1,18 @@
 """dango/web/routes/catalog.py
 
 Data catalog API endpoints for column schema introspection, profiling,
-lineage, and impact analysis.
+lineage, impact analysis, and unified model browsing.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
 import duckdb
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from dango.auth.models import User
 from dango.auth.permissions import require_permission
@@ -183,6 +184,448 @@ def _table_exists(db_path: Path, source: str, table: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Manifest / model helpers (called via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _get_run_results() -> dict[str, Any] | None:
+    """Load ``dbt/target/run_results.json``.
+
+    Returns:
+        Parsed dict or ``None`` if the file does not exist.
+    """
+    path = get_project_root() / "dbt" / "target" / "run_results.json"
+    if not path.exists():
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            result: dict[str, Any] = json.load(f)
+            return result
+    except Exception:
+        logger.warning("Failed to parse run_results.json")
+        return None
+
+
+def _build_test_status_map(
+    manifest: dict[str, Any],
+    run_results: dict[str, Any] | None,
+) -> dict[str, list[dict[str, str | None]]]:
+    """Map model/source unique_ids to their test results.
+
+    Args:
+        manifest: Parsed dbt manifest.
+        run_results: Parsed ``run_results.json`` or ``None``.
+
+    Returns:
+        ``{model_unique_id: [{"name": ..., "status": "pass"|"fail"|"error"|None}]}``.
+    """
+    # Build status lookup from run_results
+    result_status: dict[str, str] = {}
+    if run_results:
+        for r in run_results.get("results", []):
+            uid = r.get("unique_id", "")
+            status = r.get("status", "")
+            if uid and status:
+                result_status[uid] = status
+
+    test_map: dict[str, list[dict[str, str | None]]] = {}
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "test":
+            continue
+        test_name = node.get("name", uid)
+        status = result_status.get(uid)
+        for dep in node.get("depends_on", {}).get("nodes", []):
+            test_map.setdefault(dep, []).append({"name": test_name, "status": status})
+
+    return test_map
+
+
+def _classify_model_type(node: dict[str, Any]) -> str:
+    """Classify a dbt model as ``staging``, ``intermediate``, or ``marts``.
+
+    Classification priority:
+    1. Schema name: ``staging`` / ``intermediate`` / ``marts``.
+    2. Name prefix: ``stg_`` → staging, ``fct_`` / ``dim_`` → marts,
+       ``int_`` → intermediate.
+    3. Fallback: ``intermediate``.
+
+    Args:
+        node: A manifest model node dict.
+
+    Returns:
+        One of ``"staging"``, ``"intermediate"``, ``"marts"``.
+    """
+    schema = (node.get("schema") or "").lower()
+    if schema == "staging":
+        return "staging"
+    if schema == "intermediate":
+        return "intermediate"
+    if schema == "marts":
+        return "marts"
+
+    name = (node.get("name") or "").lower()
+    if name.startswith("stg_"):
+        return "staging"
+    if name.startswith(("fct_", "dim_")):
+        return "marts"
+    if name.startswith("int_"):
+        return "intermediate"
+
+    return "intermediate"
+
+
+def _get_model_column_schema(
+    db_path: Path,
+    schema: str,
+    table: str,
+) -> list[dict[str, Any]]:
+    """Query DuckDB ``information_schema.columns`` for any schema.
+
+    Unlike :func:`_get_column_schema`, this is not restricted to
+    ``raw_*`` schemas — it works for staging, intermediate, and marts.
+
+    Args:
+        db_path: Path to the DuckDB warehouse file.
+        schema: Schema name (e.g. ``staging``, ``marts``).
+        table: Table/view name.
+
+    Returns:
+        List of ``{"name": ..., "type": ..., "nullable": bool}``,
+        or empty list if the table does not exist.
+    """
+    conn = duckdb.connect(str(db_path), read_only=True)
+    try:
+        rows = conn.execute(
+            "SELECT column_name, data_type, is_nullable "
+            "FROM information_schema.columns "
+            f"WHERE table_schema = '{schema}' AND table_name = '{table}' "
+            "ORDER BY ordinal_position"
+        ).fetchall()
+    except Exception:
+        rows = []
+    finally:
+        conn.close()
+
+    return [{"name": r[0], "type": r[1], "nullable": r[2] == "YES"} for r in rows]
+
+
+def _build_catalog_models(
+    manifest: dict[str, Any],
+    run_results: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the full catalog models + sources response from manifest.
+
+    Args:
+        manifest: Parsed dbt manifest.
+        run_results: Parsed run_results or ``None``.
+
+    Returns:
+        Dict with ``models`` and ``sources`` lists.
+    """
+    test_map = _build_test_status_map(manifest, run_results)
+
+    models: list[dict[str, Any]] = []
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "model":
+            continue
+        columns = node.get("columns", {})
+        cols_documented = sum(1 for c in columns.values() if c.get("description"))
+        tests = test_map.get(uid, [])
+        tests_passing = sum(1 for t in tests if t["status"] == "pass")
+        tests_failing = sum(1 for t in tests if t["status"] in ("fail", "error"))
+
+        models.append(
+            {
+                "unique_id": uid,
+                "name": node.get("name", ""),
+                "type": _classify_model_type(node),
+                "schema": node.get("schema", ""),
+                "materialization": node.get("config", {}).get("materialized", "view"),
+                "description": node.get("description", ""),
+                "test_count": len(tests),
+                "tests_passing": tests_passing,
+                "tests_failing": tests_failing,
+                "columns_total": len(columns),
+                "columns_documented": cols_documented,
+                "tags": node.get("tags", []),
+            }
+        )
+
+    # Sort: type order (staging → intermediate → marts), then name
+    type_order = {"staging": 0, "intermediate": 1, "marts": 2}
+    models.sort(key=lambda m: (type_order.get(m["type"], 1), m["name"].lower()))
+
+    sources: list[dict[str, Any]] = []
+    for uid, src in manifest.get("sources", {}).items():
+        columns = src.get("columns", {})
+        cols_documented = sum(1 for c in columns.values() if c.get("description"))
+        tests = test_map.get(uid, [])
+
+        sources.append(
+            {
+                "unique_id": uid,
+                "name": src.get("name", ""),
+                "type": "source",
+                "schema": src.get("schema", ""),
+                "description": src.get("description", ""),
+                "source_name": src.get("source_name", ""),
+                "test_count": len(tests),
+                "columns_total": len(columns),
+                "columns_documented": cols_documented,
+            }
+        )
+
+    sources.sort(key=lambda s: s["name"].lower())
+
+    return {"models": models, "sources": sources}
+
+
+def _find_model_in_manifest(
+    manifest: dict[str, Any],
+    model_name: str,
+) -> tuple[str | None, dict[str, Any] | None, str]:
+    """Find a model or source by name in the manifest.
+
+    Models are preferred over sources when names collide.
+
+    Args:
+        manifest: Parsed dbt manifest.
+        model_name: Name to search for.
+
+    Returns:
+        Tuple of ``(unique_id, node_dict, kind)`` where *kind* is
+        ``"model"`` or ``"source"``.  Returns ``(None, None, "")``
+        if not found.
+    """
+    # Search models first
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") == "model" and node.get("name") == model_name:
+            return uid, node, "model"
+    # Then sources
+    for uid, src in manifest.get("sources", {}).items():
+        if src.get("name") == model_name:
+            return uid, src, "source"
+    return None, None, ""
+
+
+def _build_model_detail(
+    manifest: dict[str, Any],
+    run_results: dict[str, Any] | None,
+    target_uid: str,
+    target_node: dict[str, Any],
+    kind: str,
+    db_columns: list[dict[str, Any]],
+    profiled_at: str | None,
+) -> dict[str, Any]:
+    """Build the detail response for a single model or source.
+
+    Args:
+        manifest: Full dbt manifest.
+        run_results: Parsed run_results or ``None``.
+        target_uid: The unique_id of the target.
+        target_node: The manifest node dict.
+        kind: ``"model"`` or ``"source"``.
+        db_columns: Column schema from DuckDB (may be empty).
+        profiled_at: Last profiling timestamp or ``None``.
+
+    Returns:
+        Full detail response dict.
+    """
+    test_map = _build_test_status_map(manifest, run_results)
+    model_tests = test_map.get(target_uid, [])
+    manifest_columns = target_node.get("columns", {})
+
+    # Build reverse dependency map
+    reverse_map: dict[str, list[str]] = {}
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") == "model":
+            for dep in node.get("depends_on", {}).get("nodes", []):
+                reverse_map.setdefault(dep, []).append(uid)
+
+    # Merge DuckDB columns with manifest column descriptions
+    model_name = target_node.get("name", "")
+    columns: list[dict[str, Any]] = []
+    if db_columns:
+        for col in db_columns:
+            manifest_col = manifest_columns.get(col["name"], {})
+            # Map tests to this column by name pattern
+            col_tests = [
+                t
+                for t in model_tests
+                if t["name"]
+                and (
+                    t["name"].endswith(f"_{model_name}_{col['name']}")
+                    or t["name"].endswith(f"_{col['name']}")
+                )
+            ]
+            columns.append(
+                {
+                    "name": col["name"],
+                    "type": col["type"],
+                    "nullable": col["nullable"],
+                    "description": manifest_col.get("description") or None,
+                    "tests": col_tests if col_tests else None,
+                    "stats": None,
+                }
+            )
+    else:
+        # Model not materialised — show manifest columns without type info
+        for col_name, col_info in manifest_columns.items():
+            columns.append(
+                {
+                    "name": col_name,
+                    "type": None,
+                    "nullable": None,
+                    "description": col_info.get("description") or None,
+                    "tests": None,
+                    "stats": None,
+                }
+            )
+
+    result: dict[str, Any] = {
+        "unique_id": target_uid,
+        "name": model_name,
+        "schema": target_node.get("schema", ""),
+        "description": target_node.get("description", ""),
+        "tags": target_node.get("tags", []),
+        "meta": target_node.get("meta", {}),
+        "columns": columns,
+        "depends_on": target_node.get("depends_on", {}).get("nodes", []),
+        "depended_on_by": reverse_map.get(target_uid, []),
+        "tests": model_tests if model_tests else None,
+        "row_count": None,
+        "profiled_at": profiled_at,
+    }
+
+    if kind == "model":
+        result["type"] = _classify_model_type(target_node)
+        result["materialization"] = target_node.get("config", {}).get("materialized", "view")
+        result["raw_code"] = target_node.get("raw_code") or target_node.get("raw_sql")
+        result["compiled_code"] = target_node.get("compiled_code") or target_node.get(
+            "compiled_sql"
+        )
+    else:
+        result["type"] = "source"
+        result["materialization"] = None
+        result["raw_code"] = None
+        result["compiled_code"] = None
+        result["source_name"] = target_node.get("source_name", "")
+
+    return result
+
+
+def _search_manifest(
+    manifest: dict[str, Any],
+    query: str,
+) -> list[dict[str, Any]]:
+    """Search manifest models and sources by name, description, column names.
+
+    Args:
+        manifest: Parsed dbt manifest.
+        query: Case-insensitive search string.
+
+    Returns:
+        List of search result dicts (max 50).
+    """
+    q = query.lower()
+    name_matches: list[dict[str, Any]] = []
+    desc_matches: list[dict[str, Any]] = []
+    col_matches: list[dict[str, Any]] = []
+
+    # Search models
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "model":
+            continue
+        name = node.get("name", "")
+        desc = node.get("description", "")
+        model_type = _classify_model_type(node)
+
+        if q in name.lower():
+            name_matches.append(
+                {
+                    "unique_id": uid,
+                    "name": name,
+                    "type": model_type,
+                    "description": desc,
+                    "match_type": "name",
+                }
+            )
+            continue
+
+        if desc and q in desc.lower():
+            desc_matches.append(
+                {
+                    "unique_id": uid,
+                    "name": name,
+                    "type": model_type,
+                    "description": desc,
+                    "match_type": "description",
+                }
+            )
+            continue
+
+        for col_name in node.get("columns", {}):
+            if q in col_name.lower():
+                col_matches.append(
+                    {
+                        "unique_id": uid,
+                        "name": name,
+                        "type": model_type,
+                        "description": desc,
+                        "match_type": "column",
+                        "matched_column": col_name,
+                    }
+                )
+                break
+
+    # Search sources
+    for uid, src in manifest.get("sources", {}).items():
+        name = src.get("name", "")
+        desc = src.get("description", "")
+
+        if q in name.lower():
+            name_matches.append(
+                {
+                    "unique_id": uid,
+                    "name": name,
+                    "type": "source",
+                    "description": desc,
+                    "match_type": "name",
+                }
+            )
+            continue
+
+        if desc and q in desc.lower():
+            desc_matches.append(
+                {
+                    "unique_id": uid,
+                    "name": name,
+                    "type": "source",
+                    "description": desc,
+                    "match_type": "description",
+                }
+            )
+            continue
+
+        for col_name in src.get("columns", {}):
+            if q in col_name.lower():
+                col_matches.append(
+                    {
+                        "unique_id": uid,
+                        "name": name,
+                        "type": "source",
+                        "description": desc,
+                        "match_type": "column",
+                        "matched_column": col_name,
+                    }
+                )
+                break
+
+    results = name_matches + desc_matches + col_matches
+    return results[:50]
+
+
+# ---------------------------------------------------------------------------
 # Shared validation
 # ---------------------------------------------------------------------------
 
@@ -261,8 +704,23 @@ async def get_table_columns(
         asyncio.to_thread(_get_profiled_at, project_root, source, table),
     )
 
+    # Merge column descriptions from manifest if available
+    manifest = await asyncio.to_thread(get_dbt_manifest)
+    col_descriptions: dict[str, str] = {}
+    if manifest:
+        for src in manifest.get("sources", {}).values():
+            if src.get("name") == table:
+                src_schema = src.get("schema", "")
+                if src_schema == f"raw_{source}" or src_schema == source:
+                    for cname, cinfo in src.get("columns", {}).items():
+                        desc = cinfo.get("description", "")
+                        if desc:
+                            col_descriptions[cname] = desc
+                    break
+
     for col in columns:
         col["stats"] = cached_stats.get(col["name"])
+        col["description"] = col_descriptions.get(col["name"])
 
     return {
         "source": source,
@@ -317,6 +775,139 @@ async def refresh_table_profile(
         "profiled_at": profiled_at,
         "columns": columns,
     }
+
+
+# ---------------------------------------------------------------------------
+# Catalog model endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/catalog/models")
+async def list_catalog_models(
+    user: User = Depends(require_permission("governance.view")),  # noqa: ARG001
+) -> dict[str, Any]:
+    """List all models and sources from the dbt manifest.
+
+    Returns models categorized by type (staging/intermediate/marts) and
+    sources.  Degrades gracefully when no manifest exists.
+
+    Args:
+        user: Authenticated user with ``governance.view`` permission.
+
+    Returns:
+        Dict with ``models`` and ``sources`` lists.
+    """
+    manifest, run_results = await asyncio.gather(
+        asyncio.to_thread(get_dbt_manifest),
+        asyncio.to_thread(_get_run_results),
+    )
+
+    if manifest is None:
+        return {"models": [], "sources": []}
+
+    return await asyncio.to_thread(_build_catalog_models, manifest, run_results)
+
+
+@router.get("/api/catalog/models/{model_name}")
+async def get_catalog_model(
+    model_name: str,
+    user: User = Depends(require_permission("governance.view")),  # noqa: ARG001
+) -> dict[str, Any]:
+    """Return detailed information for a single model or source.
+
+    Includes column schema (merged with manifest descriptions), SQL code,
+    test results, tags, and dependency information.
+
+    Args:
+        model_name: Model or source name (URL path parameter).
+        user: Authenticated user with ``governance.view`` permission.
+
+    Returns:
+        Full model/source detail response.
+    """
+    model_name = validate_identifier(model_name)
+    project_root = get_project_root()
+
+    manifest, run_results = await asyncio.gather(
+        asyncio.to_thread(get_dbt_manifest),
+        asyncio.to_thread(_get_run_results),
+    )
+
+    if manifest is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No dbt manifest found. Run dbt first.",
+        )
+
+    target_uid, target_node, kind = _find_model_in_manifest(manifest, model_name)
+    if target_uid is None or target_node is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model or source '{model_name}' not found in manifest.",
+        )
+
+    # Determine schema + table for DuckDB column lookup
+    db_path = project_root / "data" / "warehouse.duckdb"
+    schema = target_node.get("schema", "")
+    table = target_node.get("name", "")
+
+    db_columns: list[dict[str, Any]] = []
+    profiled_at: str | None = None
+
+    if db_path.exists() and schema and table:
+        db_columns = await asyncio.to_thread(_get_model_column_schema, db_path, schema, table)
+
+    # For source tables, try to get profiled_at
+    if kind == "source":
+        source_name = target_node.get("source_name", "")
+        if source_name:
+            profiled_at = await asyncio.to_thread(
+                _get_profiled_at, project_root, source_name, table
+            )
+
+    result = _build_model_detail(
+        manifest, run_results, target_uid, target_node, kind, db_columns, profiled_at
+    )
+
+    # Get row count if DuckDB is available and table exists
+    if db_path.exists() and schema and table and db_columns:
+        try:
+            conn = duckdb.connect(str(db_path), read_only=True)
+            try:
+                count = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
+                result["row_count"] = count[0] if count else 0
+            finally:
+                conn.close()
+        except Exception:
+            pass
+
+    return result
+
+
+@router.get("/api/catalog/search")
+async def search_catalog(
+    q: str = Query(..., min_length=2, max_length=100),
+    user: User = Depends(require_permission("governance.view")),  # noqa: ARG001
+) -> dict[str, Any]:
+    """Search across model names, descriptions, and column names.
+
+    Args:
+        q: Search query (2–100 characters).
+        user: Authenticated user with ``governance.view`` permission.
+
+    Returns:
+        Dict with ``query`` and ``results`` list.
+    """
+    query = q.strip()
+    if len(query) < 2:
+        raise HTTPException(status_code=400, detail="Query must be at least 2 characters.")
+
+    manifest = await asyncio.to_thread(get_dbt_manifest)
+    if manifest is None:
+        return {"query": query, "results": []}
+
+    results = await asyncio.to_thread(_search_manifest, manifest, query)
+    return {"query": query, "results": results}
 
 
 # ---------------------------------------------------------------------------

--- a/dango/web/static/css/catalog.css
+++ b/dango/web/static/css/catalog.css
@@ -1,5 +1,146 @@
 /* catalog.css — Catalog page styles that can't be achieved with Tailwind */
 
+/* Model type badges */
+.model-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 9999px;
+    line-height: 1.25rem;
+}
+.model-badge-source { background-color: #dbeafe; color: #1e40af; }
+.model-badge-staging { background-color: #d1fae5; color: #065f46; }
+.model-badge-intermediate { background-color: #fef3c7; color: #92400e; }
+.model-badge-marts { background-color: #ede9fe; color: #5b21b6; }
+
+/* Catalog tabs */
+.catalog-tabs {
+    display: flex;
+    gap: 0.25rem;
+    border-bottom: 1px solid #e5e7eb;
+    margin-bottom: 1rem;
+}
+.catalog-tab {
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #6b7280;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+    background: none;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+}
+.catalog-tab:hover { color: #374151; }
+.catalog-tab.active { color: #4f46e5; border-bottom-color: #4f46e5; }
+
+/* Detail sub-tabs */
+.detail-tabs {
+    display: flex;
+    gap: 0.25rem;
+    border-bottom: 1px solid #e5e7eb;
+    margin-bottom: 1rem;
+}
+.detail-tab {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #6b7280;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    background: none;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+}
+.detail-tab:hover { color: #374151; }
+.detail-tab.active { color: #4f46e5; border-bottom-color: #4f46e5; }
+
+/* Code view */
+.code-block {
+    background: #1e293b;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+}
+.code-block code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    color: #e2e8f0;
+    white-space: pre;
+}
+.code-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+}
+
+/* Search bar */
+.catalog-search {
+    width: 100%;
+    padding: 0.5rem 0.75rem 0.5rem 2.25rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.catalog-search:focus {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+.catalog-search-wrapper {
+    position: relative;
+}
+.catalog-search-icon {
+    position: absolute;
+    left: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #9ca3af;
+    pointer-events: none;
+}
+
+/* Description truncation */
+.desc-truncate {
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Test status indicators */
+.test-pass { color: #059669; }
+.test-fail { color: #dc2626; }
+
+/* Tag badges */
+.tag-badge {
+    display: inline-flex;
+    padding: 0.0625rem 0.375rem;
+    font-size: 0.6875rem;
+    border-radius: 0.25rem;
+    background: #f3f4f6;
+    color: #4b5563;
+    margin-right: 0.25rem;
+}
+
+/* Dep links */
+.dep-link {
+    color: #4f46e5;
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+.dep-link:hover { text-decoration: underline; }
+
 .sparkline-container {
     display: inline-flex;
     align-items: center;

--- a/dango/web/static/js/catalog.js
+++ b/dango/web/static/js/catalog.js
@@ -1,0 +1,49 @@
+/**
+ * catalog.js — Search debounce and code highlighting helpers for the
+ * data catalog page.
+ */
+(function () {
+    "use strict";
+
+    window.DangoCatalog = {
+        _searchTimer: null,
+
+        /**
+         * Debounce a search callback.
+         * @param {string} query - The search string.
+         * @param {function} callback - Called with (query) after delay.
+         * @param {number} [delay=300] - Debounce milliseconds.
+         */
+        debounceSearch: function (query, callback, delay) {
+            if (this._searchTimer) clearTimeout(this._searchTimer);
+            if (!query || query.trim().length < 2) {
+                callback(null);
+                return;
+            }
+            this._searchTimer = setTimeout(function () {
+                callback(query.trim());
+            }, delay || 300);
+        },
+
+        /**
+         * Apply syntax highlighting to a <code> element via highlight.js.
+         * No-op if hljs is not loaded.
+         * @param {string} elementId - DOM id of the <code> element.
+         */
+        highlightCode: function (elementId) {
+            if (typeof hljs === "undefined") return;
+            var el = document.getElementById(elementId);
+            if (el) hljs.highlightElement(el);
+        },
+
+        /**
+         * Highlight all <code> blocks with class "catalog-sql".
+         */
+        highlightAll: function () {
+            if (typeof hljs === "undefined") return;
+            document.querySelectorAll("code.catalog-sql").forEach(function (el) {
+                hljs.highlightElement(el);
+            });
+        },
+    };
+})();

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -1,31 +1,34 @@
 {% extends "base.html" %}
 {% block title %}Data Catalog - Dango{% endblock %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/catalog.css?v=1741700000">
+<link rel="stylesheet" href="/static/css/catalog.css?v=1744500000">
 <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
     <div x-data="catalogPage()" x-init="init()" x-cloak>
         <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
             <p class="text-sm text-red-700" x-text="error"></p>
         </div>
-        <!-- Breadcrumb + Lineage toggle -->
-        <div class="flex items-center justify-between mb-4">
-            <nav class="text-sm text-gray-500">
-                <button @click="goToSources()" class="hover:text-gray-700"
-                        :class="view === 'sources' ? 'font-semibold text-gray-900' : ''">Sources</button>
-                <template x-if="selectedSource">
-                    <span>
+        <!-- Header: Search + Lineage toggle -->
+        <div class="flex items-center justify-between mb-4 gap-4">
+            <div class="flex-1">
+                <template x-if="view === 'detail'">
+                    <nav class="text-sm text-gray-500 mb-2">
+                        <button @click="goToList()" class="hover:text-gray-700">Catalog</button>
                         <span class="mx-1">/</span>
-                        <button @click="goToTables()" class="hover:text-gray-700"
-                                :class="view === 'tables' ? 'font-semibold text-gray-900' : ''"
-                                x-text="selectedSource"></button>
-                    </span>
+                        <span class="font-semibold text-gray-900" x-text="selectedModel ? selectedModel.name : ''"></span>
+                    </nav>
                 </template>
-                <template x-if="selectedTable">
-                    <span><span class="mx-1">/</span><span class="font-semibold text-gray-900" x-text="selectedTable"></span></span>
+                <template x-if="view !== 'detail' && view !== 'lineage'">
+                    <div class="catalog-search-wrapper">
+                        <svg class="catalog-search-icon w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                        </svg>
+                        <input type="text" class="catalog-search" placeholder="Search models, columns, descriptions..."
+                               x-model="searchQuery" @input="onSearchInput()">
+                    </div>
                 </template>
-            </nav>
+            </div>
             <button x-show="hasLineage" @click="toggleLineageView()"
-                    class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors"
+                    class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors flex-shrink-0"
                     :class="view === 'lineage' ? 'bg-indigo-100 text-indigo-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'">
                 <span x-text="view === 'lineage' ? 'Table View' : 'Lineage'"></span>
             </button>
@@ -33,211 +36,314 @@
         <div x-show="loading" x-cloak class="flex items-center justify-center py-12">
             <div class="text-gray-400 text-sm">Loading catalog...</div>
         </div>
-        <!-- View 1: Sources list -->
-        <div x-show="!loading && view === 'sources'">
-            <h2 class="text-xl font-bold text-gray-900 mb-4">Data Catalog</h2>
-            <template x-if="sources.length === 0 && !loading">
-                <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
-                    No sources configured. Add a source to get started.
+
+        <!-- View 1: Model/Source list -->
+        <div x-show="!loading && view === 'list'">
+            <div class="flex items-center justify-between mb-2">
+                <h2 class="text-xl font-bold text-gray-900">Data Catalog</h2>
+            </div>
+            <!-- Type filter tabs -->
+            <div class="catalog-tabs">
+                <template x-for="tab in tabs" :key="tab.key">
+                    <button class="catalog-tab" :class="activeTab === tab.key ? 'active' : ''"
+                            @click="activeTab = tab.key" x-text="tab.label + ' (' + tabCount(tab.key) + ')'"></button>
+                </template>
+            </div>
+            <!-- Search results or filtered list -->
+            <template x-if="searchResults !== null">
+                <div>
+                    <p class="text-sm text-gray-500 mb-3">
+                        <span x-text="searchResults.length"></span> result<span x-show="searchResults.length !== 1">s</span>
+                        for "<span x-text="searchQuery" class="font-medium"></span>"
+                        <button @click="clearSearch()" class="ml-2 text-indigo-600 hover:underline text-xs">Clear</button>
+                    </p>
+                    <template x-if="searchResults.length === 0">
+                        <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">No results found.</div>
+                    </template>
+                    <template x-if="searchResults.length > 0">
+                        <div class="bg-white shadow rounded-lg overflow-hidden">
+                            <div class="catalog-table-wrapper">
+                                <table class="min-w-full divide-y divide-gray-200">
+                                    <thead class="bg-gray-50">
+                                        <tr>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Match</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Description</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="bg-white divide-y divide-gray-200">
+                                        <template x-for="r in searchResults" :key="r.unique_id">
+                                            <tr class="hover:bg-gray-50 cursor-pointer" @click="openModel(r.name)">
+                                                <td class="px-6 py-4 whitespace-nowrap">
+                                                    <span class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="r.name"></span>
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap">
+                                                    <span class="model-badge" :class="'model-badge-' + r.type" x-text="r.type"></span>
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell">
+                                                    <span x-text="r.match_type"></span>
+                                                    <span x-show="r.matched_column" class="text-gray-400">(<span x-text="r.matched_column"></span>)</span>
+                                                </td>
+                                                <td class="px-6 py-4 hidden lg:table-cell"><div class="desc-truncate text-sm text-gray-500" x-text="r.description || '--'"></div></td>
+                                            </tr>
+                                        </template>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </template>
                 </div>
             </template>
-            <template x-if="sources.length > 0">
-                <div class="bg-white shadow rounded-lg overflow-hidden">
-                    <div class="catalog-table-wrapper">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Status</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Tables</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Rows</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Freshness</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                <template x-for="src in sources" :key="src.name">
-                                    <tr class="hover:bg-gray-50 cursor-pointer" @click="selectSource(src.name)">
-                                        <td class="px-6 py-4 whitespace-nowrap">
-                                            <span class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="src.name"></span>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap">
-                                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800" x-text="src.type"></span>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap hidden sm:table-cell">
-                                            <span class="inline-flex items-center">
-                                                <span class="w-2 h-2 rounded-full mr-2"
-                                                      :class="{'bg-green-400': src.status === 'synced', 'bg-yellow-400': src.status === 'syncing', 'bg-red-400': src.status === 'failed', 'bg-gray-300': src.status === 'unknown'}"></span>
-                                                <span class="text-sm text-gray-700" x-text="src.status === 'unknown' ? 'Not synced' : src.status"></span>
-                                            </span>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="src.tables ? src.tables.length : '--'"></td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="src.row_count != null ? src.row_count.toLocaleString() : '--'"></td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden lg:table-cell" x-text="formatFreshness(src.freshness)"></td>
-                                    </tr>
-                                </template>
-                            </tbody>
-                        </table>
-                    </div>
+            <template x-if="searchResults === null">
+                <div>
+                    <template x-if="filteredItems.length === 0 && !loading">
+                        <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
+                            <template x-if="allModels.length === 0 && allSources.length === 0">
+                                <p>No models found. Run dbt to generate models, or add a source and sync data.</p>
+                            </template>
+                            <template x-if="allModels.length > 0 || allSources.length > 0">
+                                <p>No items match this filter.</p>
+                            </template>
+                        </div>
+                    </template>
+                    <template x-if="filteredItems.length > 0">
+                        <div class="bg-white shadow rounded-lg overflow-hidden">
+                            <div class="catalog-table-wrapper">
+                                <table class="min-w-full divide-y divide-gray-200">
+                                    <thead class="bg-gray-50">
+                                        <tr>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Description</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Tests</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Documented</th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Tags</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="bg-white divide-y divide-gray-200">
+                                        <template x-for="item in filteredItems" :key="item.unique_id">
+                                            <tr class="hover:bg-gray-50 cursor-pointer" @click="openModel(item.name)">
+                                                <td class="px-6 py-4 whitespace-nowrap">
+                                                    <span class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="item.name"></span>
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap">
+                                                    <span class="model-badge" :class="'model-badge-' + item.type" x-text="item.type"></span>
+                                                </td>
+                                                <td class="px-6 py-4 hidden sm:table-cell">
+                                                    <div class="desc-truncate text-sm text-gray-500" x-text="item.description || '--'"></div>
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm hidden md:table-cell">
+                                                    <template x-if="item.test_count > 0">
+                                                        <span>
+                                                            <span x-show="item.tests_passing > 0" class="test-pass" x-text="item.tests_passing + ' pass'"></span>
+                                                            <span x-show="item.tests_passing > 0 && item.tests_failing > 0"> / </span>
+                                                            <span x-show="item.tests_failing > 0" class="test-fail" x-text="item.tests_failing + ' fail'"></span>
+                                                        </span>
+                                                    </template>
+                                                    <template x-if="!item.test_count">
+                                                        <span class="text-gray-400">--</span>
+                                                    </template>
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell"
+                                                    x-text="item.columns_total > 0 ? item.columns_documented + '/' + item.columns_total : '--'"></td>
+                                                <td class="px-6 py-4 whitespace-nowrap hidden lg:table-cell">
+                                                    <template x-if="item.tags && item.tags.length > 0">
+                                                        <div>
+                                                            <template x-for="tag in item.tags.slice(0, 3)" :key="tag">
+                                                                <span class="tag-badge" x-text="tag"></span>
+                                                            </template>
+                                                            <span x-show="item.tags.length > 3" class="text-xs text-gray-400" x-text="'+' + (item.tags.length - 3)"></span>
+                                                        </div>
+                                                    </template>
+                                                    <template x-if="!item.tags || item.tags.length === 0">
+                                                        <span class="text-gray-400 text-sm">--</span>
+                                                    </template>
+                                                </td>
+                                            </tr>
+                                        </template>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </template>
                 </div>
             </template>
         </div>
-        <!-- View 2: Tables list for selected source -->
-        <div x-show="!loading && view === 'tables'">
+
+        <!-- View 2: Model detail -->
+        <div x-show="!loading && view === 'detail' && selectedModel">
             <div class="flex items-center justify-between mb-4">
                 <div>
-                    <h2 class="text-xl font-bold text-gray-900">
-                        <span x-text="selectedSource"></span>
-                        <span class="text-gray-400 font-normal text-base ml-2">tables</span>
-                    </h2>
-                </div>
-                <div class="hidden sm:flex items-center space-x-2 text-sm text-gray-500">
-                    <span>Sync trend</span>
-                    <div class="sparkline-container" x-effect="renderSparkline($el, sourceDetail ? sourceDetail.history : [])"></div>
-                </div>
-            </div>
-            <div x-show="tablesLoading" x-cloak class="flex items-center justify-center py-12">
-                <div class="text-gray-400 text-sm">Loading tables...</div>
-            </div>
-            <template x-if="!tablesLoading && tablesList.length === 0">
-                <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">No tables found. Run a sync first.</div>
-            </template>
-            <template x-if="!tablesLoading && tablesList.length > 0">
-                <div class="bg-white shadow rounded-lg overflow-hidden">
-                    <div class="catalog-table-wrapper">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Table</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Rows</th>
-                                    <template x-if="hasLineage">
-                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Documentation</th>
-                                    </template>
-                                    <template x-if="hasLineage">
-                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Tests</th>
-                                    </template>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Drift</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                <template x-for="tbl in tablesList" :key="tbl.name">
-                                    <tr class="hover:bg-gray-50 cursor-pointer" @click="selectTable(tbl.name)">
-                                        <td class="px-6 py-4 whitespace-nowrap">
-                                            <span class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="tbl.name"></span>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell" x-text="tbl.row_count != null ? tbl.row_count.toLocaleString() : '--'"></td>
-                                        <template x-if="hasLineage">
-                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="getDocStatus(tbl.name)"></td>
-                                        </template>
-                                        <template x-if="hasLineage">
-                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="getTestCount(tbl.name)"></td>
-                                        </template>
-                                        <td class="px-6 py-4 whitespace-nowrap hidden lg:table-cell">
-                                            <template x-if="getTableDriftCount(tbl.name) > 0">
-                                                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-orange-100 text-orange-800" x-text="getTableDriftCount(tbl.name) + ' drift'"></span>
-                                            </template>
-                                            <template x-if="getTableDriftCount(tbl.name) === 0">
-                                                <span class="text-sm text-gray-400">--</span>
-                                            </template>
-                                        </td>
-                                    </tr>
-                                </template>
-                            </tbody>
-                        </table>
+                    <div class="flex items-center gap-3">
+                        <h2 class="text-xl font-bold text-gray-900" x-text="selectedModel.name"></h2>
+                        <span class="model-badge" :class="'model-badge-' + selectedModel.type" x-text="selectedModel.type"></span>
                     </div>
-                </div>
-            </template>
-            <template x-if="!hasLineage && !tablesLoading">
-                <div class="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-md">
-                    <p class="text-sm text-blue-700">Run dbt to see documentation and test coverage.</p>
-                </div>
-            </template>
-        </div>
-        <!-- View 3: Column detail -->
-        <div x-show="!loading && view === 'columns'">
-            <div class="flex items-center justify-between mb-4">
-                <div>
-                    <h2 class="text-xl font-bold text-gray-900" x-text="selectedSource + '.' + selectedTable"></h2>
+                    <p x-show="selectedModel.description" class="mt-1 text-sm text-gray-600" x-text="selectedModel.description"></p>
                     <div class="mt-1 text-sm text-gray-500 space-x-4">
-                        <span x-show="columnData"><span x-text="columnData ? columnData.row_count.toLocaleString() : ''"></span> rows</span>
-                        <span x-show="columnData && columnData.profiled_at">Profiled <span x-text="columnData ? timeAgo(columnData.profiled_at) : ''"></span></span>
-                        <span x-show="columnData && !columnData.profiled_at" class="text-gray-400">Not profiled</span>
+                        <span x-show="selectedModel.materialization">
+                            <span class="text-gray-400">Materialization:</span> <span x-text="selectedModel.materialization"></span>
+                        </span>
+                        <span x-show="selectedModel.row_count != null">
+                            <span x-text="selectedModel.row_count.toLocaleString()"></span> rows
+                        </span>
+                        <span x-show="selectedModel.profiled_at">Profiled <span x-text="timeAgo(selectedModel.profiled_at)"></span></span>
                     </div>
                 </div>
-                <button @click="refreshProfile()" :disabled="profilingLoading"
-                        class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors disabled:opacity-50">
-                    <span x-show="!profilingLoading">Refresh Profile</span>
-                    <span x-show="profilingLoading" x-cloak>Profiling...</span>
-                </button>
+                <template x-if="selectedModel.type === 'source'">
+                    <button @click="refreshProfile()" :disabled="profilingLoading"
+                            class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors disabled:opacity-50">
+                        <span x-show="!profilingLoading">Refresh Profile</span>
+                        <span x-show="profilingLoading" x-cloak>Profiling...</span>
+                    </button>
+                </template>
             </div>
-            <div x-show="columnsLoading" x-cloak class="flex items-center justify-center py-12">
-                <div class="text-gray-400 text-sm">Loading columns...</div>
+            <!-- Detail sub-tabs -->
+            <div class="detail-tabs">
+                <button class="detail-tab" :class="detailTab === 'columns' ? 'active' : ''" @click="detailTab = 'columns'">Columns</button>
+                <template x-if="selectedModel.type !== 'source'">
+                    <button class="detail-tab" :class="detailTab === 'code' ? 'active' : ''" @click="showCodeTab()">Code</button>
+                </template>
+                <button class="detail-tab" :class="detailTab === 'info' ? 'active' : ''" @click="detailTab = 'info'">Info</button>
             </div>
-            <template x-if="!columnsLoading && columnData">
-                <div class="bg-white shadow rounded-lg overflow-hidden">
-                    <div class="catalog-table-wrapper">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Column</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Nullable</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Null %</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Distinct</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Min / Max</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Indicators</th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                <template x-for="col in columnData.columns" :key="col.name">
-                                    <tr :class="isUndocumented() ? 'undocumented-marker' : ''">
-                                        <td class="px-6 py-4 whitespace-nowrap">
-                                            <div class="text-sm font-medium text-gray-900" x-text="col.name"></div>
-                                            <template x-if="isUndocumented()">
-                                                <span class="text-xs text-yellow-600">No description</span>
-                                            </template>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap"><span class="col-type text-gray-600" x-text="col.type"></span></td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell" x-text="col.nullable ? 'Yes' : 'No'"></td>
-                                        <td class="px-6 py-4 whitespace-nowrap hidden sm:table-cell">
-                                            <template x-if="col.stats && col.stats.null_pct != null">
-                                                <div class="flex items-center space-x-2">
-                                                    <div class="null-bar"><div class="null-bar-fill" :style="'width: ' + Math.min(parseFloat(col.stats.null_pct), 100) + '%'"></div></div>
-                                                    <span class="text-xs text-gray-500" x-text="parseFloat(col.stats.null_pct).toFixed(1) + '%'"></span>
-                                                </div>
-                                            </template>
-                                            <template x-if="!col.stats || col.stats.null_pct == null">
-                                                <span class="text-sm text-gray-400">--</span>
-                                            </template>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="col.stats && col.stats.distinct_count != null ? parseInt(col.stats.distinct_count).toLocaleString() : '--'"></td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden lg:table-cell">
-                                            <template x-if="col.stats && (col.stats.min_value != null || col.stats.max_value != null)">
-                                                <span><span x-text="col.stats.min_value ?? '--'"></span><span class="text-gray-300 mx-1">/</span><span x-text="col.stats.max_value ?? '--'"></span></span>
-                                            </template>
-                                            <template x-if="!col.stats || (col.stats.min_value == null && col.stats.max_value == null)">
-                                                <span class="text-gray-400">--</span>
-                                            </template>
-                                        </td>
-                                        <td class="px-6 py-4 whitespace-nowrap hidden lg:table-cell">
-                                            <div class="flex items-center space-x-1">
-                                                <template x-if="hasColumnDrift(col.name)">
-                                                    <span class="px-1.5 py-0.5 text-xs font-medium rounded bg-orange-100 text-orange-800">Drift</span>
-                                                </template>
-                                                <template x-if="hasColumnPii(col.name)">
-                                                    <span class="px-1.5 py-0.5 text-xs font-medium rounded bg-red-100 text-red-800">PII</span>
-                                                </template>
-                                            </div>
-                                        </td>
+            <!-- Columns sub-tab -->
+            <div x-show="detailTab === 'columns'">
+                <template x-if="selectedModel.columns && selectedModel.columns.length > 0">
+                    <div class="bg-white shadow rounded-lg overflow-hidden">
+                        <div class="catalog-table-wrapper">
+                            <table class="min-w-full divide-y divide-gray-200">
+                                <thead class="bg-gray-50">
+                                    <tr>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Column</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Description</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Nullable</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Tests</th>
                                     </tr>
-                                </template>
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody class="bg-white divide-y divide-gray-200">
+                                    <template x-for="col in selectedModel.columns" :key="col.name">
+                                        <tr>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" x-text="col.name"></td>
+                                            <td class="px-6 py-4 whitespace-nowrap"><span class="col-type text-gray-600" x-text="col.type || '--'"></span></td>
+                                            <td class="px-6 py-4 text-sm text-gray-500 hidden sm:table-cell" x-text="col.description || '--'"></td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="col.nullable != null ? (col.nullable ? 'Yes' : 'No') : '--'"></td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm hidden lg:table-cell">
+                                                <template x-if="col.tests && col.tests.length > 0">
+                                                    <div class="flex flex-wrap gap-1">
+                                                        <template x-for="t in col.tests" :key="t.name">
+                                                            <span class="text-xs px-1.5 py-0.5 rounded"
+                                                                  :class="t.status === 'pass' ? 'bg-green-100 text-green-800' : t.status === 'fail' || t.status === 'error' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-600'"
+                                                                  x-text="t.name.replace(/^(not_null|unique|accepted_values)_/, '$1: ').substring(0, 30)"></span>
+                                                        </template>
+                                                    </div>
+                                                </template>
+                                                <template x-if="!col.tests || col.tests.length === 0">
+                                                    <span class="text-gray-400">--</span>
+                                                </template>
+                                            </td>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </template>
+                <template x-if="!selectedModel.columns || selectedModel.columns.length === 0">
+                    <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
+                        No column information available. The model may not be materialized yet.
+                    </div>
+                </template>
+            </div>
+            <!-- Code sub-tab -->
+            <div x-show="detailTab === 'code'" x-cloak>
+                <template x-if="selectedModel.raw_code">
+                    <div class="space-y-4">
+                        <div>
+                            <div class="code-label">Raw SQL (with Jinja)</div>
+                            <div class="code-block"><code id="raw-code" class="catalog-sql language-sql" x-text="selectedModel.raw_code"></code></div>
+                        </div>
+                        <template x-if="selectedModel.compiled_code">
+                            <div>
+                                <div class="code-label">Compiled SQL</div>
+                                <div class="code-block"><code id="compiled-code" class="catalog-sql language-sql" x-text="selectedModel.compiled_code"></code></div>
+                            </div>
+                        </template>
+                    </div>
+                </template>
+                <template x-if="!selectedModel.raw_code">
+                    <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
+                        No SQL code available for this model.
+                    </div>
+                </template>
+            </div>
+            <!-- Info sub-tab -->
+            <div x-show="detailTab === 'info'" x-cloak>
+                <div class="bg-white shadow rounded-lg p-6 space-y-6">
+                    <div x-show="selectedModel.description">
+                        <h3 class="text-sm font-semibold text-gray-900 mb-1">Description</h3>
+                        <p class="text-sm text-gray-700" x-text="selectedModel.description"></p>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                        <div>
+                            <h3 class="text-sm font-semibold text-gray-900 mb-1">Schema</h3>
+                            <p class="text-sm text-gray-600" x-text="selectedModel.schema || '--'"></p>
+                        </div>
+                        <div x-show="selectedModel.materialization">
+                            <h3 class="text-sm font-semibold text-gray-900 mb-1">Materialization</h3>
+                            <p class="text-sm text-gray-600" x-text="selectedModel.materialization"></p>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold text-gray-900 mb-1">Type</h3>
+                            <span class="model-badge" :class="'model-badge-' + selectedModel.type" x-text="selectedModel.type"></span>
+                        </div>
+                    </div>
+                    <div x-show="selectedModel.tags && selectedModel.tags.length > 0">
+                        <h3 class="text-sm font-semibold text-gray-900 mb-1">Tags</h3>
+                        <div class="flex flex-wrap gap-1">
+                            <template x-for="tag in selectedModel.tags" :key="tag">
+                                <span class="tag-badge" x-text="tag"></span>
+                            </template>
+                        </div>
+                    </div>
+                    <div x-show="selectedModel.tests && selectedModel.tests.length > 0">
+                        <h3 class="text-sm font-semibold text-gray-900 mb-2">Tests</h3>
+                        <div class="space-y-1">
+                            <template x-for="t in selectedModel.tests" :key="t.name">
+                                <div class="flex items-center gap-2 text-sm">
+                                    <span class="w-2 h-2 rounded-full"
+                                          :class="t.status === 'pass' ? 'bg-green-400' : t.status === 'fail' || t.status === 'error' ? 'bg-red-400' : 'bg-gray-300'"></span>
+                                    <span x-text="t.name"></span>
+                                    <span class="text-gray-400" x-text="t.status || 'not run'"></span>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                    <div x-show="selectedModel.depends_on && selectedModel.depends_on.length > 0">
+                        <h3 class="text-sm font-semibold text-gray-900 mb-1">Upstream Dependencies</h3>
+                        <div class="flex flex-wrap gap-2">
+                            <template x-for="dep in selectedModel.depends_on" :key="dep">
+                                <span class="dep-link" @click="openModelByUid(dep)" x-text="dep.split('.').pop()"></span>
+                            </template>
+                        </div>
+                    </div>
+                    <div x-show="selectedModel.depended_on_by && selectedModel.depended_on_by.length > 0">
+                        <h3 class="text-sm font-semibold text-gray-900 mb-1">Downstream Dependents</h3>
+                        <div class="flex flex-wrap gap-2">
+                            <template x-for="dep in selectedModel.depended_on_by" :key="dep">
+                                <span class="dep-link" @click="openModelByUid(dep)" x-text="dep.split('.').pop()"></span>
+                            </template>
+                        </div>
                     </div>
                 </div>
-            </template>
+            </div>
         </div>
-        <!-- View 4: Lineage graph -->
+        <div x-show="!loading && view === 'detail' && !selectedModel && detailLoading" x-cloak
+             class="flex items-center justify-center py-12">
+            <div class="text-gray-400 text-sm">Loading model details...</div>
+        </div>
+
+        <!-- View 3: Lineage graph (unchanged) -->
         <div x-show="!loading && view === 'lineage'">
             <h2 class="text-xl font-bold text-gray-900 mb-4">Data Lineage</h2>
             <template x-if="lineageNodes.length === 0">
@@ -253,7 +359,6 @@
                         <button @click="lineageZoomOut()" title="Zoom out">&minus;</button>
                         <button @click="lineageFitAll()" title="Fit all">&#8694;</button>
                     </div>
-                    <!-- Detail panel -->
                     <div class="lineage-detail" x-show="selectedNode" x-cloak x-transition.opacity>
                         <div class="lineage-detail-header">
                             <div class="flex items-center justify-between">
@@ -283,6 +388,10 @@
                                 <span class="lineage-detail-value" x-text="selectedNode ? (selectedNode.columns_documented + '/' + selectedNode.columns_total) : ''"></span>
                             </div>
                             <div class="mt-4 space-y-2">
+                                <button @click="openModel(selectedNode.name)"
+                                        class="w-full px-3 py-1.5 text-sm font-medium bg-dango-600 text-white rounded-md hover:bg-dango-700">
+                                    View Details
+                                </button>
                                 <button @click="showDownstream()" :disabled="impactHighlighted"
                                         class="w-full px-3 py-1.5 text-sm font-medium bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:opacity-50">
                                     Show Downstream
@@ -307,21 +416,39 @@
 <script>
 function catalogPage() {
     return {
-        view: 'sources', selectedSource: null, selectedTable: null,
-        sources: [], sourceDetail: null, tablesList: [], columnData: null,
-        lineageNodes: [], lineageEdges: [], driftEvents: [], piiFindings: [],
+        view: 'list',
+        activeTab: 'all',
+        searchQuery: '',
+        searchResults: null,
+        allModels: [],
+        allSources: [],
+        selectedModel: null,
+        detailTab: 'columns',
+        detailLoading: false,
+        // Lineage state
+        lineageNodes: [], lineageEdges: [],
         selectedNode: null, impactHighlighted: false, impactCount: 0, _lineage: null,
-        loading: true, tablesLoading: false, columnsLoading: false,
-        profilingLoading: false, error: null, hasLineage: false,
+        // Shared state
+        loading: true, profilingLoading: false, error: null, hasLineage: false,
+        // Tab config
+        tabs: [
+            { key: 'all', label: 'All' },
+            { key: 'source', label: 'Sources' },
+            { key: 'staging', label: 'Staging' },
+            { key: 'intermediate', label: 'Intermediate' },
+            { key: 'marts', label: 'Marts' },
+        ],
 
         async init() {
             try {
-                const [sourcesRes, lineageRes] = await Promise.allSettled([
-                    fetch('/api/sources'), fetch('/api/catalog/lineage'),
+                const [modelsRes, lineageRes] = await Promise.allSettled([
+                    fetch('/api/catalog/models'), fetch('/api/catalog/lineage'),
                 ]);
-                if (sourcesRes.status === 'fulfilled' && sourcesRes.value.ok) {
-                    this.sources = await sourcesRes.value.json();
-                } else { this.error = 'Failed to load sources.'; }
+                if (modelsRes.status === 'fulfilled' && modelsRes.value.ok) {
+                    const data = await modelsRes.value.json();
+                    this.allModels = data.models || [];
+                    this.allSources = data.sources || [];
+                } else { this.error = 'Failed to load catalog data.'; }
                 if (lineageRes.status === 'fulfilled' && lineageRes.value.ok) {
                     const dag = await lineageRes.value.json();
                     this.lineageNodes = dag.nodes || [];
@@ -331,106 +458,97 @@ function catalogPage() {
             } catch (e) { this.error = 'Failed to load catalog data.'; }
             finally { this.loading = false; }
         },
-        goToSources() {
+
+        get filteredItems() {
+            const items = [...this.allSources, ...this.allModels];
+            if (this.activeTab === 'all') return items;
+            return items.filter(i => i.type === this.activeTab);
+        },
+
+        tabCount(key) {
+            if (key === 'all') return this.allModels.length + this.allSources.length;
+            if (key === 'source') return this.allSources.length;
+            return this.allModels.filter(m => m.type === key).length;
+        },
+
+        goToList() {
             if (this._lineage) { this._lineage.destroy(); this._lineage = null; }
             this.selectedNode = null; this.impactHighlighted = false; this.impactCount = 0;
-            this.view = 'sources'; this.selectedSource = null; this.selectedTable = null;
-            this.sourceDetail = null; this.columnData = null; this.driftEvents = []; this.tablesList = [];
+            this.view = 'list'; this.selectedModel = null; this.detailTab = 'columns';
         },
-        // No lineage cleanup needed — breadcrumb is hidden in lineage view,
-        // so goToTables() is only reachable from tables/columns views.
-        goToTables() {
-            this.view = 'tables'; this.selectedTable = null; this.columnData = null; this.driftEvents = [];
-        },
-        async selectSource(sourceName) {
-            this.selectedSource = sourceName; this.selectedTable = null;
-            this.view = 'tables'; this.tablesLoading = true; this.error = null;
+
+        async openModel(name) {
+            this.view = 'detail'; this.detailLoading = true; this.selectedModel = null;
+            this.detailTab = 'columns'; this.error = null;
             try {
-                const res = await fetch('/api/sources/' + encodeURIComponent(sourceName) + '/details');
-                if (!res.ok) { this.error = 'Failed to load source details.'; this.tablesLoading = false; return; }
-                this.sourceDetail = await res.json();
-                if (this.sourceDetail.tables && this.sourceDetail.tables.length > 0) {
-                    this.tablesList = this.sourceDetail.tables;
+                const res = await fetch('/api/catalog/models/' + encodeURIComponent(name));
+                if (res.ok) {
+                    this.selectedModel = await res.json();
                 } else {
-                    this.tablesList = [{ name: sourceName, row_count: this.sourceDetail.row_count, schema: 'raw_' + sourceName }];
+                    const err = await res.json().catch(() => ({}));
+                    this.error = err.detail || 'Failed to load model details.';
+                    this.view = 'list';
                 }
-                try {
-                    const driftRes = await fetch('/api/governance/schema-drift?source=' + encodeURIComponent(sourceName));
-                    if (driftRes.ok) { const d = await driftRes.json(); this.driftEvents = d.events || []; }
-                } catch (_) { /* graceful */ }
-            } catch (e) { this.error = 'Failed to load source details.'; }
-            finally { this.tablesLoading = false; }
+            } catch (e) { this.error = 'Failed to load model details.'; this.view = 'list'; }
+            finally { this.detailLoading = false; }
         },
-        async selectTable(tableName) {
-            this.selectedTable = tableName; this.view = 'columns';
-            this.columnsLoading = true; this.error = null;
+
+        openModelByUid(uid) {
+            const name = uid.split('.').pop();
+            if (name) this.openModel(name);
+        },
+
+        showCodeTab() {
+            this.detailTab = 'code';
+            this.$nextTick(() => {
+                if (typeof DangoCatalog !== 'undefined') DangoCatalog.highlightAll();
+            });
+        },
+
+        onSearchInput() {
+            const self = this;
+            if (typeof DangoCatalog !== 'undefined') {
+                DangoCatalog.debounceSearch(this.searchQuery, function(q) {
+                    if (q) self.doSearch(q); else self.searchResults = null;
+                }, 300);
+            } else {
+                if (this.searchQuery.length >= 2) this.doSearch(this.searchQuery);
+                else this.searchResults = null;
+            }
+        },
+
+        async doSearch(query) {
             try {
-                const base = '/api/catalog/' + encodeURIComponent(this.selectedSource) + '/' + encodeURIComponent(tableName);
-                const driftQ = '/api/governance/schema-drift?source=' + encodeURIComponent(this.selectedSource) + '&table=' + encodeURIComponent(tableName);
-                const piiQ = '/api/governance/pii?source=' + encodeURIComponent(this.selectedSource) + '&table=' + encodeURIComponent(tableName);
-                const [colRes, driftRes, piiRes] = await Promise.allSettled([
-                    fetch(base + '/columns'), fetch(driftQ), fetch(piiQ),
-                ]);
-                if (colRes.status === 'fulfilled' && colRes.value.ok) {
-                    this.columnData = await colRes.value.json();
-                } else { this.error = 'Failed to load columns. Run a sync first.'; }
-                if (driftRes.status === 'fulfilled' && driftRes.value.ok) {
-                    const d = await driftRes.value.json(); this.driftEvents = d.events || [];
+                const res = await fetch('/api/catalog/search?q=' + encodeURIComponent(query));
+                if (res.ok) {
+                    const data = await res.json();
+                    this.searchResults = data.results;
                 }
-                if (piiRes.status === 'fulfilled' && piiRes.value.ok) {
-                    const p = await piiRes.value.json(); this.piiFindings = p.findings || [];
-                } else { this.piiFindings = []; }
-            } catch (e) { this.error = 'Failed to load column data.'; }
-            finally { this.columnsLoading = false; }
+            } catch (_) { /* silent */ }
         },
+
+        clearSearch() {
+            this.searchQuery = '';
+            this.searchResults = null;
+        },
+
         async refreshProfile() {
-            if (!this.selectedSource || !this.selectedTable) return;
+            if (!this.selectedModel || this.selectedModel.type !== 'source') return;
+            const srcName = this.selectedModel.source_name;
+            const tblName = this.selectedModel.name;
+            if (!srcName || !tblName) return;
             this.profilingLoading = true; this.error = null;
             try {
-                const url = '/api/catalog/' + encodeURIComponent(this.selectedSource) + '/' + encodeURIComponent(this.selectedTable) + '/profile';
+                const url = '/api/catalog/' + encodeURIComponent(srcName) + '/' + encodeURIComponent(tblName) + '/profile';
                 const res = await fetch(url, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
-                if (res.ok) { this.columnData = await res.json(); }
-                else { this.error = 'Failed to refresh profile.'; }
+                if (res.ok) {
+                    // Reload model detail to get fresh profiling
+                    await this.openModel(tblName);
+                } else { this.error = 'Failed to refresh profile.'; }
             } catch (e) { this.error = 'Failed to refresh profile.'; }
             finally { this.profilingLoading = false; }
         },
-        getLineageNode(tableName) { return this.lineageNodes.find(n => n.name === tableName); },
-        getDocStatus(tableName) {
-            const node = this.getLineageNode(tableName);
-            if (!node) return '--';
-            return node.columns_documented + '/' + node.columns_total + ' documented';
-        },
-        getTestCount(tableName) {
-            const node = this.getLineageNode(tableName);
-            if (!node) return '--';
-            return node.test_count + (node.test_count === 1 ? ' test' : ' tests');
-        },
-        getTableDriftCount(tableName) { return this.driftEvents.filter(e => e.table_name === tableName).length; },
-        hasColumnDrift(colName) { return this.driftEvents.some(e => e.column_name === colName); },
-        hasColumnPii(colName) { return this.piiFindings.some(f => f.column_name === colName); },
-        isUndocumented() {
-            if (!this.hasLineage) return false;
-            const node = this.getLineageNode(this.selectedTable);
-            if (!node) return false;
-            return node.columns_total > 0 && node.columns_documented === 0;
-        },
-        renderSparkline(el, history) {
-            if (!history || !Array.isArray(history)) { el.innerHTML = '<span class="text-xs text-gray-400">--</span>'; return; }
-            const durations = history.filter(h => h.status === 'success' && h.duration_seconds != null).slice(-30).map(h => h.duration_seconds);
-            if (durations.length < 2) { el.innerHTML = '<span class="text-xs text-gray-400">--</span>'; return; }
-            const w = 80, ht = 24, max = Math.max(...durations), min = Math.min(...durations), range = max - min || 1;
-            const points = durations.map((d, i) => {
-                const x = 2 + (i / (durations.length - 1)) * 76, y = 2 + (1 - (d - min) / range) * 20;
-                return x + ',' + y;
-            }).join(' ');
-            el.innerHTML = '<svg width="' + w + '" height="' + ht + '"><polyline points="' + points + '" fill="none" stroke="#6366f1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-        },
-        formatFreshness(freshness) {
-            if (!freshness) return '--';
-            if (freshness.last_sync_time) return this.timeAgo(freshness.last_sync_time);
-            if (freshness.freshness_status) return freshness.freshness_status;
-            return '--';
-        },
+
         timeAgo(dateStr) {
             if (!dateStr) return '--';
             const diff = Math.floor((new Date() - new Date(dateStr)) / 1000);
@@ -439,9 +557,10 @@ function catalogPage() {
             if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
             return Math.floor(diff / 86400) + 'd ago';
         },
+
         toggleLineageView() {
             if (this.view === 'lineage') {
-                this.goToSources();
+                this.goToList();
             } else {
                 this.view = 'lineage'; this.selectedNode = null;
                 this.impactHighlighted = false; this.impactCount = 0;
@@ -491,5 +610,9 @@ function catalogPage() {
 }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
-<script src="/static/js/lineage.js?v=1741700000"></script>
+<script src="/static/js/lineage.js?v=1744500000"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/sql.min.js"></script>
+<script src="/static/js/catalog.js?v=1744500000"></script>
 {% endblock %}

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -305,9 +305,15 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/catalog.py
-    lines: 566
+    lines: 1157
     category: exempt
-    reason: "P7-001+P7-002: Column schema, profiling, lineage DAG, and impact analysis endpoints. Single router file per file conflict matrix — lineage helpers are private to the same module."
+    reason: "P7-001+P7-002+BUG-016: Column schema, profiling, lineage DAG, impact analysis, model list/detail/search endpoints. Single router file — manifest parsing helpers are private to the same module."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_catalog_models.py
+    lines: 678
+    category: exempt
+    reason: "BUG-016: 16 tests covering catalog model list (8) + model detail (8). Test infrastructure shared with test_catalog_lineage.py."
     review_by: "v1.1"
 
   - file: tests/unit/test_schedule_crud_api.py

--- a/tests/unit/test_catalog_models.py
+++ b/tests/unit/test_catalog_models.py
@@ -1,0 +1,678 @@
+"""tests/unit/test_catalog_models.py
+
+Unit tests for catalog model list and detail endpoints (BUG-016).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    DangoError,
+    ValidationError,
+)
+from dango.web.routes.catalog import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.ADMIN) -> User:
+    """Create a test user."""
+    return User(
+        id="u-test-1",
+        email="test@test.com",
+        password_hash="hashed",
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the catalog router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        ValidationError: 400,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(
+        request: Request,
+        exc: DangoError,
+    ) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_client(
+    tmp_path: Path,
+    role: Role = Role.ADMIN,
+) -> tuple[TestClient, Path]:
+    """Create a test client with auth middleware injecting a user."""
+    user = _make_user(role)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+def _make_manifest(
+    models: dict[str, dict[str, Any]] | None = None,
+    sources: dict[str, dict[str, Any]] | None = None,
+    tests: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal dbt manifest for testing."""
+    nodes: dict[str, Any] = {}
+    if models:
+        for uid, m in models.items():
+            nodes[uid] = {
+                "resource_type": "model",
+                "name": m.get("name", uid.split(".")[-1]),
+                "schema": m.get("schema", "staging"),
+                "config": {"materialized": m.get("materialized", "view")},
+                "description": m.get("description", ""),
+                "depends_on": {"nodes": m.get("depends_on", [])},
+                "columns": m.get("columns", {}),
+                "tags": m.get("tags", []),
+                "meta": m.get("meta", {}),
+                "raw_code": m.get("raw_code", ""),
+                "compiled_code": m.get("compiled_code", ""),
+            }
+    if tests:
+        for uid, t in tests.items():
+            nodes[uid] = {
+                "resource_type": "test",
+                "name": t.get("name", uid.split(".")[-1]),
+                "depends_on": {"nodes": t.get("depends_on", [])},
+            }
+
+    src: dict[str, Any] = {}
+    if sources:
+        for uid, s in sources.items():
+            src[uid] = {
+                "name": s.get("name", uid.split(".")[-1]),
+                "schema": s.get("schema", "raw_shop"),
+                "description": s.get("description", ""),
+                "columns": s.get("columns", {}),
+                "resource_type": "source",
+                "source_name": s.get("source_name", ""),
+            }
+
+    return {"nodes": nodes, "sources": src}
+
+
+def _make_run_results(
+    results: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal run_results.json for testing."""
+    return {
+        "metadata": {"generated_at": "2026-04-13T10:00:00Z"},
+        "results": results or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /api/catalog/models
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestListCatalogModels:
+    """Tests for GET /api/catalog/models."""
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_response_includes_all_model_types(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Response includes staging, intermediate, and marts models."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {
+                    "name": "orders",
+                    "source_name": "shop",
+                },
+            },
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                },
+                "model.proj.int_clean": {
+                    "name": "int_clean",
+                    "schema": "intermediate",
+                },
+                "model.proj.fct_revenue": {
+                    "name": "fct_revenue",
+                    "schema": "marts",
+                },
+            },
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["models"]) == 3
+        assert len(data["sources"]) == 1
+        types = {m["type"] for m in data["models"]}
+        assert types == {"staging", "intermediate", "marts"}
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_model_type_classification(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Models are classified by schema name first, then name prefix."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                },
+                "model.proj.dim_customers": {
+                    "name": "dim_customers",
+                    "schema": "marts",
+                },
+                "model.proj.some_model": {
+                    "name": "some_model",
+                    "schema": "custom_schema",
+                },
+            },
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+        data = resp.json()
+
+        model_map = {m["name"]: m["type"] for m in data["models"]}
+        assert model_map["stg_orders"] == "staging"
+        assert model_map["dim_customers"] == "marts"
+        assert model_map["some_model"] == "intermediate"
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_test_counts_from_run_results(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Test counts and pass/fail from run_results are correct."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {"name": "stg_orders", "schema": "staging"},
+            },
+            tests={
+                "test.proj.not_null": {
+                    "name": "not_null_stg_orders_id",
+                    "depends_on": ["model.proj.stg_orders"],
+                },
+                "test.proj.unique": {
+                    "name": "unique_stg_orders_id",
+                    "depends_on": ["model.proj.stg_orders"],
+                },
+            },
+        )
+        mock_run_results.return_value = _make_run_results(
+            [
+                {"unique_id": "test.proj.not_null", "status": "pass"},
+                {"unique_id": "test.proj.unique", "status": "fail"},
+            ]
+        )
+
+        resp = client.get("/api/catalog/models")
+        data = resp.json()
+
+        model = data["models"][0]
+        assert model["test_count"] == 2
+        assert model["tests_passing"] == 1
+        assert model["tests_failing"] == 1
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_documentation_counts(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Columns total and documented counts are correct."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                    "columns": {
+                        "id": {"name": "id", "description": "Primary key"},
+                        "amount": {"name": "amount", "description": ""},
+                        "status": {"name": "status", "description": "Order status"},
+                    },
+                },
+            },
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+        data = resp.json()
+
+        model = data["models"][0]
+        assert model["columns_total"] == 3
+        assert model["columns_documented"] == 2
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_empty_when_no_manifest(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Returns empty lists (not 404) when no manifest exists."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = None
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["models"] == []
+        assert data["sources"] == []
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_tags_included(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Tags array from manifest is included in response."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                    "tags": ["daily", "chess"],
+                },
+            },
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+        data = resp.json()
+
+        assert data["models"][0]["tags"] == ["daily", "chess"]
+
+    def test_requires_permission(self, tmp_path: Path) -> None:
+        """Endpoint requires governance.view permission (viewer has it)."""
+        client, _ = _setup_client(tmp_path, role=Role.VIEWER)
+        resp = client.get("/api/catalog/models")
+        assert resp.status_code != 403
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_sources_included(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Sources from manifest appear in response with source_name."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {
+                    "name": "orders",
+                    "source_name": "shop",
+                    "schema": "raw_shop",
+                },
+            },
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+        data = resp.json()
+
+        assert len(data["sources"]) == 1
+        assert data["sources"][0]["name"] == "orders"
+        assert data["sources"][0]["type"] == "source"
+        assert data["sources"][0]["source_name"] == "shop"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/catalog/models/{model_name}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetCatalogModel:
+    """Tests for GET /api/catalog/models/{model_name}."""
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_model_column_schema")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_model_detail_response_shape(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_col_schema: MagicMock,
+        mock_profiled: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Response has all required fields."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_root.return_value = project_root
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                    "description": "Cleaned orders",
+                    "tags": ["daily"],
+                    "raw_code": "SELECT * FROM {{ source('shop', 'orders') }}",
+                    "compiled_code": "SELECT * FROM raw_shop.orders",
+                },
+            },
+        )
+        mock_run_results.return_value = None
+        mock_col_schema.return_value = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+        ]
+        mock_profiled.return_value = None
+
+        resp = client.get("/api/catalog/models/stg_orders")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "stg_orders"
+        assert data["type"] == "staging"
+        assert data["description"] == "Cleaned orders"
+        assert data["tags"] == ["daily"]
+        assert "raw_code" in data
+        assert "compiled_code" in data
+        assert "columns" in data
+        assert "depends_on" in data
+        assert "depended_on_by" in data
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_model_column_schema")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_includes_sql_code(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_col_schema: MagicMock,
+        mock_profiled: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Raw and compiled SQL code from manifest is included."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_root.return_value = project_root
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                    "raw_code": "SELECT id FROM {{ source('shop', 'orders') }}",
+                    "compiled_code": "SELECT id FROM raw_shop.orders",
+                },
+            },
+        )
+        mock_run_results.return_value = None
+        mock_col_schema.return_value = []
+        mock_profiled.return_value = None
+
+        resp = client.get("/api/catalog/models/stg_orders")
+        data = resp.json()
+
+        assert data["raw_code"] == "SELECT id FROM {{ source('shop', 'orders') }}"
+        assert data["compiled_code"] == "SELECT id FROM raw_shop.orders"
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_model_column_schema")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_column_descriptions_merged(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_col_schema: MagicMock,
+        mock_profiled: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """DuckDB columns get descriptions merged from manifest."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_root.return_value = project_root
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                    "columns": {
+                        "id": {"name": "id", "description": "Primary key"},
+                        "amount": {"name": "amount", "description": ""},
+                    },
+                },
+            },
+        )
+        mock_run_results.return_value = None
+        mock_col_schema.return_value = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "amount", "type": "DOUBLE", "nullable": True},
+        ]
+        mock_profiled.return_value = None
+
+        resp = client.get("/api/catalog/models/stg_orders")
+        data = resp.json()
+
+        cols = {c["name"]: c for c in data["columns"]}
+        assert cols["id"]["description"] == "Primary key"
+        assert cols["amount"]["description"] is None  # empty string → None
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_model_column_schema")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_column_tests_mapped(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_col_schema: MagicMock,
+        mock_profiled: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Tests are mapped to the correct columns by name pattern."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_root.return_value = project_root
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "schema": "staging",
+                    "columns": {"id": {"name": "id", "description": ""}},
+                },
+            },
+            tests={
+                "test.proj.not_null_stg_orders_id": {
+                    "name": "not_null_stg_orders_id",
+                    "depends_on": ["model.proj.stg_orders"],
+                },
+            },
+        )
+        mock_run_results.return_value = _make_run_results(
+            [{"unique_id": "test.proj.not_null_stg_orders_id", "status": "pass"}]
+        )
+        mock_col_schema.return_value = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+        ]
+        mock_profiled.return_value = None
+
+        resp = client.get("/api/catalog/models/stg_orders")
+        data = resp.json()
+
+        id_col = data["columns"][0]
+        assert id_col["tests"] is not None
+        assert len(id_col["tests"]) == 1
+        assert id_col["tests"][0]["name"] == "not_null_stg_orders_id"
+        assert id_col["tests"][0]["status"] == "pass"
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_404_model_not_found(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """404 when model name is not in manifest."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={"model.proj.stg_orders": {"name": "stg_orders"}},
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models/nonexistent")
+
+        assert resp.status_code == 404
+        assert "nonexistent" in resp.json()["detail"]
+
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_404_no_manifest(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """404 when no manifest exists."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = None
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models/stg_orders")
+
+        assert resp.status_code == 404
+        assert "manifest" in resp.json()["detail"].lower()
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_model_column_schema")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_model_preferred_over_source(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_col_schema: MagicMock,
+        mock_profiled: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """When model and source share a name, model is preferred."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_root.return_value = project_root
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {
+                    "name": "orders",
+                    "source_name": "shop",
+                },
+            },
+            models={
+                "model.proj.orders": {
+                    "name": "orders",
+                    "schema": "marts",
+                },
+            },
+        )
+        mock_run_results.return_value = None
+        mock_col_schema.return_value = []
+        mock_profiled.return_value = None
+
+        resp = client.get("/api/catalog/models/orders")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["type"] == "marts"  # model, not source
+
+    def test_requires_permission(self, tmp_path: Path) -> None:
+        """Endpoint requires governance.view permission (viewer has it)."""
+        client, _ = _setup_client(tmp_path, role=Role.VIEWER)
+        resp = client.get("/api/catalog/models/stg_orders")
+        assert resp.status_code != 403

--- a/tests/unit/test_catalog_search.py
+++ b/tests/unit/test_catalog_search.py
@@ -1,0 +1,373 @@
+"""tests/unit/test_catalog_search.py
+
+Unit tests for catalog search endpoint and column descriptions (BUG-016).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    DangoError,
+    ValidationError,
+)
+from dango.web.routes.catalog import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.ADMIN) -> User:
+    """Create a test user."""
+    return User(
+        id="u-test-1",
+        email="test@test.com",
+        password_hash="hashed",
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    """Create a minimal FastAPI app with the catalog router."""
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    status_map: dict[type[DangoError], int] = {
+        AuthenticationError: 401,
+        AuthorizationError: 403,
+        ValidationError: 400,
+        DangoError: 500,
+    }
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(
+        request: Request,
+        exc: DangoError,
+    ) -> JSONResponse:
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_client(
+    tmp_path: Path,
+    role: Role = Role.ADMIN,
+) -> tuple[TestClient, Path]:
+    """Create a test client with auth middleware injecting a user."""
+    user = _make_user(role)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+def _make_manifest(
+    models: dict[str, dict[str, Any]] | None = None,
+    sources: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal dbt manifest for testing."""
+    nodes: dict[str, Any] = {}
+    if models:
+        for uid, m in models.items():
+            nodes[uid] = {
+                "resource_type": "model",
+                "name": m.get("name", uid.split(".")[-1]),
+                "schema": m.get("schema", "staging"),
+                "config": {"materialized": m.get("materialized", "view")},
+                "description": m.get("description", ""),
+                "depends_on": {"nodes": m.get("depends_on", [])},
+                "columns": m.get("columns", {}),
+                "tags": m.get("tags", []),
+            }
+
+    src: dict[str, Any] = {}
+    if sources:
+        for uid, s in sources.items():
+            src[uid] = {
+                "name": s.get("name", uid.split(".")[-1]),
+                "schema": s.get("schema", "raw_shop"),
+                "description": s.get("description", ""),
+                "columns": s.get("columns", {}),
+                "resource_type": "source",
+                "source_name": s.get("source_name", ""),
+            }
+
+    return {"nodes": nodes, "sources": src}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/catalog/search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSearchCatalog:
+    """Tests for GET /api/catalog/search."""
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_search_by_name(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Search matches model names."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {"name": "stg_orders"},
+                "model.proj.stg_customers": {"name": "stg_customers"},
+            },
+        )
+
+        resp = client.get("/api/catalog/search?q=orders")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["query"] == "orders"
+        assert len(data["results"]) == 1
+        assert data["results"][0]["name"] == "stg_orders"
+        assert data["results"][0]["match_type"] == "name"
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_search_by_description(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Search matches model descriptions."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {
+                    "name": "stg_orders",
+                    "description": "Cleaned order data from chess.com",
+                },
+                "model.proj.stg_profiles": {
+                    "name": "stg_profiles",
+                    "description": "Player profiles",
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/search?q=chess")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["results"]) == 1
+        assert data["results"][0]["name"] == "stg_orders"
+        assert data["results"][0]["match_type"] == "description"
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_search_by_column_name(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Search matches column names within models."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.fct_revenue": {
+                    "name": "fct_revenue",
+                    "schema": "marts",
+                    "columns": {
+                        "order_id": {"name": "order_id", "description": ""},
+                        "total": {"name": "total", "description": ""},
+                    },
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/search?q=order_id")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["results"]) == 1
+        assert data["results"][0]["name"] == "fct_revenue"
+        assert data["results"][0]["match_type"] == "column"
+        assert data["results"][0]["matched_column"] == "order_id"
+
+    def test_short_query_returns_422(self, tmp_path: Path) -> None:
+        """Query shorter than 2 characters returns 422 (FastAPI validation)."""
+        client, _ = _setup_client(tmp_path)
+
+        resp = client.get("/api/catalog/search?q=a")
+
+        assert resp.status_code == 422
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_no_results(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Returns empty results list when nothing matches."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            models={"model.proj.stg_orders": {"name": "stg_orders"}},
+        )
+
+        resp = client.get("/api/catalog/search?q=zzzznotfound")
+
+        assert resp.status_code == 200
+        assert resp.json()["results"] == []
+
+    def test_requires_permission(self, tmp_path: Path) -> None:
+        """Endpoint requires governance.view permission (viewer has it)."""
+        client, _ = _setup_client(tmp_path, role=Role.VIEWER)
+        resp = client.get("/api/catalog/search?q=orders")
+        assert resp.status_code != 403
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_empty_results_when_no_manifest(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Returns empty results (not 404) when no manifest exists."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = None
+
+        resp = client.get("/api/catalog/search?q=orders")
+
+        assert resp.status_code == 200
+        assert resp.json()["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# Column descriptions in GET /api/catalog/{source}/{table}/columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestColumnsWithDescriptions:
+    """Tests for column description field in existing columns endpoint."""
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_row_count")
+    @patch("dango.web.routes.catalog._get_cached_stats")
+    @patch("dango.web.routes.catalog._get_column_schema")
+    @patch("dango.web.routes.catalog._table_exists")
+    @patch("dango.web.routes.catalog._source_schema_exists")
+    def test_descriptions_added_from_manifest(
+        self,
+        mock_schema_exists: MagicMock,
+        mock_table_exists: MagicMock,
+        mock_get_schema: MagicMock,
+        mock_get_stats: MagicMock,
+        mock_get_count: MagicMock,
+        mock_get_profiled: MagicMock,
+        mock_manifest: MagicMock,
+        mock_get_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Column descriptions from manifest are merged into response."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_get_root.return_value = project_root
+        mock_schema_exists.return_value = True
+        mock_table_exists.return_value = True
+        mock_get_schema.return_value = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+            {"name": "email", "type": "VARCHAR", "nullable": True},
+        ]
+        mock_get_stats.return_value = {}
+        mock_get_count.return_value = 100
+        mock_get_profiled.return_value = None
+        mock_manifest.return_value = {
+            "nodes": {},
+            "sources": {
+                "source.proj.shop.orders": {
+                    "name": "orders",
+                    "schema": "raw_shopify",
+                    "columns": {
+                        "id": {"name": "id", "description": "Primary key"},
+                        "email": {"name": "email", "description": "User email"},
+                    },
+                    "resource_type": "source",
+                },
+            },
+        }
+
+        resp = client.get("/api/catalog/shopify/orders/columns")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        cols = {c["name"]: c for c in data["columns"]}
+        assert cols["id"]["description"] == "Primary key"
+        assert cols["email"]["description"] == "User email"
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_row_count")
+    @patch("dango.web.routes.catalog._get_cached_stats")
+    @patch("dango.web.routes.catalog._get_column_schema")
+    @patch("dango.web.routes.catalog._table_exists")
+    @patch("dango.web.routes.catalog._source_schema_exists")
+    def test_descriptions_null_without_manifest(
+        self,
+        mock_schema_exists: MagicMock,
+        mock_table_exists: MagicMock,
+        mock_get_schema: MagicMock,
+        mock_get_stats: MagicMock,
+        mock_get_count: MagicMock,
+        mock_get_profiled: MagicMock,
+        mock_manifest: MagicMock,
+        mock_get_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Column descriptions are None when no manifest exists."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_get_root.return_value = project_root
+        mock_schema_exists.return_value = True
+        mock_table_exists.return_value = True
+        mock_get_schema.return_value = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+        ]
+        mock_get_stats.return_value = {}
+        mock_get_count.return_value = 50
+        mock_get_profiled.return_value = None
+        mock_manifest.return_value = None
+
+        resp = client.get("/api/catalog/shopify/orders/columns")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["columns"][0]["description"] is None


### PR DESCRIPTION
## Summary

- **Make the catalog the single source of truth** for data documentation — users no longer need `/dbt-docs`
- Add 3 new API endpoints: model list, model detail (with SQL code, column descriptions, test results), and search
- Modify existing columns endpoint to include descriptions from dbt manifest
- Redesign catalog UI with tab navigation (Sources/Staging/Intermediate/Marts), search bar, model detail view with Columns/Code/Info sub-tabs, and highlight.js SQL rendering
- 25 new unit tests across 2 test files, 0 regressions on existing 29 catalog tests

## Changes

### Backend (`dango/web/routes/catalog.py`: 566 → 1157 lines)

**New endpoints:**
| Endpoint | Purpose |
|----------|---------|
| `GET /api/catalog/models` | List all models + sources with test/doc counts, tags |
| `GET /api/catalog/models/{name}` | Detail: columns (DuckDB + manifest descriptions), SQL code, tests, deps |
| `GET /api/catalog/search?q=` | Search model names, descriptions, column names |

**Modified:** `GET /api/catalog/{source}/{table}/columns` — adds `description` field from manifest

### Frontend
- `catalog.html` (495 → 618 lines): Tab filter, search, model detail with Columns/Code/Info tabs
- `catalog.js` (new): Search debounce + highlight.js wrappers
- `catalog.css` (86 → 226 lines): Model type badges, tabs, code blocks, search bar

### Tests
- `test_catalog_models.py` (678 lines): 16 tests — list (8) + detail (8)
- `test_catalog_search.py` (373 lines): 9 tests — search (7) + column descriptions (2)

### Docs
- `file-exemptions.yml`: Updated catalog.py line count, added test_catalog_models.py
- Root `CLAUDE.md` + `web/CLAUDE.md`: Updated file descriptions and line counts

## Test plan

- [ ] `pytest tests/unit/test_catalog_*.py` — all 54 tests pass
- [ ] `ruff check` + `ruff format --check` — clean
- [ ] `mypy dango/web/routes/catalog.py` — clean
- [ ] Manual: open `/catalog`, verify all model types shown with correct type badges
- [ ] Manual: click a staging model → verify columns, SQL code tab, info tab
- [ ] Manual: search for a column name → verify results show correct model
- [ ] Manual: verify lineage view still works (no regression)
- [ ] Manual: verify graceful degradation when no manifest exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)