### PR TITLE
fix: BUG-027 + BUG-035 — graceful PII scan failure, non-destructive metabase refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ dango/                          # Python package source
 │   ├── __init__.py             # Re-exports public API
 │   ├── models.py               # Pydantic V2 response models
 │   ├── schema_drift.py         # Schema drift detection engine (490 lines)
-│   └── pii_detector.py         # PII scanning engine (454 lines)
+│   └── pii_detector.py         # PII scanning engine (515 lines)
 │
 ├── notebooks/                  # Level 1 — Marimo notebook management
 │   ├── __init__.py             # Re-exports public symbols
@@ -365,6 +365,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `platform/local/watcher.py` | 518 | — |
 | `cli/model_wizard.py` | 507 | — |
 | `platform/cloud/scheduled_backup.py` | 505 | — (server-side scheduled backup) |
+| `governance/pii_detector.py` | 515 | — (BUG-027: 3-level spaCy download fallback) |
 
 ## Module Documentation Index
 

--- a/dango/cli/commands/metabase_cmd.py
+++ b/dango/cli/commands/metabase_cmd.py
@@ -308,22 +308,23 @@ def metabase_load(ctx: click.Context, overwrite: bool, dry_run: bool) -> None:
 @click.pass_context
 def metabase_refresh(ctx: click.Context) -> None:
     """
-    Refresh Metabase database connection to discover new schemas.
+    Refresh Metabase schema to discover new tables and schemas.
 
     Use this when you've created new schemas (e.g., marts) and want
-    Metabase to discover them. This recreates the database connection.
+    Metabase to discover them. This triggers a non-destructive schema
+    sync that preserves all existing questions and dashboards.
 
     Examples:
       dango metabase refresh    # Refresh to discover new schemas
     """
-    import time
-
     import requests
     import yaml
 
+    from dango.visualization.metabase import sync_metabase_schema
+
     from ..utils import require_project_context
 
-    console.print("\n🍡 [bold]Refreshing Metabase Connection[/bold]\n")
+    console.print("\n🍡 [bold]Refreshing Metabase Schema[/bold]\n")
 
     try:
         project_root = require_project_context(ctx)
@@ -333,13 +334,12 @@ def metabase_refresh(ctx: click.Context) -> None:
             console.print("[red]✗[/red] Metabase not configured. Run 'dango start' first.")
             raise click.Abort()
 
-        # Load credentials
+        # Load credentials for health check and display
         with open(credentials_file) as f:
             credentials = yaml.safe_load(f)
 
-        admin = credentials.get("admin", {})
-        old_db = credentials.get("database", {})
         metabase_url = credentials.get("metabase_url", "http://localhost:3000")
+        db_id = credentials.get("database", {}).get("id")
 
         # Check if Metabase is running
         try:
@@ -351,93 +351,55 @@ def metabase_refresh(ctx: click.Context) -> None:
             console.print("[red]✗[/red] Cannot connect to Metabase. Start with 'dango start'.")
             raise click.Abort() from None
 
-        console.print("[cyan]Step 1:[/cyan] Logging in to Metabase...")
-        login_response = requests.post(
-            f"{metabase_url}/api/session",
-            json={"username": admin.get("email"), "password": admin.get("password")},
-            timeout=10,
-        )
+        console.print("[green]✓[/green] Metabase is running")
 
-        if login_response.status_code != 200:
-            console.print("[red]✗[/red] Failed to login to Metabase")
+        # Trigger non-destructive schema sync (handles login, sync, polling,
+        # and visibility rules internally)
+        console.print("[cyan]Syncing schema...[/cyan]")
+        success = sync_metabase_schema(project_root, metabase_url)
+
+        if not success:
+            console.print("[red]✗[/red] Schema sync failed. Check Metabase logs for details.")
             raise click.Abort()
 
-        session_id = login_response.json().get("id")
-        headers = {"X-Metabase-Session": session_id}
+        console.print("[green]✓[/green] Schema sync complete")
 
