### PR TITLE
R8-F: Fix deploy pipeline integration bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ dango/                          # Python package source
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
 │   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (808 lines)
-│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (737 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (813 lines)
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
 │   │   ├── remote_env.py       # remote env subgroup (set/get/list/delete)
@@ -234,7 +234,7 @@ dango/                          # Python package source
 │   │   ├── domain.py           # DNS check, domain set/remove
 │   │   ├── backup.py           # Backup + rollback + service lifecycle
 │   │   ├── file_sync.py        # Project file sync (SFTP + rsync)
-│   │   ├── deployer.py         # Push deploy workflow + deploy lock (578 lines)
+│   │   ├── deployer.py         # Push deploy workflow + deploy lock (595 lines)
 │   │   ├── deploy_journal.py   # Append-only JSONL deployment history
 │   │   ├── scheduled_backup.py # Server-side scheduled backup (505 lines)
 │   │   ├── resize.py           # In-place droplet resize
@@ -350,14 +350,14 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/source.py` | 748 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
-| `platform/cloud/deployer.py` | 578 | — (push deploy workflow + deploy lock + journal) |
+| `platform/cloud/deployer.py` | 595 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 600 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 808 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 548 | — |
 | `web/routes/catalog.py` | 1157 | — (data catalog: columns, profiling, lineage, impact, models, search) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
-| `cli/commands/deploy_provision.py` | 737 | — (provisioning orchestration + BYOS) |
+| `cli/commands/deploy_provision.py` | 813 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 542 | — (DO REST API v2 client) |
 | `cli/commands/auth.py` | 660 | — (13 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -30,7 +30,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/serve.py` (~171 lines) | `serve` production foreground server. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
 | `commands/deploy.py` (705 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
 | `commands/deploy_wizard.py` (808 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
-| `commands/deploy_provision.py` (737 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
+| `commands/deploy_provision.py` (813 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -200,6 +200,14 @@ def run_provisioning(
         finally:
             ssh.disconnect()
 
+        # --- Sub-step 6b: Generate dbt profiles.yml for cloud ---
+        _status("Generating dbt profiles...")
+        ssh.connect(droplet_ip, username="root")
+        try:
+            _generate_cloud_profiles(ssh, project_root, config.size_slug)
+        finally:
+            ssh.disconnect()
+
         # --- Sub-step 7: Push secrets ---
         warnings: list[str] = []
         _status("Pushing secrets to server...")
@@ -357,6 +365,14 @@ def run_byos_setup(
                 remote_host=config.server_ip,
                 on_progress=_setup_progress,
             )
+        finally:
+            ssh.disconnect()
+
+        # --- Sub-step 2b: Generate dbt profiles.yml for cloud ---
+        _status("Generating dbt profiles...")
+        ssh.connect(config.server_ip, username=config.ssh_user)
+        try:
+            _generate_cloud_profiles(ssh, project_root)
         finally:
             ssh.disconnect()
 
@@ -556,6 +572,13 @@ def _create_admin_and_enable_auth(
         timeout=30,
     )
 
+    # Persist admin email for systemd service (BUG-100)
+    ssh.exec_command(
+        f"grep -q '^DANGO_ADMIN_EMAIL=' /srv/dango/project/.env 2>/dev/null "
+        f"|| echo 'DANGO_ADMIN_EMAIL={email}' >> /srv/dango/project/.env"
+    )
+    ssh.exec_command("chown dango:dango /srv/dango/project/.env 2>/dev/null; true")
+
     # Enable auth
     ssh.write_remote_file("/srv/dango/project/.dango/auth.yml", "enabled: true\n", mode=0o644)
     ssh.exec_command("chown dango:dango /srv/dango/project/.dango/auth.yml")
@@ -688,6 +711,59 @@ def _save_extra_metadata(
 
     updated = existing.model_copy(update=update)
     loader.save_cloud_config(updated)
+
+
+def _generate_cloud_profiles(
+    ssh: Any,
+    project_root: Path,
+    size_slug: str | None = None,
+) -> None:
+    """Generate ``dbt/profiles.yml`` on the remote server tuned for its hardware.
+
+    Args:
+        ssh: Connected SSHManager.
+        project_root: Local project root (to read dbt_project.yml).
+        size_slug: DO size slug (e.g. ``"s-2vcpu-4gb"``).  If ``None``
+            (BYOS), hardware is auto-detected via SSH.
+    """
+    import yaml
+
+    from dango.platform.cloud.resize import generate_dbt_profiles_yml
+
+    # Read project name from local dbt_project.yml
+    dbt_project_path = project_root / "dbt" / "dbt_project.yml"
+    project_name = "dango"
+    if dbt_project_path.is_file():
+        try:
+            dbt_cfg = yaml.safe_load(dbt_project_path.read_text()) or {}
+            project_name = dbt_cfg.get("name", "dango")
+        except Exception:
+            pass
+
+    if size_slug:
+        # Known DO size — look up tier specs
+        from dango.platform.cloud.provisioning import get_size_tier
+
+        tier = get_size_tier(size_slug)
+        vcpus = tier.vcpus if tier else 2
+        ram_gb = tier.ram_gb if tier else 4
+    else:
+        # BYOS — auto-detect hardware via SSH
+        nproc_result = ssh.exec_command("nproc")
+        try:
+            vcpus = int(nproc_result.stdout.strip())
+        except (ValueError, AttributeError):
+            vcpus = 2
+
+        mem_result = ssh.exec_command("free -g | awk '/Mem:/{print $2}'")
+        try:
+            ram_gb = int(mem_result.stdout.strip())
+        except (ValueError, AttributeError):
+            ram_gb = 4
+
+    content = generate_dbt_profiles_yml(project_name, vcpus, ram_gb)
+    ssh.write_remote_file("/srv/dango/project/dbt/profiles.yml", content, mode=0o644)
+    ssh.exec_command("chown dango:dango /srv/dango/project/dbt/profiles.yml")
 
 
 def _start_services(ssh: Any) -> None:

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -54,6 +54,11 @@ def serve(ctx: click.Context, host: str, port: int | None) -> None:
     except (click.Abort, SystemExit):
         raise SystemExit(1) from None
 
+    # Load .env so DANGO_ADMIN_EMAIL and other env vars are available under systemd (BUG-100)
+    from dotenv import load_dotenv
+
+    load_dotenv(project_root / ".env")
+
     # Load config (M6: catch config errors cleanly)
     try:
         config_loader = ConfigLoader(project_root)

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -41,6 +41,9 @@ DBT_PROJECT_DIR = "/srv/dango/project/dbt"
 #: Pattern for valid dbt model/macro names (shell-safe for SSH commands).
 _SAFE_DBT_NAME = re.compile(r"^[a-zA-Z0-9_]+$")
 
+#: Docker files that require ``docker compose up --build`` when changed.
+_DOCKER_FILES = {"docker-compose.yml", "Dockerfile.metabase", "entrypoint.sh"}
+
 
 # ---------------------------------------------------------------------------
 # Dataclasses
@@ -208,13 +211,26 @@ def _start_web_service(ssh: SSHManager) -> None:
     ssh.exec_command("systemctl start dango-web || true", timeout=60)
 
 
-def _start_all_services(ssh: SSHManager) -> None:
-    """Start Metabase then dango-web (same order as backup.start_services)."""
-    ssh.exec_command(
-        f"docker compose -f {REMOTE_PROJECT_DIR}/docker-compose.yml "
-        "start metabase 2>/dev/null || true",
-        timeout=120,
-    )
+def _start_all_services(ssh: SSHManager, *, rebuild_docker: bool = False) -> None:
+    """Start Metabase then dango-web (same order as backup.start_services).
+
+    Args:
+        ssh: Connected SSHManager.
+        rebuild_docker: If True, rebuild Docker images before starting
+            (used when Docker files changed during push deploy).
+    """
+    if rebuild_docker:
+        # Docker files changed — rebuild images before starting
+        ssh.exec_command(
+            f"cd {REMOTE_PROJECT_DIR} && sudo -u dango docker compose up --build -d",
+            timeout=300,
+        )
+    else:
+        ssh.exec_command(
+            f"docker compose -f {REMOTE_PROJECT_DIR}/docker-compose.yml "
+            "start metabase 2>/dev/null || true",
+            timeout=120,
+        )
     ssh.exec_command("systemctl start dango-web || true", timeout=60)
 
 
@@ -543,7 +559,8 @@ def push_deploy(
             # Always restart all services and release lock
             if services_stopped:
                 _notify(on_progress, "start_services", "running")
-                _start_all_services(ssh)
+                docker_files_changed = bool(set(sync_result.synced_files) & _DOCKER_FILES)
+                _start_all_services(ssh, rebuild_docker=docker_files_changed)
                 _notify(on_progress, "start_services", "done")
 
             if lock is not None:

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -51,9 +51,13 @@ REMOTE_PROJECT_DIR = "/srv/dango/project"
 
 #: Config files to upload via SFTP.  Tuples of (local_relative, remote_relative).
 #: Files that may not exist locally are skipped gracefully.
+#:
+#: Note: ``metabase-plugins/`` is intentionally NOT synced — the server's
+#: ``ensure_duckdb_driver()`` handles driver download independently.
 SYNC_CONFIG_FILES: list[tuple[str, str]] = [
     (".dango/sources.yml", f"{REMOTE_PROJECT_DIR}/.dango/sources.yml"),
     (".dango/schedules.yml", f"{REMOTE_PROJECT_DIR}/.dango/schedules.yml"),
+    (".dango/project.yml", f"{REMOTE_PROJECT_DIR}/.dango/project.yml"),
     ("dbt/dbt_project.yml", f"{REMOTE_PROJECT_DIR}/dbt/dbt_project.yml"),
     ("dbt/packages.yml", f"{REMOTE_PROJECT_DIR}/dbt/packages.yml"),
     # Docker build context files — both required to build the Metabase image on the server

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -235,7 +235,10 @@ def setup_metabase_if_needed(
             if db_path.exists():
                 users = list_users(db_path, active_only=True)
                 admins = [u for u in users if u.role == Role.ADMIN]
-                if admins and admins[0].email != "admin@dango.local":
+                if admins and admins[0].email not in (
+                    "admin@dango.local",
+                    "admin@localhost",
+                ):
                     admin_email = admins[0].email
         except Exception:
             pass
@@ -248,6 +251,19 @@ def setup_metabase_if_needed(
             reason="No admin email found. Metabase setup will complete on next restart.",
         )
         return {"already_configured": False, "success": True, "skipped": True}
+
+    # Validate email domain — Metabase rejects domains without a dot (e.g. localhost)
+    if "@" in admin_email:
+        domain = admin_email.split("@")[1]
+        if "." not in domain:
+            from dango.logging import get_logger as _get_logger2
+
+            _logger2 = _get_logger2(__name__)
+            _logger2.warning(
+                "metabase_setup_skipped",
+                reason=f"Admin email domain invalid for Metabase: {domain}",
+            )
+            return {"already_configured": False, "success": True, "skipped": True}
 
     setup_result = setup_metabase(
         project_root,

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -68,9 +68,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy_provision.py
-    lines: 737
+    lines: 813
     category: exempt
-    reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery."
+    reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery. R8-F added _generate_cloud_profiles + DANGO_ADMIN_EMAIL persistence."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy.py
@@ -117,9 +117,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/cloud/deployer.py
-    lines: 578
+    lines: 595
     category: exempt
-    reason: "P8-004: Push deployment workflow with deploy lock and journal writing. Added git_info passthrough, nested try/finally for journal write, _write_deploy_journal helper."
+    reason: "P8-004: Push deployment workflow with deploy lock and journal writing. Added git_info passthrough, nested try/finally for journal write, _write_deploy_journal helper. R8-F added Docker rebuild detection."
     review_by: "v1.1"
 
   # --- Exempt (stable, not modified in v1) ---
@@ -291,9 +291,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_deploy_provision.py
-    lines: 562
+    lines: 682
     category: exempt
-    reason: "TASK-029: 9 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, and sync trigger. Each requires isolated mock setup."
+    reason: "TASK-029+R8-F: 11 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, sync trigger, admin email persistence, and cloud profiles generation."
     review_by: "v1.1"
 
   - file: tests/unit/test_sync_jobs.py

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -14,6 +14,7 @@ import pytest
 from dango.cli.commands.deploy_provision import (
     _create_admin_and_enable_auth,
     _extract_ip,
+    _generate_cloud_profiles,
     _health_check,
     _push_secrets,
     _ResourceTracker,
@@ -560,3 +561,122 @@ class TestTriggerInitialSync:
         """Trigger does not raise on connection failure."""
         # Should not raise
         _trigger_initial_sync("http://1.2.3.4", "test-token-123")
+
+
+# ---------------------------------------------------------------------------
+# 10. Admin email persistence (BUG-100)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAdminEmailPersistence:
+    def test_appends_admin_email_to_env(self):
+        """BUG-100: _create_admin_and_enable_auth appends DANGO_ADMIN_EMAIL to .env."""
+        ssh = _make_mock_ssh()
+        _create_admin_and_enable_auth(ssh, "admin@test.com", "password123")
+
+        # Find the grep/echo command that appends DANGO_ADMIN_EMAIL
+        email_cmds = [
+            str(c) for c in ssh.exec_command.call_args_list if "DANGO_ADMIN_EMAIL" in str(c)
+        ]
+        assert len(email_cmds) >= 1, "Expected DANGO_ADMIN_EMAIL append command"
+        assert "admin@test.com" in email_cmds[0]
+
+    def test_email_append_uses_grep_guard(self):
+        """DANGO_ADMIN_EMAIL append uses grep -q to avoid duplicates."""
+        ssh = _make_mock_ssh()
+        _create_admin_and_enable_auth(ssh, "admin@test.com", "password123")
+
+        email_cmds = [
+            str(c)
+            for c in ssh.exec_command.call_args_list
+            if "DANGO_ADMIN_EMAIL" in str(c) and "grep -q" in str(c)
+        ]
+        assert len(email_cmds) >= 1, "Expected grep -q guard for DANGO_ADMIN_EMAIL"
+
+
+# ---------------------------------------------------------------------------
+# 11. Cloud profiles generation (BUG-114)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGenerateCloudProfiles:
+    def test_with_known_size_slug(self, project_root):
+        """BUG-114: Generates profiles.yml with known DO size tier specs."""
+        # Create dbt_project.yml
+        dbt_dir = project_root / "dbt"
+        dbt_dir.mkdir(exist_ok=True)
+        (dbt_dir / "dbt_project.yml").write_text("name: my_project\n")
+
+        ssh = _make_mock_ssh()
+        _generate_cloud_profiles(ssh, project_root, size_slug="s-2vcpu-4gb")
+
+        # Verify write_remote_file was called with profiles.yml
+        write_calls = [
+            c for c in ssh.write_remote_file.call_args_list if "profiles.yml" in str(c[0][0])
+        ]
+        assert len(write_calls) == 1
+        content = write_calls[0][0][1]
+        assert "my_project" in content
+        assert "threads: 2" in content  # s-2vcpu-4gb has 2 vcpus
+        assert "warehouse.duckdb" in content
+
+    def test_with_byos_auto_detect(self, project_root):
+        """BUG-114: BYOS auto-detects hardware via SSH when no size_slug."""
+        dbt_dir = project_root / "dbt"
+        dbt_dir.mkdir(exist_ok=True)
+        (dbt_dir / "dbt_project.yml").write_text("name: byos_project\n")
+
+        ssh = _make_mock_ssh()
+
+        def _exec_side_effect(cmd, **kwargs):
+            result = MagicMock()
+            result.success = True
+            result.stderr = ""
+            result.exit_code = 0
+            if cmd == "nproc":
+                result.stdout = "4"
+            elif "free -g" in cmd:
+                result.stdout = "8"
+            else:
+                result.stdout = ""
+            return result
+
+        ssh.exec_command.side_effect = _exec_side_effect
+
+        _generate_cloud_profiles(ssh, project_root)
+
+        write_calls = [
+            c for c in ssh.write_remote_file.call_args_list if "profiles.yml" in str(c[0][0])
+        ]
+        assert len(write_calls) == 1
+        content = write_calls[0][0][1]
+        assert "byos_project" in content
+        assert "threads: 4" in content  # auto-detected 4 vcpus
+
+    def test_falls_back_to_defaults(self, project_root):
+        """Falls back to project_name='dango' and 2/4 specs when dbt_project.yml missing."""
+        ssh = _make_mock_ssh()
+        _generate_cloud_profiles(ssh, project_root, size_slug="custom-size")
+
+        write_calls = [
+            c for c in ssh.write_remote_file.call_args_list if "profiles.yml" in str(c[0][0])
+        ]
+        assert len(write_calls) == 1
+        content = write_calls[0][0][1]
+        # Falls back to "dango" project name and 2 vcpus / 4gb ram defaults
+        assert "dango" in content
+        assert "threads: 2" in content
+
+    def test_chowns_profiles_to_dango(self, project_root):
+        """profiles.yml is chowned to dango:dango after creation."""
+        ssh = _make_mock_ssh()
+        _generate_cloud_profiles(ssh, project_root, size_slug="s-2vcpu-4gb")
+
+        chown_calls = [
+            str(c)
+            for c in ssh.exec_command.call_args_list
+            if "chown dango:dango" in str(c) and "profiles.yml" in str(c)
+        ]
+        assert len(chown_calls) >= 1

--- a/tests/unit/test_deployer_push.py
+++ b/tests/unit/test_deployer_push.py
@@ -15,7 +15,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dango.exceptions import CloudProvisioningError
-from dango.platform.cloud.deployer import DEPLOY_LOCK_PATH, push_deploy
+from dango.platform.cloud.deployer import (
+    _DOCKER_FILES,
+    DEPLOY_LOCK_PATH,
+    _start_all_services,
+    push_deploy,
+)
 from dango.platform.cloud.file_sync import SyncResult
 from dango.platform.cloud.ssh import CommandResult
 
@@ -386,3 +391,99 @@ class TestPushDeploy:
         assert call_kwargs["deploy_succeeded"] is False
         assert call_kwargs["deploy_error"] is not None
         assert "dbt compile failed" in call_kwargs["deploy_error"]
+
+
+# ---------------------------------------------------------------------------
+# Docker rebuild detection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDockerRebuild:
+    """Test Docker rebuild detection in _start_all_services and push_deploy."""
+
+    def test_docker_files_constant(self):
+        """_DOCKER_FILES contains the expected Docker filenames."""
+        assert "docker-compose.yml" in _DOCKER_FILES
+        assert "Dockerfile.metabase" in _DOCKER_FILES
+        assert "entrypoint.sh" in _DOCKER_FILES
+
+    def test_start_all_services_rebuild_true(self):
+        """With rebuild_docker=True, uses 'up --build -d'."""
+        ssh = _make_ssh_mock()
+        commands: list[str] = []
+
+        def _track(cmd: str, **kwargs: object) -> CommandResult:
+            commands.append(cmd)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _track
+
+        _start_all_services(ssh, rebuild_docker=True)
+
+        assert any("up --build -d" in c for c in commands)
+        # Should NOT use 'start metabase' pattern
+        assert not any("start metabase 2>/dev/null" in c for c in commands)
+        # Should still start dango-web
+        assert any("systemctl start dango-web" in c for c in commands)
+
+    def test_start_all_services_rebuild_false(self):
+        """With rebuild_docker=False, uses 'start metabase' (no rebuild)."""
+        ssh = _make_ssh_mock()
+        commands: list[str] = []
+
+        def _track(cmd: str, **kwargs: object) -> CommandResult:
+            commands.append(cmd)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _track
+
+        _start_all_services(ssh, rebuild_docker=False)
+
+        assert any("start metabase" in c for c in commands)
+        assert not any("up --build" in c for c in commands)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_push_deploy_detects_docker_changes(self, mock_sync, mock_backup, tmp_path):
+        """push_deploy triggers Docker rebuild when Docker files are in synced_files."""
+        mock_sync.return_value = _make_sync_result(
+            synced_files=["docker-compose.yml", "dbt/models/", ".dango/sources.yml"],
+        )
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        commands: list[str] = []
+
+        def _tracking_exec(cmd: str, **kwargs: object) -> CommandResult:
+            commands.append(cmd)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _tracking_exec
+
+        push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert any("up --build -d" in c for c in commands)
+
+    @patch("dango.platform.cloud.backup.create_backup")
+    @patch("dango.platform.cloud.file_sync.sync_project_files")
+    def test_push_deploy_no_docker_changes(self, mock_sync, mock_backup, tmp_path):
+        """push_deploy does NOT rebuild Docker when no Docker files changed."""
+        mock_sync.return_value = _make_sync_result(
+            synced_files=["dbt/models/", ".dango/sources.yml"],
+        )
+        mock_backup.return_value = _make_backup_result()
+        ssh = _make_ssh_mock()
+
+        commands: list[str] = []
+
+        def _tracking_exec(cmd: str, **kwargs: object) -> CommandResult:
+            commands.append(cmd)
+            return CommandResult(stdout="", stderr="", exit_code=0)
+
+        ssh.exec_command.side_effect = _tracking_exec
+
+        push_deploy(ssh, tmp_path, "10.0.0.1")
+
+        assert not any("up --build" in c for c in commands)
+        assert any("start metabase" in c for c in commands)

--- a/tests/unit/test_file_sync.py
+++ b/tests/unit/test_file_sync.py
@@ -15,6 +15,7 @@ import pytest
 
 from dango.platform.cloud.file_sync import (
     REMOTE_PROJECT_DIR,
+    SYNC_CONFIG_FILES,
     SyncResult,
     _build_rsync_ssh_arg,
     _compute_local_hashes,
@@ -77,6 +78,31 @@ def _make_project(tmp_path: Path, *, with_packages: bool = True) -> Path:
 # ---------------------------------------------------------------------------
 # SyncResult tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSyncConfigFiles:
+    """Test SYNC_CONFIG_FILES list contents."""
+
+    def test_project_yml_in_sync_list(self):
+        """BUG-098: .dango/project.yml must be synced to the server."""
+        local_paths = [local for local, _ in SYNC_CONFIG_FILES]
+        assert ".dango/project.yml" in local_paths
+
+    def test_project_yml_remote_path(self):
+        """project.yml remote path matches standard layout."""
+        for local, remote in SYNC_CONFIG_FILES:
+            if local == ".dango/project.yml":
+                assert remote == f"{REMOTE_PROJECT_DIR}/.dango/project.yml"
+                return
+        pytest.fail(".dango/project.yml not found in SYNC_CONFIG_FILES")
+
+    def test_docker_files_in_sync_list(self):
+        """Docker build context files are synced (R8-B)."""
+        local_paths = [local for local, _ in SYNC_CONFIG_FILES]
+        assert "docker-compose.yml" in local_paths
+        assert "Dockerfile.metabase" in local_paths
+        assert "entrypoint.sh" in local_paths
 
 
 @pytest.mark.unit

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -229,18 +229,18 @@ class TestSetupMetabaseIfNeeded:
 
     def test_returns_errors_when_setup_fails_before_duckdb(self, tmp_path, monkeypatch):
         """Pre-DuckDB failures are returned in the result dict, not masked (BUG-105)."""
-        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "bad@localhost")
+        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "bad@example.com")
         setup_result = {
             "success": False,
             "duckdb_connected": False,
-            "errors": ["Invalid email domain: localhost"],
+            "errors": ["Some setup error"],
         }
 
         with patch("dango.visualization.metabase.setup_metabase", return_value=setup_result):
             result = setup_metabase_if_needed(tmp_path, "MyProject", None)
 
         assert result["success"] is False
-        assert "Invalid email domain" in result["errors"][0]
+        assert "Some setup error" in result["errors"][0]
 
     def test_success(self, tmp_path, monkeypatch):
         """setup_metabase_if_needed returns result dict on successful first-run setup."""
@@ -265,6 +265,46 @@ class TestSetupMetabaseIfNeeded:
         result = setup_metabase_if_needed(tmp_path, "MyProject", None)
         assert result["skipped"] is True
         assert result["success"] is True
+
+    def test_skips_admin_at_localhost(self, tmp_path, monkeypatch):
+        """BUG-100: admin@localhost is filtered like admin@dango.local."""
+        monkeypatch.delenv("DANGO_ADMIN_EMAIL", raising=False)
+        # Create auth DB with admin@localhost
+        from dango.auth.admin import get_auth_db_path
+        from dango.auth.database import create_user
+        from dango.auth.models import Role, User
+        from dango.migrations.runner import MigrationRunner
+
+        db_path = get_auth_db_path(tmp_path)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+        MigrationRunner(
+            db_path=db_path, db_name="auth", migrations_dir=migrations_dir
+        ).apply_pending()
+        create_user(
+            db_path,
+            User(email="admin@localhost", password_hash="$2b$12$fakehash", role=Role.ADMIN),
+        )
+
+        result = setup_metabase_if_needed(tmp_path, "MyProject", None)
+        assert result["skipped"] is True
+        assert result["success"] is True
+
+    def test_skips_dotless_email_domain(self, tmp_path, monkeypatch):
+        """BUG-100: Emails with dot-less domains (e.g. localhost) skip Metabase setup."""
+        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "user@localhost")
+        result = setup_metabase_if_needed(tmp_path, "MyProject", None)
+        assert result["skipped"] is True
+        assert result["success"] is True
+
+    def test_valid_email_domain_proceeds(self, tmp_path, monkeypatch):
+        """Emails with proper domains (e.g. test.com) proceed to setup."""
+        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "admin@test.com")
+        setup_result = {"success": True, "duckdb_connected": True, "errors": []}
+        with patch("dango.visualization.metabase.setup_metabase", return_value=setup_result):
+            result = setup_metabase_if_needed(tmp_path, "MyProject", None)
+        assert result["success"] is True
+        assert result.get("skipped") is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **BUG-098:** Sync `.dango/project.yml` to server (was missing from `SYNC_CONFIG_FILES`)
- **BUG-100:** Fix admin email not reaching Metabase setup under systemd — `load_dotenv()` in `serve.py`, persist `DANGO_ADMIN_EMAIL` to remote `.env`, filter `admin@localhost` and dot-less domains in `startup.py`
- **BUG-110:** Document intentional `metabase-plugins/` exclusion from sync
- **BUG-114:** Generate `dbt/profiles.yml` during cloud deploy (DO uses size tier specs, BYOS auto-detects hardware via SSH)
- **Docker rebuild:** `push_deploy()` detects Docker file changes in `synced_files` and uses `docker compose up --build -d` instead of `start`
- **BUG-111/113:** Verified already fixed by R8-E/R8-B respectively

## Test plan

- [x] 111 targeted tests pass across 4 test files (15 new tests added)
- [x] Full unit suite passes (all background runs exit 0)
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, file-size-check)
- [x] File-exemptions.yml and CLAUDE.md line counts updated
- [ ] Cloud deploy retest in Session 8 (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)