### PR TITLE
R6F: CLI polish — BUG-019,028,034,037-041

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,15 +333,15 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 2276 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
-| `cli/source_wizard.py` | 2097 | — |
+| `cli/source_wizard.py` | 2108 | — |
 | `visualization/metabase.py` | 1152 | — |
 | `cli/init.py` | 1301 | — |
-| `visualization/dashboard_manager.py` | 1113 | — |
+| `visualization/dashboard_manager.py` | 1117 | — |
 | `cli/commands/platform.py` | 983 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 812 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 810 | — (extracted from app.py by TASK-085) |
-| `ingestion/csv_loader.py` | 766 | — |
+| `ingestion/csv_loader.py` | 765 | — |
 | `platform/scheduling/jobs.py` | 732 | — (module-level job functions) |
 | `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
 | `web/routes/upload.py` | 699 | — (extracted from app.py by TASK-085) |
@@ -352,9 +352,9 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
-| `config/models.py` | 594 | — (Pydantic config models) |
+| `config/models.py` | 588 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
-| `transformation/generator.py` | 593 | — |
+| `transformation/generator.py` | 548 | — |
 | `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 704 | — (provisioning orchestration + BYOS) |
@@ -363,6 +363,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 527 | — (admin user CRUD + invite) |
 | `platform/local/watcher.py` | 518 | — |
+| `cli/commands/schedule.py` | 729 | — (schedule wizard + time customization) |
 | `cli/model_wizard.py` | 507 | — |
 | `platform/cloud/scheduled_backup.py` | 505 | — (server-side scheduled backup) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 527 | — (admin user CRUD + invite) |
 | `platform/local/watcher.py` | 518 | — |
-| `cli/commands/schedule.py` | 729 | — (schedule wizard + time customization) |
+| `cli/commands/schedule.py` | 743 | — (schedule wizard + time customization) |
 | `cli/model_wizard.py` | 507 | — |
 | `platform/cloud/scheduled_backup.py` | 505 | — (server-side scheduled backup) |
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -35,7 +35,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query` | `remote_status()`, `remote_logs()` |
-| `commands/schedule.py` (729 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
+| `commands/schedule.py` (743 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/governance.py` (125 lines) | `governance` group (drift-report, pii-report) | `governance`, `drift_report()`, `pii_report()` |
 | `commands/notebook.py` (179 lines) | `notebook` group (new, open) + `snapshot` top-level | `notebook`, `notebook_new()`, `notebook_open()`, `snapshot()` |
 | `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -35,7 +35,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query` | `remote_status()`, `remote_logs()` |
