### PR TITLE
R9-D: Schema drift protection + CSV evolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ dango/                          # Python package source
 │   │   ├── model.py            # model group (add/remove)
 │   │   ├── platform.py         # start/stop/status + port helpers (970 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (750 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (757 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
@@ -135,7 +135,7 @@ dango/                          # Python package source
 ├── governance/                 # Level 1 — Data governance (schema drift + PII scanning)
 │   ├── __init__.py             # Re-exports public API
 │   ├── models.py               # Pydantic V2 response models
-│   ├── schema_drift.py         # Schema drift detection engine (490 lines)
+│   ├── schema_drift.py         # Schema drift detection engine (654 lines)
 │   ├── pii_detector.py         # PII scanning engine (602 lines)
 │   └── pii_overrides.py        # PII override CRUD
 │
@@ -250,7 +250,7 @@ dango/                          # Python package source
 │
 ├── ingestion/                  # Level 1 — Data loading
 │   ├── dlt_runner.py           # ⚠ 2373 lines — orchestrates full sync pipeline
-│   ├── csv_loader.py           # Multi-format file loading with dedup (766 lines)
+│   ├── csv_loader.py           # Multi-format file loading with dedup (847 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
@@ -342,13 +342,13 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
-| `ingestion/csv_loader.py` | 766 | — |
+| `ingestion/csv_loader.py` | 847 | — |
 | `platform/scheduling/jobs.py` | 839 | — (module-level job functions) |
 | `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 748 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 757 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 595 | — (push deploy workflow + deploy lock + journal) |
@@ -368,6 +368,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/schedule.py` | 743 | — (schedule wizard + time customization) |
 | `cli/model_wizard.py` | 507 | — |
 | `platform/cloud/scheduled_backup.py` | 505 | — (server-side scheduled backup) |
+| `governance/schema_drift.py` | 654 | — (R9-D: breaking drift protection + accept flow) |
 | `governance/pii_detector.py` | 602 | — (BUG-027/BUG-133/BUG-139: spaCy fallback + PERSON threshold + override application) |
 
 ## Module Documentation Index

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ dango/                          # Python package source
 │
 ├── ingestion/                  # Level 1 — Data loading
 │   ├── dlt_runner.py           # ⚠ 2373 lines — orchestrates full sync pipeline
-│   ├── csv_loader.py           # Multi-format file loading with dedup (847 lines)
+│   ├── csv_loader.py           # Multi-format file loading with dedup (867 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
@@ -342,7 +342,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
-| `ingestion/csv_loader.py` | 847 | — |
+| `ingestion/csv_loader.py` | 867 | — |
 | `platform/scheduling/jobs.py` | 839 | — (module-level job functions) |
 | `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -72,6 +72,7 @@ class AuditEvent(str, Enum):
     DEPLOYMENT_HISTORY_VIEWED    = "deployment_history_viewed"
     GOVERNANCE_PII_OVERRIDE_SET     = "governance_pii_override_set"
     GOVERNANCE_PII_OVERRIDE_DELETED = "governance_pii_override_deleted"
+    GOVERNANCE_DRIFT_ACCEPTED   = "governance_drift_accepted"
     # fmt: on
 
 

--- a/dango/cli/commands/governance.py
+++ b/dango/cli/commands/governance.py
@@ -206,3 +206,17 @@ def pii_list(ctx: click.Context, source: str | None) -> None:
         )
 
     console.print(tbl)
+
+
+@governance.command("accept")
+@click.argument("source")
+@click.pass_context
+def accept(ctx: click.Context, source: str) -> None:
+    """Accept schema drift for a source and resume dbt."""
+    from dango.cli.utils import require_project_context
+    from dango.governance.schema_drift import accept_drift
+
+    project_root = require_project_context(ctx)
+    accept_drift(project_root, source)
+    console.print(f"[green]Schema changes accepted for '{source}'.[/green]")
+    console.print("[dim]dbt will run on next sync.[/dim]")

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -490,6 +490,11 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 @click.option("--limit", type=int, help="Limit rows per source (dev testing)")
 @click.option("--full-refresh", is_flag=True, help="Drop existing data and reload from scratch")
 @click.option("--dry-run", is_flag=True, help="Show what would be synced without executing")
+@click.option(
+    "--allow-schema-changes",
+    is_flag=True,
+    help="Allow CSV schema changes (add columns, treat missing as NULL)",
+)
 @click.pass_context
 def sync(
     ctx: click.Context,
@@ -500,6 +505,7 @@ def sync(
     limit: int | None,
     full_refresh: bool,
     dry_run: bool,
+    allow_schema_changes: bool,
 ) -> None:
     """
     Load data from all sources (or specific source).
@@ -693,6 +699,7 @@ def sync(
                 end_date=end_date_obj,
                 full_refresh=full_refresh,
                 limit=limit,
+                allow_schema_changes=allow_schema_changes,
             )
         except KeyboardInterrupt:
             console.print("\n[yellow]Sync interrupted — progress saved.[/yellow]")

--- a/dango/governance/CLAUDE.md
+++ b/dango/governance/CLAUDE.md
@@ -8,9 +8,9 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `__init__.py` | Re-exports public API | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiOverride`, `PiiOverrideRequest`, `PiiOverridesResponse`, `PiiResponse`, `detect_drift_for_sources`, `detect_table_drift`, `get_drift_history`, `scan_sources_for_pii`, `scan_table_for_pii`, `get_pii_findings`, `get_pii_overrides`, `set_pii_override`, `delete_pii_override` |
-| `models.py` (~93 lines) | Pydantic V2 response models | `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiResponse`, `PiiOverride`, `PiiOverrideRequest`, `PiiOverridesResponse` |
-| `schema_drift.py` (~490 lines) | Schema drift detection engine | `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()`, `_send_drift_webhook()` |
+| `__init__.py` | Re-exports public API | `AcceptDriftResponse`, `DriftEvent`, `DriftResponse`, `PiiFinding`, `PiiOverride`, `PiiOverrideRequest`, `PiiOverridesResponse`, `PiiResponse`, `SourceAttention`, `accept_drift`, `detect_drift_for_sources`, `detect_table_drift`, `get_drift_history`, `get_sources_needing_attention`, `scan_sources_for_pii`, `scan_table_for_pii`, `get_pii_findings`, `get_pii_overrides`, `set_pii_override`, `delete_pii_override` |
+| `models.py` (~115 lines) | Pydantic V2 response models | `DriftEvent`, `DriftResponse`, `SourceAttention`, `AcceptDriftResponse`, `PiiFinding`, `PiiResponse`, `PiiOverride`, `PiiOverrideRequest`, `PiiOverridesResponse` |
+| `schema_drift.py` (~654 lines) | Schema drift detection + breaking drift protection | `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()`, `accept_drift()`, `get_sources_needing_attention()`, `_send_drift_webhook()` |
 | `pii_detector.py` (~602 lines) | PII scanning engine (Presidio + spaCy) | `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`, `_send_pii_webhook()`, `_register_intl_phone_recognizer()` |
 | `pii_overrides.py` (~174 lines) | PII override CRUD | `get_overrides_for_table()`, `get_pii_overrides()`, `set_pii_override()`, `delete_pii_override()` |
 
@@ -22,6 +22,8 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 | Query drift history | `schema_drift.py` (`get_drift_history()`) | `pytest tests/unit/test_drift_detection.py` |
 | Change drift webhook format | `schema_drift.py` (`_send_drift_webhook()`) | `pytest tests/unit/test_drift_detection.py` |
 | Add drift CLI output columns | `dango/cli/commands/governance.py` | `dango governance drift-report` |
+| Accept breaking drift | `schema_drift.py` (`accept_drift()`) | `dango governance accept <source>` or `POST /api/governance/drift/{source}/accept` |
+| Check sources needing attention | `schema_drift.py` (`get_sources_needing_attention()`) | `GET /api/governance/attention` |
 | View drift via API | `dango/web/routes/governance.py` | `GET /api/governance/schema-drift` |
 | Add PII entity types | `pii_detector.py` (`SCAN_ENTITIES` constant) | `pytest tests/unit/test_pii_detection.py` |
 | Change PII scan threshold | `pii_detector.py` (`SCORE_THRESHOLD` constant) | `pytest tests/unit/test_pii_detection.py` |
@@ -47,9 +49,11 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 - `presidio_analyzer` — PII analysis engine (lazy import, `pii_detector.py`)
 
 **Used by:**
-- `dango/utils/post_sync.py` — `_run_drift_detection()` calls `detect_drift_for_sources()`, `_run_pii_scan()` calls `scan_sources_for_pii()`
-- `dango/web/routes/governance.py` — `GET /api/governance/schema-drift` calls `get_drift_history()`, `GET /api/governance/pii` calls `get_pii_findings()`
-- `dango/cli/commands/governance.py` — `dango governance drift-report` calls `get_drift_history()`, `dango governance pii-report` calls `get_pii_findings()`
+- `dango/ingestion/dlt_runner.py` — pre-dbt drift check calls `detect_drift_for_sources()` (breaking drift skips dbt)
+- `dango/utils/post_sync.py` — `_run_pii_scan()` calls `scan_sources_for_pii()`
+- `dango/web/routes/governance.py` — `GET /api/governance/schema-drift` calls `get_drift_history()`, `POST /api/governance/drift/{source}/accept` calls `accept_drift()`, `GET /api/governance/attention` calls `get_sources_needing_attention()`, `GET /api/governance/pii` calls `get_pii_findings()`
+- `dango/web/routes/sources.py` — enriches `/api/sources` with attention state via `get_sources_needing_attention()`
+- `dango/cli/commands/governance.py` — `dango governance drift-report` calls `get_drift_history()`, `dango governance accept` calls `accept_drift()`, `dango governance pii-report` calls `get_pii_findings()`
 
 ## Testing
 
@@ -58,6 +62,7 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 - **Unit (PII overrides):** `pytest tests/unit/test_pii_overrides.py`
 - **Integration (drift):** `pytest tests/integration/test_drift_integration.py`
 - **Integration (PII):** `pytest tests/integration/test_pii_integration.py`
+- **Unit (governance API):** `pytest tests/unit/test_governance_api.py`
 - **Related:** `pytest tests/unit/test_post_sync.py tests/unit/test_webhook.py tests/unit/test_slack_formatter.py`
 
 ## Don't Modify

