### PR TITLE
R8-D: Fix apt lock contention and Metabase container detection

### DIFF
--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -140,8 +140,9 @@ def _setup_apt_packages(
     _notify(on_progress, step, "running")
     _run_checked(
         ssh,
-        "DEBIAN_FRONTEND=noninteractive apt-get update -qq"
-        " && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq"
+        "add-apt-repository -y universe 2>/dev/null || true"
+        " && DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 update -qq"
+        " && DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -qq"
         " python3-pip python3-venv fail2ban unattended-upgrades"
         " logrotate curl",
         step=step,

--- a/dango/platform/cloud/server_status.py
+++ b/dango/platform/cloud/server_status.py
@@ -196,9 +196,16 @@ def _get_services(ssh: Any) -> list[ServiceInfo]:
             status = "not-found"
         services.append(ServiceInfo(name=unit, status=status))
 
-    # Metabase runs as a Docker container
-    result = ssh.exec_command("docker inspect -f '{{.State.Status}}' metabase 2>/dev/null")
-    status = result.stdout.strip() if result.success and result.stdout.strip() else "not-found"
+    # Metabase runs as a Docker container — use docker ps with name filter
+    # to match Compose v2 naming (e.g. dango-project-metabase-1)
+    result = ssh.exec_command(
+        "docker ps --filter 'name=metabase' --format '{{.Status}}' 2>/dev/null"
+    )
+    raw = result.stdout.strip() if result.success else ""
+    if raw:
+        status = "running" if raw.lower().startswith("up") else "stopped"
+    else:
+        status = "not-found"
     services.append(ServiceInfo(name="metabase", status=status))
 
     return services

--- a/dango/platform/cloud/server_status.py
+++ b/dango/platform/cloud/server_status.py
@@ -199,7 +199,7 @@ def _get_services(ssh: Any) -> list[ServiceInfo]:
     # Metabase runs as a Docker container — use docker ps with name filter
     # to match Compose v2 naming (e.g. dango-project-metabase-1)
     result = ssh.exec_command(
-        "docker ps --filter 'name=metabase' --format '{{.Status}}' 2>/dev/null"
+        "docker ps -a --filter 'name=metabase' --format '{{.Status}}' 2>/dev/null"
     )
     raw = result.stdout.strip() if result.success else ""
     if raw:

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -225,7 +225,7 @@ class TestSetupServer:
 
         ssh = _make_ssh_mock(
             exec_results={
-                "apt-get": ("", "apt lock held", 100),
+                "apt-get -o DPkg": ("", "apt lock held", 100),
             }
         )
 

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -225,7 +225,7 @@ class TestSetupServer:
 
         ssh = _make_ssh_mock(
             exec_results={
-                "apt-get update": ("", "apt lock held", 100),
+                "apt-get": ("", "apt lock held", 100),
             }
         )
 
@@ -249,9 +249,12 @@ class TestSetupSteps:
         _setup_apt_packages(ssh, result, None)
 
         cmd = ssh.exec_command.call_args_list[0][0][0]
-        assert "apt-get update" in cmd
-        assert "apt-get install" in cmd
+        assert "apt-get" in cmd
+        assert "update" in cmd
+        assert "install" in cmd
         assert "fail2ban" in cmd
+        assert "universe" in cmd
+        assert "DPkg::Lock::Timeout=120" in cmd
         assert "apt_packages" in result.steps_completed
 
     def test_dango_user_created(self):

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -120,6 +120,16 @@ class TestCollectServerStatus:
         assert status.services[1] == ServiceInfo(name="caddy", status="active")
         assert status.services[2] == ServiceInfo(name="metabase", status="running")
 
+    def test_metabase_stopped_reports_stopped(self):
+        """Exited Metabase container is reported as stopped, not not-found."""
+        responses = {
+            "docker ps": _make_result(stdout="Exited (0) 5 minutes ago"),
+        }
+        ssh = _make_ssh(responses)
+        status = collect_server_status(ssh, _make_cloud_config())
+        metabase = [s for s in status.services if s.name == "metabase"][0]
+        assert metabase.status == "stopped"
+
     def test_parses_duckdb_size(self):
         """DuckDB size in bytes is parsed from stat output."""
         responses = {

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -111,7 +111,7 @@ class TestCollectServerStatus:
         responses = {
             "systemctl is-active dango-web": _make_result(stdout="active"),
             "systemctl is-active caddy": _make_result(stdout="active"),
-            "docker inspect": _make_result(stdout="running"),
+            "docker ps": _make_result(stdout="Up 2 hours"),
         }
         ssh = _make_ssh(responses)
         status = collect_server_status(ssh, _make_cloud_config())


### PR DESCRIPTION
## Summary
- **BUG-097:** Add `universe` repo and `DPkg::Lock::Timeout=120` to apt commands in `server_setup.py` — fixes failures on fresh Ubuntu 22.04 droplets where `cloud-init` holds the dpkg lock and `fail2ban` requires the `universe` repository.
- **BUG-109:** Replace `docker inspect metabase` with `docker ps --filter 'name=metabase'` in `server_status.py` — fixes Metabase detection under Docker Compose v2 naming (`dango-project-metabase-1`).

## Test plan
- [x] `pytest tests/unit/test_server_setup.py tests/unit/test_server_status.py -v` — 45/45 pass
- [ ] Verify on next cloud deploy that apt packages install without lock errors
- [ ] Verify `dango remote status` correctly detects Metabase container

🤖 Generated with [Claude Code](https://claude.com/claude-code)