### PR TITLE
R7-E: Password email check, change-role command, CLI audit logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ dango/                          # Python package source
 │   ├── main.py                 # Slim entry point (~121 lines) — registers commands
 │   ├── commands/               # Command modules (extracted from main.py by TASK-005)
 │   │   ├── __init__.py         # Package marker
-│   │   ├── auth.py             # auth group (12 subcommands, 538 lines)
+│   │   ├── auth.py             # auth group (13 subcommands, 660 lines)
 │   │   ├── cleanup.py          # cleanup old logs, dbt artifacts, Python cache
 │   │   ├── oauth.py            # oauth group + 10 subcommands (812 lines)
 │   │   ├── config_cmd.py       # config group (validate/show)
@@ -359,7 +359,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 704 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
-| `cli/commands/auth.py` | 538 | — (12 auth subcommands) |
+| `cli/commands/auth.py` | 660 | — (13 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 527 | — (admin user CRUD + invite) |
 | `platform/local/watcher.py` | 518 | — |

--- a/dango/auth/CLAUDE.md
+++ b/dango/auth/CLAUDE.md
@@ -240,7 +240,7 @@ Session bridging syncs Dango auth state to Metabase so users get single sign-on.
 - `web/routes/ui.py` (183 lines) — login/account/invite page rendering
 - `web/routes/metabase_proxy.py` (268 lines) — SSO re-bridging on 401
 - `web/app.py` (~370 lines) — first-run admin bootstrap in `lifespan()`
-- `cli/commands/auth.py` (538 lines) — 12 auth subcommands (add-user, list-users, unlock, etc.)
+- `cli/commands/auth.py` (660 lines) — 13 auth subcommands (add-user, list-users, change-role, unlock, etc.)
 
 ## Testing
 

--- a/dango/auth/security.py
+++ b/dango/auth/security.py
@@ -205,14 +205,16 @@ def verify_password(password: str, password_hash: str) -> bool:
     return _hasher.verify(password, password_hash)
 
 
-def check_password_strength(password: str) -> list[str]:
+def check_password_strength(password: str, *, email: str | None = None) -> list[str]:
     """Check password strength per NIST SP 800-63B guidelines.
 
-    Checks minimum length (8 characters) and common password blocklist.
+    Checks minimum length (8 characters), common password blocklist, and
+    optionally whether the password is too similar to the user's email.
     Does **not** require digits, uppercase, or special characters.
 
     Args:
         password: Password to evaluate.
+        email: Optional email address to check against (keyword-only).
 
     Returns:
         List of issue descriptions.  Empty list means the password
@@ -223,6 +225,11 @@ def check_password_strength(password: str) -> list[str]:
         issues.append(f"Password must be at least {_MIN_PASSWORD_LENGTH} characters")
     if password.lower() in _COMMON_PASSWORDS:
         issues.append("Password is too common")
+    if email:
+        if password.lower() == email.lower():
+            issues.append("Password cannot be the same as your email address")
+        elif email.split("@")[0].lower() in password.lower():
+            issues.append("Password should not contain your email username")
     return issues
 
 

--- a/dango/auth/security.py
+++ b/dango/auth/security.py
@@ -228,7 +228,11 @@ def check_password_strength(password: str, *, email: str | None = None) -> list[
     if email:
         if password.lower() == email.lower():
             issues.append("Password cannot be the same as your email address")
-        elif email.split("@")[0].lower() in password.lower():
+        elif (
+            (username := email.split("@")[0].lower())
+            and len(username) >= 3
+            and username in password.lower()
+        ):
             issues.append("Password should not contain your email username")
     return issues
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -15,7 +15,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
 | `commands/source.py` (707 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
 | `commands/platform.py` (988 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
-| `commands/auth.py` (538 lines) | `auth` group (12 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_status()`, etc. |
+| `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (812 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
 | `commands/transform.py` (326 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
@@ -80,7 +80,7 @@ dango (top-level group)
 ├── auth (group)                ← commands/auth.py
 │   ├── enable, disable, add-user, list-users, reset-password,
 │   │   deactivate-user, reactivate-user, delete-user, status,
-│   │   unlock, audit, recover
+│   │   unlock, change-role, audit, recover
 ├── oauth (group)               ← commands/oauth.py
 │   ├── status, setup, check, list, remove, refresh,
 │   │   facebook_ads, google_sheets, google_analytics, google_ads

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -403,6 +403,7 @@ def auth_delete_user(ctx: click.Context, email: str) -> None:
         log_auth_event(
             event_type=AuditEvent.USER_DELETED,
             email=user.email,
+            user_id=user.id,
             details={"via": "cli"},
             log_dir=project_root / ".dango" / "logs",
         )

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -132,7 +132,7 @@ def auth_add_user(
     from dango.exceptions import UserExistsError
 
     try:
-        _, db_path = _get_db_path(ctx)
+        project_root, db_path = _get_db_path(ctx)
 
         if use_password:
             from dango.auth.admin import format_credentials_panel
@@ -165,6 +165,15 @@ def auth_add_user(
             console.print(f"\n[green]User created:[/green] {user.email}")
             console.print(f"[bold]Invite link:[/bold] {invite_url}")
             console.print("[dim]Link expires in 72 hours. Share it securely.[/dim]\n")
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.USER_CREATED,
+            email=email,
+            user_id=user.id,
+            details={"via": "cli", "role": role},
+            log_dir=project_root / ".dango" / "logs",
+        )
     except click.Abort:
         raise
     except UserExistsError:
@@ -243,7 +252,7 @@ def auth_reset_password(ctx: click.Context, email: str) -> None:
     from dango.cli.utils import print_error
 
     try:
-        _, db_path = _get_db_path(ctx)
+        project_root, db_path = _get_db_path(ctx)
         user = get_user_by_email(db_path, email)
         if user is None:
             print_error(f"User '{email}' not found.")
@@ -257,6 +266,15 @@ def auth_reset_password(ctx: click.Context, email: str) -> None:
         )
         invalidate_all_user_sessions(db_path, user.id)
         console.print(format_credentials_panel(user.email, password, title="Password reset"))
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.PASSWORD_RESET,
+            email=user.email,
+            user_id=user.id,
+            details={"via": "cli"},
+            log_dir=project_root / ".dango" / "logs",
+        )
     except click.Abort:
         raise
     except Exception as exc:
@@ -279,7 +297,7 @@ def auth_deactivate_user(ctx: click.Context, email: str) -> None:
     from dango.cli.utils import print_error, print_success
 
     try:
-        _, db_path = _get_db_path(ctx)
+        project_root, db_path = _get_db_path(ctx)
         user = get_user_by_email(db_path, email)
         if user is None:
             print_error(f"User '{email}' not found.")
@@ -294,6 +312,15 @@ def auth_deactivate_user(ctx: click.Context, email: str) -> None:
         deactivate_user(db_path, user.id)
         invalidate_all_user_sessions(db_path, user.id)
         print_success(f"User '{user.email}' deactivated.")
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.USER_DEACTIVATED,
+            email=user.email,
+            user_id=user.id,
+            details={"via": "cli"},
+            log_dir=project_root / ".dango" / "logs",
+        )
     except click.Abort:
         raise
     except Exception as exc:
@@ -311,7 +338,7 @@ def auth_reactivate_user(ctx: click.Context, email: str) -> None:
     from dango.cli.utils import print_error, print_info, print_success
 
     try:
-        _, db_path = _get_db_path(ctx)
+        project_root, db_path = _get_db_path(ctx)
         user = get_user_by_email(db_path, email)
         if user is None:
             print_error(f"User '{email}' not found.")
@@ -321,6 +348,15 @@ def auth_reactivate_user(ctx: click.Context, email: str) -> None:
             return
         update_user(db_path, user.id, UserUpdate(is_active=True))
         print_success(f"User '{user.email}' reactivated.")
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.USER_REACTIVATED,
+            email=user.email,
+            user_id=user.id,
+            details={"via": "cli"},
+            log_dir=project_root / ".dango" / "logs",
+        )
     except click.Abort:
         raise
     except Exception as exc:
@@ -362,6 +398,14 @@ def auth_delete_user(ctx: click.Context, email: str) -> None:
             print_warning("Metabase cleanup failed (user will still be deleted).")
         delete_user(db_path, user.id)
         print_success(f"User '{user.email}' deleted.")
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.USER_DELETED,
+            email=user.email,
+            details={"via": "cli"},
+            log_dir=project_root / ".dango" / "logs",
+        )
     except click.Abort:
         raise
     except Exception as exc:
@@ -429,7 +473,7 @@ def auth_unlock(ctx: click.Context, email: str) -> None:
     from dango.cli.utils import print_error, print_info, print_success
 
     try:
-        _, db_path = _get_db_path(ctx)
+        project_root, db_path = _get_db_path(ctx)
         user = get_user_by_email(db_path, email)
         if user is None:
             print_error(f"User '{email}' not found.")
@@ -443,6 +487,68 @@ def auth_unlock(ctx: click.Context, email: str) -> None:
             UserUpdate(failed_login_attempts=0, locked_until=None),
         )
         print_success(f"User '{user.email}' unlocked.")
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.ACCOUNT_UNLOCKED,
+            email=user.email,
+            user_id=user.id,
+            details={"via": "cli"},
+            log_dir=project_root / ".dango" / "logs",
+        )
+    except click.Abort:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        raise click.Abort() from None
+
+
+@auth.command("change-role")
+@click.argument("email")
+@click.argument("role", type=click.Choice(["admin", "editor", "viewer"]))
+@click.pass_context
+def auth_change_role(ctx: click.Context, email: str, role: str) -> None:
+    """Change a user's role (admin, editor, viewer)."""
+    from dango.auth.database import get_user_by_email, list_users, update_user
+    from dango.auth.models import Role, UserUpdate
+    from dango.cli.utils import print_error, print_info, print_success, print_warning
+
+    try:
+        project_root, db_path = _get_db_path(ctx)
+        user = get_user_by_email(db_path, email)
+        if user is None:
+            print_error(f"User '{email}' not found.")
+            raise click.Abort()
+        if user.role == Role(role):
+            print_info(f"User '{user.email}' already has role '{role}'.")
+            return
+        old_role = user.role.value
+        if user.role == Role.ADMIN:
+            active_admins = [
+                u for u in list_users(db_path, active_only=True) if u.role == Role.ADMIN
+            ]
+            if len(active_admins) <= 1:
+                print_error("Cannot demote the only active admin.")
+                raise click.Abort()
+        update_user(db_path, user.id, UserUpdate(role=Role(role)))
+        try:
+            from dango.auth.metabase_sync import _load_metabase_credentials, sync_user_role
+
+            creds = _load_metabase_credentials(project_root)
+            if creds and creds.get("metabase_url"):
+                sync_user_role(db_path, user.id, project_root, creds["metabase_url"])
+        except Exception:
+            print_warning("Metabase role sync failed (local role still updated).")
+        print_success(f"User '{user.email}' role changed to {role}.")
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.ROLE_CHANGED,
+            email=user.email,
+            user_id=user.id,
+            details={"via": "cli", "old_role": old_role, "new_role": role},
+            log_dir=project_root / ".dango" / "logs",
+        )
     except click.Abort:
         raise
     except Exception as exc:
