### PR TITLE
fix(cli): default dashboard provision URL to port 3000 to match metabase_port (#18)

### DIFF
--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -3350,7 +3350,7 @@ def dashboard(ctx):
 
 
 @dashboard.command("provision")
-@click.option("--url", default="http://localhost:3001", help="Metabase URL")
+@click.option("--url", default="http://localhost:3000", help="Metabase URL")
 @click.option("--username", default="admin@example.com", help="Metabase admin username")
 @click.option("--password", prompt=True, hide_input=True, help="Metabase admin password")
 @click.pass_context
@@ -3368,7 +3368,7 @@ def dashboard_provision(ctx, url, username, password):
     The dashboard provides instant visibility into your data pipeline.
 
     Examples:
-      dango dashboard provision                  # Use defaults (localhost:3001)
+      dango dashboard provision                  # Use defaults (localhost:3000)
       dango dashboard provision --url http://metabase.local
     """
     from rich.panel import Panel


### PR DESCRIPTION
Fixes #18. `dango dashboard provision` defaulted `--url` to `http://localhost:3001`, but the default `metabase_port` (defined in `dango/config/models.py:438` and `dango/platform/network.py:204`) is `3000`. Running the command without overrides connected to the wrong port and failed.

Updated the click default and the example string in the docstring to `3000`. Single-file change in `dango/cli/main.py:3353`.

## Test plan

- [x] AST parse on `dango/cli/main.py` is clean
- [x] Default now matches `PlatformConfig.metabase_port` and `PlatformConfig.network.metabase_port`