### PR TITLE
R8-C: Static asset cache busting (BUG-066)

### DIFF
--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -28,7 +28,7 @@ _static_hashes: dict[str, str] = {}
 if _static_dir.exists():
     for _file in _static_dir.rglob("*"):
         if _file.is_file():
-            _hash = hashlib.md5(_file.read_bytes()).hexdigest()[:8]
+            _hash = hashlib.md5(_file.read_bytes(), usedforsecurity=False).hexdigest()[:8]
             _static_hashes[_file.relative_to(_static_dir).as_posix()] = _hash
 
 

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -3,6 +3,7 @@
 UI page endpoints and API documentation.
 """
 
+import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -20,6 +21,26 @@ from dango.auth.permissions import require_permission
 router = APIRouter(tags=["ui"])
 
 templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+
+# Static asset cache busting (BUG-066): compute MD5 content hashes at import time.
+_static_dir = Path(__file__).parent.parent / "static"
+_static_hashes: dict[str, str] = {}
+if _static_dir.exists():
+    for _file in _static_dir.rglob("*"):
+        if _file.is_file():
+            _hash = hashlib.md5(_file.read_bytes()).hexdigest()[:8]
+            _static_hashes[_file.relative_to(_static_dir).as_posix()] = _hash
+
+
+def _static_url(path: str) -> str:
+    """Return versioned static URL for cache busting."""
+    h = _static_hashes.get(path)
+    if h:
+        return f"/static/{path}?v={h}"
+    return f"/static/{path}"
+
+
+templates.env.globals["static_url"] = _static_url
 
 _FALLBACK_HTML = """
 <html>

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -7,10 +7,10 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🍡</text></svg>">
 
     <!-- Tailwind CSS (compiled, see tailwind.config.js) -->
