### PR TITLE
R6-C: Fix 5 core functionality bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,28 +331,28 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `ingestion/dlt_runner.py` | 2276 | — (exempt, too risky) |
+| `ingestion/dlt_runner.py` | 2291 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2108 | — |
 | `visualization/metabase.py` | 1152 | — |
 | `cli/init.py` | 1301 | — |
-| `visualization/dashboard_manager.py` | 1117 | — |
-| `cli/commands/platform.py` | 983 | — (extracted from main.py by TASK-005) |
+| `visualization/dashboard_manager.py` | 1113 | — |
+| `cli/commands/platform.py` | 988 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 812 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 810 | — (extracted from app.py by TASK-085) |
-| `ingestion/csv_loader.py` | 765 | — |
-| `platform/scheduling/jobs.py` | 732 | — (module-level job functions) |
+| `ingestion/csv_loader.py` | 766 | — |
+| `platform/scheduling/jobs.py` | 839 | — (module-level job functions) |
 | `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
-| `web/routes/upload.py` | 699 | — (extracted from app.py by TASK-085) |
+| `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 686 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 707 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
-| `config/models.py` | 588 | — (Pydantic config models) |
+| `config/models.py` | 609 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 548 | — |
 | `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,8 +13,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (686 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (983 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/source.py` (707 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/platform.py` (988 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (538 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (812 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |

--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -188,6 +188,37 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
             f"[green]✓[/green] Deleted model file: {model_file.relative_to(project_root)}"
         )
 
+        # Remove model entry from schema.yml
+        assert layer is not None  # guaranteed by model_file check above
+        schema_path = dbt_dir / layer / "schema.yml"
+        if schema_path.exists():
+            import yaml
+
+            try:
+                with open(schema_path) as f:
+                    schema_data = yaml.safe_load(f) or {}
+                if "models" in schema_data and isinstance(schema_data["models"], list):
+                    before = len(schema_data["models"])
+                    schema_data["models"] = [
+                        m for m in schema_data["models"] if m.get("name") != model_name
+                    ]
+                    if len(schema_data["models"]) < before:
+                        if schema_data["models"]:
+                            with open(schema_path, "w") as f:
+                                yaml.dump(
+                                    schema_data,
+                                    f,
+                                    default_flow_style=False,
+                                    sort_keys=False,
+                                )
+                        else:
+                            schema_path.unlink()
+                        console.print(
+                            f"[green]✓[/green] Removed from {schema_path.relative_to(project_root)}"
+                        )
+            except Exception:
+                pass  # Non-critical — don't block removal
+
         # Handle table deletion if it exists
         if table_exists:
             console.print()

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -857,6 +857,15 @@ def status(ctx: click.Context) -> None:
             else:
                 table.add_row("File Watcher (auto-sync)", "[dim]● Disabled[/dim]")
 
+        # Add Web UI / FastAPI
+        if fastapi_status["running"]:
+            table.add_row(
+                f"Web UI (port {fastapi_status['port']})",
+                f"[green]● Running[/green] (PID {fastapi_status['pid']})",
+            )
+        else:
+            table.add_row(f"Web UI (port {fastapi_status['port']})", "[red]● Stopped[/red]")
+
         # Add Metabase
         if docker_statuses and "metabase" in docker_statuses:
             svc_status = docker_statuses["metabase"]

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -385,6 +385,27 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
             with open(sources_file, "w") as f:
                 yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
+            # Clean up dbt staging files for this source
+            # Naming: stg_{name}__*.sql, sources_{name}.yml, stg_{name}.yml
+            staging_dir = project_root / "dbt" / "models" / "staging"
+            if staging_dir.exists():
+                removed_files = []
+                for sql_file in staging_dir.glob(f"stg_{source_name}__*.sql"):
+                    sql_file.unlink()
+                    removed_files.append(sql_file.name)
+                for yml_name in [
+                    f"sources_{source_name}.yml",
+                    f"stg_{source_name}.yml",
+                ]:
+                    yml_file = staging_dir / yml_name
+                    if yml_file.exists():
+                        yml_file.unlink()
+                        removed_files.append(yml_name)
+                if removed_files:
+                    console.print(
+                        f"[green]✓[/green] Removed {len(removed_files)} dbt staging file(s)"
+                    )
+
             console.print(f"[green]✅ Source '{source_name}' removed successfully[/green]")
             console.print()
             console.print("[yellow]⚠️  Important:[/yellow]")

--- a/dango/cli/helpers/process_manager.py
+++ b/dango/cli/helpers/process_manager.py
@@ -324,7 +324,16 @@ def get_fastapi_status(project_root: Path) -> dict:
     """
     pid = read_pid_file(project_root)
     log_file = project_root / ".dango" / "web.log"
-    port = 8080  # Default port
+
+    # Read port from project config (default 8800)
+    port = 8800
+    try:
+        from dango.config import ConfigLoader
+
+        config = ConfigLoader(project_root).load_config()
+        port = config.platform.port
+    except Exception:
+        pass
 
     status: dict = {"running": False, "pid": None, "port": port, "url": None, "log_file": log_file}
 

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -465,6 +465,13 @@ class PlatformSettings(BaseModel):
     # Watch directories (relative to project root)
     watch_directories: list[str] = Field(default_factory=lambda: ["data/uploads"])
 
+    # dbt coalesce window — seconds to wait before dbt run to allow
+    # multiple syncs to finish and merge into a single dbt invocation
+    dbt_coalesce_seconds: int = Field(
+        default=10,
+        description="Seconds to wait before dbt run to coalesce multiple syncs",
+    )
+
 
 class RateLimitGroupConfig(BaseModel):
     """Rate limit settings for a single route group."""

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2087,6 +2087,7 @@ def run_sync(
     end_date: datetime | None = None,
     full_refresh: bool = False,
     limit: int | None = None,
+    skip_dbt: bool = False,
 ) -> dict[str, Any]:
     """
     Sync multiple sources and return summary
@@ -2098,6 +2099,7 @@ def run_sync(
         end_date: Override end date
         full_refresh: Full refresh mode
         limit: Max rows per source (dev testing)
+        skip_dbt: If True, skip dbt run/docs/Metabase refresh (caller handles separately)
 
     Returns:
         Summary dictionary with success/failed counts
@@ -2207,58 +2209,63 @@ def run_sync(
 
         console.print()
 
-        # Run dbt to create staging/marts tables
-        # Use selective runs to only process models dependent on synced sources
-        console.print("🔄 [bold]Running dbt models...[/bold]\n")
-        from dango.transformation import run_dbt_models
+        # Run dbt to create staging/marts tables (unless caller handles dbt separately)
+        if not skip_dbt:
+            # Use selective runs to only process models dependent on synced sources
+            console.print("🔄 [bold]Running dbt models...[/bold]\n")
+            from dango.transformation import run_dbt_models
 
-        # Build source-based selection criteria
-        # Format: "source:source1+ source:source2+" (runs models dependent on these sources)
-        if success_sources:
-            select_criteria = " ".join([f"source:{source}+" for source in success_sources])
-            console.print(f"[dim]Targeting models for sources: {', '.join(success_sources)}[/dim]")
-            dbt_success, dbt_output = run_dbt_models(project_root, select=select_criteria)
-        else:
-            # No sources synced, run all models (backward compatibility)
-            dbt_success, dbt_output = run_dbt_models(project_root)
-
-        if dbt_success:
-            # Parse and display dbt model execution details
-            _display_dbt_output(dbt_output)
-            console.print("[green]✓ dbt models executed successfully[/green]")
-
-            # Generate dbt docs
-            console.print("[dim]Generating dbt documentation...[/dim]")
-            from dango.transformation import generate_dbt_docs
-
-            docs_success, docs_output = generate_dbt_docs(project_root)
-            if docs_success:
-                console.print("[green]✓ dbt docs generated[/green]")
+            # Build source-based selection criteria
+            # Format: "source:source1+ source:source2+" (runs models dependent on these sources)
+            if success_sources:
+                select_criteria = " ".join([f"source:{source}+" for source in success_sources])
+                console.print(
+                    f"[dim]Targeting models for sources: {', '.join(success_sources)}[/dim]"
+                )
+                dbt_success, dbt_output = run_dbt_models(project_root, select=select_criteria)
             else:
-                console.print("[yellow]⚠️  dbt docs generation failed (non-critical)[/yellow]")
+                # No sources synced, run all models (backward compatibility)
+                dbt_success, dbt_output = run_dbt_models(project_root)
 
-            # Refresh Metabase connection to see new data
-            console.print("[dim]Refreshing Metabase connection...[/dim]")
-            from dango.visualization.metabase import (
-                refresh_metabase_connection,
-                sync_metabase_schema,
-            )
+            if dbt_success:
+                # Parse and display dbt model execution details
+                _display_dbt_output(dbt_output)
+                console.print("[green]✓ dbt models executed successfully[/green]")
 
-            if refresh_metabase_connection(project_root):
-                console.print("[green]✓ Metabase connection refreshed[/green]")
+                # Generate dbt docs
+                console.print("[dim]Generating dbt documentation...[/dim]")
+                from dango.transformation import generate_dbt_docs
 
-                # Sync schema metadata to ensure all tables are discovered and descriptions updated
-                console.print("[dim]Syncing Metabase schema metadata...[/dim]")
-                if sync_metabase_schema(project_root):
-                    console.print("[green]✓ Metabase schema synced[/green]")
+                docs_success, docs_output = generate_dbt_docs(project_root)
+                if docs_success:
+                    console.print("[green]✓ dbt docs generated[/green]")
+                else:
+                    console.print("[yellow]⚠️  dbt docs generation failed (non-critical)[/yellow]")
+
+                # Refresh Metabase connection to see new data
+                console.print("[dim]Refreshing Metabase connection...[/dim]")
+                from dango.visualization.metabase import (
+                    refresh_metabase_connection,
+                    sync_metabase_schema,
+                )
+
+                if refresh_metabase_connection(project_root):
+                    console.print("[green]✓ Metabase connection refreshed[/green]")
+
+                    # Sync schema metadata to ensure all tables are discovered
+                    console.print("[dim]Syncing Metabase schema metadata...[/dim]")
+                    if sync_metabase_schema(project_root):
+                        console.print("[green]✓ Metabase schema synced[/green]")
+                else:
+                    console.print("[dim]ℹ Metabase not running (will sync when started)[/dim]")
             else:
-                console.print("[dim]ℹ Metabase not running (will sync when started)[/dim]")
-        else:
-            console.print("[red]✗ dbt run failed[/red]")
-            console.print(f"[dim]{dbt_output}[/dim]")
-            console.print("[yellow]⚠️  Staging/marts tables were not created[/yellow]")
+                console.print("[red]✗ dbt run failed[/red]")
+                console.print(f"[dim]{dbt_output}[/dim]")
+                console.print("[yellow]⚠️  Staging/marts tables were not created[/yellow]")
 
-        console.print()
+            console.print()
+        else:
+            console.print("[dim]⏭  Skipping dbt run (will be coalesced)[/dim]\n")
 
     # Post-sync hooks (profiling, drift detection, PII scanning, analysis)
     if success_sources:

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,7 +12,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (430 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (211 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (732 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `jobs.py` (839 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `sync_trigger.py` (147 lines) | Server-side manual sync runner invoked via SSH from `dango remote sync` | `main()`, `_run_sync()` |
 
 ## Key Conventions

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -312,15 +312,18 @@ def _get_coalesce_seconds(project_root: Path) -> int:
         return 10
 
 
-def _run_coalesced_dbt(project_root: Path) -> None:
-    """Run dbt for all pending sources, plus dbt docs and Metabase refresh."""
+def _run_coalesced_dbt(project_root: Path) -> bool:
+    """Run dbt for all pending sources, plus dbt docs and Metabase refresh.
+
+    Returns True if dbt succeeded (or no pending sources), False on failure.
+    """
     coalesce_seconds = _get_coalesce_seconds(project_root)
     if coalesce_seconds > 0:
         time.sleep(coalesce_seconds)
 
     pending = _consume_pending_dbt_sources(project_root)
     if not pending:
-        return
+        return True
 
     from dango.transformation import generate_dbt_docs, run_dbt_models
 
@@ -341,6 +344,10 @@ def _run_coalesced_dbt(project_root: Path) -> None:
                 sync_metabase_schema(project_root)
         except Exception:
             logger.debug("metabase_refresh_after_coalesced_dbt_failed", exc_info=True)
+    else:
+        logger.warning("coalesced_dbt_run_failed", sources=pending, select=select_criteria)
+
+    return dbt_success
 
 
 # ---------------------------------------------------------------------------
@@ -488,7 +495,18 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             _add_pending_dbt_source(project_root, src.name)
 
         # Run coalesced dbt (waits for coalesce window, merges pending sources)
-        _run_coalesced_dbt(project_root)
+        dbt_ok = _run_coalesced_dbt(project_root)
+
+        if not dbt_ok:
+            _broadcast(
+                {
+                    "event": "dbt_run_all_failed",
+                    "schedule": schedule_name,
+                    "sources": source_names,
+                    "message": "Coalesced dbt run failed after sync",
+                    "timestamp": _ts(),
+                }
+            )
 
         elapsed = time.monotonic() - t0
 

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -15,6 +15,8 @@ Public API:
 from __future__ import annotations
 
 import asyncio
+import fcntl
+import json
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -258,6 +260,90 @@ def _check_freshness(
 
 
 # ---------------------------------------------------------------------------
+# Pending dbt sources — shared state for coalescing
+# ---------------------------------------------------------------------------
+
+_PENDING_DBT_FILE = ".dango/state/pending_dbt_sources.json"
+
+
+def _add_pending_dbt_source(project_root: Path, source_name: str) -> None:
+    """Atomically add a source to the pending dbt list."""
+    path = project_root / _PENDING_DBT_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a+") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        f.seek(0)
+        try:
+            data = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            data = []
+        if source_name not in data:
+            data.append(source_name)
+        f.seek(0)
+        f.truncate()
+        json.dump(data, f)
+
+
+def _consume_pending_dbt_sources(project_root: Path) -> list[str]:
+    """Atomically read and clear the pending dbt sources list."""
+    path = project_root / _PENDING_DBT_FILE
+    if not path.exists():
+        return []
+    with open(path, "r+") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            data = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            data = []
+        f.seek(0)
+        f.truncate()
+        json.dump([], f)
+    return list(data)
+
+
+def _get_coalesce_seconds(project_root: Path) -> int:
+    """Read dbt_coalesce_seconds from config."""
+    try:
+        from dango.config import ConfigLoader
+
+        config = ConfigLoader(project_root).load_config()
+        return config.platform.dbt_coalesce_seconds
+    except Exception:
+        return 10
+
+
+def _run_coalesced_dbt(project_root: Path) -> None:
+    """Run dbt for all pending sources, plus dbt docs and Metabase refresh."""
+    coalesce_seconds = _get_coalesce_seconds(project_root)
+    if coalesce_seconds > 0:
+        time.sleep(coalesce_seconds)
+
+    pending = _consume_pending_dbt_sources(project_root)
+    if not pending:
+        return
+
+    from dango.transformation import generate_dbt_docs, run_dbt_models
+
+    select_criteria = " ".join(f"source:{s}+" for s in pending)
+    logger.info("coalesced_dbt_run", sources=pending, select=select_criteria)
+    dbt_success, _dbt_output = run_dbt_models(project_root, select=select_criteria)
+
+    if dbt_success:
+        # Generate docs and refresh Metabase (mirrors run_sync post-dbt steps)
+        generate_dbt_docs(project_root)
+        try:
+            from dango.visualization.metabase import (
+                refresh_metabase_connection,
+                sync_metabase_schema,
+            )
+
+            if refresh_metabase_connection(project_root):
+                sync_metabase_schema(project_root)
+        except Exception:
+            logger.debug("metabase_refresh_after_coalesced_dbt_failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
 # Main job functions
 # ---------------------------------------------------------------------------
 
@@ -295,48 +381,64 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
     record_id: int | None = None
 
     try:
-        try:
-            lock.acquire()
-        except DbtLockError:
-            elapsed = time.monotonic() - t0
-            logger.warning(
-                "scheduler_lock_contention", schedule=schedule_name, sources=source_names
-            )
-            _broadcast(
-                {
-                    "event": "job_queued",
-                    "schedule": schedule_name,
-                    "sources": source_names,
-                    "message": "Lock contention",
-                    "timestamp": _ts(),
-                }
-            )
-            _broadcast(
-                {
-                    "event": "sync_failed",
-                    "schedule": schedule_name,
-                    "sources": source_names,
-                    "error": "Could not acquire lock",
-                    "timestamp": _ts(),
-                }
-            )
-            _notify(
-                sender,
-                event_type=EventType.SYNC_FAILED,
-                schedule_name=schedule_name,
-                sources=source_names,
-                error="Could not acquire lock",
-                duration_seconds=elapsed,
-            )
-            _log_execution_event(
-                schedule_name=schedule_name,
-                job_type="sync",
-                status="lock_failed",
-                duration_seconds=elapsed,
-                error="Lock contention",
-                sources=source_names,
-            )
-            return
+        # Acquire lock with retry (wait up to 5 minutes, retry every 5 seconds)
+        max_wait = 300
+        retry_interval = 5
+        acquired = False
+        wait_start = time.monotonic()
+        queued_broadcast = False
+
+        while not acquired:
+            try:
+                lock.acquire()
+                acquired = True
+            except DbtLockError:
+                elapsed_wait = time.monotonic() - wait_start
+                if elapsed_wait >= max_wait:
+                    elapsed = time.monotonic() - t0
+                    logger.warning(
+                        "scheduler_lock_timeout",
+                        schedule=schedule_name,
+                        sources=source_names,
+                    )
+                    _broadcast(
+                        {
+                            "event": "sync_failed",
+                            "schedule": schedule_name,
+                            "sources": source_names,
+                            "error": "Could not acquire lock after 5 minutes",
+                            "timestamp": _ts(),
+                        }
+                    )
+                    _notify(
+                        sender,
+                        event_type=EventType.SYNC_FAILED,
+                        schedule_name=schedule_name,
+                        sources=source_names,
+                        error="Could not acquire lock after 5 minutes",
+                        duration_seconds=elapsed,
+                    )
+                    _log_execution_event(
+                        schedule_name=schedule_name,
+                        job_type="sync",
+                        status="lock_failed",
+                        duration_seconds=elapsed,
+                        error="Lock timeout after 5 minutes",
+                        sources=source_names,
+                    )
+                    return
+                if not queued_broadcast:
+                    _broadcast(
+                        {
+                            "event": "job_queued",
+                            "schedule": schedule_name,
+                            "sources": source_names,
+                            "message": "Waiting for lock...",
+                            "timestamp": _ts(),
+                        }
+                    )
+                    queued_broadcast = True
+                time.sleep(retry_interval)
 
         resolved = _resolve_sources(project_root, source_names)
         if not resolved:
@@ -366,11 +468,12 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         from dango.utils.sync_history import save_sync_history_entry
 
         job_id = f"schedule:{schedule_name}"
+        # Sync each source with skip_dbt=True (dbt coalesced after all sources)
         for src in resolved:
             if _scheduler_service is not None and _scheduler_service.is_cancelled(job_id):
                 raise JobCancelledError(f"Sync cancelled between sources for {schedule_name}")
             src_t0 = time.monotonic()
-            run_sync(project_root, [src], full_refresh=full_refresh)
+            run_sync(project_root, [src], full_refresh=full_refresh, skip_dbt=True)
             save_sync_history_entry(
                 project_root,
                 src.name,
@@ -382,6 +485,10 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                     "duration_seconds": round(time.monotonic() - src_t0, 2),
                 },
             )
+            _add_pending_dbt_source(project_root, src.name)
+
+        # Run coalesced dbt (waits for coalesce window, merges pending sources)
+        _run_coalesced_dbt(project_root)
 
         elapsed = time.monotonic() - t0
 

--- a/dango/transformation/__init__.py
+++ b/dango/transformation/__init__.py
@@ -38,7 +38,11 @@ def _get_dbt_executable() -> str:
     return "dbt"
 
 
-def run_dbt_models(project_root: Path, select: str | None = None) -> tuple[bool, str]:
+def run_dbt_models(
+    project_root: Path,
+    select: str | None = None,
+    full_refresh: bool = False,
+) -> tuple[bool, str]:
     """
     Run dbt models to create staging/marts tables in DuckDB.
 
@@ -46,6 +50,7 @@ def run_dbt_models(project_root: Path, select: str | None = None) -> tuple[bool,
         project_root: Path to project root
         select: Optional dbt selection criteria (e.g., "source:test_csv+", "model_name+")
                 If None, runs all models. Use source-based selection for targeted runs.
+        full_refresh: If True, pass --full-refresh to rebuild models from scratch.
 
     Returns:
         Tuple of (success, output)
@@ -61,6 +66,8 @@ def run_dbt_models(project_root: Path, select: str | None = None) -> tuple[bool,
     cmd = [dbt_cmd, "run", "--project-dir", str(dbt_dir), "--profiles-dir", str(dbt_dir)]
     if select:
         cmd.extend(["--select", select])
+    if full_refresh:
+        cmd.append("--full-refresh")
 
     try:
         result = subprocess.run(

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -597,7 +597,9 @@ async def run_dbt_after_delete(source_name: str):
         # Run dbt for this source and downstream models
         # Use source:source_name+ to run all models dependent on this source
         select_criteria = f"source:{source_name}+"
-        dbt_success, dbt_output = run_dbt_models(get_project_root(), select=select_criteria)
+        dbt_success, dbt_output = run_dbt_models(
+            get_project_root(), select=select_criteria, full_refresh=True
+        )
 
         # Calculate duration
         duration = time.time() - start_time

--- a/dango/web/templates/account.html
+++ b/dango/web/templates/account.html
@@ -473,6 +473,7 @@ function accountPage() {
                 });
                 const data = await res.json();
                 if (!res.ok) { this.twoFaError = data.message || 'Setup failed'; this.twoFaLoading = false; return; }
+                this.twoFaPassword = '';
                 this.twoFaSecret = data.secret;
                 this.twoFaUri = data.provisioning_uri;
                 this.twoFaRecoveryCodes = data.recovery_codes;
@@ -489,6 +490,7 @@ function accountPage() {
                 });
                 const data = await res.json();
                 if (!res.ok) { this.twoFaError = data.message || 'Verification failed'; this.twoFaLoading = false; return; }
+                this.twoFaCode = '';
                 this.twoFaStep = 'recovery';
                 this.user = {...this.user, totp_enabled: true};
             } catch (e) { this.twoFaError = 'Unable to connect'; }
@@ -517,6 +519,7 @@ function accountPage() {
                 });
                 const data = await res.json();
                 if (!res.ok) { this.twoFaError = data.message || 'Regeneration failed'; this.twoFaLoading = false; return; }
+                this.twoFaPassword = ''; this.twoFaCode = '';
                 this.twoFaRecoveryCodes = data.recovery_codes;
                 this.twoFaStep = 'recovery';
             } catch (e) { this.twoFaError = 'Unable to connect'; }

--- a/dango/web/templates/account.html
+++ b/dango/web/templates/account.html
@@ -154,12 +154,165 @@
         <!-- Two-Factor Authentication Section -->
         <div class="bg-white shadow rounded-lg p-6">
             <h3 class="text-lg font-medium text-gray-900 mb-4">Two-Factor Authentication</h3>
-            <div class="flex items-center space-x-3">
+            <div class="flex items-center space-x-3 mb-4">
                 <span class="px-2 py-0.5 text-xs font-semibold rounded-full"
                       :class="user.totp_enabled ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'"
                       x-text="user.totp_enabled ? 'Enabled' : 'Disabled'"></span>
-                <span class="text-sm text-gray-500">2FA setup is not yet available.</span>
             </div>
+
+            <!-- Error display -->
+            <div x-show="twoFaError" class="mb-3 p-2 bg-red-50 border border-red-200 rounded text-sm text-red-700" x-text="twoFaError"></div>
+
+            <!-- 2FA NOT enabled: setup flow -->
+            <template x-if="!user.totp_enabled">
+                <div>
+                    <!-- Step: idle -->
+                    <div x-show="twoFaStep === 'idle'">
+                        <p class="text-sm text-gray-500 mb-3">Add an extra layer of security to your account using a TOTP authenticator app.</p>
+                        <button @click="twoFaStep = 'password'; twoFaError = ''"
+                                class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700">Enable 2FA</button>
+                    </div>
+
+                    <!-- Step: enter password -->
+                    <div x-show="twoFaStep === 'password'">
+                        <form @submit.prevent="setup2FA()" class="max-w-sm">
+                            <p class="text-sm text-gray-500 mb-3">Enter your password to begin setup.</p>
+                            <div class="mb-3">
+                                <input type="password" x-model="twoFaPassword" required placeholder="Current password" autocomplete="current-password"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm">
+                            </div>
+                            <div class="flex space-x-2">
+                                <button type="submit" :disabled="twoFaLoading"
+                                        class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">Continue</button>
+                                <button type="button" @click="reset2FA()"
+                                        class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <!-- Step: show secret + verify code -->
+                    <div x-show="twoFaStep === 'qr'">
+                        <p class="text-sm text-gray-500 mb-3">Add this key to your authenticator app (Google Authenticator, Authy, etc.):</p>
+                        <div class="mb-3 p-3 bg-gray-50 rounded-md border">
+                            <p class="text-xs text-gray-500 mb-1">Secret key (manual entry)</p>
+                            <div class="flex items-center space-x-2">
+                                <code class="text-sm font-mono break-all" x-text="twoFaSecret"></code>
+                                <button @click="navigator.clipboard.writeText(twoFaSecret)"
+                                        class="shrink-0 px-2 py-1 text-xs bg-gray-200 rounded hover:bg-gray-300">Copy</button>
+                            </div>
+                        </div>
+                        <form @submit.prevent="verify2FASetup()" class="max-w-sm">
+                            <p class="text-sm text-gray-500 mb-2">Enter the 6-digit code from your authenticator app to verify:</p>
+                            <div class="mb-3">
+                                <input type="text" x-model="twoFaCode" required placeholder="000000" maxlength="6" pattern="[0-9]{6}" inputmode="numeric" autocomplete="one-time-code"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm font-mono tracking-widest">
+                            </div>
+                            <div class="flex space-x-2">
+                                <button type="submit" :disabled="twoFaLoading"
+                                        class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">Verify & Enable</button>
+                                <button type="button" @click="reset2FA()"
+                                        class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <!-- Step: recovery codes -->
+                    <div x-show="twoFaStep === 'recovery'">
+                        <div class="p-3 bg-yellow-50 border border-yellow-200 rounded-md mb-3">
+                            <p class="text-sm font-medium text-yellow-800 mb-1">Save your recovery codes</p>
+                            <p class="text-xs text-yellow-700">Store these codes safely. Each can be used once if you lose access to your authenticator.</p>
+                        </div>
+                        <div class="mb-3 p-3 bg-gray-50 rounded-md border font-mono text-sm grid grid-cols-2 gap-1">
+                            <template x-for="code in twoFaRecoveryCodes" :key="code">
+                                <span x-text="code"></span>
+                            </template>
+                        </div>
+                        <div class="flex space-x-2">
+                            <button @click="copyRecoveryCodes()"
+                                    class="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Copy</button>
+                            <button @click="downloadRecoveryCodes()"
+                                    class="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Download</button>
+                            <button @click="reset2FA()"
+                                    class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700">Done</button>
+                        </div>
+                    </div>
+                </div>
+            </template>
+
+            <!-- 2FA IS enabled: disable / regenerate -->
+            <template x-if="user.totp_enabled">
+                <div>
+                    <!-- Step: idle (enabled state) -->
+                    <div x-show="twoFaStep === 'idle'">
+                        <p class="text-sm text-gray-500 mb-3">Two-factor authentication is active on your account.</p>
+                        <div class="flex space-x-2">
+                            <button @click="twoFaStep = 'disable'; twoFaError = ''"
+                                    class="px-4 py-2 text-sm text-red-700 bg-red-50 rounded-md hover:bg-red-100 border border-red-200">Disable 2FA</button>
+                            <button @click="twoFaStep = 'regenerate'; twoFaError = ''"
+                                    class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Regenerate Recovery Codes</button>
+                        </div>
+                    </div>
+
+                    <!-- Step: disable -->
+                    <div x-show="twoFaStep === 'disable'">
+                        <form @submit.prevent="disable2FA()" class="max-w-sm">
+                            <p class="text-sm text-gray-500 mb-3">Enter your password to disable 2FA.</p>
+                            <div class="mb-3">
+                                <input type="password" x-model="twoFaPassword" required placeholder="Current password" autocomplete="current-password"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm">
+                            </div>
+                            <div class="flex space-x-2">
+                                <button type="submit" :disabled="twoFaLoading"
+                                        class="px-4 py-2 text-sm text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50">Disable 2FA</button>
+                                <button type="button" @click="reset2FA()"
+                                        class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <!-- Step: regenerate recovery codes -->
+                    <div x-show="twoFaStep === 'regenerate'">
+                        <form @submit.prevent="regenerateRecoveryCodes()" class="max-w-sm">
+                            <p class="text-sm text-gray-500 mb-3">Enter your password and a TOTP code to regenerate recovery codes.</p>
+                            <div class="mb-3">
+                                <input type="password" x-model="twoFaPassword" required placeholder="Current password" autocomplete="current-password"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm">
+                            </div>
+                            <div class="mb-3">
+                                <input type="text" x-model="twoFaCode" required placeholder="TOTP code" maxlength="6" pattern="[0-9]{6}" inputmode="numeric" autocomplete="one-time-code"
+                                       class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500 text-sm font-mono tracking-widest">
+                            </div>
+                            <div class="flex space-x-2">
+                                <button type="submit" :disabled="twoFaLoading"
+                                        class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">Regenerate</button>
+                                <button type="button" @click="reset2FA()"
+                                        class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                            </div>
+                        </form>
+                    </div>
+
+                    <!-- Step: recovery codes (after regeneration) -->
+                    <div x-show="twoFaStep === 'recovery'">
+                        <div class="p-3 bg-yellow-50 border border-yellow-200 rounded-md mb-3">
+                            <p class="text-sm font-medium text-yellow-800 mb-1">New recovery codes</p>
+                            <p class="text-xs text-yellow-700">Your old recovery codes are no longer valid. Save these new codes safely.</p>
+                        </div>
+                        <div class="mb-3 p-3 bg-gray-50 rounded-md border font-mono text-sm grid grid-cols-2 gap-1">
+                            <template x-for="code in twoFaRecoveryCodes" :key="code">
+                                <span x-text="code"></span>
+                            </template>
+                        </div>
+                        <div class="flex space-x-2">
+                            <button @click="copyRecoveryCodes()"
+                                    class="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Copy</button>
+                            <button @click="downloadRecoveryCodes()"
+                                    class="px-3 py-2 text-sm bg-gray-100 rounded-md hover:bg-gray-200">Download</button>
+                            <button @click="reset2FA()"
+                                    class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700">Done</button>
+                        </div>
+                    </div>
+                </div>
+            </template>
         </div>
 
         <!-- Create API Key Modal -->
@@ -221,6 +374,10 @@ function accountPage() {
         apiKeys: [], keyError: '', keyLoading: false,
         showKeyModal: false, newKeyName: '',
         showNewKey: false, newKeyValue: '',
+        // 2FA state
+        twoFaStep: 'idle', twoFaPassword: '', twoFaCode: '',
+        twoFaSecret: '', twoFaUri: '', twoFaRecoveryCodes: [],
+        twoFaError: '', twoFaLoading: false,
 
         async init() {
             await Promise.all([this.loadSessions(), this.loadKeys()]);
@@ -304,6 +461,80 @@ function accountPage() {
                 if (!res.ok) { const d = await res.json(); this.keyError = d.message; return; }
                 await this.loadKeys();
             } catch (e) { this.keyError = 'Failed to revoke key'; }
+        },
+
+        // --- 2FA methods ---
+        async setup2FA() {
+            this.twoFaLoading = true; this.twoFaError = '';
+            try {
+                const res = await fetch('/api/auth/2fa/setup', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ password: this.twoFaPassword })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.twoFaError = data.message || 'Setup failed'; this.twoFaLoading = false; return; }
+                this.twoFaSecret = data.secret;
+                this.twoFaUri = data.provisioning_uri;
+                this.twoFaRecoveryCodes = data.recovery_codes;
+                this.twoFaStep = 'qr';
+            } catch (e) { this.twoFaError = 'Unable to connect'; }
+            this.twoFaLoading = false;
+        },
+        async verify2FASetup() {
+            this.twoFaLoading = true; this.twoFaError = '';
+            try {
+                const res = await fetch('/api/auth/2fa/verify-setup', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ code: this.twoFaCode })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.twoFaError = data.message || 'Verification failed'; this.twoFaLoading = false; return; }
+                this.twoFaStep = 'recovery';
+                this.user = {...this.user, totp_enabled: true};
+            } catch (e) { this.twoFaError = 'Unable to connect'; }
+            this.twoFaLoading = false;
+        },
+        async disable2FA() {
+            this.twoFaLoading = true; this.twoFaError = '';
+            try {
+                const res = await fetch('/api/auth/2fa/disable', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ password: this.twoFaPassword })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.twoFaError = data.message || 'Failed to disable'; this.twoFaLoading = false; return; }
+                this.user = {...this.user, totp_enabled: false};
+                this.reset2FA();
+            } catch (e) { this.twoFaError = 'Unable to connect'; }
+            this.twoFaLoading = false;
+        },
+        async regenerateRecoveryCodes() {
+            this.twoFaLoading = true; this.twoFaError = '';
+            try {
+                const res = await fetch('/api/auth/2fa/regenerate-recovery', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ password: this.twoFaPassword, code: this.twoFaCode })
+                });
+                const data = await res.json();
+                if (!res.ok) { this.twoFaError = data.message || 'Regeneration failed'; this.twoFaLoading = false; return; }
+                this.twoFaRecoveryCodes = data.recovery_codes;
+                this.twoFaStep = 'recovery';
+            } catch (e) { this.twoFaError = 'Unable to connect'; }
+            this.twoFaLoading = false;
+        },
+        reset2FA() {
+            this.twoFaStep = 'idle'; this.twoFaPassword = ''; this.twoFaCode = '';
+            this.twoFaError = ''; this.twoFaSecret = ''; this.twoFaUri = '';
+            this.twoFaRecoveryCodes = [];
+        },
+        copyRecoveryCodes() {
+            navigator.clipboard.writeText(this.twoFaRecoveryCodes.join('\n'));
+        },
+        downloadRecoveryCodes() {
+            const text = 'Dango Recovery Codes\n' + '='.repeat(30) + '\n\n' + this.twoFaRecoveryCodes.join('\n') + '\n\nStore these codes safely. Each code can only be used once.\n';
+            const blob = new Blob([text], { type: 'text/plain' });
+            const a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+            a.download = 'dango-recovery-codes.txt'; a.click();
         }
     }
 }

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -18,7 +18,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/upload.py
-    lines: 699
+    lines: 701
     category: exempt
     reason: "CSV upload/list/delete endpoints. Extracted from web/app.py by TASK-085. DELETE endpoint alone has ~300 lines of DuckDB cleanup logic."
     review_by: "v1.1"
@@ -75,7 +75,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 983
+    lines: 988
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
@@ -87,7 +87,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 686
+    lines: 707
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"
@@ -231,13 +231,13 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/config/models.py
-    lines: 588
+    lines: 609
     category: exempt
     reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py
-    lines: 732
+    lines: 839
     category: exempt
     reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
     review_by: "v1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,6 +329,7 @@ module = [
     "tests.unit.test_web_imports",
     "tests.unit.test_byos",
     "tests.unit.test_driver_utils",
+    "tests.unit.test_process_manager",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_process_manager.py
+++ b/tests/unit/test_process_manager.py
@@ -475,8 +475,8 @@ class TestGetFastapiStatus:
         assert status["running"] is False
         assert status["pid"] is None
         assert status["url"] is None
-        # Default port and log file path
-        assert status["port"] == 8080
+        # Default port (8800 from PlatformSettings) and log file path
+        assert status["port"] == 8800
         assert status["log_file"] == tmp_path / ".dango" / "web.log"
 
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=True)
@@ -486,7 +486,7 @@ class TestGetFastapiStatus:
         status = get_fastapi_status(tmp_path)
         assert status["running"] is True
         assert status["pid"] == 7777
-        assert status["url"] == "http://localhost:8080"
+        assert status["url"] == "http://localhost:8800"
 
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
     def test_stale_pid(self, _mock_running, tmp_path):

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -157,6 +157,8 @@ class TestRunScheduledSync:
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify"),
             patch(f"{_JOBS_MOD}._check_freshness"),
+            patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
+            patch(f"{_JOBS_MOD}._run_coalesced_dbt"),
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -171,6 +173,13 @@ class TestRunScheduledSync:
         mock_lock = MagicMock()
         mock_lock.acquire.side_effect = DbtLockError("busy")
 
+        # Simulate time passing beyond max_wait to exit the retry loop quickly
+        elapsed = [0.0]
+
+        def fake_monotonic():
+            elapsed[0] += 301  # Jump past 300s max_wait
+            return elapsed[0]
+
         with (
             patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
@@ -178,13 +187,14 @@ class TestRunScheduledSync:
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify") as mock_notify,
             patch(f"{_JOBS_MOD}._log_execution_event") as mock_record,
+            patch(f"{_JOBS_MOD}.time.sleep"),
+            patch(f"{_JOBS_MOD}.time.monotonic", side_effect=fake_monotonic),
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
             run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
 
         events = [c.args[0]["event"] for c in mock_bc.call_args_list]
-        assert "job_queued" in events
         assert "sync_failed" in events
         mock_notify.assert_called_once()
         mock_record.assert_called_once()
@@ -204,6 +214,8 @@ class TestRunScheduledSync:
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify"),
             patch(f"{_JOBS_MOD}._check_freshness"),
+            patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
+            patch(f"{_JOBS_MOD}._run_coalesced_dbt"),
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -225,6 +237,7 @@ class TestRunScheduledSync:
             patch(f"{_SYNC_MOD}.run_sync", side_effect=RuntimeError("boom")),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -248,6 +261,8 @@ class TestRunScheduledSync:
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify"),
             patch(f"{_JOBS_MOD}._check_freshness"),
+            patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
+            patch(f"{_JOBS_MOD}._run_coalesced_dbt"),
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -270,6 +285,8 @@ class TestRunScheduledSync:
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify") as mock_notify,
             patch(f"{_JOBS_MOD}._check_freshness"),
+            patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
+            patch(f"{_JOBS_MOD}._run_coalesced_dbt"),
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 

--- a/tests/unit/test_upgrade_command.py
+++ b/tests/unit/test_upgrade_command.py
@@ -477,6 +477,7 @@ class TestStatusVersionCheck:
         mock_fastapi.return_value = {
             "running": False,
             "pid": None,
+            "port": 8800,
             "url": "http://localhost:8800",
             "log_file": tmp_path / "x.log",
         }


### PR DESCRIPTION
## Summary

Fix round 6, Session C — 5 medium-severity bugs found during Phase 8 manual testing.

- **BUG-026:** `dango status` showed wrong port (hardcoded 8080 → reads `platform.port` from config, default 8800). Added Web UI row to services table.
- **BUG-031:** CSV file deletion left stale rows in staging tables. Now runs dbt with `--full-refresh` after delete to rebuild staging from current raw data.
- **BUG-033:** `dango source remove` left orphaned dbt files. Now cleans up `stg_*__*.sql`, `sources_*.yml`, `stg_*.yml`. `dango model remove` now also removes the model entry from `schema.yml`.
- **BUG-042:** Scheduled sync lock contention failed immediately. Now retries every 5s for up to 5 min. Added dbt coalescing: syncs use `skip_dbt=True`, register in `pending_dbt_sources.json`, then one coalesced dbt run executes after a configurable wait (`platform.dbt_coalesce_seconds`, default 10s).
- **BUG-050:** 2FA UI was a placeholder. Wired up full Alpine.js multi-step flow (enable → password → secret key → verify → recovery codes; disable; regenerate recovery codes). All backend endpoints already existed in `auth_2fa.py`.

## Test plan

- [x] All 2947 unit tests pass (0 failures)
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, file sizes)
- [x] Line counts updated in `file-exemptions.yml`, root `CLAUDE.md`, module `CLAUDE.md` files
- [ ] Manual: `dango status` shows correct port and Web UI row
- [ ] Manual: `dango source remove` + verify dbt files deleted
- [ ] Manual: CSV upload → delete → verify staging purged
- [ ] Manual: Account page → 2FA enable/disable flow
- [ ] Manual: Trigger concurrent scheduled syncs → verify lock retry + coalesced dbt run

🤖 Generated with [Claude Code](https://claude.com/claude-code)