### PR TITLE
R8-I: Fix OAuth/credential UX bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ dango/                          # Python package source
 │   │   ├── __init__.py         # Package marker
 │   │   ├── auth.py             # auth group (13 subcommands, 660 lines)
 │   │   ├── cleanup.py          # cleanup old logs, dbt artifacts, Python cache
-│   │   ├── oauth.py            # oauth group + 10 subcommands (812 lines)
+│   │   ├── oauth.py            # oauth group + 10 subcommands (813 lines)
 │   │   ├── config_cmd.py       # config group (validate/show)
 │   │   ├── dashboard.py        # dashboard group (provision)
 │   │   ├── data.py             # db group (status/clean) + validate
@@ -339,7 +339,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 988 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
-| `cli/commands/oauth.py` | 812 | — (renamed from auth.py by TASK-093) |
+| `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 810 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 766 | — |
 | `platform/scheduling/jobs.py` | 839 | — (module-level job functions) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -17,7 +17,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/platform.py` (988 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
-| `commands/oauth.py` (812 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
+| `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
 | `commands/transform.py` (326 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
 | `commands/upgrade.py` (236 lines) | `upgrade` command — local Dango upgrade via pip + migrations | `upgrade()`, `get_latest_version_cached()` |
 | `commands/data.py` (360 lines) | `db` group (`status`, `clean`) + `validate` | `db`, `validate()` |

--- a/dango/cli/commands/oauth.py
+++ b/dango/cli/commands/oauth.py
@@ -764,7 +764,7 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
                 masked = current_value[:8] + "..." if len(current_value) > 8 else "***"
                 console.print(f"  [dim]Current {display_name}: {masked}[/dim]")
 
-            value = click.prompt(display_name, default="", show_default=False)
+            value = click.prompt(display_name, default="", show_default=False).strip()
             if not value:
                 if current_value:
                     console.print("  [dim]Keeping existing value[/dim]")

--- a/dango/cli/commands/oauth.py
+++ b/dango/cli/commands/oauth.py
@@ -359,9 +359,11 @@ def oauth_google_sheets(ctx: click.Context) -> None:
             console.print("[red]Authentication failed[/red]")
             raise click.Abort()
 
-        console.print("\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,")
-        console.print("refresh tokens expire after 7 days. Publish your app for production use.")
-        console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
+        console.print(
+            "\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,\n"
+            "refresh tokens expire after 7 days. Publish your app for production use.\n"
+            f"See: {escape('https://console.cloud.google.com/apis/credentials/consent')}[/dim]"
+        )
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {escape(str(e))}")
@@ -401,9 +403,11 @@ def oauth_google_analytics(ctx: click.Context) -> None:
             console.print("[red]Authentication failed[/red]")
             raise click.Abort()
 
-        console.print("\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,")
-        console.print("refresh tokens expire after 7 days. Publish your app for production use.")
-        console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
+        console.print(
+            "\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,\n"
+            "refresh tokens expire after 7 days. Publish your app for production use.\n"
+            f"See: {escape('https://console.cloud.google.com/apis/credentials/consent')}[/dim]"
+        )
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {escape(str(e))}")
@@ -443,9 +447,11 @@ def oauth_google_ads(ctx: click.Context) -> None:
             console.print("[red]Authentication failed[/red]")
             raise click.Abort()
 
-        console.print("\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,")
-        console.print("refresh tokens expire after 7 days. Publish your app for production use.")
-        console.print("See: https://console.cloud.google.com/apis/credentials/consent[/dim]")
+        console.print(
+            "\n[dim]Note: If your GCP OAuth consent screen is in 'Testing' mode,\n"
+            "refresh tokens expire after 7 days. Publish your app for production use.\n"
+            f"See: {escape('https://console.cloud.google.com/apis/credentials/consent')}[/dim]"
+        )
 
     except Exception as e:
         console.print(f"[red]Error:[/red] {escape(str(e))}")
@@ -584,11 +590,9 @@ def oauth_check(ctx: click.Context) -> None:
             # GCP Testing mode caveat
             if has_google:
                 console.print(
-                    "\n  [dim]Note: If your GCP OAuth app is in 'Testing' mode, refresh tokens"
-                )
-                console.print("  expire after 7 days. Publish your app for permanent tokens.")
-                console.print(
-                    "  See: https://console.cloud.google.com/apis/credentials/consent[/dim]"
+                    "\n  [dim]Note: If your GCP OAuth app is in 'Testing' mode, refresh tokens\n"
+                    "  expire after 7 days. Publish your app for permanent tokens.\n"
+                    f"  See: {escape('https://console.cloud.google.com/apis/credentials/consent')}[/dim]"
                 )
         else:
             console.print("  [dim]No tokens to validate[/dim]")
@@ -646,9 +650,7 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
     """
     import os
 
-    import inquirer
     from dotenv import load_dotenv, set_key
-    from inquirer import themes
     from rich.panel import Panel
     from rich.prompt import Confirm
 
@@ -679,7 +681,10 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
                     "3. Application type: 'Web application'",
                     "4. Name: 'Dango Local' (or any name)",
                     "5. Authorized redirect URIs: Add 'http://localhost:8080/callback'",
-                    "6. Click 'Create' and copy the Client ID and Client Secret",
+                    "   (Dango uses a temporary server on port 8080 for the OAuth callback —",
+                    "    this is separate from the Dango web UI on port 8800)",
+                    "6. Also add 'http://localhost:8800/api/oauth/callback' (for web UI OAuth flow)",
+                    "7. Click 'Create' and copy the Client ID and Client Secret",
                 ],
                 "services": ["Google Ads", "Google Analytics", "Google Sheets"],
             },
@@ -696,6 +701,9 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
                     "3. Add 'Marketing API' product",
                     "4. Go to Settings → Basic to get App ID and App Secret",
                     "5. Add 'http://localhost:8080/callback' to Valid OAuth Redirect URIs",
+                    "   (Dango uses a temporary server on port 8080 for the OAuth callback —",
+                    "    this is separate from the Dango web UI on port 8800)",
+                    "6. Also add 'http://localhost:8800/api/oauth/callback' (for web UI OAuth flow)",
                 ],
                 "services": ["Facebook Ads"],
             },
@@ -756,15 +764,8 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
                 masked = current_value[:8] + "..." if len(current_value) > 8 else "***"
                 console.print(f"  [dim]Current {display_name}: {masked}[/dim]")
 
-            questions = [
-                inquirer.Text(
-                    env_var,
-                    message=display_name,
-                    default="" if not current_value else None,
-                )
-            ]
-            answers = inquirer.prompt(questions, theme=themes.GreenPassion())
-            if not answers or not answers[env_var]:
+            value = click.prompt(display_name, default="", show_default=False)
+            if not value:
                 if current_value:
                     console.print("  [dim]Keeping existing value[/dim]")
                     credentials[env_var] = current_value
@@ -772,7 +773,7 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
                     console.print(f"\n[red]✗ {display_name} is required[/red]")
                     raise click.Abort()
             else:
-                credentials[env_var] = answers[env_var]
+                credentials[env_var] = value
 
         # Save to .env
         console.print("\n[dim]Saving credentials to .env...[/dim]")

--- a/dango/cli/oauth.py
+++ b/dango/cli/oauth.py
@@ -351,7 +351,7 @@ class GoogleOAuthHelper(OAuthHelper):
                 console.print(
                     "[dim]  Use a manager (MCC) account ID if managing multiple accounts,[/dim]"
                 )
-                console.print("[dim]  or a regular account ID for a single account.[/dim]\n")
+                console.print("[dim]  or a regular account ID for a single account.[/dim]")
                 dev_token = Prompt.ask("Developer Token (from Google Ads API Center)")
                 if dev_token:
                     self.save_to_env(

--- a/dango/cli/oauth.py
+++ b/dango/cli/oauth.py
@@ -342,6 +342,16 @@ class GoogleOAuthHelper(OAuthHelper):
             # Additional info for Google Ads
             if service == "ads":
                 console.print("\n[bold]Google Ads requires additional credentials:[/bold]")
+                console.print(
+                    "[dim]  Developer Token: From Google Ads API Center (Tools → API Center)[/dim]"
+                )
+                console.print(
+                    "[dim]  Customer ID: Your Google Ads account number (XXX-XXX-XXXX)[/dim]"
+                )
+                console.print(
+                    "[dim]  Use a manager (MCC) account ID if managing multiple accounts,[/dim]"
+                )
+                console.print("[dim]  or a regular account ID for a single account.[/dim]\n")
                 dev_token = Prompt.ask("Developer Token (from Google Ads API Center)")
                 if dev_token:
                     self.save_to_env(
@@ -350,6 +360,7 @@ class GoogleOAuthHelper(OAuthHelper):
 
                 customer_id = Prompt.ask("Customer ID (optional, can add later)", default="")
                 if customer_id:
+                    customer_id = customer_id.replace("-", "")
                     self.save_to_env(
                         "GOOGLE_ADS_CUSTOMER_ID", customer_id, "Google Ads Customer ID"
                     )

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -87,7 +87,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/oauth.py
-    lines: 812
+    lines: 813
     category: exempt
     reason: "OAuth authentication commands (10 subcommands). Renamed from auth.py by TASK-093. One command per provider — file grows linearly with providers."
     review_by: "v1.1"

--- a/tests/unit/test_oauth_cli.py
+++ b/tests/unit/test_oauth_cli.py
@@ -6,6 +6,10 @@ Rich markup escaping, setup instructions, and inquirer removal.
 
 from __future__ import annotations
 
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -14,111 +18,147 @@ pytestmark = pytest.mark.unit
 class TestGoogleAdsCustomerIdDashStripping:
     """BUG-073: Customer IDs with dashes should be accepted and stripped."""
 
-    def test_strip_dashes_from_customer_id(self) -> None:
-        customer_id = "123-456-7890"
-        result = customer_id.replace("-", "")
-        assert result == "1234567890"
+    def _run_ads_authenticate(self, tmp_path: Path, customer_id_input: str) -> MagicMock:
+        """Run GoogleOAuthHelper.authenticate(service="ads") with mocked prompts.
 
-    def test_no_dashes_unchanged(self) -> None:
-        customer_id = "1234567890"
-        result = customer_id.replace("-", "")
-        assert result == "1234567890"
+        Prompt.ask sequence for ads flow:
+          1. "Credentials file path" → /fake/creds.json
+          2. "Developer Token ..." → "" (skip)
+          3. "Customer ID ..." → customer_id_input
+        """
+        from dango.cli.oauth import GoogleOAuthHelper
 
-    def test_empty_string_unchanged(self) -> None:
-        customer_id = ""
-        result = customer_id.replace("-", "")
-        assert result == ""
+        helper = GoogleOAuthHelper(tmp_path)
+        helper.save_to_env = MagicMock()  # type: ignore[method-assign]
+
+        # Create a fake credentials JSON file
+        creds_file = tmp_path / "creds.json"
+        creds_file.write_text(
+            '{"type": "service_account", "client_email": "test@test.iam.gserviceaccount.com"}'
+        )
+
+        with (
+            patch(
+                "dango.cli.oauth.Prompt.ask",
+                side_effect=[str(creds_file), "", customer_id_input],
+            ),
+            patch("dango.cli.oauth.Confirm.ask", return_value=False),
+            patch("dango.cli.oauth.webbrowser"),
+        ):
+            helper.authenticate(service="ads")
+
+        return helper.save_to_env
+
+    def test_dashed_id_saved_without_dashes(self, tmp_path: Path) -> None:
+        """Verify the actual GoogleOAuthHelper strips dashes before saving."""
+        save_mock = self._run_ads_authenticate(tmp_path, "123-456-7890")
+
+        customer_id_calls = [
+            call for call in save_mock.call_args_list if call[0][0] == "GOOGLE_ADS_CUSTOMER_ID"
+        ]
+        assert len(customer_id_calls) == 1
+        assert customer_id_calls[0][0][1] == "1234567890"  # dashes stripped
+
+    def test_id_without_dashes_unchanged(self, tmp_path: Path) -> None:
+        """Verify IDs without dashes pass through unchanged."""
+        save_mock = self._run_ads_authenticate(tmp_path, "1234567890")
+
+        customer_id_calls = [
+            call for call in save_mock.call_args_list if call[0][0] == "GOOGLE_ADS_CUSTOMER_ID"
+        ]
+        assert len(customer_id_calls) == 1
+        assert customer_id_calls[0][0][1] == "1234567890"
+
+    def test_empty_customer_id_not_saved(self, tmp_path: Path) -> None:
+        """Verify empty customer ID is not saved."""
+        save_mock = self._run_ads_authenticate(tmp_path, "")
+
+        customer_id_calls = [
+            call for call in save_mock.call_args_list if call[0][0] == "GOOGLE_ADS_CUSTOMER_ID"
+        ]
+        assert len(customer_id_calls) == 0
 
 
 class TestRichMarkupEscaping:
-    """BUG-071: URLs containing [ must be escaped for Rich markup."""
+    """BUG-071: Consent URLs must be wrapped with escape() for Rich."""
 
-    def test_consent_url_escaped(self) -> None:
-        from rich.markup import escape
-
-        url = "https://console.cloud.google.com/apis/credentials/consent"
-        escaped = escape(url)
-        # escape() ensures the URL is safe for Rich markup rendering
-        assert isinstance(escaped, str)
-        assert "consent" in escaped
-
-    def test_source_code_uses_escape_for_consent_url(self) -> None:
-        """Verify the actual source wraps the consent URL with escape()."""
-        import inspect
-
+    def test_all_consent_urls_use_escape(self) -> None:
+        """Verify all 4 consent URL locations in the module use escape()."""
         from dango.cli.commands import oauth as oauth_module
 
         source = inspect.getsource(oauth_module)
-        # All 4 consent URL locations should use escape()
         assert source.count("escape('https://console.cloud.google.com") >= 4
+
+    def test_consent_urls_in_single_print_call(self) -> None:
+        """Verify consent URLs are in single print() calls (not split across
+        multiple calls where [dim] tags can break)."""
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
+        # The old pattern was 3 separate console.print() calls with [/dim]
+        # in the URL line. The fix consolidates into one call.
+        # Check there's no bare "See: https://console.cloud.google.com"
+        # line that isn't inside an escape() call.
+        import re
+
+        bare_urls = re.findall(
+            r"console\.print\([^)]*https://console\.cloud\.google\.com[^)]*\)",
+            source,
+        )
+        for match in bare_urls:
+            assert "escape(" in match, f"Unescaped consent URL found: {match[:80]}"
 
 
 class TestOAuthSetupInstructions:
     """BUG-070/087: Setup instructions should mention both redirect URIs
-    and explain port 8080 vs 8800."""
+    and explain port 8080 vs 8800. Tests inspect actual source code."""
 
-    def _get_setup_steps(self, provider: str) -> list[str]:
-        """Extract setup steps from the oauth_setup command's provider_config."""
-        # Import the module to access the provider_config dict
-        # We reconstruct the config here to test the actual string content
-        if provider == "google":
-            return [
-                "1. Go to Google Cloud Console → APIs & Services → Credentials",
-                "2. Click '+ CREATE CREDENTIALS' → 'OAuth client ID'",
-                "3. Application type: 'Web application'",
-                "4. Name: 'Dango Local' (or any name)",
-                "5. Authorized redirect URIs: Add 'http://localhost:8080/callback'",
-                "   (Dango uses a temporary server on port 8080 for the OAuth callback —",
-                "    this is separate from the Dango web UI on port 8800)",
-                "6. Also add 'http://localhost:8800/api/oauth/callback' (for web UI OAuth flow)",
-                "7. Click 'Create' and copy the Client ID and Client Secret",
-            ]
-        else:
-            return [
-                "1. Go to Facebook Developers → My Apps → Create App",
-                "2. Select 'Business' app type",
-                "3. Add 'Marketing API' product",
-                "4. Go to Settings → Basic to get App ID and App Secret",
-                "5. Add 'http://localhost:8080/callback' to Valid OAuth Redirect URIs",
-                "   (Dango uses a temporary server on port 8080 for the OAuth callback —",
-                "    this is separate from the Dango web UI on port 8800)",
-                "6. Also add 'http://localhost:8800/api/oauth/callback' (for web UI OAuth flow)",
-            ]
-
-    @pytest.mark.parametrize("provider", ["google", "facebook"])
-    def test_setup_contains_both_redirect_uris(self, provider: str) -> None:
-        steps_text = "\n".join(self._get_setup_steps(provider))
-        assert "http://localhost:8080/callback" in steps_text
-        assert "http://localhost:8800/api/oauth/callback" in steps_text
-
-    @pytest.mark.parametrize("provider", ["google", "facebook"])
-    def test_setup_explains_port_difference(self, provider: str) -> None:
-        steps_text = "\n".join(self._get_setup_steps(provider))
-        assert "temporary server on port 8080" in steps_text
-        assert "port 8800" in steps_text
-
-    def test_actual_source_contains_both_uris(self) -> None:
-        """Verify the actual source code contains the expected instructions."""
-        import inspect
-
+    def test_source_contains_both_redirect_uris(self) -> None:
+        """Verify both CLI and web UI redirect URIs appear in source."""
         from dango.cli.commands import oauth as oauth_module
 
         source = inspect.getsource(oauth_module)
         assert "http://localhost:8080/callback" in source
         assert "http://localhost:8800/api/oauth/callback" in source
+
+    def test_source_explains_port_difference(self) -> None:
+        """Verify the port 8080 vs 8800 explanation appears."""
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
         assert "temporary server on port 8080" in source
+        assert "separate from the Dango web UI on port 8800" in source
+
+    def test_both_providers_have_web_uri(self) -> None:
+        """Verify the web UI URI appears in both Google and Facebook sections."""
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
+        # Should appear at least twice (once per provider)
+        assert source.count("http://localhost:8800/api/oauth/callback") >= 2
+
+    def test_facebook_instructions_present(self) -> None:
+        """Verify Facebook-specific instruction text exists."""
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
         assert "Valid OAuth Redirect URIs" in source
 
 
 class TestOAuthSetupNoInquirer:
     """BUG-069/091: oauth_setup should use click.prompt(), not inquirer.Text."""
 
-    def test_no_inquirer_text_in_oauth_setup(self) -> None:
-        """Verify inquirer.Text is not used in the oauth setup command."""
-        import inspect
-
+    def test_no_inquirer_text_in_module(self) -> None:
+        """Verify inquirer.Text is not used anywhere in the oauth commands module."""
         from dango.cli.commands import oauth as oauth_module
 
         source = inspect.getsource(oauth_module)
-        # inquirer.Text should not appear anywhere in the module
         assert "inquirer.Text" not in source
+
+    def test_click_prompt_strips_whitespace(self) -> None:
+        """Verify click.prompt result is stripped (prevents trailing space bugs)."""
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
+        assert "click.prompt(" in source
+        assert ".strip()" in source

--- a/tests/unit/test_oauth_cli.py
+++ b/tests/unit/test_oauth_cli.py
@@ -1,0 +1,124 @@
+"""tests/unit/test_oauth_cli.py
+
+Tests for OAuth CLI UX fixes (R8-I) covering customer ID dash stripping,
+Rich markup escaping, setup instructions, and inquirer removal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestGoogleAdsCustomerIdDashStripping:
+    """BUG-073: Customer IDs with dashes should be accepted and stripped."""
+
+    def test_strip_dashes_from_customer_id(self) -> None:
+        customer_id = "123-456-7890"
+        result = customer_id.replace("-", "")
+        assert result == "1234567890"
+
+    def test_no_dashes_unchanged(self) -> None:
+        customer_id = "1234567890"
+        result = customer_id.replace("-", "")
+        assert result == "1234567890"
+
+    def test_empty_string_unchanged(self) -> None:
+        customer_id = ""
+        result = customer_id.replace("-", "")
+        assert result == ""
+
+
+class TestRichMarkupEscaping:
+    """BUG-071: URLs containing [ must be escaped for Rich markup."""
+
+    def test_consent_url_escaped(self) -> None:
+        from rich.markup import escape
+
+        url = "https://console.cloud.google.com/apis/credentials/consent"
+        escaped = escape(url)
+        # escape() ensures the URL is safe for Rich markup rendering
+        assert isinstance(escaped, str)
+        assert "consent" in escaped
+
+    def test_source_code_uses_escape_for_consent_url(self) -> None:
+        """Verify the actual source wraps the consent URL with escape()."""
+        import inspect
+
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
+        # All 4 consent URL locations should use escape()
+        assert source.count("escape('https://console.cloud.google.com") >= 4
+
+
+class TestOAuthSetupInstructions:
+    """BUG-070/087: Setup instructions should mention both redirect URIs
+    and explain port 8080 vs 8800."""
+
+    def _get_setup_steps(self, provider: str) -> list[str]:
+        """Extract setup steps from the oauth_setup command's provider_config."""
+        # Import the module to access the provider_config dict
+        # We reconstruct the config here to test the actual string content
+        if provider == "google":
+            return [
+                "1. Go to Google Cloud Console → APIs & Services → Credentials",
+                "2. Click '+ CREATE CREDENTIALS' → 'OAuth client ID'",
+                "3. Application type: 'Web application'",
+                "4. Name: 'Dango Local' (or any name)",
+                "5. Authorized redirect URIs: Add 'http://localhost:8080/callback'",
+                "   (Dango uses a temporary server on port 8080 for the OAuth callback —",
+                "    this is separate from the Dango web UI on port 8800)",
+                "6. Also add 'http://localhost:8800/api/oauth/callback' (for web UI OAuth flow)",
+                "7. Click 'Create' and copy the Client ID and Client Secret",
+            ]
+        else:
+            return [
+                "1. Go to Facebook Developers → My Apps → Create App",
+                "2. Select 'Business' app type",
+                "3. Add 'Marketing API' product",
+                "4. Go to Settings → Basic to get App ID and App Secret",
+                "5. Add 'http://localhost:8080/callback' to Valid OAuth Redirect URIs",
+                "   (Dango uses a temporary server on port 8080 for the OAuth callback —",
+                "    this is separate from the Dango web UI on port 8800)",
+                "6. Also add 'http://localhost:8800/api/oauth/callback' (for web UI OAuth flow)",
+            ]
+
+    @pytest.mark.parametrize("provider", ["google", "facebook"])
+    def test_setup_contains_both_redirect_uris(self, provider: str) -> None:
+        steps_text = "\n".join(self._get_setup_steps(provider))
+        assert "http://localhost:8080/callback" in steps_text
+        assert "http://localhost:8800/api/oauth/callback" in steps_text
+
+    @pytest.mark.parametrize("provider", ["google", "facebook"])
+    def test_setup_explains_port_difference(self, provider: str) -> None:
+        steps_text = "\n".join(self._get_setup_steps(provider))
+        assert "temporary server on port 8080" in steps_text
+        assert "port 8800" in steps_text
+
+    def test_actual_source_contains_both_uris(self) -> None:
+        """Verify the actual source code contains the expected instructions."""
+        import inspect
+
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
+        assert "http://localhost:8080/callback" in source
+        assert "http://localhost:8800/api/oauth/callback" in source
+        assert "temporary server on port 8080" in source
+        assert "Valid OAuth Redirect URIs" in source
+
+
+class TestOAuthSetupNoInquirer:
+    """BUG-069/091: oauth_setup should use click.prompt(), not inquirer.Text."""
+
+    def test_no_inquirer_text_in_oauth_setup(self) -> None:
+        """Verify inquirer.Text is not used in the oauth setup command."""
+        import inspect
+
+        from dango.cli.commands import oauth as oauth_module
+
+        source = inspect.getsource(oauth_module)
+        # inquirer.Text should not appear anywhere in the module
+        assert "inquirer.Text" not in source


### PR DESCRIPTION
## Summary

- **BUG-069/091:** Replace `inquirer.Text` with `click.prompt()` in oauth setup wizard — fixes garbled paste rendering
- **BUG-071:** Escape GCP consent URL with `rich.markup.escape()` in all 4 locations to prevent Rich markup parsing errors
- **BUG-073:** Strip dashes from Google Ads customer IDs so users can paste `XXX-XXX-XXXX` format directly
- **BUG-087:** Add explanation that port 8080 is a temporary OAuth callback server (separate from Dango web UI on 8800)
- **BUG-070:** Add second redirect URI (`localhost:8800/api/oauth/callback`) for web UI OAuth flow to setup instructions
- **UX-004:** Add brief explanation of developer token, customer ID, and manager vs regular account in Google Ads setup

## Test plan

- [x] 11 new unit tests in `tests/unit/test_oauth_cli.py` — all pass
- [x] Full unit suite (3005 tests) — 0 failures
- [x] All pre-commit hooks pass (ruff, format, mypy, file-size, headers, docstrings)
- [ ] Manual: `dango oauth setup google` — verify click.prompt works, paste doesn't garble
- [ ] Manual: `dango oauth google_sheets` — verify consent URL renders without markup errors
- [ ] Manual: Google Ads flow — verify customer ID with dashes is accepted and stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)