--- a/dango/governance/__init__.py
+++ b/dango/governance/__init__.py
@@ -4,6 +4,7 @@ Data governance module: schema drift detection and PII scanning.
 """
 
 from dango.governance.models import (
+    AcceptDriftResponse,
     DriftEvent,
     DriftResponse,
     PiiFinding,
@@ -11,6 +12,7 @@ from dango.governance.models import (
     PiiOverrideRequest,
     PiiOverridesResponse,
     PiiResponse,
+    SourceAttention,
 )
 from dango.governance.pii_detector import (
     get_pii_findings,
@@ -23,12 +25,15 @@ from dango.governance.pii_overrides import (
     set_pii_override,
 )
 from dango.governance.schema_drift import (
+    accept_drift,
     detect_drift_for_sources,
     detect_table_drift,
     get_drift_history,
+    get_sources_needing_attention,
 )
 
 __all__ = [
+    "AcceptDriftResponse",
     "DriftEvent",
     "DriftResponse",
     "PiiFinding",
@@ -36,12 +41,15 @@ __all__ = [
     "PiiOverrideRequest",
     "PiiOverridesResponse",
     "PiiResponse",
+    "SourceAttention",
+    "accept_drift",
     "delete_pii_override",
     "detect_drift_for_sources",
     "detect_table_drift",
     "get_drift_history",
     "get_pii_findings",
     "get_pii_overrides",
+    "get_sources_needing_attention",
     "scan_sources_for_pii",
     "scan_table_for_pii",
     "set_pii_override",

--- a/dango/governance/models.py
+++ b/dango/governance/models.py
@@ -5,7 +5,7 @@ Pydantic V2 response models for data governance endpoints.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -20,6 +20,7 @@ class DriftEvent(BaseModel):
     table_name: str
     column_name: str | None
     event_type: str
+    severity: str | None = None
     detail: str | None
     detected_at: str
 
@@ -33,6 +34,27 @@ class DriftResponse(BaseModel):
     count: int
     source: str | None
     table_name: str | None
+
+
+class SourceAttention(BaseModel):
+    """A source that needs user attention due to breaking drift."""
+
+    model_config = ConfigDict(frozen=True)
+
+    source: str
+    reason: str
+    drift_events: list[dict[str, Any]] = []
+    created_at: str
+
+
+class AcceptDriftResponse(BaseModel):
+    """Response from accepting schema drift for a source."""
+
+    model_config = ConfigDict(frozen=True)
+
+    source: str
+    accepted: bool
+    message: str
 
 
 class PiiFinding(BaseModel):

--- a/dango/governance/schema_drift.py
+++ b/dango/governance/schema_drift.py
@@ -143,13 +143,14 @@ def detect_table_drift(
     # Columns added
     for col_name, col_type in current_schema.items():
         if col_name not in baseline:
+            event_type = "column_added"
             events.append(
                 {
                     "source": source,
                     "table_name": table_name,
                     "column_name": col_name,
-                    "event_type": "column_added",
-                    "severity": "additive",
+                    "event_type": event_type,
+                    "severity": "breaking" if event_type in _BREAKING_EVENT_TYPES else "additive",
                     "detail": f"type={col_type}",
                     "detected_at": now,
                 }
@@ -158,13 +159,14 @@ def detect_table_drift(
     # Columns removed
     for col_name in baseline:
         if col_name not in current_schema:
+            event_type = "column_removed"
             events.append(
                 {
                     "source": source,
                     "table_name": table_name,
                     "column_name": col_name,
-                    "event_type": "column_removed",
-                    "severity": "breaking",
+                    "event_type": event_type,
+                    "severity": "breaking" if event_type in _BREAKING_EVENT_TYPES else "additive",
                     "detail": f"was={baseline[col_name]}",
                     "detected_at": now,
                 }
@@ -173,13 +175,14 @@ def detect_table_drift(
     # Type changed
     for col_name, col_type in current_schema.items():
         if col_name in baseline and baseline[col_name] != col_type:
+            event_type = "type_changed"
             events.append(
                 {
                     "source": source,
                     "table_name": table_name,
                     "column_name": col_name,
-                    "event_type": "type_changed",
-                    "severity": "breaking",
+                    "event_type": event_type,
+                    "severity": "breaking" if event_type in _BREAKING_EVENT_TYPES else "additive",
                     "detail": f"{baseline[col_name]} -> {col_type}",
                     "detected_at": now,
                 }
@@ -196,6 +199,9 @@ def detect_table_drift(
         if has_breaking:
             # Breaking drift: record events but do NOT update baseline.
             # Baseline stays old so drift keeps being detected until user accepts.
+            # Note: when mixed with additive events, ALL events (including additive)
+            # will be re-detected on subsequent syncs until the user accepts.
+            # This is intentional — the user must accept the full batch.
             _record_drift_events_only(project_root, events)
             _set_source_attention(project_root, source, events)
         else:
@@ -373,6 +379,36 @@ def _save_baseline(
         conn.commit()
 
 
+def _insert_drift_events(
+    conn: Any,
+    events: list[dict[str, Any]],
+) -> None:
+    """Insert drift event rows into the ``drift_events`` table.
+
+    Shared helper used by both :func:`_record_drift_events` and
+    :func:`_record_drift_events_only`.
+
+    Args:
+        conn: An open SQLite connection (caller manages transaction).
+        events: List of drift event dicts.
+    """
+    for ev in events:
+        conn.execute(
+            "INSERT INTO drift_events "
+            "(source, table_name, column_name, event_type, severity, detail, detected_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                ev["source"],
+                ev["table_name"],
+                ev.get("column_name"),
+                ev["event_type"],
+                ev.get("severity"),
+                ev.get("detail"),
+                ev["detected_at"],
+            ),
+        )
+
+
 def _record_drift_events(
     project_root: Path,
     source: str,
@@ -392,22 +428,7 @@ def _record_drift_events(
     now = datetime.now(timezone.utc).isoformat()
 
     with connect(project_root) as conn:
-        # Record events
-        for ev in events:
-            conn.execute(
-                "INSERT INTO drift_events "
-                "(source, table_name, column_name, event_type, severity, detail, detected_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (
-                    ev["source"],
-                    ev["table_name"],
-                    ev.get("column_name"),
-                    ev["event_type"],
-                    ev.get("severity"),
-                    ev.get("detail"),
-                    ev["detected_at"],
-                ),
-            )
+        _insert_drift_events(conn, events)
 
         # Update baseline
         conn.execute(
@@ -437,21 +458,7 @@ def _record_drift_events_only(
         events: List of drift event dicts.
     """
     with connect(project_root) as conn:
-        for ev in events:
-            conn.execute(
-                "INSERT INTO drift_events "
-                "(source, table_name, column_name, event_type, severity, detail, detected_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (
-                    ev["source"],
-                    ev["table_name"],
-                    ev.get("column_name"),
-                    ev["event_type"],
-                    ev.get("severity"),
-                    ev.get("detail"),
-                    ev["detected_at"],
-                ),
-            )
+        _insert_drift_events(conn, events)
         conn.commit()
 
 
