### PR TITLE
R8-B: Fix Metabase Docker healthcheck and plugin uid mismatch (BUG-099/101/112)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2108 | — |
 | `visualization/metabase.py` | 1152 | — |
-| `cli/init.py` | 1323 | — |
+| `cli/init.py` | 1324 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 988 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2108 | — |
 | `visualization/metabase.py` | 1152 | — |
-| `cli/init.py` | 1301 | — |
+| `cli/init.py` | 1323 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 988 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -41,7 +41,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1301 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1323 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2097 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -41,7 +41,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1323 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1324 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2097 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -808,6 +808,7 @@ custom_sources/
         entrypoint_path = self.project_dir / "entrypoint.sh"
         with open(entrypoint_path, "w", encoding="utf-8") as f:
             f.write(entrypoint_content)
+        entrypoint_path.chmod(0o755)
 
         console.print("[green]✓[/green] Created entrypoint.sh")
 

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -801,6 +801,16 @@ custom_sources/
 
         console.print("[green]✓[/green] Created Dockerfile.metabase")
 
+        # Copy entrypoint.sh from templates (required by Dockerfile.metabase)
+        entrypoint_template = env.get_template("entrypoint.sh")
+        entrypoint_content = entrypoint_template.render()
+
+        entrypoint_path = self.project_dir / "entrypoint.sh"
+        with open(entrypoint_path, "w", encoding="utf-8") as f:
+            f.write(entrypoint_content)
+
+        console.print("[green]✓[/green] Created entrypoint.sh")
+
         # Create metabase-plugins directory
         plugins_dir = self.project_dir / "metabase-plugins"
         plugins_dir.mkdir(exist_ok=True)
@@ -1206,6 +1216,7 @@ on-run-end:
             "metabase-plugins",
             "docker-compose.yml",
             "Dockerfile.metabase",
+            "entrypoint.sh",
             "README.md",  # Only if created by us
             "COMPATIBILITY.md",
             "SCALABILITY.md",

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -56,6 +56,10 @@ SYNC_CONFIG_FILES: list[tuple[str, str]] = [
     (".dango/schedules.yml", f"{REMOTE_PROJECT_DIR}/.dango/schedules.yml"),
     ("dbt/dbt_project.yml", f"{REMOTE_PROJECT_DIR}/dbt/dbt_project.yml"),
     ("dbt/packages.yml", f"{REMOTE_PROJECT_DIR}/dbt/packages.yml"),
+    # Docker build context files — both required to build the Metabase image on the server
+    ("docker-compose.yml", f"{REMOTE_PROJECT_DIR}/docker-compose.yml"),
+    ("Dockerfile.metabase", f"{REMOTE_PROJECT_DIR}/Dockerfile.metabase"),
+    ("entrypoint.sh", f"{REMOTE_PROJECT_DIR}/entrypoint.sh"),
 ]
 
 #: Directories to sync via rsync (with ``--delete``).

--- a/dango/templates/CLAUDE.md
+++ b/dango/templates/CLAUDE.md
@@ -11,6 +11,7 @@ Jinja2 templates and Dockerfiles used by CLI project scaffolding and dbt model g
 | `__init__.py` | Package marker | — |
 | `docker-compose.yml.j2` | Jinja2 template for Docker Compose config | Rendered by `cli/init.py` |
 | `Dockerfile.metabase` | Metabase container image | Copied by `cli/init.py` |
+| `entrypoint.sh` | Metabase container entrypoint — fixes bind-mounted plugin dir ownership, drops to metabase user via gosu | Copied by `cli/init.py` |
 | `nginx.conf.j2` | Jinja2 template for nginx reverse proxy config | Not yet consumed (placeholder) |
 | `dbt/sources.yml.j2` | dbt source definition template | Rendered by `transformation/generator.py` |
 | `dbt/staging_model.sql.j2` | dbt staging model SQL template | Rendered by `transformation/generator.py` |
@@ -21,7 +22,7 @@ Jinja2 templates and Dockerfiles used by CLI project scaffolding and dbt model g
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
 | Change Docker Compose structure | `docker-compose.yml.j2` | `dango init` in a test project |
-| Change Metabase container setup | `Dockerfile.metabase` | `docker build -f Dockerfile.metabase .` |
+| Change Metabase container setup | `Dockerfile.metabase`, `entrypoint.sh` | `docker build -f Dockerfile.metabase .` |
 | Change generated dbt model SQL | `dbt/staging_model.sql.j2` | Manual: run `dango sync` and inspect output |
 | Change generated dbt schema | `dbt/staging_schema.yml.j2` | Manual: run `dango sync` and inspect output |
 | Add a new dbt template | `dbt/` + `transformation/generator.py` | Manual: run `dango sync` and inspect output |
@@ -32,7 +33,7 @@ Jinja2 templates and Dockerfiles used by CLI project scaffolding and dbt model g
 - None (templates are static files, no Python imports)
 
 **Used by:**