@@ -520,7 +626,7 @@ def auth_recover(ctx: click.Context) -> None:
     from dango.exceptions import UserExistsError
 
     try:
-        _, db_path = _get_db_path(ctx)
+        project_root, db_path = _get_db_path(ctx)
         email = click.prompt("Recovery admin email", default="recovery@localhost")
         password = generate_temp_password()
         user = User(
@@ -538,6 +644,15 @@ def auth_recover(ctx: click.Context) -> None:
             raise click.Abort() from None
         print_warning("Recovery admin created. Delete this account after regaining access.")
         console.print(format_credentials_panel(user.email, password, title="Recovery admin"))
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(
+            event_type=AuditEvent.USER_CREATED,
+            email=user.email,
+            user_id=user.id,
+            details={"via": "cli", "role": "admin", "recovery": True},
+            log_dir=project_root / ".dango" / "logs",
+        )
     except click.Abort:
         raise
     except Exception as exc:

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -251,7 +251,7 @@ def _step_admin() -> tuple[str, str]:
     # Password (from env or prompt)
     env_password = os.environ.get("DANGO_ADMIN_PASSWORD")
     if env_password:
-        issues = check_password_strength(env_password)
+        issues = check_password_strength(env_password, email=email)
         if issues:
             console.print(f"  [red]DANGO_ADMIN_PASSWORD is weak:[/red] {'; '.join(issues)}")
             raise SystemExit(1)
@@ -260,7 +260,7 @@ def _step_admin() -> tuple[str, str]:
 
     while True:
         password = click.prompt("  Admin password", hide_input=True)
-        issues = check_password_strength(password)
+        issues = check_password_strength(password, email=email)
         if issues:
             console.print(f"  [red]Weak password:[/red] {'; '.join(issues)}")
             continue
@@ -574,7 +574,7 @@ def run_non_interactive(
             "for --non-interactive."
         )
         raise SystemExit(1)
-    issues = check_password_strength(admin_password)
+    issues = check_password_strength(admin_password, email=admin_email)
     if issues:
         console.print(f"[red]Error:[/red] Weak password: {'; '.join(issues)}")
         raise SystemExit(1)
@@ -819,7 +819,7 @@ def run_byos_non_interactive(
             "[red]Error:[/red] --admin-password or DANGO_ADMIN_PASSWORD env required for --byos."
         )
         raise SystemExit(1)
-    issues = check_password_strength(admin_password)
+    issues = check_password_strength(admin_password, email=admin_email)
     if issues:
         console.print(f"[red]Error:[/red] Weak password: {'; '.join(issues)}")
         raise SystemExit(1)

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1153,7 +1153,7 @@ on-run-end:
             # Password (from env or prompt)
             env_password = os.environ.get("DANGO_ADMIN_PASSWORD")
             if env_password:
-                issues = check_password_strength(env_password)
+                issues = check_password_strength(env_password, email=email)
                 if issues:
                     console.print(f"  [red]DANGO_ADMIN_PASSWORD is weak:[/red] {'; '.join(issues)}")
                     console.print("  [yellow]Skipping auth setup.[/yellow]")

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -365,7 +365,7 @@ async def change_password(request: Request) -> JSONResponse:
         return JSONResponse(status_code=400, content={"message": "Current password is incorrect"})
 
     # Check new password strength
-    issues = check_password_strength(data.new_password)
+    issues = check_password_strength(data.new_password, email=user.email)
     if issues:
         return JSONResponse(
             status_code=400, content={"message": "Password is too weak", "issues": issues}
@@ -588,7 +588,7 @@ async def accept_invite(request: Request) -> JSONResponse:
         return JSONResponse(status_code=400, content={"message": invalid_msg})
 
     # Validate password strength
-    issues = check_password_strength(data.password)
+    issues = check_password_strength(data.password, email=user.email)
     if issues:
         return JSONResponse(
             status_code=400,

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -54,6 +54,12 @@ exemptions:
     reason: "R7-E added change-role command and audit logging to all user management commands (+122 lines)."
     review_by: "v1.1"
 
+  - file: tests/unit/test_cli_auth.py
+    lines: 532
+    category: exempt
+    reason: "R7-E review: added TestAuthChangeRole (4 tests) and change-role to TestAuthHelp. Test files track source file growth."
+    review_by: "v1.1"
+
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
     lines: 839

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -49,9 +49,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/auth.py
-    lines: 538
+    lines: 660
     category: exempt
-    reason: "TASK-100 added invite link flow to add-user and invite status to list-users (+38 lines)."
+    reason: "R7-E added change-role command and audit logging to all user management commands (+122 lines)."
     review_by: "v1.1"
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---

--- a/tests/unit/test_auth_security.py
+++ b/tests/unit/test_auth_security.py
@@ -126,8 +126,8 @@ class TestCheckPasswordStrength:
         assert issues == []
 
     def test_email_none_skips_check(self) -> None:
-        # Without email param, no email-based issues
-        issues = check_password_strength("strongpassword123")
+        # email-like string passed as password (no email= kwarg) — no email checks run
+        issues = check_password_strength("user@example.com")
         assert issues == []
 
     def test_password_equals_email_rejected(self) -> None:
@@ -140,6 +140,10 @@ class TestCheckPasswordStrength:
 
     def test_password_contains_email_username(self) -> None:
         issues = check_password_strength("myuser12345", email="myuser@example.com")
+        assert any("email username" in i for i in issues)
+
+    def test_password_contains_email_username_case_insensitive(self) -> None:
+        issues = check_password_strength("MYUSER12345", email="myuser@example.com")
         assert any("email username" in i for i in issues)
 
     def test_email_domain_not_flagged(self) -> None:

--- a/tests/unit/test_auth_security.py
+++ b/tests/unit/test_auth_security.py
@@ -125,6 +125,32 @@ class TestCheckPasswordStrength:
         issues = check_password_strength("nospechars1234")
         assert issues == []
 
+    def test_email_none_skips_check(self) -> None:
+        # Without email param, no email-based issues
+        issues = check_password_strength("strongpassword123")
+        assert issues == []
+
+    def test_password_equals_email_rejected(self) -> None:
+        issues = check_password_strength("user@example.com", email="user@example.com")
+        assert any("same as your email" in i for i in issues)
+
+    def test_password_equals_email_case_insensitive(self) -> None:
+        issues = check_password_strength("USER@EXAMPLE.COM", email="user@example.com")
+        assert any("same as your email" in i for i in issues)
+
+    def test_password_contains_email_username(self) -> None:
+        issues = check_password_strength("myuser12345", email="myuser@example.com")
+        assert any("email username" in i for i in issues)
+
+    def test_email_domain_not_flagged(self) -> None:
+        # Domain part alone should not trigger the username check
+        issues = check_password_strength("example12345", email="user@example.com")
+        assert not any("email" in i for i in issues)
+
+    def test_strong_password_with_email_passes(self) -> None:
+        issues = check_password_strength("xK9!mQ2pL#nR", email="user@example.com")
+        assert issues == []
+
 
 @pytest.mark.unit
 class TestSessionTokens:

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -69,6 +69,7 @@ class TestAuthHelp:
             "delete-user",
             "status",
             "unlock",
+            "change-role",
             "audit",
             "recover",
         ]:
@@ -489,3 +490,43 @@ class TestAuthAudit:
         with patch("dango.cli.utils.find_project_root", return_value=project_root):
             result = runner.invoke(cli, ["auth", "audit", "--type", "bogus"])
         assert result.exit_code != 0
+
+
+@pytest.mark.unit
+class TestAuthChangeRole:
+    """Tests for 'dango auth change-role'."""
+
+    def test_change_role_happy_path(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com", role=Role.VIEWER)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "change-role", "user@test.com", "editor"])
+        assert result.exit_code == 0
+        assert "editor" in result.output.lower()
+
+    def test_change_role_user_not_found(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "change-role", "ghost@test.com", "editor"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_change_role_already_has_role(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="user@test.com", role=Role.EDITOR)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "change-role", "user@test.com", "editor"])
+        assert result.exit_code == 0
+        assert "already has role" in result.output.lower()
+
+    def test_change_role_last_admin_guard(self, tmp_path: Path) -> None:
+        project_root = _setup_project(tmp_path)
+        _add_user(project_root, email="admin@test.com", role=Role.ADMIN)
+        runner = CliRunner()
+        with patch("dango.cli.utils.find_project_root", return_value=project_root):
+            result = runner.invoke(cli, ["auth", "change-role", "admin@test.com", "viewer"])
+        assert result.exit_code != 0
+        assert "only active admin" in result.output.lower()


### PR DESCRIPTION
## Summary

- **BUG-058:** `check_password_strength()` now accepts an optional `email=` kwarg that rejects passwords equal to or containing the user's email username. All callers updated (`web/routes/auth.py`, `cli/init.py`, `cli/commands/deploy_wizard.py`).
- **BUG-062:** New `dango auth change-role <email> <role>` CLI command. Guards against demoting the last admin, syncs role to Metabase, logs audit event.
- **BUG-063:** `log_auth_event()` added to all user management CLI commands: `add-user` (USER_CREATED), `reset-password` (PASSWORD_RESET), `deactivate-user` (USER_DEACTIVATED), `reactivate-user` (USER_REACTIVATED), `delete-user` (USER_DELETED), `unlock` (ACCOUNT_UNLOCKED), `change-role` (ROLE_CHANGED), `recover` (USER_CREATED with `recovery=True`).

Also updates `docs/file-exemptions.yml` and all CLAUDE.md files for new line count (538 → 660 lines, 12 → 13 subcommands).

## Test plan

- [ ] `pytest tests/unit/test_auth_security.py` — 57 tests pass (includes 7 new email-check tests)
- [ ] `pytest tests/unit/test_cli_auth.py` — 36 tests pass
- [ ] `ruff check` + `mypy` — clean on all changed files
- [ ] Full pre-commit passes on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)