### PR TITLE
fix: BUG-010, BUG-011, BUG-021 — auth redirect, Metabase SSO, remove dango.local

### DIFF
--- a/dango/auth/admin.py
+++ b/dango/auth/admin.py
@@ -75,7 +75,7 @@ def set_auth_enabled(project_root: Path, *, enabled: bool) -> None:
 
 def ensure_admin(
     db_path: Path,
-    email: str = "admin@dango.local",
+    email: str,
 ) -> tuple[User, str] | None:
     """Create an admin user if none exists.
 

--- a/dango/auth/metabase_sync.py
+++ b/dango/auth/metabase_sync.py
@@ -327,7 +327,11 @@ def sync_user_to_metabase(
             mb_user_id: int = existing["id"]
             # Update password on existing Metabase user so we can bridge SSO
             password = generate_metabase_password()
-            _mb_put(metabase_url, session, f"/api/user/{mb_user_id}", {"password": password})
+            if (
+                _mb_put(metabase_url, session, f"/api/user/{mb_user_id}", {"password": password})
+                is None
+            ):
+                logger.warning("Failed to update Metabase password for user %s", mb_user_id)
         else:
             mb_user_id = mb_user["id"]
         encrypted_pw = encrypt_metabase_password(password, project_root)

--- a/dango/auth/metabase_sync.py
+++ b/dango/auth/metabase_sync.py
@@ -142,6 +142,23 @@ def decrypt_metabase_password(encrypted: str, project_root: Path) -> str:
     ]
 
 
+def find_metabase_user_by_email(
+    metabase_url: str, session: str, email: str
+) -> dict[str, Any] | None:
+    """Find a Metabase user by email. Returns user dict or ``None``."""
+    users = _mb_get(metabase_url, session, "/api/user?limit=2000")
+    if isinstance(users, list):
+        user_list = users
+    elif isinstance(users, dict):
+        user_list = users.get("data", [])
+    else:
+        return None
+    for u in user_list:
+        if isinstance(u, dict) and u.get("email") == email:
+            return u  # type: ignore[return-value]
+    return None
+
+
 def ensure_metabase_groups(
     metabase_url: str,
     project_root: Path,
@@ -302,9 +319,17 @@ def sync_user_to_metabase(
             },
         )
         if mb_user is None:
-            return None
-
-        mb_user_id: int = mb_user["id"]
+            # User creation failed — may already exist in Metabase.
+            # Try to find existing Metabase user by email and link them.
+            existing = find_metabase_user_by_email(metabase_url, session, user.email)
+            if existing is None:
+                return None
+            mb_user_id: int = existing["id"]
+            # Update password on existing Metabase user so we can bridge SSO
+            password = generate_metabase_password()
+            _mb_put(metabase_url, session, f"/api/user/{mb_user_id}", {"password": password})
+        else:
+            mb_user_id = mb_user["id"]
         encrypted_pw = encrypt_metabase_password(password, project_root)
         update_user(
             db_path,

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -352,7 +352,7 @@ jobs:
 1. Add data sources: `dango source add`
 2. Sync data: `dango sync`
 3. Start platform: `dango start`
-4. Open dashboards: http://dango.local or http://localhost
+4. Open dashboards: http://localhost:8800
 '''
         }
 
@@ -408,7 +408,7 @@ When creating dashboards and reports in Metabase, use tables in this priority or
 
 - **Project details**: `.dango/project.yml`
 - **Data sources**: `.dango/sources.yml`
-- **dbt documentation**: Run `dango start` and visit http://dango.local/docs
+- **dbt documentation**: Run `dango start` and visit http://localhost:8800/docs
 
 ## Limitations
 
@@ -1116,7 +1116,10 @@ on-run-end:
 
             if skip_wizard:
                 # Non-interactive: generate random admin
-                result = ensure_admin(db_path)
+                import os as _os
+
+                _email = _os.environ.get("DANGO_ADMIN_EMAIL", "admin@localhost")
+                result = ensure_admin(db_path, email=_email)
                 if result is not None:
                     user, password = result
                     set_auth_enabled(self.project_dir, enabled=True)

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1116,10 +1116,10 @@ on-run-end:
 
             if skip_wizard:
                 # Non-interactive: generate random admin
-                import os as _os
+                import os
 
-                _email = _os.environ.get("DANGO_ADMIN_EMAIL", "admin@localhost")
-                result = ensure_admin(db_path, email=_email)
+                email = os.environ.get("DANGO_ADMIN_EMAIL", "admin@localhost")
+                result = ensure_admin(db_path, email=email)
                 if result is not None:
                     user, password = result
                     set_auth_enabled(self.project_dir, enabled=True)

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -125,7 +125,7 @@ class ProjectContext(BaseModel):
                 ],
                 "sla": "Daily by 9am SGT",
                 "limitations": "Shopify data has 24h delay. Stripe doesn't include refunds.",
-                "getting_started": "Run 'dango sync' to refresh data, then open http://dango.local",
+                "getting_started": "Run 'dango sync' to refresh data, then open http://localhost:8800",
             }
         }
     )

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -302,9 +302,13 @@ def _link_metabase_admin(project_root: Path, admin_email: str) -> None:
         admin_creds = mb_creds.get("admin", {})
 
         # Get Metabase admin session
+        mb_email = admin_creds.get("email")
+        mb_password = admin_creds.get("password")
+        if not mb_email or not mb_password:
+            return
         resp = requests.post(
             f"{mb_url}/api/session",
-            json={"username": admin_creds["email"], "password": admin_creds["password"]},
+            json={"username": mb_email, "password": mb_password},
             timeout=10,
         )
         if resp.status_code != 200:
@@ -328,12 +332,19 @@ def _link_metabase_admin(project_root: Path, admin_email: str) -> None:
 
         # Generate new password, update Metabase user, store in Dango
         password = generate_metabase_password()
-        requests.put(
+        pw_resp = requests.put(
             f"{mb_url}/api/user/{mb_user['id']}",
             headers={"X-Metabase-Session": session_token},
             json={"password": password},
             timeout=10,
         )
+        if pw_resp.status_code != 200:
+            _logger.warning(
+                "metabase_password_update_failed",
+                status=pw_resp.status_code,
+                metabase_user_id=mb_user["id"],
+            )
+            return
         encrypted_pw = encrypt_metabase_password(password, project_root)
         update_user(
             db_path,

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -243,14 +243,21 @@ def setup_metabase_if_needed(
         except Exception:
             pass
     if not admin_email:
-        admin_email = "admin@dango.local"
+        from dango.logging import get_logger as _get_logger
+
+        _logger = _get_logger(__name__)
+        _logger.warning(
+            "metabase_setup_skipped",
+            reason="No admin email found. Metabase setup will complete on next restart.",
+        )
+        return {"already_configured": False, "success": True, "skipped": True}
 
     setup_result = setup_metabase(
         project_root,
         project_name,
-        organization,
+        admin_email,
+        organization=organization,
         cloud_mode=is_cloud_mode(project_root),
-        admin_email=admin_email,
     )
 
     # DuckDB connection failure is critical — caller must roll back Docker
@@ -261,7 +268,82 @@ def setup_metabase_if_needed(
             "metabase-plugins/duckdb.metabase-driver.jar is present."
         )
 
+    # Link Metabase admin to Dango admin for SSO bridging
+    _link_metabase_admin(project_root, admin_email)
+
     return {"already_configured": False, **setup_result}
+
+
+def _link_metabase_admin(project_root: Path, admin_email: str) -> None:
+    """Link the Metabase admin account to the Dango admin user for SSO."""
+    try:
+        import requests
+        import yaml
+
+        from dango.auth.admin import get_auth_db_path
+        from dango.auth.database import get_user_by_email, update_user
+        from dango.auth.metabase_sync import (
+            encrypt_metabase_password,
+            find_metabase_user_by_email,
+            generate_metabase_password,
+        )
+        from dango.auth.models import UserUpdate
+        from dango.logging import get_logger
+
+        _logger = get_logger(__name__)
+
+        # Read Metabase credentials
+        mb_yml_path = project_root / ".dango" / "metabase.yml"
+        if not mb_yml_path.exists():
+            return
+        with open(mb_yml_path) as f:
+            mb_creds = yaml.safe_load(f)
+        mb_url = mb_creds.get("metabase_url", "http://localhost:3000").rstrip("/")
+        admin_creds = mb_creds.get("admin", {})
+
+        # Get Metabase admin session
+        resp = requests.post(
+            f"{mb_url}/api/session",
+            json={"username": admin_creds["email"], "password": admin_creds["password"]},
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            return
+        session_token = resp.json().get("id")
+        if not session_token:
+            return
+
+        # Find Dango admin user
+        db_path = get_auth_db_path(project_root)
+        if not db_path.exists():
+            return
+        dango_user = get_user_by_email(db_path, admin_email)
+        if dango_user is None or dango_user.metabase_user_id is not None:
+            return  # Already linked or user doesn't exist
+
+        # Find Metabase user by email
+        mb_user = find_metabase_user_by_email(mb_url, session_token, admin_email)
+        if mb_user is None:
+            return
+
+        # Generate new password, update Metabase user, store in Dango
+        password = generate_metabase_password()
+        requests.put(
+            f"{mb_url}/api/user/{mb_user['id']}",
+            headers={"X-Metabase-Session": session_token},
+            json={"password": password},
+            timeout=10,
+        )
+        encrypted_pw = encrypt_metabase_password(password, project_root)
+        update_user(
+            db_path,
+            dango_user.id,
+            UserUpdate(metabase_user_id=mb_user["id"], metabase_password_enc=encrypted_pw),
+        )
+        _logger.info("metabase_admin_linked", email=admin_email, metabase_user_id=mb_user["id"])
+    except Exception:
+        # Non-critical — SSO bridge will lazy-sync on next login
+        pass
 
 
 def import_dashboards(project_root: Path) -> dict[str, Any] | None:

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -347,7 +347,7 @@ class DockerManager:
 
         # Service URL mappings
         urls = {
-            "nginx": "http://dango.local or http://localhost",
+            "nginx": "http://localhost:8800",
             "metabase": "http://localhost:3001 (or via nginx)",
             "dbt-docs": "http://localhost:8081 (or via nginx)",
             "prefect-server": "http://localhost:4200 (or via nginx)",

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -532,10 +532,10 @@ def hide_internal_tables(metabase_url: str, headers: dict[str, str], db_id: int)
 def setup_metabase(
     project_root: Path,
     project_name: str,
+    admin_email: str,
     organization: str | None = None,
     metabase_url: str = "http://localhost:3000",
     cloud_mode: bool = False,
-    admin_email: str = "admin@dango.local",
 ) -> dict[str, Any]:
     """
     Auto-setup Metabase on first start