-- `cli/init.py` — renders `docker-compose.yml.j2` and copies `Dockerfile.metabase` during project scaffolding (via `jinja2.PackageLoader('dango', 'templates')`)
+- `cli/init.py` — renders `docker-compose.yml.j2`, copies `Dockerfile.metabase` and `entrypoint.sh` during project scaffolding (via `jinja2.PackageLoader('dango', 'templates')`)
 - `transformation/generator.py` — renders `dbt/*.j2` templates for dbt model generation (via `jinja2.FileSystemLoader`)
 
 ## Testing

--- a/dango/templates/Dockerfile.metabase
+++ b/dango/templates/Dockerfile.metabase
@@ -37,5 +37,6 @@ RUN mkdir -p /metabase-data && chown -R metabase:metabase /metabase-data
 EXPOSE 3000
 
 # Entrypoint: fix bind-mounted plugin dir ownership, then drop to metabase user
-COPY --chmod=755 entrypoint.sh /app/entrypoint.sh
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod 755 /app/entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/dango/templates/Dockerfile.metabase
+++ b/dango/templates/Dockerfile.metabase
@@ -13,6 +13,9 @@ ENV MB_VERSION=v0.59.1
 USER root
 WORKDIR /app
 
+# Install curl (healthcheck) and gosu (entrypoint privilege dropping)
+RUN apt-get update && apt-get install -y --no-install-recommends curl gosu && rm -rf /var/lib/apt/lists/*
+
 # Download Metabase jar
 ADD https://downloads.metabase.com/${MB_VERSION}/metabase.jar /app/metabase.jar
 
@@ -30,11 +33,9 @@ RUN mkdir -p /home/metabase && chown -R metabase:metabase /home/metabase
 # Create and set permissions for metabase-data directory (H2 database location)
 RUN mkdir -p /metabase-data && chown -R metabase:metabase /metabase-data
 
-# Switch to metabase user
-USER metabase
-
 # Expose port
 EXPOSE 3000
 
-# Run Metabase
-CMD ["java", "-jar", "/app/metabase.jar"]
+# Entrypoint: fix bind-mounted plugin dir ownership, then drop to metabase user
+COPY --chmod=755 entrypoint.sh /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/dango/templates/docker-compose.yml.j2
+++ b/dango/templates/docker-compose.yml.j2
@@ -25,8 +25,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 60s
+      retries: 5
+      start_period: 300s
     restart: unless-stopped
 
   # dbt Docs - Documentation Server

--- a/dango/templates/entrypoint.sh
+++ b/dango/templates/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Fix permissions on bind-mounted plugins directory
+# Host dir may be owned by a different uid than container's metabase user
+chown -R metabase:metabase /app/plugins 2>/dev/null || true
+
+# Drop privileges and run Metabase
+exec gosu metabase java -jar /app/metabase.jar "$@"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -154,7 +154,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1323
+    lines: 1324
     category: exempt
     reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -154,7 +154,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1301
+    lines: 1323
     category: exempt
     reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary

- **BUG-099:** Healthcheck used `curl` (not installed in Eclipse Temurin image) with `start_period: 60s` — too short for Metabase's ~4 min startup, causing restart loops. Fixed: installed `curl` in Dockerfile; increased `start_period` to `300s`, `retries` to `5`.
- **BUG-101:** Bind-mounted `metabase-plugins/` owned by host uid 1000; container `metabase` user is uid 999, blocking DuckDB driver load. Fixed: added `entrypoint.sh` — runs as root, `chown`s plugins dir to `metabase:metabase`, then drops privileges via `gosu` before starting Java. H2 database ownership unaffected.
- **BUG-112:** Any manual docker-compose.yml fix was overwritten by `dango serve` regenerating from template. Fixed: changes are in the base template, no override needed.

## Changes

- `dango/templates/Dockerfile.metabase` — install `curl` + `gosu`; remove `USER metabase` and `CMD`; add `ENTRYPOINT`
- `dango/templates/entrypoint.sh` (new) — fix plugin dir ownership, drop to metabase user via gosu
- `dango/templates/docker-compose.yml.j2` — `start_period: 300s`, `retries: 5`
- `dango/cli/init.py` — copy `entrypoint.sh` to project dir during `dango init`; add to rollback cleanup
- `dango/templates/CLAUDE.md` — document `entrypoint.sh`
- `CLAUDE.md`, `dango/cli/CLAUDE.md`, `docs/file-exemptions.yml` — update `init.py` line count 1301 → 1323

## Test plan

- [ ] `dango init` in a test project — verify both `Dockerfile.metabase` and `entrypoint.sh` are created
- [ ] `docker compose build` — verify image builds cleanly with curl and gosu installed
- [ ] `docker compose up -d metabase` — verify container starts, healthcheck passes after ~4 min, container shows healthy
- [ ] Confirm DuckDB driver loads (check Metabase admin → Databases)
- [ ] `dango init` rollback path — verify `entrypoint.sh` is cleaned up on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)