-        console.print("[green]✓[/green] Logged in")
-
-        # Delete old database connection
-        console.print(
-            f"[cyan]Step 2:[/cyan] Removing old database connection (ID: {old_db.get('id')})..."
-        )
-        delete_response = requests.delete(
-            f"{metabase_url}/api/database/{old_db.get('id')}", headers=headers, timeout=10
-        )
-
-        if delete_response.status_code == 204:
-            console.print("[green]✓[/green] Old connection removed")
-        else:
-            console.print(
-                f"[yellow]⚠[/yellow] Could not remove old connection (status: {delete_response.status_code})"
+        # Show discovered schemas/tables for user feedback
+        if db_id:
+            admin = credentials.get("admin", {})
+            login_response = requests.post(
+                f"{metabase_url}/api/session",
+                json={"username": admin.get("email"), "password": admin.get("password")},
+                timeout=10,
             )
 
-        # Create new database connection
-        console.print("[cyan]Step 3:[/cyan] Creating new database connection...")
-        create_response = requests.post(
-            f"{metabase_url}/api/database",
-            headers=headers,
-            json={
-                "name": old_db.get("name", "DuckDB Analytics"),
-                "engine": "duckdb",
-                "details": {
-                    "database_file": "/data/warehouse.duckdb",
-                    "old_implicit_casting": True,
-                    "read_only": False,
-                },
-            },
-            timeout=10,
-        )
+            if login_response.status_code == 200:
+                session_id = login_response.json().get("id")
+                headers = {"X-Metabase-Session": session_id}
 
-        if create_response.status_code != 200:
-            console.print(f"[red]✗[/red] Failed to create new connection: {create_response.text}")
-            raise click.Abort()
+                metadata_response = requests.get(
+                    f"{metabase_url}/api/database/{db_id}/metadata",
+                    headers=headers,
+                    timeout=10,
+                )
 
-        new_db_id = create_response.json().get("id")
-        console.print(f"[green]✓[/green] New connection created (ID: {new_db_id})")
+                if metadata_response.status_code == 200:
+                    tables = metadata_response.json().get("tables", [])
+                    schemas = {t.get("schema") for t in tables}
 
-        # Update credentials file
-        console.print("[cyan]Step 4:[/cyan] Updating configuration...")
-        credentials["database"]["id"] = new_db_id
+                    console.print(
+                        f"\n[bold]Discovered schemas:[/bold] {', '.join(sorted(schemas))}"
+                    )
+                    console.print(f"[bold]Total tables:[/bold] {len(tables)}\n")
 
-        with open(credentials_file, "w") as f:
-            yaml.dump(credentials, f, default_flow_style=False)
+                    for schema in sorted(schemas):
+                        schema_tables = [t.get("name") for t in tables if t.get("schema") == schema]
+                        console.print(f"  [cyan]{schema}[/cyan]: {', '.join(schema_tables)}")
 
-        console.print("[green]✓[/green] Configuration updated")
+        console.print("\n[green]✨ Metabase schema refreshed successfully![/green]\n")
 
-        # Wait for sync
-        console.print("[cyan]Step 5:[/cyan] Waiting for schema sync...")
-        time.sleep(3)
-
-        # Check discovered tables
-        metadata_response = requests.get(
-            f"{metabase_url}/api/database/{new_db_id}/metadata", headers=headers, timeout=10
-        )
-
-        if metadata_response.status_code == 200:
-            tables = metadata_response.json().get("tables", [])
-            schemas = {t.get("schema") for t in tables}
-
-            console.print("[green]✓[/green] Discovery complete")
-            console.print(f"\n[bold]Discovered schemas:[/bold] {', '.join(sorted(schemas))}")
-            console.print(f"[bold]Total tables:[/bold] {len(tables)}\n")
-
-            for schema in sorted(schemas):
-                schema_tables = [t.get("name") for t in tables if t.get("schema") == schema]
-                console.print(f"  [cyan]{schema}[/cyan]: {', '.join(schema_tables)}")
-
-        console.print("\n[green]✨ Metabase connection refreshed successfully![/green]\n")
-
+    except click.Abort:
+        raise
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         from dango.exceptions import is_debug_mode

--- a/dango/governance/CLAUDE.md
+++ b/dango/governance/CLAUDE.md
@@ -11,7 +11,7 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 | `__init__.py` | Re-exports public API | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse`, `detect_drift_for_sources`, `detect_table_drift`, `get_drift_history`, `scan_sources_for_pii`, `scan_table_for_pii`, `get_pii_findings` |
 | `models.py` (~60 lines) | Pydantic V2 response models | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse` |
 | `schema_drift.py` (~490 lines) | Schema drift detection engine | `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()`, `_send_drift_webhook()` |
-| `pii_detector.py` (~454 lines) | PII scanning engine (Presidio + spaCy) | `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`, `_send_pii_webhook()` |
+| `pii_detector.py` (~515 lines) | PII scanning engine (Presidio + spaCy) | `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`, `_send_pii_webhook()` |
 
 ## Common Tasks
 

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -33,9 +33,19 @@ _STRING_TYPES = frozenset({"VARCHAR", "TEXT", "STRING", "CHAR", "BPCHAR"})
 
 _analyzer: Any = None
 
+_SPACY_MODEL = "en_core_web_sm"
+_SPACY_MODEL_URL = (
+    "https://github.com/explosion/spacy-models/releases/download/"
+    "en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl"
+)
 
-def _get_analyzer() -> Any:
-    """Return a cached Presidio ``AnalyzerEngine``, downloading spaCy model if needed."""
+
+def _get_analyzer() -> Any | None:
+    """Return a cached Presidio ``AnalyzerEngine``, downloading spaCy model if needed.
+
+    Returns ``None`` if the spaCy model cannot be loaded or downloaded,
+    allowing callers to gracefully skip PII scanning.
+    """
     global _analyzer  # noqa: PLW0603
     if _analyzer is not None:
         return _analyzer
@@ -43,16 +53,29 @@ def _get_analyzer() -> Any:
     import spacy  # lazy import
 
     try:
-        spacy.load("en_core_web_sm")
+        spacy.load(_SPACY_MODEL)
     except OSError:
+        # Fallback 1: spacy.cli.download
         try:
-            spacy.cli.download("en_core_web_sm")  # type: ignore[attr-defined]
+            spacy.cli.download(_SPACY_MODEL)  # type: ignore[attr-defined]
         except Exception:
-            msg = (
-                "Failed to download spaCy model 'en_core_web_sm'. "
-                "Install manually: python -m spacy download en_core_web_sm"
-            )
-            raise RuntimeError(msg) from None
+            # Fallback 2: direct pip install from GitHub release URL
+            import subprocess
+            import sys
+
+            try:
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", _SPACY_MODEL_URL],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                logger.warning(
+                    "pii_spacy_download_failed",
+                    model=_SPACY_MODEL,
+                    hint="Install manually: python -m spacy download en_core_web_sm",
+                )
+                return None
 
     # Suppress verbose Presidio + spaCy loggers during init (use alias to
     # avoid shadowing structlog).  Temporarily raise root logger to ERROR so
