### PR TITLE
R8-K: UI/CLI polish — 10 bugs + 1 UX item

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,15 +82,15 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (979 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (970 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (686 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (748 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
-│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (839 lines)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (843 lines)
 │   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (704 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
@@ -337,7 +337,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `visualization/metabase.py` | 1152 | — |
 | `cli/init.py` | 1324 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/commands/platform.py` | 988 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 970 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
@@ -347,13 +347,13 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 707 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 748 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 600 | — (Pydantic config models) |
-| `cli/commands/deploy_wizard.py` | 839 | — (interactive deploy wizard + BYOS) |
+| `cli/commands/deploy_wizard.py` | 843 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 548 | — |
 | `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ dango/                          # Python package source
 │   │   ├── model.py            # model group (add/remove)
 │   │   ├── platform.py         # start/stop/status + port helpers (970 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (748 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (750 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,7 +13,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (748 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/source.py` (750 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
 | `commands/platform.py` (970 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,8 +13,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (707 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (988 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/source.py` (748 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/platform.py` (970 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
@@ -29,7 +29,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~171 lines) | `serve` production foreground server. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
 | `commands/deploy.py` (689 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (839 lines) | Interactive wizard steps 1-9 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
+| `commands/deploy_wizard.py` (843 lines) | Interactive wizard steps 1-9 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
 | `commands/deploy_provision.py` (704 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -250,7 +250,7 @@ def _step_admin() -> tuple[str, str]:
             break
         console.print("  [red]Invalid email format.[/red]")
 
-    # Password (from env or prompt)
+    # Password (from env or auto-generated)
     env_password = os.environ.get("DANGO_ADMIN_PASSWORD")
     if env_password:
         issues = check_password_strength(env_password, email=email)
@@ -260,17 +260,19 @@ def _step_admin() -> tuple[str, str]:
         console.print("  [dim]Using password from DANGO_ADMIN_PASSWORD env var.[/dim]")
         return email, env_password
 
-    while True:
-        password = click.prompt("  Admin password", hide_input=True)
-        issues = check_password_strength(password, email=email)
-        if issues:
-            console.print(f"  [red]Weak password:[/red] {'; '.join(issues)}")
-            continue
-        confirm = click.prompt("  Confirm password", hide_input=True)
-        if password != confirm:
-            console.print("  [red]Passwords don't match.[/red]")
-            continue
-        break
+    import secrets
+
+    from rich.panel import Panel
+
+    password = secrets.token_urlsafe(16)
+    console.print(
+        Panel(
+            f"[bold]Admin password:[/bold] {password}\n\n"
+            "[yellow]Save this password now — it will not be shown again.[/yellow]",
+            title="Generated Admin Password",
+            border_style="green",
+        )
+    )
 
     return email, password
 
@@ -322,16 +324,16 @@ def _step_sources(project_root: Path) -> list[dict[str, str]]:
 
 
 def _step_oauth() -> bool:
-    """Step 7: Skip OAuth setup for now?
+    """Step 7: Skip OAuth setup (always skipped during deploy wizard).
 
     Returns:
-        True if OAuth should be skipped.
+        True (OAuth is always skipped — configured post-deployment).
     """
     console.print("\n[bold]Step 7: OAuth Sources[/bold]")
-    console.print("  Some sources (Google, Facebook) require OAuth tokens.")
-    console.print("  You can configure OAuth after deployment.\n")
+    console.print("  OAuth tokens will be configured after deployment.")
+    console.print("  Run [cyan]dango oauth setup[/cyan] on the server.\n")
 
-    return not click.confirm("  Configure OAuth now?", default=False)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -107,7 +107,11 @@ def _check_docker_ports(platform_config: object) -> None:
                 console.print(f"    [dim]Used by: {process_info}[/dim]")
 
         console.print()
-        console.print("[bold]To fix, choose one option:[/bold]\n")
+        console.print(
+            "  [bold yellow]→ If you have a previous Dango instance running, "
+            "run [cyan]dango stop[/cyan] first.[/bold yellow]\n"
+        )
+        console.print("[bold]Other options:[/bold]\n")
         console.print("[bold]Option 1:[/bold] Stop the conflicting process(es)")
         console.print(f"  [cyan]lsof -ti :{conflicts[0][0]} | xargs kill -9[/cyan]\n")
 
@@ -685,56 +689,34 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
         config = config_loader.load_config()
         project_name = config.project.name
 
-        # Stop file watcher first
-        console.print("[cyan]Stopping file watcher...[/cyan]")
+        console.print("[cyan]Stopping services...[/cyan]")
+
+        # Stop file watcher
         from dango.platform.watcher_lifecycle import get_watcher_status, stop_file_watcher
 
         watcher_was_running = get_watcher_status(project_root)["running"]
         watcher_stopped = stop_file_watcher(project_root)
-
-        if watcher_stopped:
-            console.print("[green]✓[/green] File watcher stopped")
-        elif watcher_was_running:
+        if watcher_was_running and not watcher_stopped:
             console.print("[yellow]⚠[/yellow] Failed to stop file watcher")
-        else:
-            console.print("[dim]File watcher was not running[/dim]")
-
-        console.print()
 
         # Stop Marimo notebook server
-        console.print("[cyan]Stopping Marimo notebook server...[/cyan]")
         from dango.notebooks.manager import get_marimo_status, stop_marimo
 
         marimo_was_running = get_marimo_status(project_root)["running"]
         marimo_stopped = stop_marimo(project_root)
-        if marimo_stopped:
-            console.print("[green]✓[/green] Marimo notebook server stopped")
-        elif marimo_was_running:
+        if marimo_was_running and not marimo_stopped:
             console.print("[yellow]⚠[/yellow] Failed to stop Marimo")
-        else:
-            console.print("[dim]Marimo was not running[/dim]")
-
-        console.print()
 
         # Stop FastAPI backend
-        console.print("[cyan]Stopping Web UI backend...[/cyan]")
-        fastapi_stopped = stop_fastapi_server(project_root, verbose=True)
-
-        if not fastapi_stopped:
-            console.print("[dim]Web UI was not running[/dim]")
-
-        console.print()
+        stop_fastapi_server(project_root, verbose=False)
 
         # Stop Docker services
-        console.print("[cyan]Stopping Docker services...[/cyan]")
         manager = DockerManager(project_root)
         docker_success = manager.stop_services()
-
         if not docker_success:
             console.print(
                 "[yellow]Warning:[/yellow] Some Docker services may not have stopped cleanly"
             )
-            console.print()
 
         # Update project status in routing registry
         net_config = NetworkConfig()

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -418,6 +418,34 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
                     "[dim]Could not regenerate dbt documentation — catalog will update on next sync.[/dim]"
                 )
 
+            # Offer to clean up related .env variables
+            env_file = project_root / ".env"
+            if env_file.exists():
+                from dango.utils.env_file import parse_env_file, serialize_env_file
+
+                env_content = env_file.read_text()
+                env_vars = parse_env_file(env_content)
+                source_token = source_name.upper().replace("-", "_")
+                matching = {k: v for k, v in env_vars.items() if source_token in k}
+
+                if matching:
+                    console.print("[dim]Found related environment variables in .env:[/dim]")
+                    for k in matching:
+                        console.print(f"  [cyan]{k}[/cyan]")
+                    console.print()
+                    if Confirm.ask("Remove these environment variables?", default=False):
+                        for k in matching:
+                            del env_vars[k]
+                        env_file.write_text(serialize_env_file(env_vars))
+                        console.print(f"[green]✓[/green] Removed {len(matching)} env variable(s)")
+                    else:
+                        console.print("[dim]Environment variables left unchanged.[/dim]")
+                else:
+                    console.print("[dim]No related environment variables found in .env.[/dim]")
+            else:
+                console.print("[dim]No .env file found.[/dim]")
+
+            console.print()
             console.print(f"[green]✅ Source '{source_name}' removed successfully[/green]")
             console.print()
             console.print("[yellow]⚠️  Important:[/yellow]")
@@ -425,7 +453,6 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
             console.print("  • [bold]Data still exists[/bold] in DuckDB tables:")
             console.print(f"    - raw.{source_name}")
             console.print(f"    - staging.{source_name}")
-            console.print("  • Environment variables in .env are unchanged")
             console.print()
             console.print("[dim]To clean up orphaned tables:[/dim]")
             console.print(

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -426,7 +426,11 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
                 env_content = env_file.read_text()
                 env_vars = parse_env_file(env_content)
                 source_token = source_name.upper().replace("-", "_")
-                matching = {k: v for k, v in env_vars.items() if source_token in k}
+                matching = {
+                    k: v
+                    for k, v in env_vars.items()
+                    if k.startswith(source_token + "_") or k == source_token
+                }
 
                 if matching:
                     console.print("[dim]Found related environment variables in .env:[/dim]")

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -3,6 +3,8 @@
 Handles Docker Compose operations for Dango services.
 """
 
+import hashlib
+import os
 import subprocess
 from enum import Enum
 from pathlib import Path
@@ -31,6 +33,20 @@ class DockerManager:
     def __init__(self, project_root: Path):
         self.project_root = project_root
         self.compose_file = project_root / "docker-compose.yml"
+
+    @property
+    def compose_project_name(self) -> str:
+        """Deterministic project name derived from path to avoid collisions."""
+        path_hash = hashlib.md5(str(self.project_root).encode(), usedforsecurity=False).hexdigest()[
+            :8
+        ]
+        return f"dango-{path_hash}"
+
+    def _compose_env(self) -> dict[str, str]:
+        """Return env dict with COMPOSE_PROJECT_NAME set."""
+        env = os.environ.copy()
+        env["COMPOSE_PROJECT_NAME"] = self.compose_project_name
+        return env
 
     def is_docker_available(self) -> bool:
         """Check if Docker is available"""
@@ -134,7 +150,12 @@ class DockerManager:
 
         try:
             result = subprocess.run(
-                cmd, cwd=self.project_root, capture_output=True, text=True, timeout=120
+                cmd,
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=self._compose_env(),
             )
 
             if result.returncode == 0:
@@ -200,7 +221,12 @@ class DockerManager:
 
         try:
             result = subprocess.run(
-                cmd, cwd=self.project_root, capture_output=True, text=True, timeout=60
+                cmd,
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env=self._compose_env(),
             )
 
             if result.returncode == 0:
@@ -285,7 +311,12 @@ class DockerManager:
 
         try:
             result = subprocess.run(
-                cmd, cwd=self.project_root, capture_output=True, text=True, timeout=10
+                cmd,
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=self._compose_env(),
             )
 
             if result.returncode != 0:

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -36,7 +36,12 @@ class DockerManager:
 
     @property
     def compose_project_name(self) -> str:
-        """Deterministic project name derived from path to avoid collisions."""
+        """Deterministic project name derived from path to avoid collisions.
+
+        NOTE: Containers started before this change used Docker's default
+        naming (directory-based) and will be orphaned.  ``dango stop --all``
+        cleans those up via ``docker ps --filter name=``.
+        """
         path_hash = hashlib.md5(str(self.project_root).encode(), usedforsecurity=False).hexdigest()[
             :8
         ]
@@ -231,6 +236,7 @@ class DockerManager:
 
             if result.returncode == 0:
                 console.print("[green]✓[/green] Services stopped")
+                self._warn_orphaned_containers()
                 return True
             else:
                 console.print("[red]Error:[/red] Failed to stop services")
@@ -243,6 +249,23 @@ class DockerManager:
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}")
             return False
+
+    def _warn_orphaned_containers(self) -> None:
+        """Warn if Dango containers from a previous naming scheme are still running."""
+        try:
+            result = subprocess.run(
+                ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                console.print(
+                    "[yellow]⚠[/yellow]  Other Dango containers still running. "
+                    "Run [cyan]dango stop --all[/cyan] to stop them."
+                )
+        except Exception:
+            pass  # Best-effort, never block stop
 
     def stop_all_dango_containers(self) -> bool:
         """

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1184,7 +1184,7 @@ function renderSourcesTable() {
                             ${source.supports_date_range ? `<a href="#" onclick="event.preventDefault(); event.stopPropagation(); closeSyncMenus(); openDateRangeModal('${source.name}')" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Custom Date Range...</a>` : ''}`}
                         </div>
                     </div>
-                </div>` : '<span class="text-gray-300">—</span>';
+                </div>` : '<span class="inline-block w-full text-center text-gray-300">—</span>';
 
         return `
         <tr id="source-${source.name}" class="hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
@@ -1209,7 +1209,7 @@ function renderSourcesTable() {
                 ${formatRelativeTime(source.last_sync)}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
-                ${source.has_schedule ? `<span title="${source.schedule_display || ''}">${source.schedule_display || 'Scheduled'}</span>` : '<span class="text-gray-300">—</span>'}
+                ${source.has_schedule ? `<span title="${source.schedule_display || ''}">${source.schedule_display || 'Scheduled'}</span>` : '<span class="inline-block w-full text-center text-gray-300">—</span>'}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                 ${actionColumn}
@@ -2243,8 +2243,7 @@ function renderDbtModelsTable() {
                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     ${actionButtons}
                     <a
-                        href="/dbt-docs#!/model/${model.unique_id}"
-                        target="_blank"
+                        href="/catalog"
                         class="text-blue-600 hover:text-blue-900"
                         title="View documentation"
                     >

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -62,7 +62,7 @@ exemptions:
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
-    lines: 839
+    lines: 843
     category: exempt
     reason: "TASK-029+075e: Interactive wizard steps 1-9 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps."
     review_by: "v1.1"
@@ -81,7 +81,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 988
+    lines: 970
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
@@ -93,7 +93,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 707
+    lines: 748
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -93,7 +93,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 748
+    lines: 750
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,20 +1,40 @@
 #!/usr/bin/env bash
-# scripts/smoke_test.sh
+# scripts/smoke_test.sh — v1.1 (2026-04-25)
 #
 # Automated smoke test for a running Dango instance.
 # Requires: dango start running in a test project, venv activated.
 #
 # Usage:
 #   ./scripts/smoke_test.sh [BASE_URL]
+#   ./scripts/smoke_test.sh --help
 #
 # Environment variables:
-#   DANGO_BASE_URL      — Server URL (default: http://localhost:8800)
-#   DANGO_ADMIN_EMAIL   — Admin email (default: admin@localhost)
+#   DANGO_BASE_URL       — Server URL (default: http://localhost:8800)
+#   DANGO_ADMIN_EMAIL    — Admin email (default: admin@localhost)
 #   DANGO_ADMIN_PASSWORD — Admin password (required, no default)
 
 # Note: -e is intentionally omitted — test commands are expected to return
 # non-zero on failure; the script handles each result individually.
 set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    echo "Usage: $0 [BASE_URL]"
+    echo ""
+    echo "Run automated smoke tests against a running Dango instance."
+    echo ""
+    echo "Arguments:"
+    echo "  BASE_URL    Server URL (default: \$DANGO_BASE_URL or http://localhost:8800)"
+    echo ""
+    echo "Environment variables:"
+    echo "  DANGO_BASE_URL       Server URL"
+    echo "  DANGO_ADMIN_EMAIL    Admin email (default: admin@localhost)"
+    echo "  DANGO_ADMIN_PASSWORD Admin password (required)"
+    exit 0
+fi
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -35,6 +55,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 trap 'rm -f "$COOKIE_JAR"' EXIT
+
+# Validate ADMIN_EMAIL format
+if ! echo "$ADMIN_EMAIL" | grep -qE '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'; then
+    echo "ERROR: DANGO_ADMIN_EMAIL ('$ADMIN_EMAIL') is not a valid email address."
+    exit 1
+fi
+
+# Check BASE_URL reachability
+if ! curl --head --silent --connect-timeout 5 "$BASE_URL" > /dev/null 2>&1; then
+    echo "ERROR: Cannot reach $BASE_URL — is Dango running?"
+    echo "       Start with: dango start"
+    exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Counters and state

--- a/tests/unit/test_r8k_ui_cli_polish.py
+++ b/tests/unit/test_r8k_ui_cli_polish.py
@@ -1,0 +1,244 @@
+"""tests/unit/test_r8k_ui_cli_polish.py
+
+Tests for R8-K UI/CLI polish fixes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestComposeProjectName:
+    """BUG-085: COMPOSE_PROJECT_NAME collision prevention."""
+
+    def test_deterministic(self) -> None:
+        """Same path always produces the same project name."""
+        from dango.platform.docker import DockerManager
+
+        mgr1 = DockerManager(Path("/tmp/project-a"))
+        mgr2 = DockerManager(Path("/tmp/project-a"))
+        assert mgr1.compose_project_name == mgr2.compose_project_name
+
+    def test_unique_per_path(self) -> None:
+        """Different paths produce different project names."""
+        from dango.platform.docker import DockerManager
+
+        mgr_a = DockerManager(Path("/tmp/project-a"))
+        mgr_b = DockerManager(Path("/tmp/project-b"))
+        assert mgr_a.compose_project_name != mgr_b.compose_project_name
+
+    def test_format(self) -> None:
+        """Project name starts with 'dango-' and has 8-char hex suffix."""
+        from dango.platform.docker import DockerManager
+
+        mgr = DockerManager(Path("/tmp/test-project"))
+        name = mgr.compose_project_name
+        assert name.startswith("dango-")
+        suffix = name[len("dango-") :]
+        assert len(suffix) == 8
+        # Verify it's valid hex
+        int(suffix, 16)
+
+    def test_compose_env_includes_project_name(self) -> None:
+        """_compose_env() sets COMPOSE_PROJECT_NAME."""
+        from dango.platform.docker import DockerManager
+
+        mgr = DockerManager(Path("/tmp/test"))
+        env = mgr._compose_env()
+        assert "COMPOSE_PROJECT_NAME" in env
+        assert env["COMPOSE_PROJECT_NAME"] == mgr.compose_project_name
+
+    def test_hash_matches_manual(self) -> None:
+        """Project name matches manual md5 calculation."""
+        from dango.platform.docker import DockerManager
+
+        path = Path("/srv/dango/project")
+        mgr = DockerManager(path)
+        expected_hash = hashlib.md5(str(path).encode(), usedforsecurity=False).hexdigest()[:8]
+        assert mgr.compose_project_name == f"dango-{expected_hash}"
+
+
+@pytest.mark.unit
+class TestEnvCleanupLogic:
+    """BUG-086: source remove .env cleanup."""
+
+    def test_matching_vars_found(self) -> None:
+        """Variables containing the uppercased source name are matched."""
+        from dango.utils.env_file import parse_env_file
+
+        content = "STRIPE_API_KEY=sk_test_123\nOTHER_VAR=hello\nSTRIPE_WEBHOOK_SECRET=whsec_456"
+        env_vars = parse_env_file(content)
+        source_token = "stripe".upper().replace("-", "_")
+        matching = {k: v for k, v in env_vars.items() if source_token in k}
+        assert len(matching) == 2
+        assert "STRIPE_API_KEY" in matching
+        assert "STRIPE_WEBHOOK_SECRET" in matching
+        assert "OTHER_VAR" not in matching
+
+    def test_roundtrip_after_removal(self) -> None:
+        """Removing matched vars and serializing produces valid .env."""
+        from dango.utils.env_file import parse_env_file, serialize_env_file
+
+        content = "STRIPE_KEY=abc\nDB_HOST=localhost\nSTRIPE_SECRET=xyz\n"
+        env_vars = parse_env_file(content)
+        source_token = "STRIPE"
+        matching = {k for k in env_vars if source_token in k}
+        for k in matching:
+            del env_vars[k]
+
+        result = serialize_env_file(env_vars)
+        reparsed = parse_env_file(result)
+        assert reparsed == {"DB_HOST": "localhost"}
+
+    def test_no_match_returns_empty(self) -> None:
+        """No matches when source name not in any var."""
+        from dango.utils.env_file import parse_env_file
+
+        content = "DB_HOST=localhost\nDB_PORT=5432\n"
+        env_vars = parse_env_file(content)
+        source_token = "STRIPE"
+        matching = {k: v for k, v in env_vars.items() if source_token in k}
+        assert len(matching) == 0
+
+    def test_hyphenated_source_name(self) -> None:
+        """Hyphens in source name are converted to underscores for matching."""
+        from dango.utils.env_file import parse_env_file
+
+        content = "MY_SOURCE_KEY=val1\nOTHER=val2\n"
+        env_vars = parse_env_file(content)
+        source_token = "my-source".upper().replace("-", "_")
+        matching = {k: v for k, v in env_vars.items() if source_token in k}
+        assert len(matching) == 1
+        assert "MY_SOURCE_KEY" in matching
+
+
+@pytest.mark.unit
+class TestAutoGeneratePassword:
+    """BUG-095: Auto-generate admin password for cloud deploy."""
+
+    def test_auto_generates_when_no_env_var(self) -> None:
+        """_step_admin() auto-generates password when DANGO_ADMIN_PASSWORD unset."""
+        from dango.cli.commands.deploy_wizard import _step_admin
+
+        env_no_password = {
+            k: v for k, v in __import__("os").environ.items() if k != "DANGO_ADMIN_PASSWORD"
+        }
+        with (
+            patch.dict("os.environ", env_no_password, clear=True),
+            patch("click.prompt", return_value="admin@example.com"),
+        ):
+            email, password = _step_admin()
+
+        assert email == "admin@example.com"
+        # token_urlsafe(16) produces ~22 chars
+        assert len(password) >= 16
+
+    def test_uses_env_var_when_set(self) -> None:
+        """_step_admin() uses DANGO_ADMIN_PASSWORD from env when set."""
+        from dango.cli.commands.deploy_wizard import _step_admin
+
+        with (
+            patch.dict("os.environ", {"DANGO_ADMIN_PASSWORD": "Str0ng!P@ssw0rd99"}),
+            patch(
+                "dango.auth.security.check_password_strength",
+                return_value=[],
+            ),
+            patch("click.prompt", return_value="admin@example.com"),
+        ):
+            email, password = _step_admin()
+
+        assert password == "Str0ng!P@ssw0rd99"
+
+    def test_rejects_weak_env_password(self) -> None:
+        """_step_admin() exits if DANGO_ADMIN_PASSWORD is weak."""
+        from dango.cli.commands.deploy_wizard import _step_admin
+
+        with (
+            patch.dict("os.environ", {"DANGO_ADMIN_PASSWORD": "weak"}),
+            patch(
+                "dango.auth.security.check_password_strength",
+                return_value=["Too short"],
+            ),
+            patch("click.prompt", return_value="admin@example.com"),
+            pytest.raises(SystemExit),
+        ):
+            _step_admin()
+
+
+@pytest.mark.unit
+class TestStaleBinaryDetection:
+    """UX-009: Warn when dango binary is outside active venv.
+
+    Tests the detection logic directly rather than going through CliRunner,
+    since Click's group callback + ``click.echo(err=True)`` interactions
+    with CliRunner make stderr assertion unreliable.
+    """
+
+    def test_warns_outside_venv(self) -> None:
+        """Warning emitted when sys.executable is outside VIRTUAL_ENV."""
+        with (
+            patch.dict("os.environ", {"VIRTUAL_ENV": "/home/user/project/venv"}, clear=False),
+            patch("sys.executable", "/usr/local/bin/python3"),
+            patch("click.echo") as mock_echo,
+        ):
+            import os
+            import sys
+
+            venv_prefix = os.environ.get("VIRTUAL_ENV")
+            if venv_prefix and not sys.executable.startswith(venv_prefix):
+                import click
+
+                click.echo(
+                    "Warning: Running 'dango' from outside the active venv. "
+                    "Run 'hash -r' or restart your terminal.",
+                    err=True,
+                )
+
+        mock_echo.assert_called_once()
+        assert "outside the active venv" in mock_echo.call_args[0][0]
+        assert mock_echo.call_args[1]["err"] is True
+
+    def test_no_warn_inside_venv(self) -> None:
+        """No warning when executable is inside the venv."""
+        with (
+            patch.dict(
+                "os.environ",
+                {"VIRTUAL_ENV": "/home/user/project/venv"},
+                clear=False,
+            ),
+            patch("sys.executable", "/home/user/project/venv/bin/python3"),
+            patch("click.echo") as mock_echo,
+        ):
+            import os
+            import sys
+
+            venv_prefix = os.environ.get("VIRTUAL_ENV")
+            if venv_prefix and not sys.executable.startswith(venv_prefix):
+                import click
+
+                click.echo("should not fire", err=True)
+
+        mock_echo.assert_not_called()
+
+    def test_no_warn_without_venv(self) -> None:
+        """No warning when VIRTUAL_ENV is unset."""
+        env_without_venv = {k: v for k, v in __import__("os").environ.items() if k != "VIRTUAL_ENV"}
+        with (
+            patch.dict("os.environ", env_without_venv, clear=True),
+            patch("click.echo") as mock_echo,
+        ):
+            import os
+            import sys
+
+            venv_prefix = os.environ.get("VIRTUAL_ENV")
+            if venv_prefix and not sys.executable.startswith(venv_prefix):
+                import click
+
+                click.echo("should not fire", err=True)
+
+        mock_echo.assert_not_called()

--- a/tests/unit/test_r8k_ui_cli_polish.py
+++ b/tests/unit/test_r8k_ui_cli_polish.py
@@ -67,18 +67,42 @@ class TestComposeProjectName:
 class TestEnvCleanupLogic:
     """BUG-086: source remove .env cleanup."""
 
+    @staticmethod
+    def _match(env_vars: dict[str, str], source_name: str) -> dict[str, str]:
+        """Replicate the matching logic from source_remove."""
+        source_token = source_name.upper().replace("-", "_")
+        return {
+            k: v
+            for k, v in env_vars.items()
+            if k.startswith(source_token + "_") or k == source_token
+        }
+
     def test_matching_vars_found(self) -> None:
-        """Variables containing the uppercased source name are matched."""
+        """Variables prefixed with the uppercased source name are matched."""
         from dango.utils.env_file import parse_env_file
 
         content = "STRIPE_API_KEY=sk_test_123\nOTHER_VAR=hello\nSTRIPE_WEBHOOK_SECRET=whsec_456"
         env_vars = parse_env_file(content)
-        source_token = "stripe".upper().replace("-", "_")
-        matching = {k: v for k, v in env_vars.items() if source_token in k}
+        matching = self._match(env_vars, "stripe")
         assert len(matching) == 2
         assert "STRIPE_API_KEY" in matching
         assert "STRIPE_WEBHOOK_SECRET" in matching
         assert "OTHER_VAR" not in matching
+
+    def test_no_false_positive_on_short_names(self) -> None:
+        """A source named 'db' must NOT match 'DB_HOST' or 'DUCKDB_PATH'."""
+        from dango.utils.env_file import parse_env_file
+
+        content = "DB_HOST=localhost\nDB_PORT=5432\nDUCKDB_PATH=/data\nDB=inline_val\n"
+        env_vars = parse_env_file(content)
+        matching = self._match(env_vars, "db")
+        # DB_HOST and DB_PORT start with "DB_" → matched
+        # DUCKDB_PATH does NOT start with "DB_" → excluded
+        # DB (exact match) → matched
+        assert "DB_HOST" in matching
+        assert "DB_PORT" in matching
+        assert "DB" in matching
+        assert "DUCKDB_PATH" not in matching
 
     def test_roundtrip_after_removal(self) -> None:
         """Removing matched vars and serializing produces valid .env."""
@@ -86,8 +110,7 @@ class TestEnvCleanupLogic:
 
         content = "STRIPE_KEY=abc\nDB_HOST=localhost\nSTRIPE_SECRET=xyz\n"
         env_vars = parse_env_file(content)
-        source_token = "STRIPE"
-        matching = {k for k in env_vars if source_token in k}
+        matching = self._match(env_vars, "stripe")
         for k in matching:
             del env_vars[k]
 
@@ -101,8 +124,7 @@ class TestEnvCleanupLogic:
 
         content = "DB_HOST=localhost\nDB_PORT=5432\n"
         env_vars = parse_env_file(content)
-        source_token = "STRIPE"
-        matching = {k: v for k, v in env_vars.items() if source_token in k}
+        matching = self._match(env_vars, "stripe")
         assert len(matching) == 0
 
     def test_hyphenated_source_name(self) -> None:
@@ -111,8 +133,7 @@ class TestEnvCleanupLogic:
 
         content = "MY_SOURCE_KEY=val1\nOTHER=val2\n"
         env_vars = parse_env_file(content)
-        source_token = "my-source".upper().replace("-", "_")
-        matching = {k: v for k, v in env_vars.items() if source_token in k}
+        matching = self._match(env_vars, "my-source")
         assert len(matching) == 1
         assert "MY_SOURCE_KEY" in matching
 
@@ -174,71 +195,58 @@ class TestAutoGeneratePassword:
 class TestStaleBinaryDetection:
     """UX-009: Warn when dango binary is outside active venv.
 
-    Tests the detection logic directly rather than going through CliRunner,
-    since Click's group callback + ``click.echo(err=True)`` interactions
-    with CliRunner make stderr assertion unreliable.
+    Calls the real ``cli`` group callback directly (bypassing CliRunner,
+    which swallows ``click.echo(err=True)`` output) to verify the stale
+    binary warning.  Patches ``click.echo`` globally since that's what
+    the callback calls at runtime.
     """
+
+    @staticmethod
+    def _invoke_cli_callback(**env_overrides: str) -> list:
+        """Call the cli group callback and return click.echo calls."""
+        import click
+
+        from dango.cli.main import cli
+
+        mock_ctx = click.Context(cli, info_name="dango")
+        mock_ctx.ensure_object(dict)
+        echo_calls: list = []
+
+        def capturing_echo(*args, **kwargs):  # type: ignore[no-untyped-def]
+            echo_calls.append((args, kwargs))
+
+        with (
+            patch.dict("os.environ", env_overrides, clear=False),
+            patch("click.echo", side_effect=capturing_echo),
+            patch("dango.config.helpers.find_project_root", side_effect=Exception("no project")),
+        ):
+            # pass_context injects ctx automatically — just invoke with no args
+            mock_ctx.invoke(cli.callback)  # type: ignore[arg-type]
+
+        return echo_calls
 
     def test_warns_outside_venv(self) -> None:
         """Warning emitted when sys.executable is outside VIRTUAL_ENV."""
-        with (
-            patch.dict("os.environ", {"VIRTUAL_ENV": "/home/user/project/venv"}, clear=False),
-            patch("sys.executable", "/usr/local/bin/python3"),
-            patch("click.echo") as mock_echo,
-        ):
-            import os
-            import sys
+        with patch("sys.executable", "/usr/local/bin/python3"):
+            calls = self._invoke_cli_callback(VIRTUAL_ENV="/home/user/project/venv")
 
-            venv_prefix = os.environ.get("VIRTUAL_ENV")
-            if venv_prefix and not sys.executable.startswith(venv_prefix):
-                import click
-
-                click.echo(
-                    "Warning: Running 'dango' from outside the active venv. "
-                    "Run 'hash -r' or restart your terminal.",
-                    err=True,
-                )
-
-        mock_echo.assert_called_once()
-        assert "outside the active venv" in mock_echo.call_args[0][0]
-        assert mock_echo.call_args[1]["err"] is True
+        warning_calls = [c for c in calls if c[0] and "outside the active venv" in c[0][0]]
+        assert len(warning_calls) == 1
+        assert warning_calls[0][1].get("err") is True
 
     def test_no_warn_inside_venv(self) -> None:
         """No warning when executable is inside the venv."""
-        with (
-            patch.dict(
-                "os.environ",
-                {"VIRTUAL_ENV": "/home/user/project/venv"},
-                clear=False,
-            ),
-            patch("sys.executable", "/home/user/project/venv/bin/python3"),
-            patch("click.echo") as mock_echo,
-        ):
-            import os
-            import sys
+        with patch("sys.executable", "/home/user/project/venv/bin/python3"):
+            calls = self._invoke_cli_callback(VIRTUAL_ENV="/home/user/project/venv")
 
-            venv_prefix = os.environ.get("VIRTUAL_ENV")
-            if venv_prefix and not sys.executable.startswith(venv_prefix):
-                import click
-
-                click.echo("should not fire", err=True)
-
-        mock_echo.assert_not_called()
+        warning_calls = [c for c in calls if c[0] and "outside the active venv" in c[0][0]]
+        assert len(warning_calls) == 0
 
     def test_no_warn_without_venv(self) -> None:
         """No warning when VIRTUAL_ENV is unset."""
         env_without_venv = {k: v for k, v in __import__("os").environ.items() if k != "VIRTUAL_ENV"}
-        with (
-            patch.dict("os.environ", env_without_venv, clear=True),
-            patch("click.echo") as mock_echo,
-        ):
-            import os
-            import sys
+        with patch.dict("os.environ", env_without_venv, clear=True):
+            calls = self._invoke_cli_callback()
 
-            venv_prefix = os.environ.get("VIRTUAL_ENV")
-            if venv_prefix and not sys.executable.startswith(venv_prefix):
-                import click
-
-                click.echo("should not fire", err=True)
-
-        mock_echo.assert_not_called()
+        warning_calls = [c for c in calls if c[0] and "outside the active venv" in c[0][0]]
+        assert len(warning_calls) == 0


### PR DESCRIPTION
## Summary

- **BUG-067:** Center dash placeholders in sources table (action + schedule columns)
- **BUG-068:** Models docs icon links to `/catalog` instead of external dbt-docs
- **BUG-096:** Remove OAuth interactive question from deploy wizard — always skips
- **BUG-095/084:** Auto-generate admin password for cloud deploy (`secrets.token_urlsafe(16)`)
- **BUG-093:** Port conflict message suggests `dango stop` first
- **BUG-092:** Simplify `dango stop` — suppress per-service detail, only show failures
- **BUG-085:** Set `COMPOSE_PROJECT_NAME` to `dango-{md5(path)[:8]}` to prevent cross-project collisions
- **BUG-086:** `source remove` offers to clean up matching `.env` variables
- **BUG-064:** Smoke test: `--help` flag, `BASE_URL` reachability check, `ADMIN_EMAIL` format validation
- **UX-009:** Unit tests for stale binary detection logic

## Test plan

- [x] 15 new tests in `tests/unit/test_r8k_ui_cli_polish.py` — all pass
- [x] Full unit suite: 3040 passed, 7 skipped, 0 failures
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, file-size, file-header, docstring, CLAUDE.md staleness, JS null guards)
- [ ] Manual: verify sources table dash alignment in browser
- [ ] Manual: verify models docs icon links to `/catalog`
- [ ] Manual: `dango stop` shows single "Stopping services..." line

🤖 Generated with [Claude Code](https://claude.com/claude-code)