@@ -494,6 +501,15 @@ def accept_drift(project_root: Path, source: str) -> None:
         source: Source name.
     """
     source = validate_source_name(source)
+
+    db_path = project_root / "data" / "warehouse.duckdb"
+    if not db_path.exists():
+        # No warehouse — just clear the attention flag
+        with connect(project_root) as conn:
+            conn.execute("DELETE FROM source_attention WHERE source = ?", (source,))
+            conn.commit()
+        logger.info("drift_accepted_no_warehouse", source=source)
+        return
 
     # Get all tables for this source from the current baseline
     with connect(project_root) as conn:

--- a/dango/governance/schema_drift.py
+++ b/dango/governance/schema_drift.py
@@ -20,6 +20,9 @@ from dango.validation import validate_identifier, validate_source_name
 
 logger = get_logger(__name__)
 
+# Event types that represent breaking schema changes.
+_BREAKING_EVENT_TYPES: frozenset[str] = frozenset({"column_removed", "type_changed"})
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -146,6 +149,7 @@ def detect_table_drift(
                     "table_name": table_name,
                     "column_name": col_name,
                     "event_type": "column_added",
+                    "severity": "additive",
                     "detail": f"type={col_type}",
                     "detected_at": now,
                 }
@@ -160,6 +164,7 @@ def detect_table_drift(
                     "table_name": table_name,
                     "column_name": col_name,
                     "event_type": "column_removed",
+                    "severity": "breaking",
                     "detail": f"was={baseline[col_name]}",
                     "detected_at": now,
                 }
@@ -174,6 +179,7 @@ def detect_table_drift(
                     "table_name": table_name,
                     "column_name": col_name,
                     "event_type": "type_changed",
+                    "severity": "breaking",
                     "detail": f"{baseline[col_name]} -> {col_type}",
                     "detected_at": now,
                 }
@@ -182,9 +188,19 @@ def detect_table_drift(
     if not events:
         return []
 
-    # Record events + update baseline (resilient cache pattern)
+    # Determine if any events are breaking
+    has_breaking = any(ev.get("severity") == "breaking" for ev in events)
+
+    # Record events (resilient cache pattern)
     try:
-        _record_drift_events(project_root, source, table_name, events, current_schema)
+        if has_breaking:
+            # Breaking drift: record events but do NOT update baseline.
+            # Baseline stays old so drift keeps being detected until user accepts.
+            _record_drift_events_only(project_root, events)
+            _set_source_attention(project_root, source, events)
+        else:
+            # Additive-only: record events + update baseline as before
+            _record_drift_events(project_root, source, table_name, events, current_schema)
     except Exception:
         logger.warning(
             "drift_record_error",
@@ -233,7 +249,8 @@ def get_drift_history(
     params.append(limit)
 
     query = (
-        "SELECT id, source, table_name, column_name, event_type, detail, detected_at "
+        "SELECT id, source, table_name, column_name, event_type, severity, "
+        "detail, detected_at "
         f"FROM drift_events {where_clause} "
         "ORDER BY id DESC LIMIT ?"
     )
@@ -248,8 +265,9 @@ def get_drift_history(
             "table_name": row[2],
             "column_name": row[3],
             "event_type": row[4],
-            "detail": row[5],
-            "detected_at": row[6],
+            "severity": row[5],
+            "detail": row[6],
+            "detected_at": row[7],
         }
         for row in rows
     ]
@@ -378,13 +396,14 @@ def _record_drift_events(
         for ev in events:
             conn.execute(
                 "INSERT INTO drift_events "
-                "(source, table_name, column_name, event_type, detail, detected_at) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
+                "(source, table_name, column_name, event_type, severity, detail, detected_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     ev["source"],
                     ev["table_name"],
                     ev.get("column_name"),
                     ev["event_type"],
+                    ev.get("severity"),
                     ev.get("detail"),
                     ev["detected_at"],
                 ),
@@ -403,6 +422,126 @@ def _record_drift_events(
                 (source, table_name, col_name, col_type, now),
             )
         conn.commit()
+
+
+def _record_drift_events_only(
+    project_root: Path,
+    events: list[dict[str, Any]],
+) -> None:
+    """Record drift events WITHOUT updating baseline.
+
+    Used for breaking drift so drift keeps being detected until user accepts.
+
+    Args:
+        project_root: Path to the Dango project root.
+        events: List of drift event dicts.
+    """
+    with connect(project_root) as conn:
+        for ev in events:
+            conn.execute(
+                "INSERT INTO drift_events "
+                "(source, table_name, column_name, event_type, severity, detail, detected_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    ev["source"],
+                    ev["table_name"],
+                    ev.get("column_name"),
+                    ev["event_type"],
+                    ev.get("severity"),
+                    ev.get("detail"),
+                    ev["detected_at"],
+                ),
+            )
+        conn.commit()
+
+
+def _set_source_attention(
+    project_root: Path,
+    source: str,
+    events: list[dict[str, Any]],
+) -> None:
+    """Flag a source as needing attention due to breaking drift.
+
+    Args:
+        project_root: Path to the Dango project root.
+        source: Source name.
+        events: Breaking drift event dicts.
+    """
+    import json
+
+    now = datetime.now(timezone.utc).isoformat()
+    breaking = [e for e in events if e.get("severity") == "breaking"]
+    reason = f"{len(breaking)} breaking schema change(s) detected"
+
+    with connect(project_root) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO source_attention "
+            "(source, reason, drift_events, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (source, reason, json.dumps(breaking), now),
+        )
+        conn.commit()
+
+
+def accept_drift(project_root: Path, source: str) -> None:
+    """Accept current schema as new baseline and clear attention flag.
+
+    For each table in the source, reads the current DuckDB schema and saves
+    it as the new baseline, then removes the attention flag.
+
+    Args:
+        project_root: Path to the Dango project root.
+        source: Source name.
+    """
+    source = validate_source_name(source)
+
+    # Get all tables for this source from the current baseline
+    with connect(project_root) as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT table_name FROM schema_baselines WHERE source = ?",
+            (source,),
+        ).fetchall()
+    table_names = [row[0] for row in rows]
+
+    # Re-save baseline from current DuckDB state for each table
+    for table_name in table_names:
+        current_schema = _get_current_schema(project_root, source, table_name)
+        if current_schema:
+            _save_baseline(project_root, source, table_name, current_schema)
+
+    # Clear the attention flag
+    with connect(project_root) as conn:
+        conn.execute("DELETE FROM source_attention WHERE source = ?", (source,))
+        conn.commit()
+
+    logger.info("drift_accepted", source=source, tables=len(table_names))
+
+
+def get_sources_needing_attention(project_root: Path) -> list[dict[str, Any]]:
+    """Return list of sources with unresolved breaking drift.
+
+    Args:
+        project_root: Path to the Dango project root.
+
+    Returns:
+        List of dicts with source, reason, drift_events, created_at.
+    """
+    import json
+
+    with connect(project_root) as conn:
+        rows = conn.execute(
+            "SELECT source, reason, drift_events, created_at FROM source_attention"
+        ).fetchall()
+
+    return [
+        {
+            "source": row[0],
+            "reason": row[1],
+            "drift_events": json.loads(row[2]) if row[2] else [],
+            "created_at": row[3],
+        }
+        for row in rows
+    ]
 
 
 def _send_drift_webhook(
@@ -438,12 +577,21 @@ def _send_drift_webhook(
         if not config.webhooks:
             return
 
-        # Build summary string
+        # Build summary string with severity breakdown
         event_counts: dict[str, int] = {}
         for ev in events:
             event_counts[ev["event_type"]] = event_counts.get(ev["event_type"], 0) + 1
-        summary_parts = [f"{count} {etype}" for etype, count in event_counts.items()]
-        summary = f"Schema drift detected: {', '.join(summary_parts)}"
+        breaking_count = sum(1 for ev in events if ev.get("severity") == "breaking")
+        additive_count = len(events) - breaking_count
+        severity_parts = []
+        if breaking_count:
+            severity_parts.append(f"{breaking_count} breaking")
+        if additive_count:
+            severity_parts.append(f"{additive_count} additive")
+        type_parts = [f"{count} {etype}" for etype, count in event_counts.items()]
+        summary = (
+            f"Schema drift detected: {', '.join(type_parts)} ({', '.join(severity_parts)} changes)"
+        )
 
         payload = WebhookPayload(
             event_type=EventType.SCHEMA_DRIFT_DETECTED,

--- a/dango/ingestion/csv_loader.py
+++ b/dango/ingestion/csv_loader.py
@@ -202,12 +202,24 @@ class CSVLoader:
         try:
             # Load new files
             for filepath, _metadata in classified["new"]:
-                if self._load_new_file(conn, filepath, target_table, source_name):
+                if self._load_new_file(
+                    conn,
+                    filepath,
+                    target_table,
+                    source_name,
+                    skip_schema_check=allow_schema_changes,
+                ):
                     stats["new"] += 1
 
             # Reload updated files
             for filepath, _metadata in classified["updated"]:
-                if self._reload_updated_file(conn, filepath, target_table, source_name):
+                if self._reload_updated_file(
+                    conn,
+                    filepath,
+                    target_table,
+                    source_name,
+                    skip_schema_check=allow_schema_changes,
+                ):
                     stats["updated"] += 1
 
             # Delete removed files
@@ -419,7 +431,9 @@ class CSVLoader:
         Args:
             conn: DuckDB connection
             target_table: Fully qualified table name (schema.table)
-            new_columns: Mapping of {column_name: column_type} to add
+            new_columns: Mapping of {column_name: column_type} to add.
+                Both col_name and col_type come from DuckDB's DESCRIBE output
+                (inferred from the data file), not from raw user input.
         """
         for col_name, col_type in new_columns.items():
             conn.execute(f'ALTER TABLE {target_table} ADD COLUMN "{col_name}" {col_type}')
@@ -679,6 +693,7 @@ class CSVLoader:
         filepath: str,
         target_table: str,
         source_name: str,
+        skip_schema_check: bool = False,
     ) -> bool:
         """Load a new file"""
         filename = os.path.basename(filepath)
@@ -686,7 +701,9 @@ class CSVLoader:
 
         try:
             # Validate schema matches table (strict mode - fail on any mismatch)
-            self._validate_schema_match(conn, filepath, target_table, source_name)
+            # Skipped when allow_schema_changes=True (pre-validation already handled)
+            if not skip_schema_check:
+                self._validate_schema_match(conn, filepath, target_table, source_name)
 
             metadata = self._get_file_metadata(filepath)
             read_fn = self._get_read_function(filepath)
@@ -747,6 +764,7 @@ class CSVLoader:
         filepath: str,
         target_table: str,
         source_name: str,
+        skip_schema_check: bool = False,
     ) -> bool:
         """Reload an updated file (transactional)"""
         filename = os.path.basename(filepath)
@@ -754,7 +772,9 @@ class CSVLoader:
 
         try:
             # Validate schema matches table (strict mode - fail on any mismatch)
-            self._validate_schema_match(conn, filepath, target_table, source_name)
+            # Skipped when allow_schema_changes=True (pre-validation already handled)
+            if not skip_schema_check:
+                self._validate_schema_match(conn, filepath, target_table, source_name)
 
             metadata = self._get_file_metadata(filepath)
             read_fn = self._get_read_function(filepath)

--- a/dango/ingestion/csv_loader.py
+++ b/dango/ingestion/csv_loader.py
@@ -64,6 +64,7 @@ class CSVLoader:
         source_name: str,
         config: CSVSourceConfig,
         target_schema: str = "raw",
+        allow_schema_changes: bool = False,
     ) -> dict[str, Any]:
         """
         Load CSV files incrementally
@@ -72,6 +73,7 @@ class CSVLoader:
             source_name: Name of the source (used as table prefix)
             config: CSV source configuration
             target_schema: Target schema name (default: 'raw')
+            allow_schema_changes: If True, allow schema evolution (add cols, NULL missing)
 
         Returns:
             Dictionary with load statistics
@@ -145,10 +147,16 @@ class CSVLoader:
         # PRE-VALIDATE: Check ALL file schemas match before loading ANY data
         # This prevents partial data loading when schema mismatches exist
         files_to_validate = classified["new"] + classified["updated"]
+        evolution_columns: dict[str, str] = {}  # new columns to add if evolving
         if files_to_validate:
             try:
-                self._validate_all_files_schema_match(
-                    conn, files_to_validate, target_table, source_name, table_exists
+                evolution_columns = self._validate_all_files_schema_match(
+                    conn,
+                    files_to_validate,
+                    target_table,
+                    source_name,
+                    table_exists,
+                    allow_schema_changes=allow_schema_changes,
                 )
             except CSVSchemaMismatchError as e:
                 # Schema validation failed - exit immediately without loading anything
@@ -165,6 +173,14 @@ class CSVLoader:
                     "skipped": len(classified["unchanged"]),
                     "total_rows": 0,
                 }
+
+        # Apply schema evolution if needed (add new columns before loading)
+        if evolution_columns and table_exists:
+            self._evolve_table_schema(conn, target_table, evolution_columns)
+            console.print(
+                f"  [green]Schema evolved: added {len(evolution_columns)} column(s): "
+                f"{', '.join(evolution_columns.keys())}[/green]"
+            )
 
         # Note: We don't drop the table when all files are deleted
         # Instead, we let the file deletion logic below handle it by deleting rows
@@ -364,6 +380,50 @@ class CSVLoader:
         ]
         return columns
 
+    def _get_file_column_types(
+        self, conn: duckdb.DuckDBPyConnection, filepath: str
+    ) -> dict[str, str]:
+        """Get column names and types from a data file.
+
+        Args:
+            conn: DuckDB connection
+            filepath: Path to data file
+
+        Returns:
+            Mapping of {column_name: data_type}
+        """
+        read_fn = self._get_read_function(filepath)
+        temp_view = f"_temp_types_check_{int(datetime.now().timestamp())}"
+        try:
+            conn.execute(
+                f"CREATE TEMP VIEW {temp_view} AS SELECT * FROM {read_fn}('{filepath}') LIMIT 0"
+            )
+            rows = conn.execute(f"DESCRIBE {temp_view}").fetchall()
+            conn.execute(f"DROP VIEW {temp_view}")
+            return {row[0]: row[1] for row in rows}
+        except Exception:
+            try:
+                conn.execute(f"DROP VIEW IF EXISTS {temp_view}")
+            except Exception:
+                pass
+            return {}
+
+    def _evolve_table_schema(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        target_table: str,
+        new_columns: dict[str, str],
+    ) -> None:
+        """Add new columns to an existing table for schema evolution.
+
+        Args:
+            conn: DuckDB connection
+            target_table: Fully qualified table name (schema.table)
+            new_columns: Mapping of {column_name: column_type} to add
+        """
+        for col_name, col_type in new_columns.items():
+            conn.execute(f'ALTER TABLE {target_table} ADD COLUMN "{col_name}" {col_type}')
+
     def _validate_all_files_schema_match(
         self,
         conn: duckdb.DuckDBPyConnection,
@@ -371,14 +431,16 @@ class CSVLoader:
         target_table: str,
         source_name: str,
         table_exists: bool,
-    ) -> None:
+        allow_schema_changes: bool = False,
+    ) -> dict[str, str]:
         """
         Pre-validate ALL CSV files have matching schemas before loading ANY data.
 
         For first load (no table): Validates all files have identical schemas.
         For incremental (table exists): Validates all files match existing table schema.
 