@@ -592,12 +592,9 @@ def setup_metabase(
         properties = response.json()
         setup_token = properties.get("setup-token")
 
-        if cloud_mode:
-            import secrets as _secrets
+        import secrets as _secrets
 
-            admin_password = _secrets.token_urlsafe(32)
-        else:
-            admin_password = "dangolocal123"
+        admin_password = _secrets.token_urlsafe(32)
         org_name = organization or project_name
 
         if not setup_token:

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -76,7 +76,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         db_path = get_auth_db_path(project_root)
         if db_path.exists():
-            email = os.environ.get("DANGO_ADMIN_EMAIL", "admin@dango.local")
+            email = os.environ.get("DANGO_ADMIN_EMAIL", "admin@localhost")
             result = ensure_admin(db_path, email=email)
             if result is not None:
                 user, password = result

--- a/dango/web/middleware/auth.py
+++ b/dango/web/middleware/auth.py
@@ -65,12 +65,7 @@ _PUBLIC_EXACT: frozenset[str] = frozenset({
     "/login",
     "/setup",
     "/api/health",
-    "/",
-    "/health",
-    "/logs",
-    "/api",
-    "/api/docs",
-    "/api/redoc",
+    "/favicon.ico",
 })
 # fmt: on
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -36,6 +36,12 @@ exemptions:
     reason: "TASK-100 added invite token lookup (+25 lines over TASK-095 base)."
     review_by: "v1.1"
 
+  - file: dango/auth/metabase_sync.py
+    lines: 521
+    category: exempt
+    reason: "BUG-011 added find_metabase_user_by_email() and email-exists fallback in sync_user_to_metabase() (+23 lines). Planned split in TASK-075b."
+    review_by: "v1.1"
+
   - file: dango/web/routes/users.py
     lines: 527
     category: exempt

--- a/tests/integration/test_metabase_sso.py
+++ b/tests/integration/test_metabase_sso.py
@@ -69,7 +69,7 @@ def _mb_yml(tmp_path: Path) -> Path:
         yaml.safe_dump(
             {
                 "metabase_url": MB_URL,
-                "admin": {"email": "admin@dango.local", "password": "dangolocal123"},
+                "admin": {"email": "admin@test.com", "password": "testpassword123"},
                 "database": {"id": 1, "name": "Test Analytics"},
             }
         )

--- a/tests/unit/test_auth_admin.py
+++ b/tests/unit/test_auth_admin.py
@@ -147,12 +147,12 @@ class TestEnsureAdmin:
         result = ensure_admin(db_path, email="new@test.com")
         assert result is None
 
-    def test_default_email(self, tmp_path: Path) -> None:
+    def test_email_required(self, tmp_path: Path) -> None:
         db_path = _make_db(tmp_path)
-        result = ensure_admin(db_path)
+        result = ensure_admin(db_path, email="admin@localhost")
         assert result is not None
         user, _ = result
-        assert user.email == "admin@dango.local"
+        assert user.email == "admin@localhost"
 
     def test_email_normalized(self, tmp_path: Path) -> None:
         db_path = _make_db(tmp_path)

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -132,12 +132,7 @@ class TestPublicRoutes:
             "/login",
             "/setup",
             "/api/health",
-            "/",
-            "/health",
-            "/logs",
-            "/api",
-            "/api/docs",
-            "/api/redoc",
+            "/favicon.ico",
             "/api/auth/oauth/callback",
         ]:
             result = asyncio.run(_collect_response(mw, _make_scope(path=path)))
