### PR TITLE
R8-E: Fix 8 non-deploy bugs from Phase 8 testing

### DIFF
--- a/dango/auth/sessions.py
+++ b/dango/auth/sessions.py
@@ -24,8 +24,8 @@ from dango.auth.models import APIKey, Session, User
 # Default timeout constants (overridable per-call)
 # ---------------------------------------------------------------------------
 
-DEFAULT_IDLE_TIMEOUT_MINUTES: int = 1440
-"""Idle timeout — invalidate session after this many minutes of inactivity (24h for local)."""
+DEFAULT_IDLE_TIMEOUT_MINUTES: int = 10080
+"""Idle timeout — invalidate session after this many minutes of inactivity (7 days for local)."""
 
 DEFAULT_SESSION_MAX_DAYS: int = 365
 """Absolute timeout — session expires this many days after creation (1 year for local)."""

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -512,6 +512,15 @@ def _destroy_do(
             raise SystemExit(1)
 
     # --- Delete resources ---
+    import os
+
+    if not os.environ.get("DIGITALOCEAN_TOKEN"):
+        console.print("[yellow]DIGITALOCEAN_TOKEN environment variable not set.[/yellow]")
+        token = click.prompt("Enter your DigitalOcean API token", hide_input=True)
+        if not token.strip():
+            raise SystemExit(1)
+        os.environ["DIGITALOCEAN_TOKEN"] = token.strip()
+
     from dango.platform.cloud.digitalocean import DigitalOceanClient
 
     client = DigitalOceanClient()

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -553,6 +553,10 @@ def _create_admin_and_enable_auth(
         timeout=15,
     )
 
+    # Ensure the entire .dango/ directory is owned by the dango user so it can
+    # create files like dbt.lock in .dango/state/ at runtime.
+    ssh.exec_command("chown -R dango:dango /srv/dango/project/.dango")
+
     return deploy_token
 
 

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -75,14 +75,16 @@ def _step_prereqs(project_root: Path) -> None:
     # Check DIGITALOCEAN_TOKEN
     token = os.environ.get("DIGITALOCEAN_TOKEN")
     if not token:
-        console.print("[red]Error:[/red] DIGITALOCEAN_TOKEN environment variable not set.")
+        console.print("[yellow]DIGITALOCEAN_TOKEN environment variable not set.[/yellow]")
         console.print(
             "\n  Create an API token at: "
             "[link=https://cloud.digitalocean.com/account/api/tokens]"
-            "https://cloud.digitalocean.com/account/api/tokens[/link]"
+            "https://cloud.digitalocean.com/account/api/tokens[/link]\n"
         )
-        console.print("  Then: [bold]export DIGITALOCEAN_TOKEN=your_token[/bold]\n")
-        raise SystemExit(1)
+        token = click.prompt("Enter your DigitalOcean API token", hide_input=True)
+        if not token.strip():
+            raise SystemExit(1)
+        os.environ["DIGITALOCEAN_TOKEN"] = token.strip()
 
     # Check project has sources
     sources_yml = project_root / ".dango" / "sources.yml"

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -55,40 +55,37 @@ def _get_analyzer() -> Any | None:
     try:
         spacy.load(_SPACY_MODEL)
     except OSError:
-        # Fallback 1: spacy.cli.download
-        try:
-            spacy.cli.download(_SPACY_MODEL)  # type: ignore[attr-defined]
-        except Exception:
-            # Fallback 2: download .whl to temp file then pip install locally
-            # (pip 25.2+ can't download from GitHub Releases redirect URLs directly)
-            import os
-            import subprocess
-            import sys
-            import tempfile
-            import urllib.request
+        # Download .whl to temp file then pip install locally.
+        # spacy.cli.download() is NOT used — it calls sys.exit() internally,
+        # which raises SystemExit (BaseException) and kills the process.
+        import os
+        import subprocess
+        import sys
+        import tempfile
+        import urllib.request
 
+        try:
+            whl_name = _SPACY_MODEL_URL.rsplit("/", 1)[-1]
+            whl_path = os.path.join(tempfile.gettempdir(), whl_name)
             try:
-                whl_name = _SPACY_MODEL_URL.rsplit("/", 1)[-1]
-                whl_path = os.path.join(tempfile.gettempdir(), whl_name)
-                try:
-                    urllib.request.urlretrieve(_SPACY_MODEL_URL, whl_path)
-                    subprocess.check_call(
-                        [sys.executable, "-m", "pip", "install", whl_path],
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                    )
-                finally:
-                    try:
-                        os.unlink(whl_path)
-                    except OSError:
-                        pass
-            except Exception:
-                logger.warning(
-                    "pii_spacy_download_failed",
-                    model=_SPACY_MODEL,
-                    hint="Install manually: python -m spacy download en_core_web_sm",
+                urllib.request.urlretrieve(_SPACY_MODEL_URL, whl_path)
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", whl_path],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                 )
-                return None
+            finally:
+                try:
+                    os.unlink(whl_path)
+                except OSError:
+                    pass
+        except Exception:
+            logger.warning(
+                "pii_spacy_download_failed",
+                model=_SPACY_MODEL,
+                hint="Install manually: python -m spacy download en_core_web_sm",
+            )
+            return None
 
     # Suppress verbose Presidio + spaCy loggers during init (use alias to
     # avoid shadowing structlog).  Temporarily raise root logger to ERROR so

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -5,12 +5,13 @@ Source sync trigger endpoint, background sync task, and remote sync trigger API.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from dango.auth.audit import AuditEvent, log_auth_event
@@ -46,9 +47,7 @@ router = APIRouter(tags=["sync"])
 
 
 @router.post("/api/sources/{source_name}/sync", response_model=SyncResponse)
-async def trigger_sync(
-    source_name: str, sync_request: SyncRequest, background_tasks: BackgroundTasks
-) -> SyncResponse:
+async def trigger_sync(source_name: str, sync_request: SyncRequest) -> SyncResponse:
     """Trigger sync for a specific source.
 
     Args:
@@ -71,13 +70,15 @@ async def trigger_sync(
     if not source_exists:
         raise HTTPException(status_code=404, detail=f"Source '{source_name}' not found")
 
-    # Start sync in background
-    background_tasks.add_task(
-        run_sync_task,
-        source_name,
-        sync_request.full_refresh,
-        sync_request.start_date,
-        sync_request.end_date,
+    # Start sync in background — use asyncio.ensure_future so the async
+    # coroutine runs on the event loop (WebSocket broadcasts work correctly).
+    asyncio.ensure_future(
+        run_sync_task(
+            source_name,
+            sync_request.full_refresh,
+            sync_request.start_date,
+            sync_request.end_date,
+        )
     )
 
     # Broadcast sync started event via WebSocket
@@ -402,7 +403,6 @@ async def run_sync_task(
 async def trigger_manual_sync(
     request: Request,
     body: SyncTriggerRequest,
-    background_tasks: BackgroundTasks,
     user: User = Depends(require_permission("source.sync")),
 ) -> JSONResponse:
     """Trigger a manual sync for one or more sources with execution history tracking.
@@ -442,15 +442,17 @@ async def trigger_manual_sync(
     db_path = get_scheduler_db_path(project_root)
     job_id = record_start(db_path, "manual", sources=body.sources)
 
-    # Launch background sync
-    background_tasks.add_task(
-        _run_manual_sync,
-        project_root,
-        body.sources,
-        body.full_refresh,
-        backfill_days,
-        job_id,
-        db_path,
+    # Launch background sync — use asyncio.ensure_future so the async
+    # coroutine runs on the event loop (WebSocket broadcasts work correctly).
+    asyncio.ensure_future(
+        _run_manual_sync(
+            project_root,
+            body.sources,
+            body.full_refresh,
+            backfill_days,
+            job_id,
+            db_path,
+        )
     )
 
     # Audit log

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -70,9 +70,9 @@ async def trigger_sync(source_name: str, sync_request: SyncRequest) -> SyncRespo
     if not source_exists:
         raise HTTPException(status_code=404, detail=f"Source '{source_name}' not found")
 
-    # Start sync in background — use asyncio.ensure_future so the async
+    # Start sync in background — use asyncio.create_task so the async
     # coroutine runs on the event loop (WebSocket broadcasts work correctly).
-    asyncio.ensure_future(
+    asyncio.create_task(
         run_sync_task(
             source_name,
             sync_request.full_refresh,
@@ -442,9 +442,9 @@ async def trigger_manual_sync(
     db_path = get_scheduler_db_path(project_root)
     job_id = record_start(db_path, "manual", sources=body.sources)
 
-    # Launch background sync — use asyncio.ensure_future so the async
+    # Launch background sync — use asyncio.create_task so the async
     # coroutine runs on the event loop (WebSocket broadcasts work correctly).
-    asyncio.ensure_future(
+    asyncio.create_task(
         _run_manual_sync(
             project_root,
             body.sources,

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -208,8 +208,23 @@ async def custom_redoc_html() -> HTMLResponse:
 @router.get("/login")
 async def login_page(request: Request) -> Response:
     """Render the login page."""
-    if getattr(request.state, "user", None):
-        return RedirectResponse(url="/", status_code=302)
+    # /login is a public route (skips auth middleware), so request.state.user
+    # is always None.  Validate the session cookie directly to redirect
+    # already-authenticated users back to the home page.
+    try:
+        from dango.auth.admin import get_auth_db_path, is_auth_enabled
+
+        project_root = request.app.state.project_root
+        if is_auth_enabled(project_root):
+            token = request.cookies.get("dango_session")
+            if token:
+                from dango.auth.sessions import validate_session
+
+                user = validate_session(get_auth_db_path(project_root), token)
+                if user is not None:
+                    return RedirectResponse(url="/", status_code=302)
+    except Exception:
+        pass  # Fall through to login page on any error
     oauth_providers: list[dict[str, str]] = []
     try:
         from dango.auth.oauth_login import get_configured_providers

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -137,6 +137,8 @@
                 <a href="/settings/users" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">User Management</a>
                 <a href="/settings/secrets" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Secrets & Credentials</a>
                 {% endif %}
+                <a href="/logs" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white{% if current_page == 'logs' %} font-semibold{% endif %}">Activity Logs</a>
+                <a href="/health" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white{% if current_page == 'health' %} font-semibold{% endif %}">Health</a>
                 <button @click="fetch('/api/auth/logout', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}}).then(() => window.location.href = '/login').catch(() => window.location.href = '/login')" class="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-red-400 hover:bg-gray-700 hover:text-red-300">Logout</button>
             </div>
             {% endif %}

--- a/tests/unit/test_deploy_destroy.py
+++ b/tests/unit/test_deploy_destroy.py
@@ -7,6 +7,7 @@ Uses Click's CliRunner with mocked DigitalOcean/SSH clients.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -82,6 +83,7 @@ def _run(args, tmp_path, input_text=None, catch_exceptions=False):
 
 
 @pytest.mark.unit
+@patch.dict(os.environ, {"DIGITALOCEAN_TOKEN": "test-token"})
 class TestDestroyConfirmation:
     def test_must_type_ip_to_confirm(self, tmp_path):
         """Destroy requires typing the droplet IP to confirm."""
@@ -159,6 +161,7 @@ class TestDestroyConfirmation:
 
 
 @pytest.mark.unit
+@patch.dict(os.environ, {"DIGITALOCEAN_TOKEN": "test-token"})
 class TestDestroyResourceDeletion:
     def test_deletes_droplet(self, tmp_path):
         """Destroy deletes the droplet."""
@@ -278,6 +281,7 @@ class TestDestroyResourceDeletion:
 
 
 @pytest.mark.unit
+@patch.dict(os.environ, {"DIGITALOCEAN_TOKEN": "test-token"})
 class TestDestroyWithSpaces:
     def test_deletes_spaces_bucket(self, tmp_path):
         """Destroy empties and deletes the Spaces bucket."""
@@ -335,6 +339,7 @@ class TestDestroyWithSpaces:
 
 
 @pytest.mark.unit
+@patch.dict(os.environ, {"DIGITALOCEAN_TOKEN": "test-token"})
 class TestDestroySSHKeyFallback:
     def test_fallback_to_fingerprint_match(self, tmp_path):
         """When ssh_key_id is None, falls back to fingerprint matching."""

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -220,6 +220,20 @@ class TestAdminCreation:
                 found = True
         assert found, "auth.yml write not found"
 
+    def test_dango_dir_chowned_recursively(self):
+        """After admin creation, .dango/ is recursively chowned to dango user."""
+        ssh = _make_mock_ssh()
+        _create_admin_and_enable_auth(ssh, "admin@test.com", "password123")
+
+        chown_calls = [
+            str(c)
+            for c in ssh.exec_command.call_args_list
+            if "chown -R dango:dango /srv/dango/project/.dango" in str(c)
+        ]
+        assert len(chown_calls) >= 1, (
+            "Expected chown -R dango:dango /srv/dango/project/.dango in SSH calls"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 5. Health check

--- a/tests/unit/test_deploy_wizard.py
+++ b/tests/unit/test_deploy_wizard.py
@@ -39,11 +39,23 @@ def project_root(tmp_path):
 
 @pytest.mark.unit
 class TestPrereqCheck:
-    def test_missing_do_token(self, project_root, monkeypatch):
-        """Missing DIGITALOCEAN_TOKEN raises SystemExit."""
+    def test_missing_do_token_prompts_user(self, project_root, monkeypatch):
+        """Missing DIGITALOCEAN_TOKEN prompts interactively."""
         monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
-        with pytest.raises(SystemExit):
+        with patch("dango.cli.commands.deploy_wizard.click.prompt", return_value="dop_test123"):
             _step_prereqs(project_root)
+        import os
+
+        assert os.environ.get("DIGITALOCEAN_TOKEN") == "dop_test123"
+        # Cleanup
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+    def test_missing_do_token_empty_input_exits(self, project_root, monkeypatch):
+        """Empty token input raises SystemExit."""
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+        with patch("dango.cli.commands.deploy_wizard.click.prompt", return_value=""):
+            with pytest.raises(SystemExit):
+                _step_prereqs(project_root)
 
     def test_missing_sources_yml(self, tmp_path, monkeypatch):
         """Missing sources.yml raises SystemExit."""

--- a/tests/unit/test_pii_detection.py
+++ b/tests/unit/test_pii_detection.py
@@ -96,49 +96,11 @@ class TestGetAnalyzer:
                 del sys.modules["spacy"]
 
     def test_download_fallback(self) -> None:
+        """On OSError, downloads .whl via urllib and pip installs it."""
         import sys
 
         mock_spacy = MagicMock()
         mock_spacy.load.side_effect = OSError("Model not found")
-        mock_analyzer = MagicMock()
-        mock_provider = MagicMock()
-        mock_provider.create_engine.return_value = MagicMock()
-        sys.modules["spacy"] = mock_spacy
-        try:
-            with (
-                patch(f"{_PII}._analyzer", None),
-                patch("presidio_analyzer.AnalyzerEngine", return_value=mock_analyzer),
-                patch("presidio_analyzer.nlp_engine.NlpEngineProvider", return_value=mock_provider),
-            ):
-                result = _get_analyzer()
-                mock_spacy.cli.download.assert_called_once_with("en_core_web_sm")
-                assert result is mock_analyzer
-        finally:
-            del sys.modules["spacy"]
-
-    def test_returns_none_on_download_failure(self) -> None:
-        import sys
-
-        mock_spacy = MagicMock()
-        mock_spacy.load.side_effect = OSError("Model not found")
-        mock_spacy.cli.download.side_effect = RuntimeError("download failed")
-        sys.modules["spacy"] = mock_spacy
-        try:
-            with (
-                patch(f"{_PII}._analyzer", None),
-                patch("subprocess.check_call", side_effect=RuntimeError("pip failed")),
-            ):
-                result = _get_analyzer()
-                assert result is None
-        finally:
-            del sys.modules["spacy"]
-
-    def test_url_fallback_on_cli_download_failure(self) -> None:
-        import sys
-
-        mock_spacy = MagicMock()
-        mock_spacy.load.side_effect = OSError("Model not found")
-        mock_spacy.cli.download.side_effect = RuntimeError("cli download failed")
         mock_analyzer = MagicMock()
         mock_provider = MagicMock()
         mock_provider.create_engine.return_value = MagicMock()
@@ -154,8 +116,28 @@ class TestGetAnalyzer:
                 ),
             ):
                 result = _get_analyzer()
+                # spacy.cli.download is NOT called (removed: it calls sys.exit)
+                mock_spacy.cli.download.assert_not_called()
+                # urllib + pip install fallback used instead
                 mock_pip.assert_called_once()
                 assert result is mock_analyzer
+        finally:
+            del sys.modules["spacy"]
+
+    def test_returns_none_on_download_failure(self) -> None:
+        """Returns None when urllib/pip download also fails."""
+        import sys
+
+        mock_spacy = MagicMock()
+        mock_spacy.load.side_effect = OSError("Model not found")
+        sys.modules["spacy"] = mock_spacy
+        try:
+            with (
+                patch(f"{_PII}._analyzer", None),
+                patch("subprocess.check_call", side_effect=RuntimeError("pip failed")),
+            ):
+                result = _get_analyzer()
+                assert result is None
         finally:
             del sys.modules["spacy"]
 

--- a/tests/unit/test_r8e_bugfixes.py
+++ b/tests/unit/test_r8e_bugfixes.py
@@ -81,14 +81,14 @@ class TestLoginRedirect:
 
 
 # ---------------------------------------------------------------------------
-# BUG-107: Sync endpoint uses asyncio.ensure_future
+# BUG-107: Sync endpoint uses asyncio.create_task
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestSyncAsyncio:
-    def test_trigger_sync_uses_ensure_future(self) -> None:
-        """trigger_sync should use asyncio.ensure_future, not BackgroundTasks."""
+    def test_trigger_sync_uses_create_task(self) -> None:
+        """trigger_sync should use asyncio.create_task, not BackgroundTasks."""
         # Verify that BackgroundTasks is not imported in the module
         import inspect
 
@@ -96,17 +96,17 @@ class TestSyncAsyncio:
 
         source = inspect.getsource(sync_module.trigger_sync)
         assert "background_tasks" not in source
-        assert "ensure_future" in source
+        assert "create_task" in source
 
-    def test_trigger_manual_sync_uses_ensure_future(self) -> None:
-        """trigger_manual_sync should use asyncio.ensure_future, not BackgroundTasks."""
+    def test_trigger_manual_sync_uses_create_task(self) -> None:
+        """trigger_manual_sync should use asyncio.create_task, not BackgroundTasks."""
         import inspect
 
         from dango.web.routes import sync as sync_module
 
         source = inspect.getsource(sync_module.trigger_manual_sync)
         assert "background_tasks" not in source
-        assert "ensure_future" in source
+        assert "create_task" in source
 
     def test_no_background_tasks_import(self) -> None:
         """sync.py should not import BackgroundTasks at all."""

--- a/tests/unit/test_r8e_bugfixes.py
+++ b/tests/unit/test_r8e_bugfixes.py
@@ -1,0 +1,115 @@
+"""tests/unit/test_r8e_bugfixes.py
+
+Unit tests for R8-E bug fixes (BUG-054, BUG-083, BUG-107).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# BUG-083: Session idle timeout changed to 7 days
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIdleTimeoutDefault:
+    def test_default_idle_timeout_is_7_days(self) -> None:
+        """DEFAULT_IDLE_TIMEOUT_MINUTES should be 10080 (7 days)."""
+        from dango.auth.sessions import DEFAULT_IDLE_TIMEOUT_MINUTES
+
+        assert DEFAULT_IDLE_TIMEOUT_MINUTES == 10080
+
+
+# ---------------------------------------------------------------------------
+# BUG-054: Login page redirects authenticated users
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoginRedirect:
+    @staticmethod
+    def _run_coro(coro: Any) -> Any:
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_login_redirects_authenticated_user(self) -> None:
+        """login_page() redirects to / when a valid session cookie exists."""
+        mock_user = MagicMock()
+        mock_user.id = "user-1"
+
+        mock_request = MagicMock()
+        mock_request.cookies = {"dango_session": "fake-valid-token"}
+        mock_request.app.state.project_root = "/tmp/test-project"
+
+        with (
+            patch("dango.auth.admin.is_auth_enabled", return_value=True),
+            patch("dango.auth.admin.get_auth_db_path", return_value="/tmp/.dango/auth.db"),
+            patch("dango.auth.sessions.validate_session", return_value=mock_user),
+        ):
+            from dango.web.routes.ui import login_page
+
+            response = self._run_coro(login_page(mock_request))
+            assert response.status_code == 302
+            assert response.headers["location"] == "/"
+
+    def test_login_renders_when_no_session(self) -> None:
+        """login_page() renders login page when no session cookie is present."""
+        mock_request = MagicMock()
+        mock_request.cookies = {}
+        mock_request.app.state.project_root = "/tmp/test-project"
+        mock_request.state.user = None
+
+        with (
+            patch("dango.auth.admin.is_auth_enabled", return_value=True),
+            patch("dango.web.routes.ui._render_template") as mock_render,
+        ):
+            mock_render.return_value = MagicMock(status_code=200)
+
+            from dango.web.routes.ui import login_page
+
+            response = self._run_coro(login_page(mock_request))
+            assert response.status_code == 200
+            mock_render.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# BUG-107: Sync endpoint uses asyncio.ensure_future
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSyncAsyncio:
+    def test_trigger_sync_uses_ensure_future(self) -> None:
+        """trigger_sync should use asyncio.ensure_future, not BackgroundTasks."""
+        # Verify that BackgroundTasks is not imported in the module
+        import inspect
+
+        from dango.web.routes import sync as sync_module
+
+        source = inspect.getsource(sync_module.trigger_sync)
+        assert "background_tasks" not in source
+        assert "ensure_future" in source
+
+    def test_trigger_manual_sync_uses_ensure_future(self) -> None:
+        """trigger_manual_sync should use asyncio.ensure_future, not BackgroundTasks."""
+        import inspect
+
+        from dango.web.routes import sync as sync_module
+
+        source = inspect.getsource(sync_module.trigger_manual_sync)
+        assert "background_tasks" not in source
+        assert "ensure_future" in source
+
+    def test_no_background_tasks_import(self) -> None:
+        """sync.py should not import BackgroundTasks at all."""
+        from dango.web.routes import sync as sync_module
+
+        assert not hasattr(sync_module, "BackgroundTasks")


### PR DESCRIPTION
## Summary
- **BUG-083:** Session idle timeout increased from 24h to 7 days for local deployments
- **BUG-065:** Added Activity Logs and Health links to mobile hamburger menu
- **BUG-027b:** Removed spaCy `cli.download()` fallback that calls `sys.exit()` — goes straight to urllib `.whl` download
- **BUG-054:** `/login` now redirects already-authenticated users to `/` via direct cookie validation
- **BUG-094/094b:** `dango deploy` and `dango deploy destroy` interactively prompt for DO token when `DIGITALOCEAN_TOKEN` is unset
- **BUG-106:** `chown -R dango:dango /srv/dango/project/.dango` after deploy provision to fix root ownership
- **BUG-107:** Sync endpoints use `asyncio.ensure_future()` instead of `BackgroundTasks` so WebSocket broadcasts fire correctly

## Test plan
- [x] All 2993 unit tests pass (`pytest tests/unit/ -x`)
- [x] New test file `tests/unit/test_r8e_bugfixes.py` covers BUG-054, BUG-083, BUG-107
- [x] Updated existing tests for deploy wizard, deploy destroy, deploy provision, PII detection
- [x] `ruff check` and `ruff format --check` pass
- [x] All pre-commit hooks pass (mypy, file-size, docstrings, headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)