-        This prevents partial data loading when schema mismatches exist.
+        When ``allow_schema_changes=True`` and table exists, extra columns in files
+        are collected for ALTER TABLE, and missing columns are allowed (NULLs).
 
         Args:
             conn: DuckDB connection
@@ -386,12 +448,16 @@ class CSVLoader:
             target_table: Target table name (schema.table)
             source_name: Source name (for error messages)
             table_exists: Whether target table already exists
+            allow_schema_changes: If True, tolerate schema differences
+
+        Returns:
+            Dict of {column_name: column_type} for new columns to add (empty if none).
 
         Raises:
-            CSVSchemaMismatchError: If any schema mismatch is found
+            CSVSchemaMismatchError: If any schema mismatch is found (strict mode)
         """
         if not files:
-            return  # No files to validate
+            return {}
 
         # Extract just file paths
         filepaths = [f[0] for f in files]
@@ -410,6 +476,8 @@ class CSVLoader:
 
         # Validate each file against reference schema
         mismatched_files = []
+        # Track all new columns across files (for schema evolution)
+        all_new_columns: dict[str, str] = {}
 
         for filepath in filepaths:
             filename = os.path.basename(filepath)
@@ -426,14 +494,24 @@ class CSVLoader:
                     new_columns = file_set - reference_set
                     missing_columns = reference_set - file_set
 
-                    mismatched_files.append(
-                        {
-                            "filename": filename,
-                            "columns": file_columns,
-                            "new_columns": new_columns,
-                            "missing_columns": missing_columns,
-                        }
-                    )
+                    if allow_schema_changes and table_exists:
+                        # Collect new columns with their types for evolution
+                        if new_columns:
+                            file_types = self._get_file_column_types(conn, filepath)
+                            for col in new_columns:
+                                if col in file_types:
+                                    all_new_columns[col] = file_types[col]
+                        # Missing columns are allowed (will be NULL)
+                        # Don't add to mismatched_files
+                    else:
+                        mismatched_files.append(
+                            {
+                                "filename": filename,
+                                "columns": file_columns,
+                                "new_columns": new_columns,
+                                "missing_columns": missing_columns,
+                            }
+                        )
             except Exception as e:
                 # If we can't read the file schema, treat as mismatch
                 mismatched_files.append({"filename": filename, "error": str(e)})
@@ -494,10 +572,14 @@ class CSVLoader:
                         "  2. dango db clean",
                         f"  3. dango source add  # Re-add '{source_name}'",
                         "  4. dango sync",
+                        "",
+                        "Or use --allow-schema-changes to accept schema evolution.",
                     ]
                 )
 
             raise CSVSchemaMismatchError("\n".join(error_lines))
+
+        return all_new_columns
 
     def _validate_schema_match(
         self, conn: duckdb.DuckDBPyConnection, filepath: str, target_table: str, source_name: str

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -579,6 +579,7 @@ class DltPipelineRunner:
             source_name=source_config.name,
             config=source_config.csv,
             target_schema=target_schema,
+            allow_schema_changes=getattr(self, "allow_schema_changes", False),
         )
 
         return {
@@ -632,6 +633,7 @@ class DltPipelineRunner:
             source_name=source_config.name,
             config=source_config.local_files,
             target_schema=target_schema,
+            allow_schema_changes=getattr(self, "allow_schema_changes", False),
         )
 
         return {
@@ -2170,6 +2172,7 @@ def run_sync(
     full_refresh: bool = False,
     limit: int | None = None,
     skip_dbt: bool = False,
+    allow_schema_changes: bool = False,
 ) -> dict[str, Any]:
     """
     Sync multiple sources and return summary