@@ -85,10 +108,13 @@ def _get_analyzer() -> Any:
         provider = NlpEngineProvider(
             nlp_configuration={
                 "nlp_engine_name": "spacy",
-                "models": [{"lang_code": "en", "model_name": "en_core_web_sm"}],
+                "models": [{"lang_code": "en", "model_name": _SPACY_MODEL}],
             }
         )
         _analyzer = AnalyzerEngine(nlp_engine=provider.create_engine())
+    except Exception:
+        logger.warning("pii_analyzer_init_failed", exc_info=True)
+        return None
     finally:
         root_logger.setLevel(saved_root_level)
         for _name, _lvl in saved_levels.items():
@@ -341,6 +367,8 @@ def _is_string_type(data_type: str) -> bool:
 def _scan_column(values: list[str]) -> dict[str, dict[str, Any]]:
     """Run Presidio analyzer on sampled values, aggregating by entity type."""
     analyzer = _get_analyzer()
+    if analyzer is None:
+        return {}
     detections: dict[str, dict[str, Any]] = {}
 
     for val in values:

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -337,13 +337,13 @@ exemptions:
   - file: dango/governance/pii_detector.py
     lines: 515
     category: exempt
-    reason: "BUG-027: grew from 488 to 515 lines adding 3-level spaCy download fallback chain and None-return error handling. Single-responsibility module, not worth splitting."
+    reason: "BUG-027: grew to 515 lines adding 3-level spaCy download fallback chain and None-return error handling. Single-responsibility module, not worth splitting."
     review_by: "v1.1"
 
   - file: tests/unit/test_pii_detection.py
-    lines: 503
+    lines: 522
     category: exempt
-    reason: "BUG-027: 3 new tests for download fallback and None-analyzer handling. Marginally over limit."
+    reason: "BUG-027: 4 new tests for download fallback, None-analyzer handling, and AnalyzerEngine init failure. Marginally over limit."
     review_by: "v1.1"
 
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -334,6 +334,18 @@ exemptions:
     reason: "TEST-030: 7 test classes covering page, list, create, delete, lock, heartbeat, release, force-release, copy. Marginally over limit after locked_at test addition."
     review_by: "v1.1"
 
+  - file: dango/governance/pii_detector.py
+    lines: 515
+    category: exempt
+    reason: "BUG-027: grew from 488 to 515 lines adding 3-level spaCy download fallback chain and None-return error handling. Single-responsibility module, not worth splitting."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_pii_detection.py
+    lines: 503
+    category: exempt
+    reason: "BUG-027: 3 new tests for download fallback and None-analyzer handling. Marginally over limit."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     # Data governance and notebooks
     "marimo>=0.9.0",
     "presidio-analyzer>=2.2.0",
-    "spacy>=3.7.0",
+    "spacy>=3.7.0,<3.8.12",
 
     # Security and encryption
     "keyring>=24.0.0",    # Secure credential storage in OS keychain

--- a/tests/unit/test_pii_detection.py
+++ b/tests/unit/test_pii_detection.py
@@ -159,6 +159,25 @@ class TestGetAnalyzer:
         finally:
             del sys.modules["spacy"]
 
