### PR TITLE
R9-B: Fix Metabase password desync and container name mismatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/dlt_runner.py` | 2373 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2288 | — |
-| `visualization/metabase.py` | 1152 | — |
+| `visualization/metabase.py` | 1151 | — |
 | `cli/init.py` | 1324 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
 | `cli/commands/platform.py` | 970 | — (extracted from main.py by TASK-005) |

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -358,6 +358,9 @@ def _link_metabase_admin(project_root: Path, admin_email: str) -> None:
             dango_user.id,
             UserUpdate(metabase_user_id=mb_user["id"], metabase_password_enc=encrypted_pw),
         )
+        admin_creds["password"] = password
+        with open(mb_yml_path, "w") as f:
+            yaml.safe_dump(mb_creds, f, default_flow_style=False)
         _logger.info("metabase_admin_linked", email=admin_email, metabase_user_id=mb_user["id"])
     except Exception:
         # Non-critical — SSO bridge will lazy-sync on next login

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -1107,9 +1107,11 @@ def refresh_metabase_connection(
     import subprocess
 
     try:
-        # Get container name from project root
-        project_name = project_root.name
-        container_name = f"{project_name}-metabase-1"
+        # Get container name from DockerManager (uses hash-based naming)
+        from dango.platform.docker import DockerManager
+
+        dm = DockerManager(project_root)
+        container_name = f"{dm.compose_project_name}-metabase-1"
 
         # Check if container exists and is running
         check_result = subprocess.run(

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -142,7 +142,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
-    lines: 1152
+    lines: 1151
     category: exempt
     reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations."
     review_by: "v1.1"
@@ -368,6 +368,12 @@ exemptions:
     lines: 508
     category: exempt
     reason: "R8-A: BUG-103/104 fixes added call-order tracking test and two Metabase failure-path tests (exception + return-dict). Each test requires its own full decorator stack for startup helpers. Marginally over limit."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_platform_startup.py
+    lines: 601
+    category: exempt
+    reason: "R9-B: BUG-115/118 tests added metabase.yml write-back assertions and refresh_metabase_connection container-name tests. Each test class requires independent auth DB setup and multi-layer mocking."
     review_by: "v1.1"
 
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -472,3 +472,130 @@ class TestLinkMetabaseAdmin:
 
         _link_metabase_admin(tmp_path, "admin@test.com")
         mock_post.assert_not_called()
+
+    @patch("requests.put")
+    @patch("requests.post")
+    @patch("requests.get")
+    @patch("dango.auth.metabase_sync.SecureTokenStorage")
+    def test_happy_path_updates_metabase_yml(
+        self,
+        mock_sts: MagicMock,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        mock_put: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """BUG-115: metabase.yml is updated with the new password after linking."""
+        import yaml
+
+        self._setup_metabase_yml(tmp_path)
+        self._setup_auth_db(tmp_path)
+        mock_sts.return_value.encrypt_token.return_value = "encrypted_pw"
+
+        session_resp = MagicMock(status_code=200)
+        session_resp.json.return_value = {"id": "session123"}
+        mock_post.return_value = session_resp
+
+        user_list_resp = MagicMock(status_code=200)
+        user_list_resp.json.return_value = [{"id": 42, "email": "admin@test.com"}]
+        mock_get.return_value = user_list_resp
+
+        mock_put.return_value = MagicMock(status_code=200)
+
+        _link_metabase_admin(tmp_path, "admin@test.com")
+
+        # Verify metabase.yml was updated with the new password
+        mb_yml_path = tmp_path / ".dango" / "metabase.yml"
+        with open(mb_yml_path) as f:
+            updated_creds = yaml.safe_load(f)
+        new_password = updated_creds["admin"]["password"]
+        assert new_password != "testpw", "Password in metabase.yml should have been updated"
+        # The new password was sent to the Metabase API
+        put_json = mock_put.call_args[1]["json"]
+        assert put_json["password"] == new_password
+
+    @patch("requests.put")
+    @patch("requests.post")
+    @patch("requests.get")
+    @patch("dango.auth.metabase_sync.SecureTokenStorage")
+    def test_metabase_yml_unchanged_when_password_update_fails(
+        self,
+        mock_sts: MagicMock,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        mock_put: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """BUG-115: metabase.yml keeps old password when Metabase password update fails."""
+        import yaml
+
+        self._setup_metabase_yml(tmp_path)
+        self._setup_auth_db(tmp_path)
+
+        session_resp = MagicMock(status_code=200)
+        session_resp.json.return_value = {"id": "session123"}
+        mock_post.return_value = session_resp
+
+        user_list_resp = MagicMock(status_code=200)
+        user_list_resp.json.return_value = [{"id": 42, "email": "admin@test.com"}]
+        mock_get.return_value = user_list_resp
+
+        # Simulate password update failure (returns 400)
+        mock_put.return_value = MagicMock(status_code=400)
+
+        _link_metabase_admin(tmp_path, "admin@test.com")
+
+        # Verify metabase.yml was NOT changed
+        mb_yml_path = tmp_path / ".dango" / "metabase.yml"
+        with open(mb_yml_path) as f:
+            unchanged_creds = yaml.safe_load(f)
+        assert unchanged_creds["admin"]["password"] == "testpw"
+
+
+@pytest.mark.unit
+class TestRefreshMetabaseConnection:
+    """Tests for refresh_metabase_connection() container name resolution (BUG-118)."""
+
+    def test_uses_hash_based_container_name(self, tmp_path: Path) -> None:
+        """BUG-118: refresh_metabase_connection uses DockerManager's hash-based name."""
+        from dango.visualization.metabase import refresh_metabase_connection
+
+        mock_dm = MagicMock()
+        mock_dm.compose_project_name = "dango-abc123"
+
+        mock_subprocess_run = MagicMock(
+            side_effect=[
+                MagicMock(stdout="dango-abc123-metabase-1\n", returncode=0),  # docker ps
+                MagicMock(returncode=0),  # docker restart
+            ]
+        )
+
+        with (
+            patch("dango.platform.docker.DockerManager", return_value=mock_dm),
+            patch("subprocess.run", mock_subprocess_run),
+            patch("requests.get", return_value=MagicMock(status_code=200)),
+        ):
+            result = refresh_metabase_connection(tmp_path)
+
+        # Verify the hash-based container name was used in docker ps filter
+        ps_call = mock_subprocess_run.call_args_list[0]
+        ps_cmd = ps_call[0][0]
+        assert "name=dango-abc123-metabase-1" in " ".join(ps_cmd)
+
+        restart_call = mock_subprocess_run.call_args_list[1]
+        assert restart_call[0][0] == ["docker", "restart", "dango-abc123-metabase-1"]
+        assert result is True
+
+    def test_returns_false_when_container_not_running(self, tmp_path: Path) -> None:
+        """Returns False when the Metabase container is not found."""
+        from dango.visualization.metabase import refresh_metabase_connection
+
+        mock_dm = MagicMock()
+        mock_dm.compose_project_name = "dango-abc123"
+
+        with (
+            patch("dango.platform.docker.DockerManager", return_value=mock_dm),
+            patch("subprocess.run", return_value=MagicMock(stdout="", returncode=0)),
+        ):
+            result = refresh_metabase_connection(tmp_path)
+        assert result is False


### PR DESCRIPTION
## Summary

- **BUG-115:** `_link_metabase_admin()` now writes the new Metabase admin password back to `metabase.yml` after updating it in Metabase and auth.db, preventing subsequent API calls from using a stale password and getting 401 Unauthorized.
- **BUG-118:** `refresh_metabase_connection()` now uses `DockerManager.compose_project_name` (hash-based naming) instead of the old `{dirname}-metabase-1` pattern, so the container is actually found.

## Test plan

- [x] 4 new tests: metabase.yml write-back on success, no write-back on failure, hash-based container name, container-not-found path
- [x] All 3075 unit tests pass
- [x] All pre-commit hooks pass (ruff, mypy, file-size-check, etc.)
- [x] File exemptions updated (`metabase.py` 1152→1151, `test_platform_startup.py` added at 601)

🤖 Generated with [Claude Code](https://claude.com/claude-code)