-    <link rel="stylesheet" href="/static/css/tailwind.min.css?v=1761590000">
+    <link rel="stylesheet" href="{{ static_url('css/tailwind.min.css') }}">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/static/css/main.css?v=1761590000">
+    <link rel="stylesheet" href="{{ static_url('css/main.css') }}">
 
     <!-- Alpine.js via CDN (ADR-007: used for new page interactivity) -->
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Data Catalog - Dango{% endblock %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/catalog.css?v=1744500000">
+<link rel="stylesheet" href="{{ static_url('css/catalog.css') }}">
 <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
     <div x-data="catalogPage()" x-init="init()" x-cloak>
         <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
@@ -660,9 +660,9 @@ function catalogPage() {
 }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
-<script src="/static/js/lineage.js?v=1744500000"></script>
+<script src="{{ static_url('js/lineage.js') }}"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/languages/sql.min.js"></script>
-<script src="/static/js/catalog.js?v=1744500000"></script>
+<script src="{{ static_url('js/catalog.js') }}"></script>
 {% endblock %}

--- a/dango/web/templates/dashboard.html
+++ b/dango/web/templates/dashboard.html
@@ -218,7 +218,7 @@
 
 {% block scripts %}
     <!-- JavaScript -->
-    <script src="/static/js/app.js?v=1763651648"></script>
+    <script src="{{ static_url('js/app.js') }}"></script>
     <script>
     function initialSyncProgress() {
         return {

--- a/dango/web/templates/logs.html
+++ b/dango/web/templates/logs.html
@@ -157,5 +157,5 @@
 
 {% block scripts %}
     <!-- JavaScript -->
-    <script src="/static/js/logs.js"></script>
+    <script src="{{ static_url('js/logs.js') }}"></script>
 {% endblock %}

--- a/dango/web/templates/models.html
+++ b/dango/web/templates/models.html
@@ -55,5 +55,5 @@
 {% endblock %}
 
 {% block scripts %}
-    <script src="/static/js/app.js?v=1763651648"></script>
+    <script src="{{ static_url('js/app.js') }}"></script>
 {% endblock %}

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -268,5 +268,5 @@
 {% endblock %}
 
 {% block scripts %}
-    <script src="/static/js/app.js?v=1763651648"></script>
+    <script src="{{ static_url('js/app.js') }}"></script>
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,6 +330,7 @@ module = [
     "tests.unit.test_byos",
     "tests.unit.test_driver_utils",
     "tests.unit.test_process_manager",
+    "tests.unit.test_static_cache_busting",
 ]
 ignore_errors = true
 

--- a/tests/unit/test_static_cache_busting.py
+++ b/tests/unit/test_static_cache_busting.py
@@ -4,7 +4,6 @@ Unit tests for static asset cache busting (BUG-066).
 """
 
 import hashlib
-from pathlib import Path
 
 import pytest
 
@@ -31,30 +30,20 @@ class TestStaticCacheBusting:
         assert url == "/static/js/does-not-exist.js"
         assert "?v=" not in url
 
-    def test_different_content_different_hash(self, tmp_path: Path) -> None:
-        """Different file content produces different MD5 hashes."""
-        file_a = tmp_path / "a.js"
-        file_b = tmp_path / "b.js"
-        file_a.write_text("console.log('hello');")
-        file_b.write_text("console.log('world');")
+    def test_different_files_have_different_hashes(self) -> None:
+        """Different static files with different content produce different hashes."""
+        from dango.web.routes.ui import _static_hashes
 
-        hash_a = hashlib.md5(file_a.read_bytes()).hexdigest()[:8]
-        hash_b = hashlib.md5(file_b.read_bytes()).hexdigest()[:8]
+        # css/main.css and js/app.js have vastly different content
+        assert _static_hashes["css/main.css"] != _static_hashes["js/app.js"]
 
-        assert hash_a != hash_b
+    def test_static_url_uses_hash_from_map(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """static_url() returns the hash stored in _static_hashes, not a recomputed one."""
+        import dango.web.routes.ui as ui_module
 
-    def test_same_content_same_hash(self, tmp_path: Path) -> None:
-        """Identical content always produces the same MD5 hash."""
-        content = "console.log('identical');"
-        file_a = tmp_path / "a.js"
-        file_b = tmp_path / "b.js"
-        file_a.write_text(content)
-        file_b.write_text(content)
-
-        hash_a = hashlib.md5(file_a.read_bytes()).hexdigest()[:8]
-        hash_b = hashlib.md5(file_b.read_bytes()).hexdigest()[:8]
-
-        assert hash_a == hash_b
+        monkeypatch.setitem(ui_module._static_hashes, "js/test.js", "deadbeef")
+        url = ui_module._static_url("js/test.js")
+        assert url == "/static/js/test.js?v=deadbeef"
 
     def test_hash_matches_actual_file_content(self) -> None:
         """Stored hashes match re-computing MD5 directly from each file."""

--- a/tests/unit/test_static_cache_busting.py
+++ b/tests/unit/test_static_cache_busting.py
@@ -1,0 +1,81 @@
+"""tests/unit/test_static_cache_busting.py
+
+Unit tests for static asset cache busting (BUG-066).
+"""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+class TestStaticCacheBusting:
+    """Verify MD5 content-based static URL generation."""
+
+    def test_static_url_returns_versioned_path(self) -> None:
+        """static_url() appends ?v=<8-hex-chars> for known files."""
+        from dango.web.routes.ui import _static_url
+
+        url = _static_url("css/main.css")
+        assert url.startswith("/static/css/main.css?v=")
+        hash_part = url.split("?v=")[1]
+        assert len(hash_part) == 8
+        assert all(c in "0123456789abcdef" for c in hash_part)
+
+    def test_static_url_unknown_file_no_version(self) -> None:
+        """static_url() returns bare /static/ path for unknown files."""
+        from dango.web.routes.ui import _static_url
+
+        url = _static_url("js/does-not-exist.js")
+        assert url == "/static/js/does-not-exist.js"
+        assert "?v=" not in url
+
+    def test_different_content_different_hash(self, tmp_path: Path) -> None:
+        """Different file content produces different MD5 hashes."""
+        file_a = tmp_path / "a.js"
+        file_b = tmp_path / "b.js"
+        file_a.write_text("console.log('hello');")
+        file_b.write_text("console.log('world');")
+
+        hash_a = hashlib.md5(file_a.read_bytes()).hexdigest()[:8]
+        hash_b = hashlib.md5(file_b.read_bytes()).hexdigest()[:8]
+
+        assert hash_a != hash_b
+
+    def test_same_content_same_hash(self, tmp_path: Path) -> None:
+        """Identical content always produces the same MD5 hash."""
+        content = "console.log('identical');"
+        file_a = tmp_path / "a.js"
+        file_b = tmp_path / "b.js"
+        file_a.write_text(content)
+        file_b.write_text(content)
+
+        hash_a = hashlib.md5(file_a.read_bytes()).hexdigest()[:8]
+        hash_b = hashlib.md5(file_b.read_bytes()).hexdigest()[:8]
+
+        assert hash_a == hash_b
+
+    def test_hash_matches_actual_file_content(self) -> None:
+        """Stored hashes match re-computing MD5 directly from each file."""
+        from dango.web.routes.ui import _static_dir, _static_hashes
+
+        for relative_path, stored_hash in _static_hashes.items():
+            expected = hashlib.md5((_static_dir / relative_path).read_bytes()).hexdigest()[:8]
+            assert stored_hash == expected, f"Hash mismatch for {relative_path}"
+
+    def test_all_served_static_files_are_hashed(self) -> None:
+        """All CSS and JS files referenced in templates are in the hash map."""
+        from dango.web.routes.ui import _static_hashes
+
+        expected = [
+            "css/tailwind.min.css",
+            "css/main.css",
+            "css/catalog.css",
+            "js/app.js",
+            "js/logs.js",
+            "js/lineage.js",
+            "js/catalog.js",
+        ]
+        for path in expected:
+            assert path in _static_hashes, f"Missing hash for {path}"


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `?v=TIMESTAMP` query strings in templates with MD5 content-based hashes computed at startup
- Adds `static_url()` as a Jinja2 global in `routes/ui.py` — no changes to `app.py`
- Fixes `logs.html` which had no version string at all
- 6 templates updated (9 total static asset references)
- 6 unit tests added, all passing; ruff + mypy clean

## Files changed

- `dango/web/routes/ui.py` — hash computation + Jinja2 global
- `dango/web/templates/base.html` — 2 refs (tailwind.min.css, main.css)
- `dango/web/templates/dashboard.html` — 1 ref (app.js)
- `dango/web/templates/sources.html` — 1 ref (app.js)
- `dango/web/templates/models.html` — 1 ref (app.js)
- `dango/web/templates/catalog.html` — 3 refs (catalog.css, lineage.js, catalog.js)
- `dango/web/templates/logs.html` — 1 ref (logs.js, was missing entirely)
- `tests/unit/test_static_cache_busting.py` — new test file
- `pyproject.toml` — mypy exemption for new test file

## Test plan

- [x] `pytest tests/unit/test_static_cache_busting.py -v` — 6/6 passed
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy dango/web/routes/ui.py` — clean
- [x] All pre-commit hooks passed
- [ ] Manual: `dango web dev` → view source → confirm `?v=<hash>` on all static refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)