-| `commands/schedule.py` (499 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
+| `commands/schedule.py` (729 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/governance.py` (125 lines) | `governance` group (drift-report, pii-report) | `governance`, `drift_report()`, `pii_report()` |
 | `commands/notebook.py` (179 lines) | `notebook` group (new, open) + `snapshot` top-level | `notebook`, `notebook_new()`, `notebook_open()`, `snapshot()` |
 | `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -28,11 +28,30 @@ logger = get_logger(__name__)
 _SLUG_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 _FREQUENCY_CHOICES = [
-    ("Every hour", "0 * * * *"),
-    ("Every 6 hours", "0 */6 * * *"),
-    ("Daily (6 AM)", "0 6 * * *"),
-    ("Weekly (Monday 6 AM)", "0 6 * * 1"),
+    ("Every 2 hours", "2h"),
+    ("Every 3 hours", "3h"),
+    ("Every 4 hours", "4h"),
+    ("Every 6 hours", "6h"),
+    ("Every 8 hours", "8h"),
+    ("Every 12 hours", "12h"),
+    ("Daily", "daily"),
+    ("Weekly", "weekly"),
     ("Custom cron", "custom"),
+]
+
+_TYPE_CHOICES = [
+    ("Sync & Transform (recommended)", "sync"),
+    ("Transform only (dbt)", "dbt"),
+]
+
+_DAY_CHOICES = [
+    ("Monday", 1),
+    ("Tuesday", 2),
+    ("Wednesday", 3),
+    ("Thursday", 4),
+    ("Friday", 5),
+    ("Saturday", 6),
+    ("Sunday", 0),
 ]
 
 
@@ -74,11 +93,166 @@ def _get_next_run(cron_expr: str) -> str:
         return "—"
 
 
+def _get_next_runs(cron_expr: str, count: int = 3) -> list[str]:
+    """Return next *count* run times as formatted strings."""
+    try:
+        from croniter import croniter
+
+        it = croniter(cron_expr, datetime.now())
+        return [it.get_next(datetime).strftime("%Y-%m-%d %H:%M") for _ in range(count)]
+    except Exception:
+        return []
+
+
 def _get_local_timezone() -> str:
     """Return the local timezone name."""
     if time.daylight and time.localtime().tm_isdst > 0:
         return time.tzname[1]
     return time.tzname[0]
+
+
+def _build_hourly_hours(interval: int, start_hour: int) -> list[int]:
+    """Compute run hours for an interval starting at *start_hour*."""
+    hours: list[int] = []
+    h = start_hour
+    while h < 24:
+        hours.append(h)
+        h += interval
+    # Wrap around if start_hour > 0
+    if start_hour > 0:
+        h = start_hour - (24 - (24 // interval) * interval)
+        if h < 0:
+            h += interval
+        while h < start_hour:
+            hours.append(h)
+            h += interval
+    return sorted(set(hours))
+
+
+def _build_cron_interactive(selection: str) -> str | None:
+    """Prompt for time specifics based on frequency *selection* and return cron.
+
+    Returns ``None`` if the user cancels a prompt.
+    """
+    import inquirer
+
+    if selection == "custom":
+        from croniter import croniter
+
+        answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    "cron",
+                    message="Cron expression (5-part)",
+                    validate=lambda _, x: croniter.is_valid(x),
+                )
+            ]
+        )
+        if answers is None:
+            return None
+        cron_val: str = answers["cron"]
+        return cron_val
+
+    if selection in ("daily", "weekly"):
+        hour_default = "6"
+    else:
+        hour_default = "0"
+
+    # Prompt minute
+    answers = inquirer.prompt(
+        [
+            inquirer.Text(
+                "minute",
+                message="Minute (0-59)",
+                default="0",
+                validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 59,
+            )
+        ]
+    )
+    if answers is None:
+        return None
+    minute = int(answers["minute"])
+
+    if selection == "weekly":
+        # Prompt day of week
+        answers = inquirer.prompt(
+            [
+                inquirer.List(
+                    "day",
+                    message="Day of week",
+                    choices=[label for label, _ in _DAY_CHOICES],
+                    default="Monday",
+                )
+            ]
+        )
+        if answers is None:
+            return None
+        day_num = dict(_DAY_CHOICES)[answers["day"]]
+
+        # Prompt hour
+        answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    "hour",
+                    message="Hour (0-23)",
+                    default=hour_default,
+                    validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 23,
+                )
+            ]
+        )
+        if answers is None:
+            return None
+        hour = int(answers["hour"])
+        return f"{minute} {hour} * * {day_num}"
+
+    if selection == "daily":
+        # Prompt hour
+        answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    "hour",
+                    message="Hour (0-23)",
+                    default=hour_default,
+                    validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 23,
+                )
+            ]
+        )
+        if answers is None:
+            return None
+        hour = int(answers["hour"])
+        return f"{minute} {hour} * * *"
+
+    # Hourly intervals: 2h, 3h, 4h, 6h, 8h, 12h
+    interval = int(selection.rstrip("h"))
+
+    # Prompt start hour
+    answers = inquirer.prompt(
+        [
+            inquirer.Text(
+                "start_hour",
+                message=f"Start hour (0-23, runs every {interval}h from this hour)",
+                default="0",
+                validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 23,
+            )
+        ]
+    )
+    if answers is None:
+        return None
+    start_hour = int(answers["start_hour"])
+
+    hours = _build_hourly_hours(interval, start_hour)
+    hours_csv = ",".join(str(h) for h in hours)
+    console.print(f"  Runs at hours: {hours_csv}")
+    return f"{minute} {hours_csv} * * *"
+
+
+def _show_next_runs(cron_expr: str) -> None:
+    """Print next 3 scheduled run times."""
+    runs = _get_next_runs(cron_expr, 3)
+    if runs:
+        console.print("[dim]Next run times:[/dim]")
+        for i, r in enumerate(runs, 1):
+            console.print(f"  {i}. {r}")
 
 
 def _toggle_schedule(ctx: click.Context, name: str, *, enable: bool) -> None:
@@ -176,10 +350,59 @@ def schedule_list(ctx: click.Context) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _show_schedule_detail(project_root: Path, schedules: list[dict[str, Any]], name: str) -> None:
+    """Show detailed status for a single schedule (BUG-041)."""
+    result = _find_schedule(schedules, name)
+    if result is None:
+        console.print(f"[red]Error:[/red] Schedule '{name}' not found.")
+        raise SystemExit(1)
+
+    _, sched = result
+    enabled = sched.get("enabled", True)
+
+    console.print(f"[bold]Schedule:[/bold] {name}")
+    console.print(f"  Type:     {sched.get('type', 'sync')}")
+    console.print(f"  Cron:     {sched.get('cron', '?')}")
+    console.print(f"  Enabled:  {'yes' if enabled else 'no'}")
+    if sched.get("timezone"):
+        console.print(f"  Timezone: {sched['timezone']}")
+    if sched.get("sources"):
+        console.print(f"  Sources:  {', '.join(sched['sources'])}")
+    if sched.get("dbt_command"):
+        console.print(f"  dbt cmd:  {sched['dbt_command']}")
+    if sched.get("notify_on"):
+        console.print(f"  Notify:   {', '.join(sched['notify_on'])}")
+
+    # Next run
+    if enabled:
+        console.print(f"  Next run: {_get_next_run(sched.get('cron', ''))}")
+
+    # Recent history from scheduler.db
+    from dango.platform.scheduling.history import get_scheduler_db_path
+
+    db_path = get_scheduler_db_path(project_root)
+    if db_path.exists():
+        from dango.platform.scheduling.history import get_schedule_history
+
+        runs, _total = get_schedule_history(db_path, name, limit=5)
+        if runs:
+            console.print("\n[bold]Recent runs:[/bold]")
+            for run in runs:
+                status = run.get("status", "?")
+                started = run.get("started_at", "?")
+                style = "[green]" if status == "success" else "[red]"
+                console.print(f"  {started} — {style}{status}[/{style[1:]}")
+        else:
+            console.print("\n[dim]No run history yet.[/dim]")
+    else:
+        console.print("\n[dim]No run history yet.[/dim]")
+
+
 @schedule.command("status")
+@click.argument("name", required=False, default=None)
 @click.pass_context