@@ -2182,11 +2185,13 @@ def run_sync(
         full_refresh: Full refresh mode
         limit: Max rows per source (dev testing)
         skip_dbt: If True, skip dbt run/docs/Metabase refresh (caller handles separately)
+        allow_schema_changes: If True, allow CSV schema evolution (add cols, NULL missing)
 
     Returns:
         Summary dictionary with success/failed counts
     """
     runner = DltPipelineRunner(project_root)
+    runner.allow_schema_changes = allow_schema_changes
 
     results = []
     success_sources = []
@@ -2290,6 +2295,34 @@ def run_sync(
                     console.print(f"  • {item['source']}: {item['reason']}")
 
         console.print()
+
+        # Check for breaking schema drift BEFORE running dbt
+        if success_sources and not skip_dbt:
+            try:
+                from dango.governance.schema_drift import detect_drift_for_sources
+
+                drift_events = detect_drift_for_sources(project_root, success_sources)
+                breaking_events = [e for e in drift_events if e.get("severity") == "breaking"]
+                if breaking_events:
+                    by_source: dict[str, list[dict[str, Any]]] = {}
+                    for ev in breaking_events:
+                        by_source.setdefault(ev["source"], []).append(ev)
+                    console.print("[yellow]Breaking schema drift detected:[/yellow]")
+                    for src, evts in by_source.items():
+                        console.print(f"  [bold]{src}[/bold]:")
+                        for ev in evts:
+                            console.print(
+                                f"    {ev['column_name']}: {ev['event_type']} ({ev['detail']})"
+                            )
+                    console.print("\n[yellow]dbt skipped to protect dashboards.[/yellow]")
+                    console.print(
+                        "[dim]Accept: dango governance accept <source> (or via web UI)[/dim]\n"
+                    )
+                    skip_dbt = True
+            except Exception:
+                import logging as _drift_log
+
+                _drift_log.getLogger(__name__).debug("pre_dbt_drift_check_failed", exc_info=True)
 
         # Run dbt to create staging/marts tables (unless caller handles dbt separately)
         if not skip_dbt:

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -20,7 +20,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~497 lines) | Post-sync hook dispatcher | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_drift_detection()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_ga4_metrics()` |
+| `post_sync.py` (~481 lines) | Post-sync hook dispatcher (drift moved to pre-dbt) | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_ga4_metrics()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 

--- a/dango/utils/dango_db.py
+++ b/dango/utils/dango_db.py
@@ -179,7 +179,19 @@ CREATE TABLE IF NOT EXISTS pii_overrides (
     updated_at   TEXT NOT NULL,
     UNIQUE (source, table_name, column_name)
 );
+
+CREATE TABLE IF NOT EXISTS source_attention (
+    source       TEXT PRIMARY KEY,
+    reason       TEXT NOT NULL,
+    drift_events TEXT,
+    created_at   TEXT NOT NULL
+);
 """
+
+# Additive migrations — each wrapped in try/except to ignore "duplicate column".
+_ADDITIVE_DDL = [
+    "ALTER TABLE drift_events ADD COLUMN severity TEXT",
+]
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
@@ -189,3 +201,9 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         conn: An open SQLite connection.
     """
     conn.executescript(_DDL)
+    for stmt in _ADDITIVE_DDL:
+        try:
+            conn.execute(stmt)
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass  # Column already exists

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -300,7 +300,6 @@ def dispatch_post_sync_hooks(
     logger.info("post_sync_hooks_start", sources=sources)
 
     _run_profiling(project_root, sources)
-    _run_drift_detection(project_root, sources)
     _run_pii_scan(project_root, sources)
     _run_analysis(project_root, sources)
 
@@ -355,21 +354,6 @@ def _run_profiling(project_root: Path, sources: list[str]) -> None:
             logger.debug("profiling_source_complete", source=source)
         except Exception:
             logger.warning("profiling_source_error", source=source)
-
-
-def _run_drift_detection(project_root: Path, sources: list[str]) -> None:
-    """Detect schema drift for freshly synced sources.
-
-    Args:
-        project_root: Path to the Dango project root.
-        sources: Names of sources that synced successfully.
-    """
-    try:
-        from dango.governance.schema_drift import detect_drift_for_sources
-
-        detect_drift_for_sources(project_root, sources)
-    except Exception:
-        logger.warning("drift_detection_error", sources=sources, exc_info=True)
 
 
 def _run_pii_scan(project_root: Path, sources: list[str]) -> None:

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -32,6 +32,8 @@ class SourceStatus(BaseModel):
     schedule_display: str | None = None  # Human-readable schedule (e.g., "Every 6 hours")
     supports_incremental: bool = True  # Whether source supports incremental sync
     supports_date_range: bool = False  # Whether source supports custom date range sync
+    needs_attention: bool = False  # Whether source has unresolved breaking drift
+    attention_reason: str | None = None  # Why source needs attention
 
 
 class ServiceHealth(BaseModel):

--- a/dango/web/routes/governance.py
+++ b/dango/web/routes/governance.py
@@ -13,6 +13,7 @@ from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
 from dango.auth.permissions import require_permission
 from dango.governance.models import (
+    AcceptDriftResponse,
     DriftEvent,
     DriftResponse,
     PiiFinding,
@@ -20,6 +21,7 @@ from dango.governance.models import (
     PiiOverrideRequest,
     PiiOverridesResponse,
     PiiResponse,
+    SourceAttention,
 )
 from dango.logging import get_logger
 from dango.validation import validate_identifier, validate_source_name
@@ -236,3 +238,46 @@ async def delete_pii_override_endpoint(
         )
 
     return {"status": "ok" if deleted else "not_found"}
+
+
+@router.post("/api/governance/drift/{source}/accept")
+async def accept_source_drift(
+    source: str,
+    user: User = Depends(require_permission("governance.manage")),
+) -> AcceptDriftResponse:
+    """Accept schema drift for a source and clear attention flag."""
+    from fastapi import HTTPException
+
+    source = validate_source_name(source)
+    project_root = get_project_root()
+
+    from dango.governance.schema_drift import accept_drift, get_sources_needing_attention
+
+    # Verify the source actually has an attention flag
+    attention = await asyncio.to_thread(get_sources_needing_attention, project_root)
+    if not any(r["source"] == source for r in attention):
+        raise HTTPException(status_code=404, detail=f"No pending drift for '{source}'")
+
+    await asyncio.to_thread(accept_drift, project_root, source)
+
+    log_auth_event(
+        AuditEvent.GOVERNANCE_DRIFT_ACCEPTED,
+        user_id=user.id,
+        email=user.email,
+        details={"source": source},
+    )
+
+    return AcceptDriftResponse(source=source, accepted=True, message="Schema accepted")
+
+
+@router.get("/api/governance/attention")
+async def get_attention_sources(
+    user: User = Depends(require_permission("governance.view")),
+) -> list[SourceAttention]:
+    """Return sources with unresolved breaking drift."""
+    project_root = get_project_root()
+
+    from dango.governance.schema_drift import get_sources_needing_attention
+
+    rows = await asyncio.to_thread(get_sources_needing_attention, project_root)
+    return [SourceAttention(**r) for r in rows]

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -89,6 +89,20 @@ async def get_sources() -> list[SourceStatus]:
             status.has_schedule = True
             status.schedule_display = sched
 
+    # Enrich with attention state (breaking drift)
+    try:
+        from dango.governance.schema_drift import get_sources_needing_attention
+        from dango.web.helpers import get_project_root
+
+        attention_rows = await asyncio.to_thread(get_sources_needing_attention, get_project_root())
+        attention_map = {r["source"]: r["reason"] for r in attention_rows}
+        for status in source_statuses:
+            if status.name in attention_map:
+                status.needs_attention = True
+                status.attention_reason = attention_map[status.name]
+    except Exception:
+        pass  # Non-critical enrichment
+
     # Sort sources alphabetically by name for consistent ordering
     source_statuses = sorted(source_statuses, key=lambda s: s.name.lower())
 

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -756,6 +756,7 @@ async function loadSources() {
         // Longer timeout for sources (includes DuckDB queries for row counts)
         sources = await apiCall('/api/sources', 'GET', null, 15000);
         renderSourcesTable();
+        renderAttentionBanner();
     } catch (error) {
         console.log('⏸️ [loadSources] Error (expected during sync):', error.message);
 
@@ -1200,7 +1201,8 @@ function renderSourcesTable() {
             onclick="${rowClickHandler}" title="${rowClickHelp}">
             <td class="px-6 py-4 whitespace-nowrap">
                 <div class="flex items-center">
-                    <div class="text-sm font-medium text-gray-900">${source.name}</div>
+                    <div class="text-sm font-medium text-gray-900">${escapeHtml(source.name)}</div>
+                    ${source.needs_attention ? '<span class="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Needs Attention</span>' : ''}
                 </div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
@@ -2506,6 +2508,71 @@ function dismissMetabaseBanner() {
     localStorage.setItem('metabase-credentials-dismissed', 'true');
 }
 
+// ============================================================================
+// Schema Drift Attention
+// ============================================================================
+
+/**
+ * Render attention banner for sources with breaking schema drift.
+ * Called after loadSources() completes.
+ */
+async function renderAttentionBanner() {
+    const banner = document.getElementById('attention-banner');
+    if (!banner) return;
+
+    try {
+        const attentionSources = await apiCall('/api/governance/attention');
+        if (!attentionSources || attentionSources.length === 0) {
+            banner.innerHTML = '';
+            return;
+        }
+
+        const canManage = window.DANGO_USER_ROLE === 'admin';
+        const sourceItems = attentionSources.map(s => {
+            const acceptBtn = canManage
+                ? `<button onclick="acceptDrift('${escapeHtml(s.source)}')" class="ml-2 text-sm text-yellow-700 underline hover:text-yellow-900">Accept</button>`
+                : '';
+            return `<span class="font-medium">${escapeHtml(s.source)}</span>: ${escapeHtml(s.reason)}${acceptBtn}`;
+        }).join('<br>');
+
+        banner.innerHTML = `
+            <div class="mb-4 rounded-lg bg-yellow-50 border border-yellow-200 p-4">
+                <div class="flex">
+                    <div class="flex-shrink-0">
+                        <svg class="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+                        </svg>
+                    </div>
+                    <div class="ml-3">
+                        <h3 class="text-sm font-medium text-yellow-800">Breaking Schema Drift Detected</h3>
+                        <div class="mt-2 text-sm text-yellow-700">${sourceItems}</div>
+                        <p class="mt-1 text-xs text-yellow-600">dbt is paused for affected sources. Accept changes to resume.</p>
+                    </div>
+                </div>
+            </div>
+        `;
+    } catch (error) {
+        // Non-critical — don't show banner on error
+        banner.innerHTML = '';
+    }
+}
+
+/**
+ * Accept schema drift for a source.
+ * @param {string} sourceName - The source to accept drift for
+ */
+async function acceptDrift(sourceName) {
+    try {
+        await apiCall(`/api/governance/drift/${encodeURIComponent(sourceName)}/accept`, 'POST');
+        showToast(`Schema changes accepted for '${sourceName}'.`, 'success');
+        // Refresh sources and banner
+        await loadSources();
+        await renderAttentionBanner();
+    } catch (error) {
+        showToast(`Failed to accept drift: ${error.message}`, 'error');
+    }
+}
+
 // Make functions available globally
 window.triggerSync = triggerSync;
 window.refreshSources = refreshSources;
@@ -2525,3 +2592,4 @@ window.triggerFullRefresh = triggerFullRefresh;
 window.openDateRangeModal = openDateRangeModal;
 window.closeDateRangeModal = closeDateRangeModal;
 window.syncWithDateRange = syncWithDateRange;
+window.acceptDrift = acceptDrift;

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -756,7 +756,7 @@ async function loadSources() {
         // Longer timeout for sources (includes DuckDB queries for row counts)
         sources = await apiCall('/api/sources', 'GET', null, 15000);
         renderSourcesTable();
-        renderAttentionBanner();
+        await renderAttentionBanner();
     } catch (error) {
         console.log('⏸️ [loadSources] Error (expected during sync):', error.message);
 
@@ -2530,7 +2530,7 @@ async function renderAttentionBanner() {
         const canManage = window.DANGO_USER_ROLE === 'admin';
         const sourceItems = attentionSources.map(s => {
             const acceptBtn = canManage
-                ? `<button onclick="acceptDrift('${escapeHtml(s.source)}')" class="ml-2 text-sm text-yellow-700 underline hover:text-yellow-900">Accept</button>`
+                ? `<button onclick="acceptDrift(${JSON.stringify(s.source)})" class="ml-2 text-sm text-yellow-700 underline hover:text-yellow-900">Accept</button>`
                 : '';
             return `<span class="font-medium">${escapeHtml(s.source)}</span>: ${escapeHtml(s.reason)}${acceptBtn}`;
         }).join('<br>');
@@ -2564,12 +2564,11 @@ async function renderAttentionBanner() {
 async function acceptDrift(sourceName) {
     try {
         await apiCall(`/api/governance/drift/${encodeURIComponent(sourceName)}/accept`, 'POST');
-        showToast(`Schema changes accepted for '${sourceName}'.`, 'success');
-        // Refresh sources and banner
+        showToast(`Schema changes accepted for '${escapeHtml(sourceName)}'.`, 'success');
+        // loadSources() already calls renderAttentionBanner()
         await loadSources();
-        await renderAttentionBanner();
     } catch (error) {
-        showToast(`Failed to accept drift: ${error.message}`, 'error');
+        showToast(`Failed to accept drift: ${escapeHtml(error.message)}`, 'error');
     }
 }
 

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -4,6 +4,9 @@
 
 {% block content %}
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+        <!-- Attention banner for sources with breaking drift -->
+        <div id="attention-banner"></div>
+
         <!-- Data Sources -->
         <div class="bg-white rounded-lg shadow">
             <div class="px-6 py-4 border-b border-gray-200">

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -93,7 +93,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 750
+    lines: 757
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"
@@ -168,9 +168,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/csv_loader.py
-    lines: 765
+    lines: 847
     category: exempt
-    reason: "Multi-format file loading (CSV, JSON, JSONL, Parquet) with deduplication. Single-purpose module, stable."
+    reason: "Multi-format file loading (CSV, JSON, JSONL, Parquet) with deduplication and schema evolution. Single-purpose module."
     review_by: "v1.1"
 
   - file: dango/cli/validate.py
@@ -352,10 +352,22 @@ exemptions:
     reason: "TEST-030: 7 test classes covering page, list, create, delete, lock, heartbeat, release, force-release, copy. Marginally over limit after locked_at test addition."
     review_by: "v1.1"
 
+  - file: dango/governance/schema_drift.py
+    lines: 638
+    category: exempt
+    reason: "R9-D: grew to 638 lines adding breaking drift protection, accept flow, source attention management. Single-responsibility module (schema drift detection + resolution)."
+    review_by: "v1.1"
+
   - file: dango/governance/pii_detector.py
     lines: 602
     category: exempt
     reason: "BUG-027/BUG-133/BUG-139: grew to 602 lines adding spaCy fallback, PERSON threshold, intl phone recognizer, and PII override application. Single-responsibility module, not worth splitting."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_drift_detection.py
+    lines: 541
+    category: exempt
+    reason: "R9-D: Added severity, attention, accept tests. Marginally over limit."
     review_by: "v1.1"
 
   - file: tests/unit/test_pii_detection.py

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -168,7 +168,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/csv_loader.py
-    lines: 847
+    lines: 867
     category: exempt
     reason: "Multi-format file loading (CSV, JSON, JSONL, Parquet) with deduplication and schema evolution. Single-purpose module."
     review_by: "v1.1"
@@ -353,7 +353,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/governance/schema_drift.py
-    lines: 638
+    lines: 654
     category: exempt
     reason: "R9-D: grew to 638 lines adding breaking drift protection, accept flow, source attention management. Single-responsibility module (schema drift detection + resolution)."
     review_by: "v1.1"
@@ -365,7 +365,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_drift_detection.py
-    lines: 541
+    lines: 569
     category: exempt
     reason: "R9-D: Added severity, attention, accept tests. Marginally over limit."
     review_by: "v1.1"

--- a/tests/integration/test_drift_integration.py
+++ b/tests/integration/test_drift_integration.py
@@ -16,7 +16,6 @@ from dango.governance.schema_drift import (
     get_drift_history,
 )
 from dango.utils.dango_db import _schema_initialized, connect
-from dango.utils.post_sync import dispatch_post_sync_hooks
 
 
 def _create_test_warehouse(tmp_path: Path) -> Path:
@@ -184,21 +183,21 @@ class TestDriftDetectionIntegration:
 class TestHookBoundaryIntegration:
     """Integration tests for the full hook boundary path."""
 
-    def test_dispatch_to_drift_detection(self, tmp_path: Path) -> None:
-        """dispatch_post_sync_hooks → _run_drift_detection → drift engine."""
+    def test_drift_detection_direct(self, tmp_path: Path) -> None:
+        """detect_drift_for_sources detects drift (now called pre-dbt, not from post_sync)."""
         _clear_schema_cache()
         db_path = _create_test_warehouse(tmp_path)
 
-        # First sync via dispatcher — establishes baseline
-        dispatch_post_sync_hooks(tmp_path, ["testshop"])
+        # First call — establishes baseline
+        detect_drift_for_sources(tmp_path, ["testshop"])
 
         # Add a column
         conn = duckdb.connect(str(db_path))
         conn.execute("ALTER TABLE raw_testshop.orders ADD COLUMN status VARCHAR")
         conn.close()
 
-        # Second sync via dispatcher — detects drift
-        dispatch_post_sync_hooks(tmp_path, ["testshop"])
+        # Second call — detects drift
+        detect_drift_for_sources(tmp_path, ["testshop"])
 
         # Verify drift events were recorded
         with connect(tmp_path) as sqlite_conn:

--- a/tests/integration/test_phase7_gate.py
+++ b/tests/integration/test_phase7_gate.py
@@ -177,6 +177,11 @@ class TestFullPipelineEndToEnd:
         with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
             dispatch_post_sync_hooks(tmp_path, ["testshop"])
 
+        # Drift detection now runs pre-dbt (not from post_sync), call directly
+        from dango.governance.schema_drift import detect_drift_for_sources
+
+        detect_drift_for_sources(tmp_path, ["testshop"])
+
         with connect(tmp_path) as sqlite_conn:
             # 1. Profiling stats populated
             profiling = sqlite_conn.execute(

--- a/tests/integration/test_post_sync_chain_integration.py
+++ b/tests/integration/test_post_sync_chain_integration.py
@@ -73,12 +73,14 @@ class TestPostSyncChainIntegration:
         assert "testshop" in sources
 
     def test_drift_baseline_created(self, tmp_path: Path) -> None:
-        """First dispatch creates schema_baselines with no drift_events."""
+        """First detect_drift_for_sources call creates baselines with no events."""
+        from dango.governance.schema_drift import detect_drift_for_sources
+
         _clear_schema_cache()
         _create_test_warehouse(tmp_path)
 
-        with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
-            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+        # Drift now runs pre-dbt (not from post_sync), call directly
+        detect_drift_for_sources(tmp_path, ["testshop"])
 
         with connect(tmp_path) as sqlite_conn:
             baselines = sqlite_conn.execute(
@@ -92,22 +94,22 @@ class TestPostSyncChainIntegration:
         assert len(drift_events) == 0  # First run = baseline only, no drift
 
     def test_second_dispatch_detects_drift(self, tmp_path: Path) -> None:
-        """ALTER TABLE between dispatches produces drift_events."""
+        """ALTER TABLE between detect_drift_for_sources calls produces events."""
+        from dango.governance.schema_drift import detect_drift_for_sources
+
         _clear_schema_cache()
         db_path = _create_test_warehouse(tmp_path)
 
-        with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
-            # First run — establishes baseline
-            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+        # First run — establishes baseline
+        detect_drift_for_sources(tmp_path, ["testshop"])
 
         # ALTER TABLE — add a column
         conn = duckdb.connect(str(db_path))
         conn.execute("ALTER TABLE raw_testshop.orders ADD COLUMN notes VARCHAR")
         conn.close()
 
-        with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
-            # Second run — should detect drift
-            dispatch_post_sync_hooks(tmp_path, ["testshop"])
+        # Second run — should detect drift
+        detect_drift_for_sources(tmp_path, ["testshop"])
 
         with connect(tmp_path) as sqlite_conn:
             drift_events = sqlite_conn.execute(
@@ -119,27 +121,27 @@ class TestPostSyncChainIntegration:
         assert "column_added" in event_types
 
     def test_hook_failure_does_not_block_chain(self, tmp_path: Path) -> None:
-        """Patch drift engine to raise — profiling still ran, analysis still ran."""
+        """PII failure doesn't block analysis — profiling + analysis still run."""
         _clear_schema_cache()
         _create_test_warehouse(tmp_path)
 
         with (
-            patch(
-                "dango.governance.schema_drift.detect_drift_for_sources",
-                side_effect=RuntimeError("drift engine boom"),
-            ),
             patch("dango.governance.pii_detector._get_analyzer", return_value=None),
+            patch(
+                "dango.governance.pii_detector.scan_sources_for_pii",
+                side_effect=RuntimeError("pii boom"),
+            ),
             patch("dango.analysis.metrics.run_analysis", return_value=[]) as mock_analysis,
         ):
             dispatch_post_sync_hooks(tmp_path, ["testshop"])
 
-        # Profiling ran before drift (check profiling_stats)
+        # Profiling ran (check profiling_stats)
         with connect(tmp_path) as sqlite_conn:
             rows = sqlite_conn.execute(
                 "SELECT source FROM profiling_stats WHERE source = 'testshop'"
             ).fetchall()
 
-        assert len(rows) > 0  # Profiling succeeded despite drift failure
+        assert len(rows) > 0  # Profiling succeeded despite PII failure
 
-        # Analysis ran after drift
+        # Analysis ran after PII failure
         mock_analysis.assert_called_once()

--- a/tests/unit/test_csv_schema_evolution.py
+++ b/tests/unit/test_csv_schema_evolution.py
@@ -1,0 +1,132 @@
+"""tests/unit/test_csv_schema_evolution.py
+
+Unit tests for CSV schema evolution (--allow-schema-changes).
+Tests the _validate_all_files_schema_match and _evolve_table_schema methods.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pytest
+
+from dango.config.models import CSVSourceConfig
+from dango.ingestion.csv_loader import CSVLoader
+
+
+def _make_csv(directory: Path, filename: str, header: str, rows: list[str]) -> Path:
+    """Write a CSV file with given header and rows."""
+    filepath = directory / filename
+    lines = [header] + rows
+    filepath.write_text("\n".join(lines) + "\n")
+    return filepath
+
+
+@pytest.fixture()
+def csv_env(tmp_path: Path) -> tuple[CSVLoader, Path, Path, CSVSourceConfig]:
+    """Set up a CSV loader environment with DuckDB and a data directory."""
+    db_path = tmp_path / "data" / "warehouse.duckdb"
+    db_path.parent.mkdir(parents=True)
+
+    data_dir = tmp_path / "csv_data"
+    data_dir.mkdir()
+
+    loader = CSVLoader(tmp_path, db_path)
+    config = CSVSourceConfig(directory=data_dir, file_pattern="*.csv")
+
+    return loader, db_path, data_dir, config
+
+
+@pytest.mark.unit
+class TestStrictModeRejectsExtraColumns:
+    """Default (strict) behavior rejects schema mismatches."""
+
+    def test_extra_columns_rejected_without_flag(self, csv_env: Any) -> None:
+        """Without --allow-schema-changes, extra columns cause an error."""
+        loader, db_path, data_dir, config = csv_env
+
+        # First file: id, name
+        _make_csv(data_dir, "file1.csv", "id,name", ["1,Alice", "2,Bob"])
+
+        # Load first file to establish table
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "success"
+        assert result["total_rows"] == 2
+
+        # Second file: id, name, email (extra column)
+        _make_csv(data_dir, "file2.csv", "id,name,email", ["3,Charlie,c@x.com"])
+
+        # Strict mode (default) — should fail
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "error"
+        assert "Schema validation failed" in result.get("error", "")
+
+
+@pytest.mark.unit
+class TestAllowSchemaChangesExtraColumns:
+    """--allow-schema-changes adds extra columns via ALTER TABLE."""
+
+    def test_extra_columns_added_via_alter_table(self, csv_env: Any) -> None:
+        """Extra columns in new files are added to existing table."""
+        loader, db_path, data_dir, config = csv_env
+
+        # First file: id, name
+        _make_csv(data_dir, "file1.csv", "id,name", ["1,Alice", "2,Bob"])
+
+        # Load to establish table
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "success"
+
+        # Verify initial schema
+        conn = duckdb.connect(str(db_path), read_only=True)
+        cols = [
+            row[0]
+            for row in conn.execute("DESCRIBE raw_test_src.test_src").fetchall()
+            if not row[0].startswith("_dango_")
+        ]
+        conn.close()
+        assert "id" in cols
+        assert "name" in cols
+        assert "email" not in cols
+
+        # Second file: id, name, email (extra column)
+        _make_csv(data_dir, "file2.csv", "id,name,email", ["3,Charlie,c@x.com"])
+
+        # Load with schema evolution enabled
+        result = loader.load("test_src", config, "raw_test_src", allow_schema_changes=True)
+        assert result["status"] == "success"
+
+        # Verify new column exists
+        conn = duckdb.connect(str(db_path), read_only=True)
+        cols = [
+            row[0]
+            for row in conn.execute("DESCRIBE raw_test_src.test_src").fetchall()
+            if not row[0].startswith("_dango_")
+        ]
+        conn.close()
+        assert "email" in cols
+
+
+@pytest.mark.unit
+class TestAllowSchemaChangesMissingColumns:
+    """--allow-schema-changes loads files with missing columns as NULL."""
+
+    def test_missing_columns_loaded_as_null(self, csv_env: Any) -> None:
+        """Files missing columns from existing table load with NULLs."""
+        loader, db_path, data_dir, config = csv_env
+
+        # First file: id, name, email
+        _make_csv(data_dir, "file1.csv", "id,name,email", ["1,Alice,a@x.com", "2,Bob,b@x.com"])
+
+        # Load to establish table with 3 columns
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "success"
+
+        # Second file: id, name (missing email column)
+        _make_csv(data_dir, "file2.csv", "id,name", ["3,Charlie"])
+
+        # Load with schema evolution — missing column should be tolerated
+        result = loader.load("test_src", config, "raw_test_src", allow_schema_changes=True)
+        assert result["status"] == "success"

--- a/tests/unit/test_drift_detection.py
+++ b/tests/unit/test_drift_detection.py
@@ -12,9 +12,11 @@ import pytest
 
 from dango.governance.schema_drift import (
     _send_drift_webhook,
+    accept_drift,
     detect_drift_for_sources,
     detect_table_drift,
     get_drift_history,
+    get_sources_needing_attention,
 )
 
 _DRIFT = "dango.governance.schema_drift"
@@ -244,8 +246,26 @@ class TestGetDriftHistory:
         """Events are returned newest first (descending id)."""
         mock_conn = MagicMock()
         mock_conn.execute.return_value.fetchall.return_value = [
-            (2, "shopify", "orders", "email", "column_added", "type=VARCHAR", "2026-01-02"),
-            (1, "shopify", "orders", "name", "column_removed", "was=VARCHAR", "2026-01-01"),
+            (
+                2,
+                "shopify",
+                "orders",
+                "email",
+                "column_added",
+                "additive",
+                "type=VARCHAR",
+                "2026-01-02",
+            ),
+            (
+                1,
+                "shopify",
+                "orders",
+                "name",
+                "column_removed",
+                "breaking",
+                "was=VARCHAR",
+                "2026-01-01",
+            ),
         ]
         with patch(f"{_DRIFT}.connect") as mock_ctx:
             mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_conn)
@@ -357,3 +377,165 @@ class TestSendDriftWebhook:
         ):
             _send_drift_webhook(tmp_path, ["shopify"], self._events)
         mock_fmt.assert_called_once()
+
+
+@pytest.mark.unit
+class TestDriftSeverity:
+    """Tests for drift severity classification."""
+
+    def test_breaking_drift_severity_column_removed(self, tmp_path: Path) -> None:
+        """column_removed event has severity 'breaking'."""
+        with (
+            patch(f"{_DRIFT}._get_current_schema", return_value={"id": "INTEGER"}),
+            patch(
+                f"{_DRIFT}._get_baseline",
+                return_value={"id": "INTEGER", "name": "VARCHAR"},
+            ),
+            patch(f"{_DRIFT}._record_drift_events_only"),
+            patch(f"{_DRIFT}._set_source_attention"),
+        ):
+            result = detect_table_drift(tmp_path, "shopify", "orders")
+
+        assert len(result) == 1
+        assert result[0]["event_type"] == "column_removed"
+        assert result[0]["severity"] == "breaking"
+
+    def test_breaking_drift_severity_type_changed(self, tmp_path: Path) -> None:
+        """type_changed event has severity 'breaking'."""
+        with (
+            patch(
+                f"{_DRIFT}._get_current_schema",
+                return_value={"id": "INTEGER", "total": "DOUBLE"},
+            ),
+            patch(
+                f"{_DRIFT}._get_baseline",
+                return_value={"id": "INTEGER", "total": "INTEGER"},
+            ),
+            patch(f"{_DRIFT}._record_drift_events_only"),
+            patch(f"{_DRIFT}._set_source_attention"),
+        ):
+            result = detect_table_drift(tmp_path, "shopify", "orders")
+
+        assert len(result) == 1
+        assert result[0]["event_type"] == "type_changed"
+        assert result[0]["severity"] == "breaking"
+
+    def test_additive_drift_severity(self, tmp_path: Path) -> None:
+        """column_added event has severity 'additive'."""
+        with (
+            patch(
+                f"{_DRIFT}._get_current_schema",
+                return_value={"id": "INTEGER", "email": "VARCHAR"},
+            ),
+            patch(f"{_DRIFT}._get_baseline", return_value={"id": "INTEGER"}),
+            patch(f"{_DRIFT}._record_drift_events"),
+        ):
+            result = detect_table_drift(tmp_path, "shopify", "orders")
+
+        assert len(result) == 1
+        assert result[0]["event_type"] == "column_added"
+        assert result[0]["severity"] == "additive"
+
+    def test_breaking_drift_skips_baseline_update(self, tmp_path: Path) -> None:
+        """Breaking drift records events but does NOT update baseline."""
+        with (
+            patch(f"{_DRIFT}._get_current_schema", return_value={"id": "INTEGER"}),
+            patch(
+                f"{_DRIFT}._get_baseline",
+                return_value={"id": "INTEGER", "name": "VARCHAR"},
+            ),
+            patch(f"{_DRIFT}._record_drift_events_only") as mock_record_only,
+            patch(f"{_DRIFT}._record_drift_events") as mock_record,
+            patch(f"{_DRIFT}._set_source_attention") as mock_attention,
+        ):
+            detect_table_drift(tmp_path, "shopify", "orders")
+
+        # Breaking: uses _record_drift_events_only, NOT _record_drift_events
+        mock_record_only.assert_called_once()
+        mock_record.assert_not_called()
+        mock_attention.assert_called_once()
+
+    def test_additive_drift_updates_baseline(self, tmp_path: Path) -> None:
+        """Additive-only drift updates baseline normally."""
+        current = {"id": "INTEGER", "email": "VARCHAR"}
+        with (
+            patch(f"{_DRIFT}._get_current_schema", return_value=current),
+            patch(f"{_DRIFT}._get_baseline", return_value={"id": "INTEGER"}),
+            patch(f"{_DRIFT}._record_drift_events_only") as mock_record_only,
+            patch(f"{_DRIFT}._record_drift_events") as mock_record,
+            patch(f"{_DRIFT}._set_source_attention") as mock_attention,
+        ):
+            detect_table_drift(tmp_path, "shopify", "orders")
+
+        # Additive: uses _record_drift_events (with baseline update)
+        mock_record.assert_called_once()
+        mock_record_only.assert_not_called()
+        mock_attention.assert_not_called()
+
+
+@pytest.mark.unit
+class TestSourceAttention:
+    """Tests for source attention (breaking drift state management)."""
+
+    def test_source_attention_set_on_breaking(self, tmp_path: Path) -> None:
+        """Source attention row is set when breaking drift is detected."""
+        with (
+            patch(f"{_DRIFT}._get_current_schema", return_value={"id": "INTEGER"}),
+            patch(
+                f"{_DRIFT}._get_baseline",
+                return_value={"id": "INTEGER", "name": "VARCHAR"},
+            ),
+            patch(f"{_DRIFT}._record_drift_events_only"),
+            patch(f"{_DRIFT}._set_source_attention") as mock_attention,
+        ):
+            detect_table_drift(tmp_path, "shopify", "orders")
+
+        mock_attention.assert_called_once()
+        call_args = mock_attention.call_args
+        assert call_args[0][1] == "shopify"
+        events = call_args[0][2]
+        assert len(events) == 1
+        assert events[0]["severity"] == "breaking"
+
+    def test_accept_drift_clears_attention(self, tmp_path: Path) -> None:
+        """accept_drift() clears attention and updates baseline."""
+        with (
+            patch(f"{_DRIFT}.connect") as mock_ctx,
+            patch(f"{_DRIFT}._get_current_schema", return_value={"id": "INTEGER"}),
+            patch(f"{_DRIFT}._save_baseline") as mock_save,
+        ):
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchall.return_value = [("orders",)]
+            mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_conn)
+            mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            accept_drift(tmp_path, "shopify")
+
+        # Baseline updated for each table
+        mock_save.assert_called_once()
+        # Attention cleared (DELETE query was executed)
+        delete_calls = [
+            c for c in mock_conn.execute.call_args_list if "DELETE FROM source_attention" in str(c)
+        ]
+        assert len(delete_calls) == 1
+
+    def test_get_sources_needing_attention(self, tmp_path: Path) -> None:
+        """get_sources_needing_attention returns correct sources."""
+        import json
+
+        mock_events = [{"event_type": "column_removed", "severity": "breaking"}]
+
+        with patch(f"{_DRIFT}.connect") as mock_ctx:
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchall.return_value = [
+                ("shopify", "1 breaking change(s)", json.dumps(mock_events), "2026-01-01"),
+            ]
+            mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_conn)
+            mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = get_sources_needing_attention(tmp_path)
+
+        assert len(result) == 1
+        assert result[0]["source"] == "shopify"
+        assert result[0]["reason"] == "1 breaking change(s)"
+        assert len(result[0]["drift_events"]) == 1

--- a/tests/unit/test_drift_detection.py
+++ b/tests/unit/test_drift_detection.py
@@ -472,6 +472,33 @@ class TestDriftSeverity:
         mock_record_only.assert_not_called()
         mock_attention.assert_not_called()
 
+    def test_mixed_breaking_and_additive_uses_breaking_path(self, tmp_path: Path) -> None:
+        """Mixed breaking+additive drift takes the breaking path for all events."""
+        # column removed (breaking) + column added (additive) in same diff
+        current = {"id": "INTEGER", "email": "VARCHAR"}
+        baseline = {"id": "INTEGER", "name": "VARCHAR"}
+        with (
+            patch(f"{_DRIFT}._get_current_schema", return_value=current),
+            patch(f"{_DRIFT}._get_baseline", return_value=baseline),
+            patch(f"{_DRIFT}._record_drift_events_only") as mock_record_only,
+            patch(f"{_DRIFT}._record_drift_events") as mock_record,
+            patch(f"{_DRIFT}._set_source_attention") as mock_attention,
+        ):
+            result = detect_table_drift(tmp_path, "shopify", "orders")
+
+        # Both events returned
+        event_types = {e["event_type"] for e in result}
+        assert event_types == {"column_added", "column_removed"}
+
+        # Breaking path used (no baseline update), even though additive events exist
+        mock_record_only.assert_called_once()
+        mock_record.assert_not_called()
+        mock_attention.assert_called_once()
+
+        # All events passed to _record_drift_events_only
+        recorded = mock_record_only.call_args[0][1]
+        assert len(recorded) == 2
+
 
 @pytest.mark.unit
 class TestSourceAttention:
@@ -499,6 +526,7 @@ class TestSourceAttention:
 
     def test_accept_drift_clears_attention(self, tmp_path: Path) -> None:
         """accept_drift() clears attention and updates baseline."""
+        _make_warehouse(tmp_path)
         with (
             patch(f"{_DRIFT}.connect") as mock_ctx,
             patch(f"{_DRIFT}._get_current_schema", return_value={"id": "INTEGER"}),

--- a/tests/unit/test_governance_api.py
+++ b/tests/unit/test_governance_api.py
@@ -1,0 +1,164 @@
+"""tests/unit/test_governance_api.py
+
+Unit tests for governance web API endpoints (dango/web/routes/governance.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from dango.auth.models import Role, User
+from dango.exceptions import AuthorizationError, DangoError
+from dango.web.routes.governance import router
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.ADMIN) -> User:
+    return User(
+        id="u-test-1",
+        email="test@test.com",
+        password_hash="hashed",
+        role=role,
+        is_active=True,
+    )
+
+
+def _make_app(project_root: Path) -> FastAPI:
+    app = FastAPI()
+    app.state.project_root = project_root
+
+    @app.exception_handler(DangoError)
+    async def dango_error_handler(request: Request, exc: DangoError) -> JSONResponse:
+        status_map: dict[type[DangoError], int] = {
+            AuthorizationError: 403,
+            DangoError: 500,
+        }
+        status_code = 500
+        for cls in type(exc).__mro__:
+            if cls in status_map:
+                status_code = status_map[cls]
+                break
+        return JSONResponse(
+            status_code=status_code,
+            content={"error_code": exc.error_code, "message": exc.user_message},
+        )
+
+    app.include_router(router)
+    return app
+
+
+def _setup_client(
+    tmp_path: Path,
+    role: Role = Role.ADMIN,
+) -> tuple[TestClient, Path]:
+    user = _make_user(role)
+    app = _make_app(tmp_path)
+
+    @app.middleware("http")
+    async def set_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        request.state.auth_method = "session"
+        return await call_next(request)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAcceptDriftEndpoint:
+    """Tests for POST /api/governance/drift/{source}/accept."""
+
+    def test_accept_drift_returns_200(self, tmp_path: Path) -> None:
+        """Admin can accept drift for a source."""
+        client, _ = _setup_client(tmp_path, Role.ADMIN)
+        with (
+            patch(
+                "dango.governance.schema_drift.accept_drift",
+            ) as mock_accept,
+            patch("dango.web.routes.governance.log_auth_event"),
+            patch("dango.web.routes.governance.get_project_root", return_value=tmp_path),
+        ):
+            resp = client.post(
+                "/api/governance/drift/shopify/accept",
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "shopify"
+        assert data["accepted"] is True
+        mock_accept.assert_called_once()
+
+    def test_accept_drift_requires_manage_permission(self, tmp_path: Path) -> None:
+        """Viewer gets 403 on accept (needs governance.manage)."""
+        client, _ = _setup_client(tmp_path, Role.VIEWER)
+        with (
+            patch("dango.web.routes.governance.log_auth_event"),
+            patch("dango.web.routes.governance.get_project_root", return_value=tmp_path),
+        ):
+            resp = client.post(
+                "/api/governance/drift/shopify/accept",
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+
+        assert resp.status_code == 403
+
+
+@pytest.mark.unit
+class TestAttentionEndpoint:
+    """Tests for GET /api/governance/attention."""
+
+    def test_attention_returns_sources(self, tmp_path: Path) -> None:
+        """Returns attention sources."""
+        client, _ = _setup_client(tmp_path, Role.ADMIN)
+        mock_rows = [
+            {
+                "source": "shopify",
+                "reason": "1 breaking change(s)",
+                "drift_events": [],
+                "created_at": "2026-01-01",
+            }
+        ]
+        with (
+            patch(
+                "dango.governance.schema_drift.get_sources_needing_attention",
+                return_value=mock_rows,
+            ),
+            patch("dango.web.routes.governance.get_project_root", return_value=tmp_path),
+        ):
+            resp = client.get("/api/governance/attention")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["source"] == "shopify"
+
+    def test_attention_empty(self, tmp_path: Path) -> None:
+        """Returns empty list when no attention needed."""
+        client, _ = _setup_client(tmp_path, Role.ADMIN)
+        with (
+            patch(
+                "dango.governance.schema_drift.get_sources_needing_attention",
+                return_value=[],
+            ),
+            patch("dango.web.routes.governance.get_project_root", return_value=tmp_path),
+        ):
+            resp = client.get("/api/governance/attention")
+
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/unit/test_governance_api.py
+++ b/tests/unit/test_governance_api.py
@@ -86,10 +86,17 @@ class TestAcceptDriftEndpoint:
     def test_accept_drift_returns_200(self, tmp_path: Path) -> None:
         """Admin can accept drift for a source."""
         client, _ = _setup_client(tmp_path, Role.ADMIN)
+        mock_attention = [
+            {"source": "shopify", "reason": "1 breaking", "drift_events": [], "created_at": "t"}
+        ]
         with (
             patch(
                 "dango.governance.schema_drift.accept_drift",
             ) as mock_accept,
+            patch(
+                "dango.governance.schema_drift.get_sources_needing_attention",
+                return_value=mock_attention,
+            ),
             patch("dango.web.routes.governance.log_auth_event"),
             patch("dango.web.routes.governance.get_project_root", return_value=tmp_path),
         ):
@@ -103,6 +110,24 @@ class TestAcceptDriftEndpoint:
         assert data["source"] == "shopify"
         assert data["accepted"] is True
         mock_accept.assert_called_once()
+
+    def test_accept_drift_404_when_no_attention(self, tmp_path: Path) -> None:
+        """Returns 404 when source has no pending drift."""
+        client, _ = _setup_client(tmp_path, Role.ADMIN)
+        with (
+            patch(
+                "dango.governance.schema_drift.get_sources_needing_attention",
+                return_value=[],
+            ),
+            patch("dango.web.routes.governance.log_auth_event"),
+            patch("dango.web.routes.governance.get_project_root", return_value=tmp_path),
+        ):
+            resp = client.post(
+                "/api/governance/drift/nonexistent/accept",
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+
+        assert resp.status_code == 404
 
     def test_accept_drift_requires_manage_permission(self, tmp_path: Path) -> None:
         """Viewer gets 403 on accept (needs governance.manage)."""

--- a/tests/unit/test_post_sync.py
+++ b/tests/unit/test_post_sync.py
@@ -18,18 +18,16 @@ class TestDispatchPostSyncHooks:
     """Unit tests for dispatch_post_sync_hooks."""
 
     def test_calls_all_hooks(self, tmp_path: Path):
-        """All four hooks are called with the correct sources."""
+        """All three hooks are called with the correct sources (drift moved to pre-dbt)."""
         sources = ["shopify", "stripe"]
         with (
             patch("dango.utils.post_sync._run_profiling") as mock_prof,
-            patch("dango.utils.post_sync._run_drift_detection") as mock_drift,
             patch("dango.utils.post_sync._run_pii_scan") as mock_pii,
             patch("dango.utils.post_sync._run_analysis") as mock_analysis,
         ):
             dispatch_post_sync_hooks(project_root=tmp_path, sources=sources)
 
         mock_prof.assert_called_once_with(tmp_path, sources)
-        mock_drift.assert_called_once_with(tmp_path, sources)
         mock_pii.assert_called_once_with(tmp_path, sources)
         mock_analysis.assert_called_once_with(tmp_path, sources)
 
@@ -57,10 +55,9 @@ class TestDispatchPostSyncHooks:
         mock_engine.assert_called_once_with(tmp_path, source_filter=["raw_stripe", "raw_ga"])
 
     def test_profiling_engine_error_isolation(self, tmp_path: Path) -> None:
-        """When profiling engine raises, _run_profiling catches it and drift/pii/analysis still run."""
+        """When profiling engine raises, _run_profiling catches it and pii/analysis still run."""
         with (
             patch("dango.utils.post_sync.profile_table", side_effect=RuntimeError("boom")),
-            patch("dango.governance.schema_drift.detect_drift_for_sources") as mock_drift,
             patch("dango.governance.pii_detector.scan_sources_for_pii") as mock_pii,
             patch("dango.analysis.metrics.run_analysis", return_value=[]) as mock_analysis,
         ):
@@ -77,24 +74,7 @@ class TestDispatchPostSyncHooks:
 
             dispatch_post_sync_hooks(project_root=tmp_path, sources=["testshop"])
 
-        # Drift, PII, and analysis still called despite profiling failure
-        mock_drift.assert_called_once()
-        mock_pii.assert_called_once()
-        mock_analysis.assert_called_once()
-
-    def test_drift_engine_error_isolation(self, tmp_path: Path) -> None:
-        """When drift engine raises, _run_drift_detection catches it and pii/analysis still run."""
-        with (
-            patch("dango.utils.post_sync._run_profiling"),
-            patch(
-                "dango.governance.schema_drift.detect_drift_for_sources",
-                side_effect=RuntimeError("drift boom"),
-            ),
-            patch("dango.governance.pii_detector.scan_sources_for_pii") as mock_pii,
-            patch("dango.analysis.metrics.run_analysis", return_value=[]) as mock_analysis,
-        ):
-            dispatch_post_sync_hooks(project_root=tmp_path, sources=["s1"])
-
+        # PII and analysis still called despite profiling failure
         mock_pii.assert_called_once()
         mock_analysis.assert_called_once()
 
@@ -102,7 +82,6 @@ class TestDispatchPostSyncHooks:
         """When PII engine raises, _run_pii_scan catches it and analysis still runs."""
         with (
             patch("dango.utils.post_sync._run_profiling"),
-            patch("dango.utils.post_sync._run_drift_detection"),
             patch(
                 "dango.governance.pii_detector.scan_sources_for_pii",
                 side_effect=RuntimeError("pii boom"),
@@ -114,7 +93,7 @@ class TestDispatchPostSyncHooks:
         mock_analysis.assert_called_once()
 
     def test_hooks_called_in_order(self, tmp_path: Path) -> None:
-        """Hooks are called in order: profiling -> drift -> pii -> analysis."""
+        """Hooks are called in order: profiling -> pii -> analysis (drift moved to pre-dbt)."""
         call_order: list[str] = []
 
         def _make_side_effect(name: str):
@@ -129,10 +108,6 @@ class TestDispatchPostSyncHooks:
                 side_effect=_make_side_effect("profiling"),
             ),
             patch(
-                "dango.utils.post_sync._run_drift_detection",
-                side_effect=_make_side_effect("drift"),
-            ),
-            patch(
                 "dango.utils.post_sync._run_pii_scan",
                 side_effect=_make_side_effect("pii"),
             ),
@@ -143,13 +118,12 @@ class TestDispatchPostSyncHooks:
         ):
             dispatch_post_sync_hooks(project_root=tmp_path, sources=["s1"])
 
-        assert call_order == ["profiling", "drift", "pii", "analysis"]
+        assert call_order == ["profiling", "pii", "analysis"]
 
     def test_log_start_and_complete(self, tmp_path: Path) -> None:
         """Verify logger.info called with post_sync_hooks_start and _complete."""
         with (
             patch("dango.utils.post_sync._run_profiling"),
-            patch("dango.utils.post_sync._run_drift_detection"),
             patch("dango.utils.post_sync._run_pii_scan"),
             patch("dango.utils.post_sync._run_analysis"),
             patch("dango.utils.post_sync.logger") as mock_logger,
@@ -161,11 +135,8 @@ class TestDispatchPostSyncHooks:
         assert "post_sync_hooks_start" in events
         assert "post_sync_hooks_complete" in events
 
-    def test_drift_hook_calls_engine(self, tmp_path: Path) -> None:
-        """Call _run_drift_detection directly and verify it calls the engine."""
-        with patch("dango.governance.schema_drift.detect_drift_for_sources") as mock_engine:
-            from dango.utils.post_sync import _run_drift_detection
+    def test_drift_detection_removed_from_post_sync(self, tmp_path: Path) -> None:
+        """_run_drift_detection was removed (drift now runs pre-dbt in dlt_runner)."""
+        import dango.utils.post_sync as ps
 
-            _run_drift_detection(tmp_path, ["shopify", "stripe"])
-
-        mock_engine.assert_called_once_with(tmp_path, ["shopify", "stripe"])
+        assert not hasattr(ps, "_run_drift_detection")


### PR DESCRIPTION
## Summary

- **BUG-138 fix**: Detect breaking schema drift (column_removed, type_changed) BEFORE dbt runs, pause dbt to protect dashboards, and provide accept flow to resume
- **BUG-136 fix**: Add opt-in CSV schema evolution via `--allow-schema-changes` flag (extra columns → ALTER TABLE, missing columns → NULLs)
- Drift detection moved from post_sync to pre-dbt in `dlt_runner.py`; breaking drift does NOT update baseline until user explicitly accepts

### Key changes
- `source_attention` SQLite table + `severity` column on `drift_events`
- `accept_drift()` / `get_sources_needing_attention()` public API
- `dango governance accept <source>` CLI command
- `POST /api/governance/drift/{source}/accept` + `GET /api/governance/attention` endpoints
- `/api/sources` enriched with `needs_attention` flag
- Web UI: yellow attention banner + "Accept" button on sources page
- CSV `--allow-schema-changes`: ALTER TABLE ADD COLUMN for extras, NULL for missing
- `GOVERNANCE_DRIFT_ACCEPTED` audit event

## Test plan

- [x] 44 targeted tests pass (drift severity, attention, accept, API endpoints, post_sync updates)
- [x] Full unit suite passes (3086 passed, 7 skipped)
- [x] `ruff check` + `ruff format` clean
- [x] All pre-commit hooks pass
- [ ] Manual E2E: sync with removed column → dbt skipped → accept → dbt resumes
- [ ] Manual E2E: CSV `--allow-schema-changes` with extra/missing columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)