### PR TITLE
R9-E: Fix session cookie max_age and WebSocket disconnect spam

### DIFF
--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -44,6 +44,7 @@ from dango.auth.security import (
     verify_password,
 )
 from dango.auth.sessions import (
+    DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES,
     DEFAULT_SESSION_MAX_DAYS,
     create_api_key,
     create_session,
@@ -99,7 +100,13 @@ def _get_user_agent(request: Request) -> str | None:
     return request.headers.get("user-agent")
 
 
-def _set_session_cookie(response: JSONResponse, token: str, request: Request) -> None:
+def _set_session_cookie(
+    response: JSONResponse | RedirectResponse,
+    token: str,
+    request: Request,
+    *,
+    max_age_seconds: int,
+) -> None:
     """Set the session cookie on a response with appropriate security flags."""
     response.set_cookie(
         key=COOKIE_NAME,
@@ -108,6 +115,7 @@ def _set_session_cookie(response: JSONResponse, token: str, request: Request) ->
         httponly=True,
         samesite="lax",
         secure=is_secure_request(request.scope),
+        max_age=max_age_seconds,
     )
 
 
@@ -263,7 +271,12 @@ async def login(request: Request) -> JSONResponse:
             is_partial=True,
         )
         response = JSONResponse(content={"requires_2fa": True})
-        _set_session_cookie(response, raw_token, request)
+        _set_session_cookie(
+            response,
+            raw_token,
+            request,
+            max_age_seconds=DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES * 60,
+        )
         return response
 
     # Check if admin requires 2FA but user hasn't set it up
@@ -289,7 +302,7 @@ async def login(request: Request) -> JSONResponse:
             "requires_2fa_setup": requires_2fa_setup,
         }
     )
-    _set_session_cookie(response, raw_token, request)
+    _set_session_cookie(response, raw_token, request, max_age_seconds=session_max_days * 86400)
     await _bridge_metabase_session(user, request, response)
 
     return response
@@ -408,7 +421,7 @@ async def change_password(request: Request) -> JSONResponse:
     )
 
     response = JSONResponse(content={"success": True})
-    _set_session_cookie(response, raw_token, request)
+    _set_session_cookie(response, raw_token, request, max_age_seconds=session_max_days * 86400)
     return response
 
 
@@ -782,13 +795,11 @@ async def _resolve_oauth_user(
             is_partial=True,
         )
         response = RedirectResponse(url="/login?requires_2fa=true", status_code=302)
-        response.set_cookie(
-            key=COOKIE_NAME,
-            value=raw_token,
-            path="/",
-            httponly=True,
-            samesite="lax",
-            secure=is_secure_request(request.scope),
+        _set_session_cookie(
+            response,
+            raw_token,
+            request,
+            max_age_seconds=DEFAULT_PARTIAL_SESSION_TIMEOUT_MINUTES * 60,
         )
         return response
 
@@ -810,14 +821,7 @@ async def _resolve_oauth_user(
             details={"provider": user_info.provider},
         )
         response = RedirectResponse(url="/setup?requires_2fa_setup=true", status_code=302)
-        response.set_cookie(
-            key=COOKIE_NAME,
-            value=raw_token,
-            path="/",
-            httponly=True,
-            samesite="lax",
-            secure=is_secure_request(request.scope),
-        )
+        _set_session_cookie(response, raw_token, request, max_age_seconds=session_max_days * 86400)
 
         await _bridge_metabase_session(user, request, response, log_context="oauth_login")
 
@@ -841,14 +845,7 @@ async def _resolve_oauth_user(
 
     target = "/setup" if user.must_change_password else "/"
     response = RedirectResponse(url=target, status_code=302)
-    response.set_cookie(
-        key=COOKIE_NAME,
-        value=raw_token,
-        path="/",
-        httponly=True,
-        samesite="lax",
-        secure=is_secure_request(request.scope),
-    )
+    _set_session_cookie(response, raw_token, request, max_age_seconds=session_max_days * 86400)
 
     await _bridge_metabase_session(user, request, response, log_context="oauth_login")
 

--- a/dango/web/routes/auth_2fa.py
+++ b/dango/web/routes/auth_2fa.py
@@ -83,7 +83,13 @@ def _get_user_agent(request: Request) -> str | None:
     return request.headers.get("user-agent")
 
 
-def _set_session_cookie(response: JSONResponse, token: str, request: Request) -> None:
+def _set_session_cookie(
+    response: JSONResponse,
+    token: str,
+    request: Request,
+    *,
+    max_age_seconds: int,
+) -> None:
     """Set the session cookie on a response with appropriate security flags."""
     response.set_cookie(
         key=COOKIE_NAME,
@@ -92,6 +98,7 @@ def _set_session_cookie(response: JSONResponse, token: str, request: Request) ->
         httponly=True,
         samesite="lax",
         secure=is_secure_request(request.scope),
+        max_age=max_age_seconds,
     )
 
 
@@ -269,7 +276,7 @@ async def verify_2fa(request: Request) -> JSONResponse:
             "must_change_password": current_user.must_change_password,
         }
     )
