### PR TITLE
R7-G: Backend + small fixes (BUG-027, 028, 033, 034)

### DIFF
--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -406,6 +406,15 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
                         f"[green]✓[/green] Removed {len(removed_files)} dbt staging file(s)"
                     )
 
+            # Regenerate dbt docs to reflect source removal
+            try:
+                from dango.transformation import generate_dbt_docs
+
+                generate_dbt_docs(project_root)
+                console.print("[green]✓[/green] dbt documentation regenerated")
+            except Exception:
+                pass  # Non-critical — catalog will update on next sync
+
             console.print(f"[green]✅ Source '{source_name}' removed successfully[/green]")
             console.print()
             console.print("[yellow]⚠️  Important:[/yellow]")

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -407,13 +407,16 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
                     )
 
             # Regenerate dbt docs to reflect source removal
+            console.print("[dim]Regenerating dbt documentation...[/dim]")
             try:
                 from dango.transformation import generate_dbt_docs
 
                 generate_dbt_docs(project_root)
                 console.print("[green]✓[/green] dbt documentation regenerated")
             except Exception:
-                pass  # Non-critical — catalog will update on next sync
+                console.print(
+                    "[dim]Could not regenerate dbt documentation — catalog will update on next sync.[/dim]"
+                )
 
             console.print(f"[green]✅ Source '{source_name}' removed successfully[/green]")
             console.print()

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -133,11 +133,11 @@ def docs(ctx: click.Context) -> None:
     Generate dbt documentation (wrapper for dbt docs generate).
 
     This command generates documentation for your dbt models, sources, and tests.
-    After generation, view docs at http://localhost:{port}/dbt-docs (if platform is running).
+    After generation, view docs at http://localhost:{port}/catalog (if platform is running).
 
     Examples:
       dango docs          Generate documentation