-def schedule_status(ctx: click.Context) -> None:
-    """Show scheduler status overview."""
+def schedule_status(ctx: click.Context, name: str | None = None) -> None:
+    """Show scheduler status overview, or details for a single schedule."""
     from dango.cli.utils import require_project_context
 
     project_root = require_project_context(ctx)
@@ -190,6 +413,11 @@ def schedule_status(ctx: click.Context) -> None:
         console.print(
             "[dim]No schedules configured.[/dim] Run [bold]dango schedule add[/bold] to create one."
         )
+        return
+
+    # Per-schedule detail mode (BUG-041)
+    if name is not None:
+        _show_schedule_detail(project_root, schedules, name)
         return
 
     # 1. Next scheduled run (earliest across enabled schedules)
@@ -302,13 +530,12 @@ def schedule_add(ctx: click.Context) -> None:
         return
     name: str = answers["name"]
 
-    # 2. Type
-    answers = inquirer.prompt(
-        [inquirer.List("type", message="Schedule type", choices=["sync", "dbt"])]
-    )
+    # 2. Type (BUG-037: friendly labels, default to sync)
+    type_labels = [label for label, _ in _TYPE_CHOICES]
+    answers = inquirer.prompt([inquirer.List("type", message="Schedule type", choices=type_labels)])
     if answers is None:
         return
-    sched_type: str = answers["type"]
+    sched_type: str = dict(_TYPE_CHOICES)[answers["type"]]
 
     # 3a. Sources (sync only) / 3b. dbt command
     sources: list[str] = []
@@ -322,7 +549,11 @@ def schedule_add(ctx: click.Context) -> None:
             available = [s.name for s in sources_cfg.sources if s.enabled]
         except Exception:
             available = []
-        if available:
+        # BUG-038: auto-select if only one source
+        if len(available) == 1:
+            sources = [available[0]]
+            console.print(f"[green]Auto-selected source: {available[0]}[/green]")
+        elif available:
             answers = inquirer.prompt(
                 [inquirer.Checkbox("sources", message="Select sources to sync", choices=available)]
             )
@@ -340,35 +571,20 @@ def schedule_add(ctx: click.Context) -> None:
             return
         dbt_command = answers["dbt_command"]
 
-    # 4. Frequency
+    # 4. Frequency (BUG-039: time customization with preview)
+    freq_labels = [label for label, _ in _FREQUENCY_CHOICES]
     answers = inquirer.prompt(
-        [
-            inquirer.List(
-                "frequency",
-                message="Run frequency",
-                choices=[label for label, _ in _FREQUENCY_CHOICES],
-            )
-        ]
+        [inquirer.List("frequency", message="Run frequency", choices=freq_labels)]
     )
     if answers is None:
         return
-    cron: str = dict(_FREQUENCY_CHOICES)[answers["frequency"]]
+    selection: str = dict(_FREQUENCY_CHOICES)[answers["frequency"]]
 
-    if cron == "custom":
-        from croniter import croniter
+    cron = _build_cron_interactive(selection)
+    if cron is None:
+        return
 