+    def test_returns_none_on_analyzer_engine_failure(self) -> None:
+        import sys
+
+        mock_spacy = MagicMock()
+        sys.modules["spacy"] = mock_spacy
+        try:
+            with (
+                patch(f"{_PII}._analyzer", None),
+                patch(
+                    "presidio_analyzer.AnalyzerEngine",
+                    side_effect=RuntimeError("engine init failed"),
+                ),
+                patch("presidio_analyzer.nlp_engine.NlpEngineProvider"),
+            ):
+                result = _get_analyzer()
+                assert result is None
+        finally:
+            del sys.modules["spacy"]
+
 
 @pytest.mark.unit
 class TestScanColumn:

--- a/tests/unit/test_pii_detection.py
+++ b/tests/unit/test_pii_detection.py
@@ -116,7 +116,7 @@ class TestGetAnalyzer:
         finally:
             del sys.modules["spacy"]
 
-    def test_runtime_error_on_download_failure(self) -> None:
+    def test_returns_none_on_download_failure(self) -> None:
         import sys
 
         mock_spacy = MagicMock()
@@ -124,9 +124,38 @@ class TestGetAnalyzer:
         mock_spacy.cli.download.side_effect = RuntimeError("download failed")
         sys.modules["spacy"] = mock_spacy
         try:
-            with patch(f"{_PII}._analyzer", None):
-                with pytest.raises(RuntimeError, match="spaCy model"):
-                    _get_analyzer()
+            with (
+                patch(f"{_PII}._analyzer", None),
+                patch("subprocess.check_call", side_effect=RuntimeError("pip failed")),
+            ):
+                result = _get_analyzer()
+                assert result is None
+        finally:
+            del sys.modules["spacy"]
+
+    def test_url_fallback_on_cli_download_failure(self) -> None:
+        import sys
+
+        mock_spacy = MagicMock()
+        mock_spacy.load.side_effect = OSError("Model not found")
+        mock_spacy.cli.download.side_effect = RuntimeError("cli download failed")
+        mock_analyzer = MagicMock()
+        mock_provider = MagicMock()
+        mock_provider.create_engine.return_value = MagicMock()
+        sys.modules["spacy"] = mock_spacy
+        try:
+            with (
+                patch(f"{_PII}._analyzer", None),
+                patch("subprocess.check_call") as mock_pip,
+                patch("presidio_analyzer.AnalyzerEngine", return_value=mock_analyzer),
+                patch(
+                    "presidio_analyzer.nlp_engine.NlpEngineProvider",
+                    return_value=mock_provider,
+                ),
+            ):
+                result = _get_analyzer()
+                mock_pip.assert_called_once()
+                assert result is mock_analyzer
         finally:
             del sys.modules["spacy"]
 
@@ -134,6 +163,11 @@ class TestGetAnalyzer:
 @pytest.mark.unit
 class TestScanColumn:
     """Unit tests for _scan_column."""
+
+    def test_returns_empty_dict_when_analyzer_is_none(self) -> None:
+        with patch(f"{_PII}._get_analyzer", return_value=None):
+            result = _scan_column(["test@example.com"])
+        assert result == {}
 
     def test_detects_entities(self) -> None:
         r = MagicMock(entity_type="EMAIL_ADDRESS", score=0.85)


### PR DESCRIPTION
## Summary

- **BUG-027 (Critical):** spaCy model download failure no longer crashes syncs. `_get_analyzer()` returns `None` instead of raising `RuntimeError`, with a 3-level fallback chain (`spacy.load` → `spacy.cli.download` → `pip install` from GitHub URL). `_scan_column()` returns empty dict when analyzer is `None`. Pinned `spacy<3.8.12` to avoid broken 3.8.14 release.
- **BUG-035 (Critical):** `dango metabase refresh` now uses the non-destructive `sync_schema` API (already used elsewhere in `metabase.py:984`) instead of deleting and recreating the DB connection. Preserves all saved questions, dashboards, and visibility rules.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Pin `spacy>=3.7.0,<3.8.12` |
| `dango/governance/pii_detector.py` | Return `None` on failure, URL fallback, `_scan_column` None guard |
| `dango/cli/commands/metabase_cmd.py` | Replace destructive delete+recreate with `sync_metabase_schema()` |
| `tests/unit/test_pii_detection.py` | 3 tests: None return, URL fallback, empty dict on None analyzer |
| `docs/file-exemptions.yml` | Add `pii_detector.py` (515) and `test_pii_detection.py` (503) |
| `CLAUDE.md`, `governance/CLAUDE.md` | Updated line counts |

## Test plan

- [x] `pytest tests/unit/test_pii_detection.py` — 34 passed
- [x] `pytest tests/integration/test_pii_integration.py` — 6 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] All pre-commit hooks pass
- [ ] Manual: `dango sync` completes with PII scan on fresh venv (BUG-027)
- [ ] Manual: `dango metabase refresh` doesn't break saved questions (BUG-035)

🤖 Generated with [Claude Code](https://claude.com/claude-code)