-    _set_session_cookie(response, raw_token, request)
+    _set_session_cookie(response, raw_token, request, max_age_seconds=session_max_days * 86400)
 
     await _bridge_metabase_session(current_user, request, response, log_context="2fa_verify")
 

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -17,6 +17,7 @@ function escapeHtml(str) {
 // Global state
 let ws = null;
 let reconnectInterval = null;
+let wsDisconnectedLogged = false;
 let sources = [];
 let activityLog = [];
 const MAX_LOG_ENTRIES = 50; // Keep compact for quick scanning
@@ -324,7 +325,12 @@ function connectWebSocket() {
         console.log('🔌 [WebSocket] ReadyState:', ws.readyState, '(1 = OPEN)');
         console.log('🔌 [WebSocket] URL:', wsUrl);
         updateConnectionStatus(true);
-        addLogEntry('info', 'Connected to server', 'websocket');
+        if (wsDisconnectedLogged) {
+            addLogEntry('info', 'Reconnected to server', 'websocket');
+        } else {
+            addLogEntry('info', 'Connected to server', 'websocket');
+        }
+        wsDisconnectedLogged = false;
 
         // Clear reconnect interval if it exists
         if (reconnectInterval) {
@@ -348,7 +354,10 @@ function connectWebSocket() {
     ws.onclose = () => {
         console.log('WebSocket disconnected');
         updateConnectionStatus(false);
-        addLogEntry('warning', 'Disconnected from server', 'websocket');
+        if (!wsDisconnectedLogged) {
+            addLogEntry('warning', 'Disconnected from server', 'websocket');
+            wsDisconnectedLogged = true;
+        }
 
         // Attempt to reconnect every 5 seconds
         if (!reconnectInterval) {

--- a/tests/unit/test_web_auth.py
+++ b/tests/unit/test_web_auth.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 from dango.auth import database as db
 from dango.auth.models import Role, User
 from dango.auth.security import hash_password, hash_token, verify_password
-from dango.auth.sessions import create_session
+from dango.auth.sessions import DEFAULT_SESSION_MAX_DAYS, create_session
 from dango.migrations.runner import MigrationRunner
 from dango.web.middleware.auth import COOKIE_NAME
 from dango.web.routes.auth import router
@@ -378,3 +378,66 @@ class TestChangePassword:
         updated = db.get_user_by_id(db_path, user.id)
         assert updated is not None
         assert updated.must_change_password is False
+
+
+# ---------------------------------------------------------------------------
+# Cookie max_age tests
+# ---------------------------------------------------------------------------
+
+
+def _get_cookie_max_age(resp: Any, cookie_name: str) -> int | None:
+    """Extract Max-Age from a Set-Cookie header for a given cookie name."""
+    for header in resp.headers.get_list("set-cookie"):
+        if header.startswith(f"{cookie_name}="):
+            for part in header.split(";"):
+                part = part.strip()
+                if part.lower().startswith("max-age="):
+                    return int(part.split("=", 1)[1])
+    return None
+
+
+@pytest.mark.unit
+class TestCookieMaxAge:
+    """Verify session cookies include Max-Age matching configured expiry."""
+
+    def test_login_cookie_has_max_age(self, tmp_path: Path) -> None:
+        """Successful login sets Max-Age = session_max_days * 86400."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path)
+        client = _make_client(_make_app(db_path))
+
+        resp = client.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+        assert resp.status_code == 200
+        max_age = _get_cookie_max_age(resp, COOKIE_NAME)
+        assert max_age == DEFAULT_SESSION_MAX_DAYS * 86400
+
+    def test_2fa_partial_cookie_has_short_max_age(self, tmp_path: Path) -> None:
+        """2FA partial session sets Max-Age = 300 (5 minutes)."""
+        db_path = _make_db(tmp_path)
+        _make_user(db_path, totp_enabled=True, totp_secret="JBSWY3DPEHPK3PXP")
+        client = _make_client(_make_app(db_path))
+
+        resp = client.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["requires_2fa"] is True
+        max_age = _get_cookie_max_age(resp, COOKIE_NAME)
+        assert max_age == 300
+
+    def test_change_password_cookie_has_max_age(self, tmp_path: Path) -> None:
+        """Password change sets Max-Age on the new session cookie."""
+        client, _db_path, _user = _setup_auth_client(tmp_path)
+
+        resp = client.post(
+            "/api/auth/change-password",
+            json={"current_password": "securepassword123", "new_password": "newpassword456"},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        max_age = _get_cookie_max_age(resp, COOKIE_NAME)
+        assert max_age == DEFAULT_SESSION_MAX_DAYS * 86400

--- a/tests/unit/test_web_auth_2fa.py
+++ b/tests/unit/test_web_auth_2fa.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from dango.auth import database as db
 from dango.auth.models import Role, User, UserUpdate
 from dango.auth.security import hash_password
+from dango.auth.sessions import DEFAULT_SESSION_MAX_DAYS
 from dango.auth.totp import (
     enable_totp,
     generate_totp_secret,
@@ -372,3 +373,55 @@ class TestLoginWith2FA:
         data = resp.json()
         assert data["requires_2fa_setup"] is True
         assert "user" in data
+
+
+# ---------------------------------------------------------------------------
+# Cookie max_age tests
+# ---------------------------------------------------------------------------
+
+
+def _get_cookie_max_age(resp: Any, cookie_name: str) -> int | None:
+    """Extract Max-Age from a Set-Cookie header for a given cookie name."""
+    for header in resp.headers.get_list("set-cookie"):
+        if header.startswith(f"{cookie_name}="):
+            for part in header.split(";"):
+                part = part.strip()
+                if part.lower().startswith("max-age="):
+                    return int(part.split("=", 1)[1])
+    return None
+
+
+@pytest.mark.unit
+class TestTwoFACookieMaxAge:
+    """Verify 2FA verify endpoint sets Max-Age on session cookie."""
+
+    def test_2fa_verify_cookie_has_max_age(self, tmp_path: Path) -> None:
+        """Successful 2FA verification sets Max-Age = session_max_days * 86400."""
+        db_path = _make_db(tmp_path)
+        secret = generate_totp_secret()
+        user = _make_user(db_path, totp_secret=secret, totp_enabled=True)
+        hashed = hash_and_store_codes(["AAAA-BBBB", "CCCC-DDDD"])
+        db.update_user(db_path, user.id, UserUpdate(recovery_codes=hashed))
+        app = _make_app(db_path)
+        tc = _client(app)
+
+        # Get partial session
+        resp = tc.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": _TEST_PASSWORD},
+        )
+        assert resp.status_code == 200
+        cookie = resp.cookies.get(COOKIE_NAME)
+        assert cookie is not None
+
+        # Verify 2FA
+        code = pyotp.TOTP(secret).now()
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": code, "is_recovery": False},
+            cookies={COOKIE_NAME: cookie},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 200
+        max_age = _get_cookie_max_age(resp, COOKIE_NAME)
+        assert max_age == DEFAULT_SESSION_MAX_DAYS * 86400


### PR DESCRIPTION
## Summary

- **BUG-117:** Add `max_age` to session cookies so browsers persist them across restarts (365d local / 30d cloud / 5min partial 2FA). Previously browsers treated them as session cookies deleted on close.
- **BUG-125:** Gate WebSocket disconnect/reconnect log entries with a state flag — only one "Disconnected" and one "Reconnected" message per cycle instead of spamming every 5 seconds.

## Changes

- `auth.py`: Add `max_age_seconds` keyword-only param to `_set_session_cookie()`, update 3 call sites, refactor 3 inline OAuth `set_cookie()` calls to use the shared helper
- `auth_2fa.py`: Same `max_age_seconds` param + update 1 call site
- `app.js`: Add `wsDisconnectedLogged` flag, gate `addLogEntry` calls in `onclose`/`onopen`

## Test plan

- [x] 40 auth unit tests pass (`test_web_auth.py` + `test_web_auth_2fa.py`)
- [x] Full unit suite: 3075 passed, 7 skipped, 0 failures
- [x] `ruff check` + `ruff format --check` clean
- [x] All pre-commit hooks pass (including mypy)
- [ ] Manual: verify `Set-Cookie` header includes `Max-Age` in browser dev tools
- [ ] Manual: verify single disconnect/reconnect log entries during server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)