-        answers = inquirer.prompt(
-            [
-                inquirer.Text(
-                    "cron",
-                    message="Cron expression (5-part)",
-                    validate=lambda _, x: croniter.is_valid(x),
-                )
-            ]
-        )
-        if answers is None:
-            return
-        cron = answers["cron"]
+    _show_next_runs(cron)
 
     # 5. Timezone
     answers = inquirer.prompt(
@@ -378,20 +594,34 @@ def schedule_add(ctx: click.Context) -> None:
         return
     timezone_str: str = answers["timezone"]
 
-    # 6. Notify on
-    answers = inquirer.prompt(
-        [
-            inquirer.Checkbox(
-                "notify_on",
-                message="Notify on (select events)",
-                choices=["failure", "success", "stale"],
-                default=["failure"],
-            )
-        ]
-    )
-    if answers is None:
-        return
-    notify_on: list[str] = answers["notify_on"]
+    # 6. Notify on (BUG-040: skip if no webhooks configured)
+    notify_on: list[str] = []
+    try:
+        from dango.platform.notifications.webhook import load_notification_config
+
+        notif_cfg = load_notification_config(project_root)
+        has_webhooks = notif_cfg is not None and len(notif_cfg.webhooks) > 0
+    except Exception:
+        has_webhooks = False
+
+    if has_webhooks:
+        answers = inquirer.prompt(
+            [
+                inquirer.Checkbox(
+                    "notify_on",
+                    message="Notify on (select events)",
+                    choices=["failure", "success", "stale"],
+                    default=["failure"],
+                )
+            ]
+        )
+        if answers is None:
+            return
+        notify_on = answers["notify_on"]
+    else:
+        console.print(
+            "[dim]Tip: Configure webhooks in .dango/schedules.yml to receive schedule alerts[/dim]"
+        )
 
     # Build + save
     entry: dict[str, Any] = {

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -28,6 +28,7 @@ logger = get_logger(__name__)
 _SLUG_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 _FREQUENCY_CHOICES = [
+    ("Every hour", "1h"),
     ("Every 2 hours", "2h"),
     ("Every 3 hours", "3h"),
     ("Every 4 hours", "4h"),
@@ -113,20 +114,7 @@ def _get_local_timezone() -> str:
 
 def _build_hourly_hours(interval: int, start_hour: int) -> list[int]:
     """Compute run hours for an interval starting at *start_hour*."""
-    hours: list[int] = []
-    h = start_hour
-    while h < 24:
-        hours.append(h)
-        h += interval
-    # Wrap around if start_hour > 0
-    if start_hour > 0:
-        h = start_hour - (24 - (24 // interval) * interval)
-        if h < 0:
-            h += interval
-        while h < start_hour:
-            hours.append(h)
-            h += interval
-    return sorted(set(hours))
+    return sorted(h % 24 for h in range(start_hour, start_hour + 24, interval))
 
 
 def _build_cron_interactive(selection: str) -> str | None:
@@ -153,28 +141,8 @@ def _build_cron_interactive(selection: str) -> str | None:
         cron_val: str = answers["cron"]
         return cron_val
 
-    if selection in ("daily", "weekly"):
-        hour_default = "6"
-    else:
-        hour_default = "0"
-
-    # Prompt minute
-    answers = inquirer.prompt(
-        [
-            inquirer.Text(
-                "minute",
-                message="Minute (0-59)",
-                default="0",
-                validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 59,
-            )
-        ]
-    )
-    if answers is None:
-        return None
-    minute = int(answers["minute"])
-
     if selection == "weekly":
-        # Prompt day of week
+        # Day → hour → minute (coarse to fine)
         answers = inquirer.prompt(
             [
                 inquirer.List(
@@ -189,13 +157,12 @@ def _build_cron_interactive(selection: str) -> str | None:
             return None
         day_num = dict(_DAY_CHOICES)[answers["day"]]
 
-        # Prompt hour
         answers = inquirer.prompt(
             [
                 inquirer.Text(
                     "hour",
                     message="Hour (0-23)",
-                    default=hour_default,
+                    default="6",
                     validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 23,
                 )
             ]
@@ -203,16 +170,30 @@ def _build_cron_interactive(selection: str) -> str | None:
         if answers is None:
             return None
         hour = int(answers["hour"])
+
+        answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    "minute",
+                    message="Minute (0-59)",
+                    default="0",
+                    validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 59,
+                )
+            ]
+        )
+        if answers is None:
+            return None
+        minute = int(answers["minute"])
         return f"{minute} {hour} * * {day_num}"
 
     if selection == "daily":
-        # Prompt hour
+        # Hour → minute
         answers = inquirer.prompt(
             [
                 inquirer.Text(
                     "hour",
                     message="Hour (0-23)",
-                    default=hour_default,
+                    default="6",
                     validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 23,
                 )
             ]
@@ -220,10 +201,43 @@ def _build_cron_interactive(selection: str) -> str | None:
         if answers is None:
             return None
         hour = int(answers["hour"])
+
+        answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    "minute",
+                    message="Minute (0-59)",
+                    default="0",
+                    validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 59,
+                )
+            ]
+        )
+        if answers is None:
+            return None
+        minute = int(answers["minute"])
         return f"{minute} {hour} * * *"
 
-    # Hourly intervals: 2h, 3h, 4h, 6h, 8h, 12h
+    # Hourly intervals: 1h, 2h, 3h, 4h, 6h, 8h, 12h
     interval = int(selection.rstrip("h"))
+
+    # Minute → start_hour (minute first since it applies to every run)
+    answers = inquirer.prompt(
+        [
+            inquirer.Text(
+                "minute",
+                message="Minute (0-59)",
+                default="0",
+                validate=lambda _, x: x.isdigit() and 0 <= int(x) <= 59,
+            )
+        ]
+    )
+    if answers is None:
+        return None
+    minute = int(answers["minute"])
+
+    # Every hour: just minute, no start_hour needed
+    if interval == 1:
+        return f"{minute} * * * *"
 
     # Prompt start hour
     answers = inquirer.prompt(
@@ -390,8 +404,8 @@ def _show_schedule_detail(project_root: Path, schedules: list[dict[str, Any]], n
             for run in runs:
                 status = run.get("status", "?")
                 started = run.get("started_at", "?")
-                style = "[green]" if status == "success" else "[red]"
-                console.print(f"  {started} — {style}{status}[/{style[1:]}")
+                color = "green" if status == "success" else "red"
+                console.print(f"  {started} — [{color}]{status}[/{color}]")
         else:
             console.print("\n[dim]No run history yet.[/dim]")
     else:

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -205,6 +205,14 @@ class SourceWizard:
                 if not directory_path.exists():
                     directory_path.mkdir(parents=True, exist_ok=True)
                     console.print(f"[green]✅ Created directory: {params['directory']}[/green]")
+                # Warn about .gitignore for non-default directories
+                default_dir = f"data/uploads/{source_name}"
+                if params["directory"] != default_dir and not params["directory"].startswith(
+                    "data/uploads"
+                ):
+                    console.print(
+                        f"[yellow]⚠️  Remember to add '{params['directory']}' to .gitignore[/yellow]"
+                    )
 
             # Step 7: Create source config
             source_config = self._create_source_config(source_name, source_type, params, metadata)
@@ -353,7 +361,10 @@ class SourceWizard:
                 console.print(f"  Copy data files to: [cyan]{params['directory']}[/cyan]")
                 if source_type == "local_files":
                     console.print("  Supported formats: CSV, JSON, JSONL, Parquet")
-                console.print("  All files must have same columns (first row = headers for CSV)")
+                console.print(
+                    "  All files matching the pattern must have the same columns"
+                    " and will be loaded into a single table."
+                )
 
             # Unified next steps
             console.print("\n[cyan]Next steps:[/cyan]")

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -136,20 +136,6 @@ class CSVSourceConfig(BaseModel):
 
     directory: Path = Field(description="Directory containing CSV files")
     file_pattern: str = Field(default="*.csv", description="Glob pattern for CSV files")
-    deduplication_strategy: DeduplicationStrategy = Field(
-        default=DeduplicationStrategy.LATEST_ONLY,
-        description="Deduplication strategy: none, latest_only, append_only, scd_type2",
-    )
-    primary_key: str | None = Field(
-        default=None, description="Primary key column for deduplication"
-    )
-    timestamp_column: str | None = Field(
-        default=None, description="Timestamp column for latest_only/scd_type2 deduplication"
-    )
-    timestamp_sort: str | None = Field(
-        default="desc",
-        description="Sort order for timestamp: 'desc' (latest first) or 'asc' (oldest first)",
-    )
     notes: str | None = Field(
         default=None,
         description="Optional notes about how to regenerate this CSV data (e.g., script to run, export steps)",

--- a/dango/ingestion/csv_loader.py
+++ b/dango/ingestion/csv_loader.py
@@ -1,6 +1,6 @@
 """dango/ingestion/csv_loader.py
 
-Incremental file loading with metadata tracking and deduplication strategies.
+Incremental file loading with metadata tracking.
 
 Supports CSV, JSON, JSONL, and Parquet formats via DuckDB's native readers.
 """
@@ -38,7 +38,6 @@ class CSVLoader:
     - File classification (new/updated/unchanged/deleted)
     - Transactional safety (load-first-then-delete pattern)
     - Metadata tracking (which files loaded when)
-    - Four deduplication strategies
     """
 
     def __init__(self, project_root: Path, duckdb_path: Path):

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -100,7 +100,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         },
     },
     "local_files": {
-        "display_name": "Local Files",
+        "display_name": "File Import (CSV, JSON, Parquet)",
         "category": "Local & Custom",
         "description": "Load CSV, JSON, JSONL, or Parquet files from a local directory with deduplication and incremental loading",
         "auth_type": AuthType.NONE,

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -10,7 +10,7 @@ from typing import Any
 import duckdb
 import jinja2
 
-from dango.config.models import DataSource, DeduplicationStrategy, SourceType
+from dango.config.models import DataSource
 
 
 class DbtModelGenerator:
@@ -30,15 +30,6 @@ class DbtModelGenerator:
         "first_seen": "Keep oldest record (first occurrence)",
         "composite_key": "Deduplicate using multiple columns as composite key",
         "row_number": "Keep first row when sorted by specified columns",
-    }
-
-    # Map CSV dedup strategies to dbt template strategies
-    # Based on CSV_LOADING_DESIGN_SUMMARY.md Phase 1 design
-    CSV_TO_DBT_STRATEGY_MAP = {
-        DeduplicationStrategy.NONE: None,  # No dedup - keep all rows
-        DeduplicationStrategy.LATEST_ONLY: "last_modified",  # Keep latest by timestamp (PARTITION BY pk, ORDER BY ts DESC)
-        DeduplicationStrategy.APPEND_ONLY: None,  # No dedup in staging (already deduped per-file during load)
-        DeduplicationStrategy.SCD_TYPE2: "scd_type2",  # SCD Type 2 with valid_from/valid_to/is_current
     }
 
     def __init__(self, project_root: Path):
@@ -157,43 +148,7 @@ class DbtModelGenerator:
         """
         column_names = [col["name"].lower() for col in columns]
 
-        # CSV sources: Map from CSV config strategy to dbt template strategy
-        if source.type == SourceType.CSV and source.csv:
-            csv_strategy = source.csv.deduplication_strategy
-
-            # Map CSV strategy to dbt template strategy
-            dbt_strategy = self.CSV_TO_DBT_STRATEGY_MAP.get(csv_strategy)
-
-            # Build dedup_columns based on strategy
-            if dbt_strategy == "last_modified":
-                # latest_only: Use primary_key + timestamp_column
-                if source.csv.primary_key and source.csv.timestamp_column:
-                    return (dbt_strategy, [source.csv.primary_key, source.csv.timestamp_column])
-                else:
-                    # Fallback: Try to infer from column names
-                    id_cols = [
-                        col
-                        for col in column_names
-                        if any(id_field in col for id_field in ["id", "uuid", "key"])
-                    ]
-                    timestamp_cols = [
-                        col
-                        for col in column_names
-                        if any(ts in col for ts in ["updated_at", "modified_at", "timestamp"])
-                    ]
-                    if id_cols and timestamp_cols:
-                        return (dbt_strategy, [id_cols[0], timestamp_cols[0]])
-
-            elif dbt_strategy == "scd_type2":
-                # SCD Type 2: Use primary_key + timestamp_column
-                if source.csv.primary_key and source.csv.timestamp_column:
-                    return (dbt_strategy, [source.csv.primary_key, source.csv.timestamp_column])
-
-            elif dbt_strategy is None:
-                # none or append_only: No deduplication
-                return (None, None)
-
-        # API sources: Usually have updated_at + id
+        # Infer dedup from column names (works for all source types)
         if any(col in column_names for col in ["updated_at", "modified_at"]):
             id_col = next((col for col in column_names if "id" in col), None)
             updated_col = next(

--- a/dango/visualization/dashboard_manager.py
+++ b/dango/visualization/dashboard_manager.py
@@ -626,10 +626,14 @@ class DashboardManager:
             # Export specific collections
             collections_to_export = [c for c in all_collections if c.get("name") in collections]
         else:
-            # Export all non-personal collections
+            # Export all non-personal, non-root collections
             collections_to_export = []
             for c in all_collections:
                 name = c.get("name", "")
+                cid = c.get("id")
+                # Skip root collection (Metabase virtual container)
+                if cid == "root" or name == "Our analytics":
+                    continue
                 # Skip personal collections unless explicitly requested
                 if not include_personal and (
                     "personal" in name.lower() or "private" in name.lower()

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -98,6 +98,12 @@ exemptions:
     reason: "P8-004: Added deployment panel to remote status + remote history command. Marginally over limit."
     review_by: "v1.1"
 
+  - file: dango/cli/commands/schedule.py
+    lines: 729
+    category: exempt
+    reason: "R6F: Schedule wizard expanded with time customization (BUG-039), per-schedule status (BUG-041), type labels (BUG-037), auto-select (BUG-038), webhook check (BUG-040). Sequential wizard flow doesn't benefit from splitting."
+    review_by: "v1.1"
+
   - file: dango/platform/cloud/deployer.py
     lines: 578
     category: exempt
@@ -118,7 +124,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py
-    lines: 2097
+    lines: 2108
     category: exempt
     reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting. P7-011 added metrics generation. P5c grew +529 lines (credential unification, resource selection, dedup collection). P8-001 added REST API wizard enhancements: headers, query params, endpoint testing, data_selector/primary_key suggestions (+267 lines)."
     review_by: "v1.1"
@@ -130,7 +136,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/visualization/dashboard_manager.py
-    lines: 1113
+    lines: 1117
     category: exempt
     reason: "Dashboard export/import operations. Tightly coupled to metabase.py API surface."
     review_by: "v1.1"
@@ -150,7 +156,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/csv_loader.py
-    lines: 766
+    lines: 765
     category: exempt
     reason: "Multi-format file loading (CSV, JSON, JSONL, Parquet) with deduplication. Single-purpose module, stable."
     review_by: "v1.1"
@@ -162,7 +168,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 593
+    lines: 548
     category: exempt
     reason: "DbtModelGenerator — generates dbt models from source configs. Stable, rarely modified."
     review_by: "v1.1"
@@ -219,7 +225,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/config/models.py
-    lines: 594
+    lines: 588
     category: exempt
     reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"
@@ -323,7 +329,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_cli_schedule.py
-    lines: 509
+    lines: 564
     category: exempt
     reason: "TASK-045a: 8 test classes covering schedule help, list, status, remove, enable, disable, add wizard (sync, dbt, custom cron, cancelled). Marginally over limit."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -99,7 +99,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/schedule.py
-    lines: 729
+    lines: 743
     category: exempt
     reason: "R6F: Schedule wizard expanded with time customization (BUG-039), per-schedule status (BUG-041), type labels (BUG-037), auto-select (BUG-038), webhook check (BUG-040). Sequential wizard flow doesn't benefit from splitting."
     review_by: "v1.1"
@@ -329,7 +329,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_cli_schedule.py
-    lines: 564
+    lines: 692
     category: exempt
     reason: "TASK-045a: 8 test classes covering schedule help, list, status, remove, enable, disable, add wizard (sync, dbt, custom cron, cancelled). Marginally over limit."
     review_by: "v1.1"

--- a/tests/unit/test_cli_schedule.py
+++ b/tests/unit/test_cli_schedule.py
@@ -202,6 +202,57 @@ class TestScheduleStatus:
         assert "Unscheduled sources:" in plain
         assert "hubspot" in plain
 
+    @patch("dango.cli.utils.find_project_root")
+    def test_status_named_schedule(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(
+            project_root,
+            {
+                "schedules": [
+                    {
+                        "name": "hourly",
+                        "type": "sync",
+                        "cron": "0 * * * *",
+                        "sources": ["stripe"],
+                        "enabled": True,
+                        "timezone": "UTC",
+                    }
+                ]
+            },
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "status", "hourly"])
+        plain = _strip_ansi(result.output)
+        assert "Schedule:" in plain
+        assert "hourly" in plain
+        assert "Cron:" in plain
+        assert "stripe" in plain
+
+    @patch("dango.cli.utils.find_project_root")
+    def test_status_named_not_found(self, mock_root: MagicMock, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(
+            project_root,
+            {
+                "schedules": [
+                    {
+                        "name": "hourly",
+                        "type": "sync",
+                        "cron": "0 * * * *",
+                        "sources": ["stripe"],
+                        "enabled": True,
+                    }
+                ]
+            },
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "status", "nope"])
+        assert result.exit_code != 0
+        plain = _strip_ansi(result.output)
+        assert "not found" in plain
+
 
 @pytest.mark.unit
 class TestScheduleRemove:
@@ -414,24 +465,27 @@ class TestScheduleAdd:
             [{"name": "stripe", "type": "stripe", "enabled": True}],
         )
 
+        # Single source → auto-selected (no Checkbox prompt).
+        # No webhooks → notification prompt skipped.
         mock_prompt.side_effect = [
-            {"name": "hourly_sync"},
-            {"type": "sync"},
-            {"sources": ["stripe"]},
-            {"frequency": "Every hour"},
+            {"name": "daily_sync"},
+            {"type": "Sync & Transform (recommended)"},
+            {"frequency": "Daily"},
+            {"minute": "0"},
+            {"hour": "6"},
             {"timezone": "UTC"},
-            {"notify_on": ["failure"]},
         ]
 
         runner = CliRunner()
         result = runner.invoke(cli, ["schedule", "add"])
         plain = _strip_ansi(result.output)
         assert "added" in plain
+        assert "Auto-selected source: stripe" in plain
 
         data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
         assert len(data["schedules"]) == 1
-        assert data["schedules"][0]["name"] == "hourly_sync"
-        assert data["schedules"][0]["cron"] == "0 * * * *"
+        assert data["schedules"][0]["name"] == "daily_sync"
+        assert data["schedules"][0]["cron"] == "0 6 * * *"
 
     @patch("inquirer.prompt")
     @patch("dango.cli.utils.find_project_root")
@@ -442,13 +496,15 @@ class TestScheduleAdd:
         mock_root.return_value = project_root
         _write_schedules_yaml(project_root, {"schedules": []})
 
+        # No webhooks → notification prompt skipped.
         mock_prompt.side_effect = [
             {"name": "daily_dbt"},
-            {"type": "dbt"},
+            {"type": "Transform only (dbt)"},
             {"dbt_command": "run"},
-            {"frequency": "Daily (6 AM)"},
+            {"frequency": "Daily"},
+            {"minute": "0"},
+            {"hour": "6"},
             {"timezone": "UTC"},
-            {"notify_on": []},
         ]
 
         runner = CliRunner()
@@ -475,12 +531,10 @@ class TestScheduleAdd:
 
         mock_prompt.side_effect = [
             {"name": "custom_sched"},
-            {"type": "sync"},
-            {"sources": ["stripe"]},
+            {"type": "Sync & Transform (recommended)"},
             {"frequency": "Custom cron"},
             {"cron": "*/15 * * * *"},
             {"timezone": "UTC"},
-            {"notify_on": []},
         ]
 
         runner = CliRunner()

--- a/tests/unit/test_cli_schedule.py
+++ b/tests/unit/test_cli_schedule.py
@@ -467,12 +467,13 @@ class TestScheduleAdd:
 
         # Single source → auto-selected (no Checkbox prompt).
         # No webhooks → notification prompt skipped.
+        # Daily prompts: hour → minute (coarse to fine)
         mock_prompt.side_effect = [
             {"name": "daily_sync"},
             {"type": "Sync & Transform (recommended)"},
             {"frequency": "Daily"},
-            {"minute": "0"},
             {"hour": "6"},
+            {"minute": "0"},
             {"timezone": "UTC"},
         ]
 
@@ -497,13 +498,14 @@ class TestScheduleAdd:
         _write_schedules_yaml(project_root, {"schedules": []})
 
         # No webhooks → notification prompt skipped.
+        # Daily prompts: hour → minute (coarse to fine)
         mock_prompt.side_effect = [
             {"name": "daily_dbt"},
             {"type": "Transform only (dbt)"},
             {"dbt_command": "run"},
             {"frequency": "Daily"},
-            {"minute": "0"},
             {"hour": "6"},
+            {"minute": "0"},
             {"timezone": "UTC"},
         ]
 
@@ -544,6 +546,133 @@ class TestScheduleAdd:
 
         data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
         assert data["schedules"][0]["cron"] == "*/15 * * * *"
+
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_hourly_interval(
+        self, mock_root: MagicMock, mock_prompt: MagicMock, tmp_path: Path
+    ) -> None:
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(project_root, {"schedules": []})
+        _write_sources_yaml(
+            project_root,
+            [{"name": "stripe", "type": "stripe", "enabled": True}],
+        )
+
+        # Hourly interval prompts: minute → start_hour
+        mock_prompt.side_effect = [
+            {"name": "every6h"},
+            {"type": "Sync & Transform (recommended)"},
+            {"frequency": "Every 6 hours"},
+            {"minute": "30"},
+            {"start_hour": "2"},
+            {"timezone": "UTC"},
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "add"])
+        plain = _strip_ansi(result.output)
+        assert "added" in plain
+
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        assert data["schedules"][0]["cron"] == "30 2,8,14,20 * * *"
+
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_every_hour(
+        self, mock_root: MagicMock, mock_prompt: MagicMock, tmp_path: Path
+    ) -> None:
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(project_root, {"schedules": []})
+        _write_sources_yaml(
+            project_root,
+            [{"name": "stripe", "type": "stripe", "enabled": True}],
+        )
+
+        # Every hour: only minute prompt (no start_hour)
+        mock_prompt.side_effect = [
+            {"name": "hourly"},
+            {"type": "Sync & Transform (recommended)"},
+            {"frequency": "Every hour"},
+            {"minute": "15"},
+            {"timezone": "UTC"},
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "add"])
+        plain = _strip_ansi(result.output)
+        assert "added" in plain
+
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        assert data["schedules"][0]["cron"] == "15 * * * *"
+
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_weekly(self, mock_root: MagicMock, mock_prompt: MagicMock, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(project_root, {"schedules": []})
+        _write_sources_yaml(
+            project_root,
+            [{"name": "stripe", "type": "stripe", "enabled": True}],
+        )
+
+        # Weekly prompts: day → hour → minute
+        mock_prompt.side_effect = [
+            {"name": "weekly_sync"},
+            {"type": "Sync & Transform (recommended)"},
+            {"frequency": "Weekly"},
+            {"day": "Wednesday"},
+            {"hour": "9"},
+            {"minute": "30"},
+            {"timezone": "UTC"},
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "add"])
+        plain = _strip_ansi(result.output)
+        assert "added" in plain
+
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        # Wednesday = 3
+        assert data["schedules"][0]["cron"] == "30 9 * * 3"
+
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_multi_source(
+        self, mock_root: MagicMock, mock_prompt: MagicMock, tmp_path: Path
+    ) -> None:
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(project_root, {"schedules": []})
+        _write_sources_yaml(
+            project_root,
+            [
+                {"name": "stripe", "type": "stripe", "enabled": True},
+                {"name": "hubspot", "type": "hubspot", "enabled": True},
+            ],
+        )
+
+        # Multiple sources → Checkbox prompt shown
+        mock_prompt.side_effect = [
+            {"name": "multi"},
+            {"type": "Sync & Transform (recommended)"},
+            {"sources": ["stripe", "hubspot"]},
+            {"frequency": "Every hour"},
+            {"minute": "0"},
+            {"timezone": "UTC"},
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "add"])
+        plain = _strip_ansi(result.output)
+        assert "added" in plain
+        assert "Auto-selected" not in plain
+
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        assert set(data["schedules"][0]["sources"]) == {"stripe", "hubspot"}
 
     @patch("inquirer.prompt")
     @patch("dango.cli.utils.find_project_root")

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -135,26 +135,15 @@ class TestCSVSourceConfig:
     def test_defaults(self) -> None:
         cfg = make_csv_source_config()
         assert cfg.file_pattern == "*.csv"
-        assert cfg.deduplication_strategy == DeduplicationStrategy.LATEST_ONLY
-        assert cfg.primary_key is None
-        assert cfg.timestamp_column is None
+        assert cfg.notes is None
 
     def test_custom_pattern(self) -> None:
         cfg = make_csv_source_config(file_pattern="*.tsv")
         assert cfg.file_pattern == "*.tsv"
 
-    def test_all_dedup_strategies(self) -> None:
-        for strategy in DeduplicationStrategy:
-            cfg = make_csv_source_config(deduplication_strategy=strategy)
-            assert cfg.deduplication_strategy == strategy
-
-    def test_primary_key_and_timestamp(self) -> None:
-        cfg = make_csv_source_config(
-            primary_key="id",
-            timestamp_column="updated_at",
-        )
-        assert cfg.primary_key == "id"
-        assert cfg.timestamp_column == "updated_at"
+    def test_notes_field(self) -> None:
+        cfg = make_csv_source_config(notes="Export from Salesforce")
+        assert cfg.notes == "Export from Salesforce"
 
 
 @pytest.mark.unit
@@ -167,27 +156,16 @@ class TestLocalFilesSourceConfig:
         cfg = LocalFilesSourceConfig(directory="data/uploads")
         assert cfg.file_pattern == "*"
 
-    def test_inherits_dedup_defaults(self) -> None:
-        cfg = LocalFilesSourceConfig(directory="data/uploads")
-        assert cfg.deduplication_strategy == DeduplicationStrategy.LATEST_ONLY
-        assert cfg.primary_key is None
-        assert cfg.timestamp_column is None
-
     def test_custom_file_pattern(self) -> None:
         cfg = LocalFilesSourceConfig(directory="data/uploads", file_pattern="*.json")
         assert cfg.file_pattern == "*.json"
 
-    def test_all_csv_fields_available(self) -> None:
+    def test_notes_field(self) -> None:
         cfg = LocalFilesSourceConfig(
             directory="data/uploads",
             file_pattern="*.parquet",
-            deduplication_strategy=DeduplicationStrategy.SCD_TYPE2,
-            primary_key="id",
-            timestamp_column="updated_at",
             notes="Test notes",
         )
-        assert cfg.primary_key == "id"
-        assert cfg.timestamp_column == "updated_at"
         assert cfg.notes == "Test notes"
 
     def test_data_source_local_files_field(self) -> None:


### PR DESCRIPTION
## Summary

- **BUG-019:** Remove dead `deduplication_strategy`, `primary_key`, `timestamp_column`, `timestamp_sort` fields from `CSVSourceConfig` (CSV source hidden, fields unused). Also remove `CSV_TO_DBT_STRATEGY_MAP` and CSV special-case in `transformation/generator.py`.
- **BUG-028:** Rename local_files display to "File Import (CSV, JSON, Parquet)", add `.gitignore` warning for non-default directories, clarify that all matching files load into a single table.
- **BUG-034:** Skip Metabase root collection ("Our analytics") in dashboard export loop.
- **BUG-037:** Schedule type labels: "Sync & Transform (recommended)" / "Transform only (dbt)" instead of raw "sync"/"dbt".
- **BUG-038:** Auto-select when only one source available in schedule wizard (skip Checkbox prompt).
- **BUG-039:** Schedule time customization — prompt for hour/minute/day after frequency selection, support 2/3/4/6/8/12h intervals with computed run hours, show preview of next 3 run times.
- **BUG-040:** Skip notification prompt when no webhooks configured, show tip instead.
- **BUG-041:** `dango schedule status <name>` shows per-schedule detail view (config, next run, recent history).

### Dual cron preset drift note

`_FREQUENCY_CHOICES` in `schedule.py` now uses intermediate tokens (e.g. `"6h"`, `"daily"`) that get computed into full cron expressions via `_build_cron_interactive()`. `CRON_PRESETS` in `config/schedules.py` is unchanged — they serve independent purposes (CLI wizard computes raw cron, YAML config resolves preset names).

## Test plan

- [x] `pytest tests/unit/test_config_models.py` — 59 passed (dedup fields removed from CSVSourceConfig/LocalFilesSourceConfig tests)
- [x] `pytest tests/unit/test_cli_schedule.py` — 22 passed (updated mock sequences for new type/frequency labels, auto-select, skipped notification prompt; added named status tests)
- [x] `ruff check dango/` — all passed
- [x] `ruff format --check dango/` — all formatted
- [x] `mypy` on modified source files — no issues
- [x] Pre-commit hooks — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)