### PR TITLE
fix: 10 UX polish items for v1 launch (R8-L)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ dango/                          # Python package source
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
 │   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (806 lines)
-│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (739 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (737 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
@@ -357,7 +357,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `transformation/generator.py` | 548 | — |
 | `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
-| `cli/commands/deploy_provision.py` | 739 | — (provisioning orchestration + BYOS) |
+| `cli/commands/deploy_provision.py` | 737 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
 | `cli/commands/auth.py` | 660 | — (13 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,8 @@ dango/                          # Python package source
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
-│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (843 lines)
-│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (704 lines)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (806 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (739 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
@@ -353,11 +353,11 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 600 | — (Pydantic config models) |
-| `cli/commands/deploy_wizard.py` | 843 | — (interactive deploy wizard + BYOS) |
+| `cli/commands/deploy_wizard.py` | 806 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 548 | — |
 | `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
-| `cli/commands/deploy_provision.py` | 704 | — (provisioning orchestration + BYOS) |
+| `cli/commands/deploy_provision.py` | 739 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
 | `cli/commands/auth.py` | 660 | — (13 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ dango/                          # Python package source
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
-│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (806 lines)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (808 lines)
 │   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (737 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
@@ -353,7 +353,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 600 | — (Pydantic config models) |
-| `cli/commands/deploy_wizard.py` | 806 | — (interactive deploy wizard + BYOS) |
+| `cli/commands/deploy_wizard.py` | 808 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 548 | — |
 | `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -28,9 +28,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote.py` (698 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~171 lines) | `serve` production foreground server. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
-| `commands/deploy.py` (704 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
+| `commands/deploy.py` (705 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
 | `commands/deploy_wizard.py` (806 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
-| `commands/deploy_provision.py` (739 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
+| `commands/deploy_provision.py` (737 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -28,9 +28,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote.py` (698 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~171 lines) | `serve` production foreground server. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
-| `commands/deploy.py` (689 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (843 lines) | Interactive wizard steps 1-9 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
-| `commands/deploy_provision.py` (704 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
+| `commands/deploy.py` (704 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
+| `commands/deploy_wizard.py` (806 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
+| `commands/deploy_provision.py` (739 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -29,7 +29,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~171 lines) | `serve` production foreground server. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
 | `commands/deploy.py` (705 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (806 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
+| `commands/deploy_wizard.py` (808 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
 | `commands/deploy_provision.py` (737 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |

--- a/dango/cli/commands/cleanup.py
+++ b/dango/cli/commands/cleanup.py
@@ -127,12 +127,37 @@ def _collect_pycache(project_root: Path) -> list[tuple[Path, int]]:
     return results
 
 
+def _collect_docker_volumes() -> list[str]:
+    """Find dangling Docker volumes.
+
+    Returns:
+        List of volume names. Empty if Docker is not available.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["docker", "volume", "ls", "--format", "{{.Name}}", "-f", "dangling=true"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
+    except FileNotFoundError:
+        return []
+    except subprocess.TimeoutExpired:
+        return []
+
+
 @click.command("cleanup")
 @click.option("--dry-run", is_flag=True, help="Show what would be deleted without deleting.")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
 @click.option("--logs-only", is_flag=True, help="Only clean log archives, skip dbt/cache.")
+@click.option("--docker", is_flag=True, help="Also prune dangling Docker volumes.")
 @click.pass_context
-def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> None:
+def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool, docker: bool) -> None:
     """Remove old log archives, dbt artifacts, and Python cache.
 
     Cleans up disk space by removing:
@@ -141,6 +166,7 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
       - Compressed log archives older than 90 days (.jsonl.gz)
       - dbt build artifacts (dbt/target/, dbt/logs/)
       - Python bytecode cache (__pycache__/ directories)
+      - Dangling Docker volumes (with --docker)
 
     Examples:
 
@@ -149,6 +175,7 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
       dango cleanup --dry-run    Show what would be deleted
       dango cleanup --yes        Clean without confirmation
       dango cleanup --logs-only  Only clean old log archives
+      dango cleanup --docker     Also prune dangling Docker volumes
     """
     import shutil
 
@@ -177,13 +204,17 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
             dbt_artifacts = _collect_dbt_artifacts(project_root)
             pycache_dirs = _collect_pycache(project_root)
 
+        docker_volumes: list[str] = []
+        if docker:
+            docker_volumes = _collect_docker_volumes()
+
         log_total = sum(size for _, size in log_archives)
         dbt_total = sum(size for _, size in dbt_artifacts)
         cache_total = sum(size for _, size in pycache_dirs)
         grand_total = log_total + dbt_total + cache_total
 
         # --- Nothing to clean ---
-        if grand_total == 0:
+        if grand_total == 0 and not docker_volumes:
             console.print("[green]Nothing to clean up.[/green]")
             return
 
@@ -208,6 +239,12 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
             )
         if pycache_dirs:
             table.add_row("Python cache", str(len(pycache_dirs)), _format_size(cache_total))
+        if docker_volumes:
+            table.add_row(
+                "Docker volumes (dangling)",
+                str(len(docker_volumes)),
+                "[dim]varies[/dim]",
+            )
 
         table.add_section()
         table.add_row("[bold]Total[/bold]", "", f"[bold]{_format_size(grand_total)}[/bold]")
@@ -229,6 +266,10 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
                 console.print("[dim]Python cache directories:[/dim]")
                 for path, size in pycache_dirs:
                     console.print(f"  {path.relative_to(project_root)}/  ({_format_size(size)})")
+            if docker_volumes:
+                console.print("[dim]Docker volumes:[/dim]")
+                for vol in docker_volumes:
+                    console.print(f"  {vol}")
             console.print()
             console.print("[yellow]Dry run — no files deleted.[/yellow]")
             return
@@ -288,6 +329,23 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool) -> No
                 f"[green]\u2713[/green] Removed {cache_removed} __pycache__ dir(s)"
                 f" ({_format_size(cache_freed)})"
             )
+
+        # Docker volumes
+        if docker_volumes:
+            import subprocess
+
+            try:
+                subprocess.run(
+                    ["docker", "volume", "prune", "-f"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                console.print(
+                    f"[green]\u2713[/green] Pruned {len(docker_volumes)} dangling Docker volume(s)"
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                console.print(f"[red]\u2717[/red] Failed to prune Docker volumes: {exc}")
 
         # --- After summary ---
         console.print()

--- a/dango/cli/commands/cleanup.py
+++ b/dango/cli/commands/cleanup.py
@@ -337,13 +337,14 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool, docke
             removed = 0
             for vol in docker_volumes:
                 try:
-                    subprocess.run(
+                    result = subprocess.run(
                         ["docker", "volume", "rm", vol],
                         capture_output=True,
                         text=True,
                         timeout=30,
                     )
-                    removed += 1
+                    if result.returncode == 0:
+                        removed += 1
                 except (FileNotFoundError, subprocess.TimeoutExpired):
                     pass
             if removed:

--- a/dango/cli/commands/cleanup.py
+++ b/dango/cli/commands/cleanup.py
@@ -330,22 +330,29 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool, docke
                 f" ({_format_size(cache_freed)})"
             )
 
-        # Docker volumes
+        # Docker volumes — remove only the specific volumes that were listed
         if docker_volumes:
             import subprocess
 
-            try:
-                subprocess.run(
-                    ["docker", "volume", "prune", "-f"],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                )
+            removed = 0
+            for vol in docker_volumes:
+                try:
+                    subprocess.run(
+                        ["docker", "volume", "rm", vol],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                    removed += 1
+                except (FileNotFoundError, subprocess.TimeoutExpired):
+                    pass
+            if removed:
+                console.print(f"[green]\u2713[/green] Removed {removed} dangling Docker volume(s)")
+            if removed < len(docker_volumes):
                 console.print(
-                    f"[green]\u2713[/green] Pruned {len(docker_volumes)} dangling Docker volume(s)"
+                    f"[yellow]![/yellow] {len(docker_volumes) - removed} volume(s)"
+                    " could not be removed"
                 )
-            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-                console.print(f"[red]\u2717[/red] Failed to prune Docker volumes: {exc}")
 
         # --- After summary ---
         console.print()

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -312,7 +312,8 @@ def _print_deploy_success(
     console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
     if not skip_initial_sync:
         console.print("  Initial data sync is running in the background.")
-    console.print("\n  To add a custom domain: [bold]dango remote domain set <domain>[/bold]")
+    if not domain:
+        console.print("\n  To add a custom domain: [bold]dango remote domain set <domain>[/bold]")
 
 
 def _load_deploy_config(ctx: click.Context) -> tuple[Any, Path]:

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -274,6 +274,7 @@ def _handle_do_deploy_with_config(project_root: Path, config: Any) -> None:
         admin_email=config.admin_email,
         warnings=result.warnings,
         skip_initial_sync=config.skip_initial_sync,
+        domain=config.domain,
     )
 
 
@@ -285,6 +286,7 @@ def _print_byos_success(result: Any, config: Any) -> None:
         admin_email=config.admin_email,
         warnings=result.warnings,
         skip_initial_sync=config.skip_initial_sync,
+        domain=config.domain,
     )
 
 
@@ -295,18 +297,22 @@ def _print_deploy_success(
     admin_email: str,
     warnings: list[str],
     skip_initial_sync: bool,
+    domain: str | None = None,
 ) -> None:
     """Print deployment success output (shared by DO and BYOS paths)."""
     console.print("\n[bold green]Deployment complete![/bold green]")
     console.print(f"  URL:    {url}")
     console.print(f"  IP:     {ip}")
     console.print(f"  Admin:  {admin_email}")
+    if domain:
+        console.print(f"\n  [bold]DNS setup:[/bold] Point an A record for {domain} to {ip}")
     if warnings:
         for w in warnings:
             console.print(f"  [yellow]Warning:[/yellow] {w}")
     console.print("\n  Next: Visit the URL above and log in with your admin credentials.")
     if not skip_initial_sync:
         console.print("  Initial data sync is running in the background.")
+    console.print("\n  To add a custom domain: [bold]dango remote domain set <domain>[/bold]")
 
 
 def _load_deploy_config(ctx: click.Context) -> tuple[Any, Path]:
@@ -427,7 +433,7 @@ def _destroy_byos(cloud_cfg: Any, project_root: Path, force: bool) -> None:
             raise SystemExit(1)
 
     # Optionally stop remote services
-    if force or click.confirm("\n  Stop Dango services on the remote server?", default=True):
+    if force or click.confirm("\n  Stop Dango services on the remote server?", default=False):
         from dango.platform.cloud.ssh import SSHManager
 
         key_path = _resolve_key_path(cloud_cfg, project_root)

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import click
+
 from dango.cli import console
 from dango.cli.commands.deploy_wizard import _EMAIL_RE, BYOSConfig, WizardConfig
 from dango.exceptions import CloudProvisioningError
@@ -169,7 +171,14 @@ def run_provisioning(
 
         ssh.connect(droplet_ip, username="root")
         try:
-            setup_result = setup_server(ssh, on_progress=_setup_progress, domain=config.domain)
+            import dango
+
+            setup_result = setup_server(
+                ssh,
+                on_progress=_setup_progress,
+                domain=config.domain,
+                dango_version=dango.__version__,
+            )
             if setup_result.warnings:
                 for w in setup_result.warnings:
                     console.print(f"  [yellow]Warning:[/yellow] {w}")
@@ -323,11 +332,14 @@ def run_byos_setup(
         _status("Setting up server (installs Docker, Caddy, Python, etc.)...")
         ssh.connect(config.server_ip, username=config.ssh_user)
         try:
+            import dango
+
             setup_result = setup_server(
                 ssh,
                 on_progress=_setup_progress,
                 domain=config.domain,
                 setup_ufw=True,
+                dango_version=dango.__version__,
             )
             if setup_result.warnings:
                 for w in setup_result.warnings:
@@ -450,16 +462,35 @@ def _push_secrets(
     warnings: list[str],
 ) -> None:
     """Push .dlt/secrets.toml and .env to remote server."""
-    # .dlt/secrets.toml
     secrets_path = project_root / ".dlt" / "secrets.toml"
+    env_path = project_root / ".env"
+
+    # Identify files to push
+    files_to_push: list[str] = []
+    if secrets_path.exists():
+        files_to_push.append(".dlt/secrets.toml")
+    if env_path.exists():
+        files_to_push.append(".env")
+
+    if not files_to_push:
+        warnings.append("No .dlt/secrets.toml or .env found locally — skipped.")
+        return
+
+    console.print("\n[bold]Secrets to push:[/bold]")
+    for f in files_to_push:
+        console.print(f"  - {f}")
+    console.print()
+
+    if not click.confirm("Push these secrets to the server?", default=True):
+        console.print("[yellow]Skipped secrets push.[/yellow]")
+        warnings.append("Secrets push skipped by user.")
+        return
+
+    # Push files
     if secrets_path.exists():
         content = secrets_path.read_text()
         ssh.write_remote_file("/srv/dango/project/.dlt/secrets.toml", content, mode=0o600)
-    else:
-        warnings.append("No .dlt/secrets.toml found locally — skipped.")
 
-    # .env
-    env_path = project_root / ".env"
     if env_path.exists():
         content = env_path.read_text()
         ssh.write_remote_file("/srv/dango/project/.env", content, mode=0o600)

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -486,22 +486,20 @@ def _push_secrets(
         warnings.append("Secrets push skipped by user.")
         return
 
-    # Push files
+    # Push files and fix ownership for each
+    pushed_paths: list[str] = []
     if secrets_path.exists():
         content = secrets_path.read_text()
         ssh.write_remote_file("/srv/dango/project/.dlt/secrets.toml", content, mode=0o600)
+        pushed_paths.append("/srv/dango/project/.dlt/secrets.toml")
 
     if env_path.exists():
         content = env_path.read_text()
         ssh.write_remote_file("/srv/dango/project/.env", content, mode=0o600)
+        pushed_paths.append("/srv/dango/project/.env")
 
-    # Fix ownership
-    ssh.exec_command(
-        "chown dango:dango "
-        "/srv/dango/project/.dlt/secrets.toml "
-        "/srv/dango/project/.env "
-        "2>/dev/null; true"
-    )
+    if pushed_paths:
+        ssh.exec_command(f"chown dango:dango {' '.join(pushed_paths)} 2>/dev/null; true")
 
 
 def _create_admin_and_enable_auth(

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -2,7 +2,7 @@
 
 Interactive deployment wizard and non-interactive validation for ``dango deploy``.
 
-Steps 1-9 gather DigitalOcean configuration (region, size, domain, admin
+Steps 1-8 gather DigitalOcean configuration (region, size, admin
 credentials, etc.) before handing off to ``deploy_provision.py``.
 
 Also provides a BYOS (Bring Your Own Server) wizard path that skips
@@ -200,47 +200,19 @@ def _step_size() -> tuple[str, Any | None]:
 
 
 # ---------------------------------------------------------------------------
-# Domain
-# ---------------------------------------------------------------------------
-
-
-def _step_domain() -> str | None:
-    """Step 4: Optional custom domain.
-
-    Returns:
-        Domain string or None.
-    """
-    console.print("\n[bold]Step 4: Custom Domain (optional)[/bold]")
-    console.print("  Your server will be accessible by IP address.")
-    console.print("  Add a domain for HTTPS and a friendly URL.\n")
-
-    domain = click.prompt("  Domain (leave blank to skip)", default="", show_default=False)
-    domain = domain.strip().lower()
-
-    if not domain:
-        return None
-
-    console.print(
-        f"\n  [dim]Point a DNS A record for [bold]{domain}[/bold] to your server IP.[/dim]"
-    )
-    console.print("  [dim]Caddy will auto-provision an HTTPS certificate via Let's Encrypt.[/dim]")
-    return str(domain)
-
-
-# ---------------------------------------------------------------------------
 # Admin credentials
 # ---------------------------------------------------------------------------
 
 
 def _step_admin() -> tuple[str, str]:
-    """Step 5: Admin email and password.
+    """Step 4: Admin email and password.
 
     Returns:
         Tuple of (email, password).
     """
     from dango.auth.security import check_password_strength
 
-    console.print("\n[bold]Step 5: Admin Account[/bold]")
+    console.print("\n[bold]Step 4: Admin Account[/bold]")
     console.print("  Create the first admin user for your deployment.\n")
 
     # Email
@@ -283,14 +255,14 @@ def _step_admin() -> tuple[str, str]:
 
 
 def _step_sources(project_root: Path) -> list[dict[str, str]]:
-    """Step 6: List configured sources and check credentials.
+    """Step 5: List configured sources and check credentials.
 
     Returns:
         List of source dicts with 'name' and 'type' keys.
     """
     from dango.config.helpers import load_config
 
-    console.print("\n[bold]Step 6: Data Sources[/bold]\n")
+    console.print("\n[bold]Step 5: Data Sources[/bold]\n")
 
     config = load_config(project_root)
     sources: list[dict[str, str]] = []
@@ -324,12 +296,12 @@ def _step_sources(project_root: Path) -> list[dict[str, str]]:
 
 
 def _step_oauth() -> bool:
-    """Step 7: Skip OAuth setup (always skipped during deploy wizard).
+    """Step 6: Skip OAuth setup (always skipped during deploy wizard).
 
     Returns:
         True (OAuth is always skipped — configured post-deployment).
     """
-    console.print("\n[bold]Step 7: OAuth Sources[/bold]")
+    console.print("\n[bold]Step 6: OAuth Sources[/bold]")
     console.print("  OAuth tokens will be configured after deployment.")
     console.print("  Run [cyan]dango oauth setup[/cyan] on the server.\n")
 
@@ -342,12 +314,12 @@ def _step_oauth() -> bool:
 
 
 def _step_backups() -> tuple[bool, str | None, str | None]:
-    """Step 8: Enable automated backups?
+    """Step 7: Enable automated backups?
 
     Returns:
         Tuple of (enable_backups, access_key, secret_key).
     """
-    console.print("\n[bold]Step 8: Automated Backups[/bold]")
+    console.print("\n[bold]Step 7: Automated Backups[/bold]")
     console.print("  Daily backups to DigitalOcean Spaces ($5/mo for storage).\n")
 
     enable = click.confirm("  Enable automated backups?", default=True)
@@ -403,10 +375,9 @@ def _get_monthly_cost(size_slug: str, enable_backups: bool) -> int:
 def _step_cost_summary(
     region: str,
     size_slug: str,
-    domain: str | None,
     enable_backups: bool,
 ) -> int:
-    """Step 9: Show cost summary and confirm.
+    """Step 8: Show cost summary and confirm.
 
     Returns:
         Monthly cost in USD.
@@ -416,7 +387,7 @@ def _step_cost_summary(
     """
     from dango.platform.cloud.provisioning import get_region_info, get_size_tier
 
-    console.print("\n[bold]Step 9: Cost Summary[/bold]\n")
+    console.print("\n[bold]Step 8: Cost Summary[/bold]\n")
 
     tier = get_size_tier(size_slug)
     region_info = get_region_info(region)
@@ -427,13 +398,15 @@ def _step_cost_summary(
 
     console.print(f"  Region:    {region_display}")
     console.print(f"  Size:      {size_display} — ${droplet_cost}/mo")
-    if domain:
-        console.print(f"  Domain:    {domain}")
     if enable_backups:
         console.print("  Backups:   Enabled — ~$5/mo")
 
     total = _get_monthly_cost(size_slug, enable_backups)
-    console.print(f"\n  [bold]Estimated total: ${total}/mo[/bold]\n")
+    console.print(f"\n  [bold]Estimated total: ${total}/mo[/bold]")
+    console.print(
+        "  [dim]Costs are billed directly by DigitalOcean to your account,"
+        " not through Dango.[/dim]\n"
+    )
 
     if not click.confirm("  Proceed with deployment?", default=True):
         console.print("[yellow]Aborted.[/yellow]")
@@ -448,7 +421,7 @@ def _step_cost_summary(
 
 
 def run_wizard(project_root: Path) -> WizardConfig:
-    """Run the interactive deployment wizard (steps 1-9).
+    """Run the interactive deployment wizard (steps 1-8).
 
     Args:
         project_root: Path to the Dango project root.
@@ -468,29 +441,26 @@ def run_wizard(project_root: Path) -> WizardConfig:
     # Step 3: Size
     size_slug, size_tier = _step_size()
 
-    # Step 4: Domain
-    domain = _step_domain()
-
-    # Step 5: Admin credentials
+    # Step 4: Admin credentials
     admin_email, admin_password = _step_admin()
 
-    # Step 6: Sources
+    # Step 5: Sources
     _step_sources(project_root)
 
-    # Step 7: OAuth
+    # Step 6: OAuth
     skip_oauth = _step_oauth()
 
-    # Step 8: Backups
+    # Step 7: Backups
     enable_backups, spaces_access_key, spaces_secret_key = _step_backups()
 
-    # Step 9: Cost summary + confirm
-    monthly_cost = _step_cost_summary(region, size_slug, domain, enable_backups)
+    # Step 8: Cost summary + confirm
+    monthly_cost = _step_cost_summary(region, size_slug, enable_backups)
 
     return WizardConfig(
         region=region,
         size_slug=size_slug,
         size_tier=size_tier,
-        domain=domain,
+        domain=None,
         admin_email=admin_email,
         admin_password=admin_password,
         skip_oauth=skip_oauth,
@@ -718,24 +688,19 @@ def run_byos_wizard(project_root: Path) -> BYOSConfig:
     # Step 2: Validate SSH
     _validate_ssh_connectivity(server_ip, ssh_user, ssh_key_path)
 
-    # Step 3: Domain
-    domain = _step_domain()
-
-    # Step 4: Admin credentials
+    # Step 3: Admin credentials
     admin_email, admin_password = _step_admin()
 
-    # Step 5: Sources
+    # Step 4: Sources
     _step_sources(project_root)
 
-    # Step 6: OAuth
+    # Step 5: OAuth
     skip_oauth = _step_oauth()
 
     # Confirmation
     console.print("\n[bold]Deployment Summary[/bold]\n")
     console.print(f"  Server:    {server_ip} (SSH user: {ssh_user})")
     console.print(f"  SSH key:   {ssh_key_path}")
-    if domain:
-        console.print(f"  Domain:    {domain}")
     console.print(f"  Admin:     {admin_email}")
     console.print()
 
@@ -747,7 +712,7 @@ def run_byos_wizard(project_root: Path) -> BYOSConfig:
         server_ip=server_ip,
         ssh_user=ssh_user,
         ssh_key_path=ssh_key_path,
-        domain=domain,
+        domain=None,
         admin_email=admin_email,
         admin_password=admin_password,
         skip_oauth=skip_oauth,

--- a/dango/cli/commands/upgrade.py
+++ b/dango/cli/commands/upgrade.py
@@ -164,7 +164,7 @@ def upgrade(ctx: click.Context, target_version: str | None, yes: bool) -> None:
     # Confirmation prompts (unless --yes)
     if not yes:
         console.print("[dim]Tip: Run 'dango stop' first if services are running.[/dim]")
-        if click.confirm("Create a backup first?", default=True):
+        if click.confirm("Pause to create a manual backup first?", default=True):
             console.print(
                 "\n  Copy your [cyan].dango/[/cyan] directory or run your "
                 "backup procedure in another terminal, then continue.\n"

--- a/dango/cli/commands/upgrade.py
+++ b/dango/cli/commands/upgrade.py
@@ -164,7 +164,7 @@ def upgrade(ctx: click.Context, target_version: str | None, yes: bool) -> None:
     # Confirmation prompts (unless --yes)
     if not yes:
         console.print("[dim]Tip: Run 'dango stop' first if services are running.[/dim]")
-        if click.confirm("Create a backup first?", default=False):
+        if click.confirm("Create a backup first?", default=True):
             console.print(
                 "\n  Copy your [cyan].dango/[/cyan] directory or run your "
                 "backup procedure in another terminal, then continue.\n"

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -272,7 +272,14 @@ def _setup_venv(
         result.steps_skipped.append(step)
         _notify(on_progress, step, "skipped")
         return
-    pkg = f"getdango=={dango_version}" if dango_version else "getdango"
+    if dango_version:
+        import re
+
+        if not re.match(r"^[a-zA-Z0-9._-]+$", dango_version):
+            raise ValueError(f"Invalid version string: {dango_version!r}")
+        pkg = f"getdango=={dango_version}"
+    else:
+        pkg = "getdango"
     _run_checked(
         ssh,
         "python3 -m venv /srv/dango/venv"

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -261,6 +261,8 @@ def _setup_venv(
     ssh: SSHManager,
     result: SetupResult,
     on_progress: Callable[[str, str], None] | None,
+    *,
+    dango_version: str | None = None,
 ) -> None:
     """Step 7: Create Python venv and install getdango."""
     step = "python_venv"
@@ -270,11 +272,12 @@ def _setup_venv(
         result.steps_skipped.append(step)
         _notify(on_progress, step, "skipped")
         return
+    pkg = f"getdango=={dango_version}" if dango_version else "getdango"
     _run_checked(
         ssh,
         "python3 -m venv /srv/dango/venv"
         " && /srv/dango/venv/bin/pip install --upgrade pip -q"
-        " && /srv/dango/venv/bin/pip install getdango -q",
+        f" && /srv/dango/venv/bin/pip install {pkg} -q",
         step=step,
         timeout=300,
     )
@@ -505,6 +508,7 @@ def setup_server(
     on_progress: Callable[[str, str], None] | None = None,
     domain: str | None = None,
     setup_ufw: bool = False,
+    dango_version: str | None = None,
 ) -> SetupResult:
     """Run all server setup steps on a connected server.
 
@@ -516,6 +520,7 @@ def setup_server(
         domain: FQDN for HTTPS (Caddy auto-TLS). ``None`` → HTTP-only.
         setup_ufw: If ``True``, install and configure UFW firewall
             (used for BYOS deployments that lack a cloud-managed firewall).
+        dango_version: Pin getdango to this version. ``None`` → latest.
 
     Raises:
         CloudProvisioningError: If any step fails.
@@ -525,6 +530,8 @@ def setup_server(
     for step_fn in _SETUP_STEPS:
         if step_fn is _setup_caddyfile:
             _setup_caddyfile(ssh, result, on_progress, domain=domain)
+        elif step_fn is _setup_venv:
+            _setup_venv(ssh, result, on_progress, dango_version=dango_version)
         else:
             step_fn(ssh, result, on_progress)
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -102,8 +102,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Cloud security warnings
     try:
-        is_cloud = (project_root / ".dango" / "cloud.yml").exists()
-        if is_cloud:
+        from dango.web.helpers import is_cloud_deployment
+
+        if is_cloud_deployment(project_root):
             auth_cfg = _load_auth_config(project_root)
             if auth_cfg is None:
                 auth_cfg = AuthConfig()

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -100,6 +100,36 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception:
         logger.warning("first_run_admin_check_failed", exc_info=True)
 
+    # Cloud security warnings
+    try:
+        is_cloud = (project_root / ".dango" / "cloud.yml").exists()
+        if is_cloud:
+            auth_cfg = _load_auth_config(project_root)
+            if auth_cfg is None:
+                auth_cfg = AuthConfig()
+            if not auth_cfg.require_2fa:
+                logger.warning(
+                    "cloud_security_recommendation",
+                    setting="require_2fa",
+                    recommendation="Enable 2FA for cloud deployments",
+                )
+            if auth_cfg.idle_timeout_minutes > 60:
+                logger.warning(
+                    "cloud_security_recommendation",
+                    setting="idle_timeout_minutes",
+                    current=auth_cfg.idle_timeout_minutes,
+                    recommendation="Set idle timeout to 60 minutes or less",
+                )
+            if auth_cfg.session_max_days > 30:
+                logger.warning(
+                    "cloud_security_recommendation",
+                    setting="session_max_days",
+                    current=auth_cfg.session_max_days,
+                    recommendation="Set session max to 30 days or less",
+                )
+    except Exception:
+        logger.debug("cloud_security_check_skipped", exc_info=True)
+
     # Initialize APScheduler for job scheduling
     try:
         import asyncio

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -30,6 +30,11 @@ def get_project_root() -> Path:
     return app.state.project_root
 
 
+def is_cloud_deployment(project_root: Path) -> bool:
+    """Check if this is a cloud deployment (cloud.yml exists)."""
+    return (project_root / ".dango" / "cloud.yml").exists()
+
+
 def load_sources_config() -> list[dict[str, Any]]:
     """Load sources configuration from .dango/sources.yml."""
     sources_file = get_project_root() / ".dango" / "sources.yml"

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -61,6 +61,12 @@ def _render_template(
     status_code: int = 200,
 ) -> HTMLResponse:
     """Render a Jinja2 template with fallback for broken installations."""
+    if "is_cloud" not in context:
+        try:
+            project_root = Path(request.app.state.project_root)
+            context["is_cloud"] = (project_root / ".dango" / "cloud.yml").exists()
+        except Exception:
+            context["is_cloud"] = False
     try:
         return templates.TemplateResponse(
             request, template_name, context=context, status_code=status_code

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -63,8 +63,10 @@ def _render_template(
     """Render a Jinja2 template with fallback for broken installations."""
     if "is_cloud" not in context:
         try:
+            from dango.web.helpers import is_cloud_deployment
+
             project_root = Path(request.app.state.project_root)
-            context["is_cloud"] = (project_root / ".dango" / "cloud.yml").exists()
+            context["is_cloud"] = is_cloud_deployment(project_root)
         except Exception:
             context["is_cloud"] = False
     try:

--- a/dango/web/static/css/main.css
+++ b/dango/web/static/css/main.css
@@ -1,5 +1,8 @@
 /* Dango Dashboard Custom Styles */
 
+/* Hide Alpine.js x-cloak elements until Alpine initializes */
+[x-cloak] { display: none !important; }
+
 /* Smooth scrolling for activity log */
 #activity-log {
     scroll-behavior: smooth;

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -43,7 +43,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-12">
                 <!-- Desktop nav links: 9-item pipeline layout -->
-                <div class="hidden md:flex items-center space-x-0.5">
+                <div class="hidden md:flex items-center space-x-1">
                     <a href="/" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'overview' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
                         Overview
                     </a>
@@ -145,6 +145,23 @@
         </div>
     </nav>
     {% endblock %}
+
+    {% if is_cloud is defined and is_cloud and request.state.user and not request.state.user.totp_enabled %}
+    <div x-data="{ dismissed: false }" x-show="!dismissed" x-cloak
+         class="bg-yellow-50 border-b border-yellow-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between">
+            <p class="text-sm text-yellow-800">
+                <span class="font-medium">Security recommendation:</span>
+                <a href="/settings/account" class="underline hover:text-yellow-900">Enable 2FA</a> for your account.
+            </p>
+            <button @click="dismissed = true" class="text-yellow-600 hover:text-yellow-800">
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+            </button>
+        </div>
+    </div>
+    {% endif %}
 
     {% block content %}{% endblock %}
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -62,7 +62,7 @@ exemptions:
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
-    lines: 806
+    lines: 808
     category: exempt
     reason: "TASK-029+075e: Interactive wizard steps 1-8 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -68,13 +68,13 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy_provision.py
-    lines: 739
+    lines: 737
     category: exempt
     reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy.py
-    lines: 704
+    lines: 705
     category: exempt
     reason: "TASK-029+075e: Deploy group with DO + BYOS routing, destroy command for both providers. Splitting would scatter the provider selection and destroy dispatch logic."
     review_by: "v1.1"
@@ -255,7 +255,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/cloud/server_setup.py
-    lines: 541
+    lines: 548
     category: exempt
     reason: "TASK-075e: Added optional UFW firewall step for BYOS deployments (+35 lines). 17 idempotent setup steps — splitting would scatter sequential orchestration."
     review_by: "v1.1"
@@ -285,7 +285,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_server_setup.py
-    lines: 575
+    lines: 584
     category: exempt
     reason: "TASK-026+027: Added domain parameter tests for setup_server(). Each test requires isolated mock setup with full exec_results map."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -62,19 +62,19 @@ exemptions:
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
-    lines: 843
+    lines: 806
     category: exempt
-    reason: "TASK-029+075e: Interactive wizard steps 1-9 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps."
+    reason: "TASK-029+075e: Interactive wizard steps 1-8 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy_provision.py
-    lines: 704
+    lines: 739
     category: exempt
     reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy.py
-    lines: 689
+    lines: 704
     category: exempt
     reason: "TASK-029+075e: Deploy group with DO + BYOS routing, destroy command for both providers. Splitting would scatter the provider selection and destroy dispatch logic."
     review_by: "v1.1"
@@ -255,7 +255,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/cloud/server_setup.py
-    lines: 533
+    lines: 541
     category: exempt
     reason: "TASK-075e: Added optional UFW firewall step for BYOS deployments (+35 lines). 17 idempotent setup steps — splitting would scatter sequential orchestration."
     review_by: "v1.1"
@@ -285,13 +285,13 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_server_setup.py
-    lines: 525
+    lines: 575
     category: exempt
     reason: "TASK-026+027: Added domain parameter tests for setup_server(). Each test requires isolated mock setup with full exec_results map."
     review_by: "v1.1"
 
   - file: tests/unit/test_deploy_provision.py
-    lines: 530
+    lines: 562
     category: exempt
     reason: "TASK-029: 9 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, and sync trigger. Each requires isolated mock setup."
     review_by: "v1.1"

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -12,11 +12,13 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
 from dango.cli.commands.cleanup import (
     _collect_dbt_artifacts,
+    _collect_docker_volumes,
     _collect_log_archives,
     _collect_pycache,
     _format_size,
@@ -214,11 +216,11 @@ def _invoke_cleanup(
     log_archives: list[tuple[Path, int]] | None = None,
     dbt_artifacts: list[tuple[Path, int]] | None = None,
     pycache_dirs: list[tuple[Path, int]] | None = None,
-    disk_before: dict | None = None,
-    disk_after: dict | None = None,
+    disk_before: dict[str, object] | None = None,
+    disk_after: dict[str, object] | None = None,
     log_before: int = 5000,
     log_after: int = 0,
-):
+) -> click.testing.Result:
     """Invoke the cleanup command with standard mocks."""
     runner = CliRunner()
 
@@ -413,3 +415,66 @@ class TestCleanupCommand:
         assert result.exit_code == 0
         out = _strip(result.output)
         assert "Freed" in out
+
+
+# ---------------------------------------------------------------------------
+# _collect_docker_volumes
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestCollectDockerVolumes:
+    def test_none_dangling(self) -> None:
+        """Empty stdout returns empty list."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            assert _collect_docker_volumes() == []
+
+    def test_with_results(self) -> None:
+        """Multiline stdout returns list of volume names."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="vol_a\nvol_b\nvol_c\n")
+            result = _collect_docker_volumes()
+            assert result == ["vol_a", "vol_b", "vol_c"]
+
+    def test_docker_not_found(self) -> None:
+        """FileNotFoundError returns empty list."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("docker not found")
+            assert _collect_docker_volumes() == []
+
+    def test_timeout(self) -> None:
+        """TimeoutExpired returns empty list."""
+        import subprocess
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("docker", 10)
+            assert _collect_docker_volumes() == []
+
+
+@pytest.mark.unit
+class TestCleanupDockerFlag:
+    def test_docker_flag_prunes(self, tmp_path: Path) -> None:
+        """--docker flag collects and prunes dangling volumes."""
+        runner = CliRunner()
+
+        log_side = [_log_usage(5000), _log_usage(0)] + [_log_usage(0)] * 5
+
+        with (
+            patch(f"{_UTILS}.require_project_context", return_value=tmp_path),
+            patch(f"{_DB_HEALTH}.get_disk_usage_summary", return_value=_disk_summary()),
+            patch(f"{_LOG_ROT}.get_log_disk_usage", side_effect=log_side),
+            patch(f"{_LOG_ROT}.cleanup_old_archives"),
+            patch(f"{_CMD}._collect_log_archives", return_value=[]),
+            patch(f"{_CMD}._collect_dbt_artifacts", return_value=[]),
+            patch(f"{_CMD}._collect_pycache", return_value=[]),
+            patch(f"{_CMD}._collect_docker_volumes", return_value=["vol1", "vol2"]),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = runner.invoke(
+                cleanup, ["--yes", "--docker"], obj={"project_root": str(tmp_path)}
+            )
+
+        assert result.exit_code == 0
+        out = _strip(result.output)
+        assert "Docker volumes" in out
+        assert "Pruned 2" in out

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -477,4 +477,7 @@ class TestCleanupDockerFlag:
         assert result.exit_code == 0
         out = _strip(result.output)
         assert "Docker volumes" in out
-        assert "Pruned 2" in out
+        assert "Removed 2" in out
+        # Verify docker volume rm called for each volume, not prune
+        rm_calls = [c for c in mock_run.call_args_list if "volume" in str(c) and "rm" in str(c)]
+        assert len(rm_calls) == 2

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -154,33 +154,50 @@ class TestSecretsPush:
 
         ssh = _make_mock_ssh()
         warnings: list[str] = []
-        _push_secrets(ssh, project_root, warnings)
+        with patch("dango.cli.commands.deploy_provision.click.confirm", return_value=True):
+            _push_secrets(ssh, project_root, warnings)
 
         assert warnings == []
         assert ssh.write_remote_file.call_count == 2
 
     def test_env_missing_continues(self, project_root):
-        """Missing .env is silently skipped."""
+        """Missing .env is silently skipped — only secrets.toml pushed."""
         dlt_dir = project_root / ".dlt"
         dlt_dir.mkdir()
         (dlt_dir / "secrets.toml").write_text("[sources]\n")
 
         ssh = _make_mock_ssh()
         warnings: list[str] = []
-        _push_secrets(ssh, project_root, warnings)
+        with patch("dango.cli.commands.deploy_provision.click.confirm", return_value=True):
+            _push_secrets(ssh, project_root, warnings)
 
         assert warnings == []
         # Only secrets.toml written
         assert ssh.write_remote_file.call_count == 1
 
     def test_secrets_missing_warns(self, project_root):
-        """Missing .dlt/secrets.toml produces a warning."""
+        """Missing both .dlt/secrets.toml and .env produces a warning."""
         ssh = _make_mock_ssh()
         warnings: list[str] = []
         _push_secrets(ssh, project_root, warnings)
 
         assert len(warnings) == 1
-        assert "secrets.toml" in warnings[0]
+        assert "No .dlt/secrets.toml or .env found locally" in warnings[0]
+
+    def test_user_declines_push(self, project_root):
+        """User declining confirm skips write and adds warning."""
+        dlt_dir = project_root / ".dlt"
+        dlt_dir.mkdir()
+        (dlt_dir / "secrets.toml").write_text("[sources]\n")
+
+        ssh = _make_mock_ssh()
+        warnings: list[str] = []
+        with patch("dango.cli.commands.deploy_provision.click.confirm", return_value=False):
+            _push_secrets(ssh, project_root, warnings)
+
+        assert len(warnings) == 1
+        assert "skipped by user" in warnings[0]
+        ssh.write_remote_file.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -347,6 +364,7 @@ class TestProvisionSequence:
             patch("dango.platform.cloud.server_setup.setup_server") as mock_setup,
             patch("dango.platform.cloud.file_sync.sync_project_files"),
             patch("dango.platform.cloud.provisioning.save_provisioning_metadata"),
+            patch("dango.cli.commands.deploy_provision.click.confirm", return_value=True),
         ):
             mock_setup.return_value = MagicMock(warnings=[])
             mock_ssh.generate_key_pair.return_value = "ssh-ed25519 AAAA..."

--- a/tests/unit/test_deploy_wizard.py
+++ b/tests/unit/test_deploy_wizard.py
@@ -314,3 +314,40 @@ class TestCostSummary:
     def test_standard_with_backups(self):
         """Standard tier with backups = $29."""
         assert _get_monthly_cost("s-2vcpu-4gb", True) == 29
+
+
+# ---------------------------------------------------------------------------
+# 6. Domain removal (UX-020)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDomainRemoval:
+    def test_non_interactive_sets_domain_none_by_default(self, project_root, monkeypatch):
+        """Non-interactive without --domain gives domain=None."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        config = run_non_interactive(
+            project_root,
+            admin_email="admin@example.com",
+            admin_password="strongpassword123",
+        )
+        assert config.domain is None
+
+    def test_non_interactive_accepts_domain_flag(self, project_root, monkeypatch):
+        """Non-interactive with --domain passes it through."""
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
+        config = run_non_interactive(
+            project_root,
+            domain="example.com",
+            admin_email="admin@example.com",
+            admin_password="strongpassword123",
+        )
+        assert config.domain == "example.com"
+
+    def test_cost_summary_no_domain_param(self):
+        """_step_cost_summary works without domain parameter."""
+        from dango.cli.commands.deploy_wizard import _step_cost_summary
+
+        with patch("dango.cli.commands.deploy_wizard.click.confirm", return_value=True):
+            cost = _step_cost_summary("nyc1", "s-2vcpu-4gb", False)
+        assert cost == 24

--- a/tests/unit/test_deploy_wizard.py
+++ b/tests/unit/test_deploy_wizard.py
@@ -344,10 +344,12 @@ class TestDomainRemoval:
         )
         assert config.domain == "example.com"
 
-    def test_cost_summary_no_domain_param(self):
-        """_step_cost_summary works without domain parameter."""
+    def test_cost_summary_no_domain_param(self, capsys):
+        """_step_cost_summary works without domain parameter and shows billing disclaimer."""
         from dango.cli.commands.deploy_wizard import _step_cost_summary
 
         with patch("dango.cli.commands.deploy_wizard.click.confirm", return_value=True):
             cost = _step_cost_summary("nyc1", "s-2vcpu-4gb", False)
         assert cost == 24
+        output = capsys.readouterr().out
+        assert "billed directly by DigitalOcean" in output

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -526,3 +526,50 @@ class TestHelpers:
 
         assert changed is False
         ssh.write_remote_file.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Version pinning in _setup_venv
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSetupVenvVersionPinning:
+    def test_setup_venv_with_version(self):
+        """Pip install command includes pinned version."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_venv
+
+        ssh = _make_ssh_mock(exec_results={"test -x": ("", "", 1)})
+        result = SetupResult()
+        _setup_venv(ssh, result, None, dango_version="1.2.3")
+
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        pip_cmd = [c for c in cmds if "pip install" in c and "getdango" in c]
+        assert pip_cmd
+        assert "getdango==1.2.3" in pip_cmd[0]
+
+    def test_setup_venv_without_version(self):
+        """Pip install command uses plain getdango (latest)."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_venv
+
+        ssh = _make_ssh_mock(exec_results={"test -x": ("", "", 1)})
+        result = SetupResult()
+        _setup_venv(ssh, result, None)
+
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        pip_cmd = [c for c in cmds if "pip install" in c and "getdango" in c]
+        assert pip_cmd
+        assert "getdango==" not in pip_cmd[0]
+        assert "getdango" in pip_cmd[0]
+
+    def test_setup_server_passes_version(self):
+        """setup_server threads dango_version through to _setup_venv."""
+        from dango.platform.cloud.server_setup import setup_server
+
+        # Make "test -x /srv/dango/venv/bin/dango" fail so venv step runs
+        ssh = _make_ssh_mock(exec_results={"test -x": ("", "", 1)})
+        setup_server(ssh, dango_version="2.0.0")
+
+        # Find the pip install command containing getdango
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        pip_cmds = [c for c in cmds if "pip install" in c and "getdango" in c]
+        assert pip_cmds
+        assert "getdango==2.0.0" in pip_cmds[0]

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -573,3 +573,12 @@ class TestSetupVenvVersionPinning:
         pip_cmds = [c for c in cmds if "pip install" in c and "getdango" in c]
         assert pip_cmds
         assert "getdango==2.0.0" in pip_cmds[0]
+
+    def test_setup_venv_rejects_malicious_version(self):
+        """Version string with shell metacharacters is rejected."""
+        from dango.platform.cloud.server_setup import SetupResult, _setup_venv
+
+        ssh = _make_ssh_mock(exec_results={"test -x": ("", "", 1)})
+        result = SetupResult()
+        with pytest.raises(ValueError, match="Invalid version string"):
+            _setup_venv(ssh, result, None, dango_version="1.0; rm -rf /")


### PR DESCRIPTION
## Summary
- **UX-008:** Nav spacing fix (`space-x-0.5` → `space-x-1`) at 1280px
- **UX-010:** `--docker` flag on `dango cleanup` to prune dangling Docker volumes
- **UX-013:** DigitalOcean billing disclaimer in deploy cost summary
- **UX-014:** Dismissible 2FA recommendation banner for cloud users without TOTP
- **UX-017:** Startup warnings when cloud deployments have weak security settings
- **UX-018:** DNS instruction with actual server IP in post-deploy output
- **UX-019:** Version pinning — deploy installs the exact local `getdango` version
- **UX-020:** Remove domain question from deploy wizard (moved to `dango remote domain set`)
- **UX-021:** Safer confirmation defaults (backup=Yes, stop services=No)
- **UX-022:** Confirmation prompt before pushing secrets to remote server

22 files changed, +447/-513 lines. 3037 tests pass (7 skipped, 8 pre-existing warnings).

## Test plan
- [x] All existing unit tests pass (`pytest tests/unit/ -x`)
- [x] New tests for Docker volume collection (4 tests), cleanup flag, deploy provision confirm, version pinning (3 tests), wizard domain removal (3 tests)
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, file-size-check)
- [x] File exemption line counts verified with `wc -l`
- [x] CLAUDE.md line counts updated in all three locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)