@@ -151,6 +146,33 @@ class TestPublicRoutes:
         for path in ["/api/auth/oauth/google", "/static/css/main.css"]:
             result = asyncio.run(_collect_response(mw, _make_scope(path=path)))
             assert result["status"] == 200, f"{path} was blocked"
+
+    @patch(f"{_M}.is_auth_enabled", return_value=True)
+    @patch(f"{_M}.get_auth_db_path")
+    @patch(f"{_M}.sessions.validate_session", return_value=None)
+    def test_page_routes_require_auth(self, _v: Any, mock_db: Any, _m: Any) -> None:
+        """Page routes (/, /health, /logs) redirect to /login when unauthenticated."""
+        mock_db.return_value = _db_exists()
+        mw = AuthMiddleware(_noop_app, project_root=_PROJECT_ROOT)
+        for path in ["/", "/health", "/logs"]:
+            scope = _make_scope(
+                path=path,
+                headers=[(b"accept", b"text/html,application/xhtml+xml")],
+            )
+            result = asyncio.run(_collect_response(mw, scope))
+            assert result["status"] == 302, f"{path} did not redirect"
+            assert result["headers"].get("location") == "/login", f"{path} wrong redirect"
+
+    @patch(f"{_M}.is_auth_enabled", return_value=True)
+    @patch(f"{_M}.get_auth_db_path")
+    @patch(f"{_M}.sessions.validate_session", return_value=None)
+    def test_api_docs_require_auth(self, _v: Any, mock_db: Any, _m: Any) -> None:
+        """API doc routes (/api, /api/docs, /api/redoc) return 401 for API clients."""
+        mock_db.return_value = _db_exists()
+        mw = AuthMiddleware(_noop_app, project_root=_PROJECT_ROOT)
+        for path in ["/api", "/api/docs", "/api/redoc"]:
+            result = asyncio.run(_collect_response(mw, _make_scope(path=path)))
+            assert result["status"] == 401, f"{path} did not return 401"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_metabase_sync.py
+++ b/tests/unit/test_metabase_sync.py
@@ -46,7 +46,7 @@ def _mb_yml(tmp_path: Path, db_id: int = 1) -> Path:
         yaml.safe_dump(
             {
                 "metabase_url": MB_URL,
-                "admin": {"email": "admin@dango.local", "password": "dangolocal123"},
+                "admin": {"email": "admin@test.com", "password": "testpassword123"},
                 "database": {"id": db_id, "name": "Test Analytics"},
             }
         )

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dango.platform.common.startup import (
+    _link_metabase_admin,
     ensure_dbt_schemas,
     ensure_duckdb_driver,
     import_dashboards,
@@ -271,3 +272,134 @@ class TestImportDashboards:
 
         assert result == expected
         mock_import.assert_called_once_with(tmp_path)
+
+
+@pytest.mark.unit
+class TestLinkMetabaseAdmin:
+    """Tests for _link_metabase_admin() SSO linking helper."""
+
+    def _setup_metabase_yml(self, tmp_path: Path, email: str = "admin@test.com") -> None:
+        """Write a minimal metabase.yml fixture."""
+        import yaml
+
+        d = tmp_path / ".dango"
+        d.mkdir(exist_ok=True)
+        (d / "metabase.yml").write_text(
+            yaml.safe_dump(
+                {
+                    "metabase_url": "http://localhost:3000",
+                    "admin": {"email": email, "password": "testpw"},
+                    "database": {"id": 1, "name": "Test"},
+                }
+            )
+        )
+
+    def _setup_auth_db(self, tmp_path: Path, email: str = "admin@test.com") -> None:
+        """Create auth.db with an admin user that has no metabase_user_id."""
+        from dango.auth.admin import get_auth_db_path
+        from dango.auth.database import create_user
+        from dango.auth.models import Role, User
+        from dango.migrations.runner import MigrationRunner
+
+        db_path = get_auth_db_path(tmp_path)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+        MigrationRunner(
+            db_path=db_path, db_name="auth", migrations_dir=migrations_dir
+        ).apply_pending()
+        user = User(email=email, password_hash="$2b$12$fakehash", role=Role.ADMIN)
+        create_user(db_path, user)
+
+    @patch("requests.put")
+    @patch("requests.post")
+    @patch("requests.get")
+    @patch("dango.auth.metabase_sync.SecureTokenStorage")
+    def test_happy_path_links_admin(
+        self,
+        mock_sts: MagicMock,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        mock_put: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Links Metabase admin to Dango admin when both exist and not yet linked."""
+        self._setup_metabase_yml(tmp_path)
+        self._setup_auth_db(tmp_path)
+        mock_sts.return_value.encrypt_token.return_value = "encrypted_pw"
+
+        # Mock Metabase API responses
+        session_resp = MagicMock(status_code=200)
+        session_resp.json.return_value = {"id": "session123"}
+        mock_post.return_value = session_resp
+
+        user_list_resp = MagicMock(status_code=200)
+        user_list_resp.json.return_value = [{"id": 42, "email": "admin@test.com"}]
+        mock_get.return_value = user_list_resp
+
+        mock_put.return_value = MagicMock(status_code=200)
+
+        _link_metabase_admin(tmp_path, "admin@test.com")
+
+        # Verify user was updated in auth.db
+        from dango.auth.admin import get_auth_db_path
+        from dango.auth.database import get_user_by_email
+
+        user = get_user_by_email(get_auth_db_path(tmp_path), "admin@test.com")
+        assert user is not None
+        assert user.metabase_user_id == 42
+        assert user.metabase_password_enc == "encrypted_pw"
+
+    @patch("requests.post")
+    def test_skips_when_no_metabase_yml(self, mock_post: MagicMock, tmp_path: Path) -> None:
+        """Returns silently when metabase.yml doesn't exist."""
+        (tmp_path / ".dango").mkdir(exist_ok=True)
+        _link_metabase_admin(tmp_path, "admin@test.com")
+        mock_post.assert_not_called()
+
+    @patch("requests.put")
+    @patch("requests.get")
+    @patch("requests.post")
+    @patch("dango.auth.metabase_sync.SecureTokenStorage")
+    def test_skips_when_already_linked(
+        self,
+        mock_sts: MagicMock,
+        mock_post: MagicMock,
+        mock_get: MagicMock,
+        mock_put: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Returns silently when Dango admin already has metabase_user_id."""
+        self._setup_metabase_yml(tmp_path)
+        self._setup_auth_db(tmp_path)
+
+        # Set metabase_user_id on the admin user
+        from dango.auth.admin import get_auth_db_path
+        from dango.auth.database import get_user_by_email, update_user
+        from dango.auth.models import UserUpdate
+
+        db_path = get_auth_db_path(tmp_path)
+        user = get_user_by_email(db_path, "admin@test.com")
+        assert user is not None
+        update_user(db_path, user.id, UserUpdate(metabase_user_id=99))
+
+        session_resp = MagicMock(status_code=200)
+        session_resp.json.return_value = {"id": "session123"}
+        mock_post.return_value = session_resp
+
+        _link_metabase_admin(tmp_path, "admin@test.com")
+
+        # Should not attempt to find or update Metabase user
+        mock_get.assert_not_called()
+        mock_put.assert_not_called()
+
+    @patch("requests.post")
+    def test_skips_when_metabase_yml_malformed(self, mock_post: MagicMock, tmp_path: Path) -> None:
+        """Returns silently when metabase.yml has no admin credentials."""
+        import yaml
+
+        d = tmp_path / ".dango"
+        d.mkdir(exist_ok=True)
+        (d / "metabase.yml").write_text(yaml.safe_dump({"metabase_url": "http://localhost:3000"}))
+
+        _link_metabase_admin(tmp_path, "admin@test.com")
+        mock_post.assert_not_called()

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -210,16 +210,18 @@ class TestSetupMetabaseIfNeeded:
         assert result["already_configured"] is True
         assert result["success"] is True
 
-    def test_raises_when_duckdb_not_connected(self, tmp_path):
+    def test_raises_when_duckdb_not_connected(self, tmp_path, monkeypatch):
         """setup_metabase_if_needed raises RuntimeError when DuckDB cannot connect."""
+        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "admin@test.com")
         setup_result = {"success": False, "duckdb_connected": False}
 
         with patch("dango.visualization.metabase.setup_metabase", return_value=setup_result):
             with pytest.raises(RuntimeError, match="connect Metabase"):
                 setup_metabase_if_needed(tmp_path, "MyProject", None)
 
-    def test_success(self, tmp_path):
+    def test_success(self, tmp_path, monkeypatch):
         """setup_metabase_if_needed returns result dict on successful first-run setup."""
+        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "admin@test.com")
         setup_result = {
             "success": True,
             "duckdb_connected": True,
@@ -233,6 +235,13 @@ class TestSetupMetabaseIfNeeded:
         assert result["already_configured"] is False
         assert result["success"] is True
         assert result["duckdb_connected"] is True
+
+    def test_skips_when_no_admin_email(self, tmp_path, monkeypatch):
+        """setup_metabase_if_needed skips when no admin email is available."""
+        monkeypatch.delenv("DANGO_ADMIN_EMAIL", raising=False)
+        result = setup_metabase_if_needed(tmp_path, "MyProject", None)
+        assert result["skipped"] is True
+        assert result["success"] is True
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **BUG-010 (Critical):** Remove page routes (`/`, `/health`, `/logs`, `/api`, `/api/docs`, `/api/redoc`) from public route whitelist so unauthenticated users are redirected to `/login` instead of seeing pages with failing API calls. Also fixes BUG-049 (user menu missing).
- **BUG-011 (Critical):** Link Metabase admin to Dango admin after setup for SSO bridging. Handle email-already-exists in `sync_user_to_metabase()`. Use random passwords for all modes (local + cloud).
- **BUG-021 (Medium):** Remove `admin@dango.local` defaults from `ensure_admin()` and `setup_metabase()`. Replace `http://dango.local` URLs with `http://localhost:8800`. Skip Metabase setup gracefully when no admin email available.

## Test plan

- [x] 626 auth/web/middleware/platform tests pass
- [x] All pre-commit hooks pass (ruff, mypy, file-size)
- [ ] Manual: access `http://localhost:8800/` without session → redirects to `/login`
- [ ] Manual: after `dango start`, admin user has `metabase_user_id` set in auth.db
- [ ] Manual: Metabase proxy works without manual Metabase login
- [ ] Verify: `grep -rn "dango\.local" dango/ --include="*.py"` returns only the two backwards-compat filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)