-      dango start         Then view at http://localhost:{port}/dbt-docs
+      dango start         Then view at http://localhost:{port}/catalog
     """
     import subprocess
 
@@ -184,7 +184,7 @@ def docs(ctx: click.Context) -> None:
         config_loader = ConfigLoader(project_root)
         config = config_loader.load_config()
         platform_port = config.platform.port
-        dbt_docs_url = f"http://localhost:{platform_port}/dbt-docs"
+        dbt_docs_url = f"http://localhost:{platform_port}/catalog"
 
         # Check if platform is running
         import socket

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -36,7 +36,7 @@ _analyzer: Any = None
 _SPACY_MODEL = "en_core_web_sm"
 _SPACY_MODEL_URL = (
     "https://github.com/explosion/spacy-models/releases/download/"
-    "en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl"
+    "en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
 )
 
 
@@ -59,13 +59,20 @@ def _get_analyzer() -> Any | None:
         try:
             spacy.cli.download(_SPACY_MODEL)  # type: ignore[attr-defined]
         except Exception:
-            # Fallback 2: direct pip install from GitHub release URL
+            # Fallback 2: download .whl to temp file then pip install locally
+            # (pip 25.2+ can't download from GitHub Releases redirect URLs directly)
+            import os
             import subprocess
             import sys
+            import tempfile
+            import urllib.request
 
             try:
+                whl_name = _SPACY_MODEL_URL.rsplit("/", 1)[-1]
+                whl_path = os.path.join(tempfile.gettempdir(), whl_name)
+                urllib.request.urlretrieve(_SPACY_MODEL_URL, whl_path)
                 subprocess.check_call(
-                    [sys.executable, "-m", "pip", "install", _SPACY_MODEL_URL],
+                    [sys.executable, "-m", "pip", "install", whl_path],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -70,12 +70,18 @@ def _get_analyzer() -> Any | None:
             try:
                 whl_name = _SPACY_MODEL_URL.rsplit("/", 1)[-1]
                 whl_path = os.path.join(tempfile.gettempdir(), whl_name)
-                urllib.request.urlretrieve(_SPACY_MODEL_URL, whl_path)
-                subprocess.check_call(
-                    [sys.executable, "-m", "pip", "install", whl_path],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
+                try:
+                    urllib.request.urlretrieve(_SPACY_MODEL_URL, whl_path)
+                    subprocess.check_call(
+                        [sys.executable, "-m", "pip", "install", whl_path],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                finally:
+                    try:
+                        os.unlink(whl_path)
+                    except OSError:
+                        pass
             except Exception:
                 logger.warning(
                     "pii_spacy_download_failed",

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -102,7 +102,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
     "local_files": {
         "display_name": "File Import (CSV, JSON, Parquet)",
         "category": "Local & Custom",
-        "description": "Load CSV, JSON, JSONL, or Parquet files from a local directory with deduplication and incremental loading",
+        "description": "Load CSV, JSON, JSONL, or Parquet files from a directory. All matching files are combined into a single raw table. On re-sync, new/modified files are loaded, deleted files are removed.",
         "auth_type": AuthType.NONE,
         "dlt_package": None,  # Custom implementation (extends CSVLoader)
         "dlt_function": None,

--- a/dango/visualization/dashboard_manager.py
+++ b/dango/visualization/dashboard_manager.py
@@ -627,7 +627,9 @@ class DashboardManager:
             collections_to_export = [c for c in all_collections if c.get("name") in collections]
         else:
             # Default: export from "Shared" collection only (team workflow)
-            collections_to_export = [c for c in all_collections if c.get("name") == "Shared"]
+            collections_to_export = [
+                c for c in all_collections if c.get("name", "").lower() == "shared"
+            ]
 
         if not collections_to_export:
             summary["errors"].append("No collections to export")

--- a/dango/visualization/dashboard_manager.py
+++ b/dango/visualization/dashboard_manager.py
@@ -626,21 +626,8 @@ class DashboardManager:
             # Export specific collections
             collections_to_export = [c for c in all_collections if c.get("name") in collections]
         else:
-            # Export all non-personal, non-root collections
-            collections_to_export = []
-            for c in all_collections:
-                name = c.get("name", "")
-                cid = c.get("id")
-                # Skip root collection (Metabase virtual container)
-                if cid == "root" or name == "Our analytics":
-                    continue
-                # Skip personal collections unless explicitly requested
-                if not include_personal and (
-                    "personal" in name.lower() or "private" in name.lower()
-                ):
-                    summary["skipped_collections"].append(name)
-                    continue
-                collections_to_export.append(c)
+            # Default: export from "Shared" collection only (team workflow)
+            collections_to_export = [c for c in all_collections if c.get("name") == "Shared"]
 
         if not collections_to_export:
             summary["errors"].append("No collections to export")


### PR DESCRIPTION
## Summary

- **BUG-027** (CRITICAL): Fix spaCy Level 3 download — `urllib.request.urlretrieve()` to temp `.whl`, then local `pip install`. pip 25.2+ silently downloads 0 bytes from GitHub Releases redirect URLs. Also updates model from `en_core_web_sm-3.7.1` → `3.8.0` (compatible with installed spaCy 3.8.11).
- **BUG-028**: Update `local_files` source description to accurately describe behavior (removed misleading "deduplication and incremental loading" language).
- **BUG-029**: No code changes needed — already implemented in R6-E (PR #174). Failure was caused by BUG-053 JS null errors (fixed in R7-A). Verify during post-R7 testing.
- **BUG-033**: Add `generate_dbt_docs()` call after `source_remove()` so catalog reflects source removal immediately. Update `/dbt-docs` → `/catalog` URL references in `dango docs` command.
- **BUG-034**: Default `dango metabase save` to export "Shared" collection only (was exporting all non-personal collections). Matches intended team workflow.

## Files changed

- `dango/governance/pii_detector.py` — BUG-027
- `dango/ingestion/sources/registry.py` — BUG-028
- `dango/cli/commands/source.py` — BUG-033
- `dango/cli/commands/transform.py` — BUG-033
- `dango/visualization/dashboard_manager.py` — BUG-034

## Test plan

- [x] `pytest` — 3063 passed, 30 skipped
- [x] `grep -n "3\.7\.1" dango/governance/pii_detector.py` — no matches
- [x] `grep -n "deduplication" dango/ingestion/sources/registry.py` — no matches
- [x] `grep -n "dbt-docs" dango/cli/commands/transform.py` — no matches
- [x] `grep -n "Our analytics" dango/visualization/dashboard_manager.py` — no matches
- [ ] BUG-027: Verify spaCy auto-downloads in test-4 environment (pip 25.2 scenario)
- [ ] BUG-033: Run `dango source remove <name>` and verify catalog updates immediately
- [ ] BUG-034: Run `dango metabase save` and verify only "Shared" collection exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)