### PR TITLE
R9-I: Notifications + metric templates (BUG-145/146/147/148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ dango/                          # Python package source
 │   │   ├── scheduler.py        # SchedulerService (lifecycle, events, cancellation)
 │   │   ├── resilience.py       # Retry, timeout, cancellation
 │   │   ├── history.py          # Execution history tracking
-│   │   ├── jobs.py             # Module-level job functions (732 lines)
+│   │   ├── jobs.py             # Module-level job functions (894 lines)
 │   │   └── sync_trigger.py     # Server-side manual sync runner
 │   ├── notifications/          # Webhook notifications (TASK-043+)
 │   │   ├── webhook.py          # Event types, config, async sender
@@ -249,7 +249,7 @@ dango/                          # Python package source
 │   └── watcher_runner.py       # → local/watcher_runner.py
 │
 ├── ingestion/                  # Level 1 — Data loading
-│   ├── dlt_runner.py           # ⚠ 2373 lines — orchestrates full sync pipeline
+│   ├── dlt_runner.py           # ⚠ 2415 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # Multi-format file loading with dedup (867 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
@@ -286,7 +286,7 @@ dango/                          # Python package source
 │   ├── data_validation.py      # Data validation utilities
 │   ├── env_file.py             # .env file parsing and serialization
 │   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
-│   ├── post_sync.py            # Post-sync hook dispatcher (~497 lines)
+│   ├── post_sync.py            # Post-sync hook dispatcher (~549 lines)
 │   └── git_info.py             # Git repository info + deployment guardrails
 │
 ├── migrations/                 # Level 0 — Database migration framework
@@ -332,7 +332,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `ingestion/dlt_runner.py` | 2373 | — (exempt, too risky) |
+| `ingestion/dlt_runner.py` | 2415 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2288 | — |
 | `visualization/metabase.py` | 1151 | — |
@@ -343,8 +343,9 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 867 | — |
-| `platform/scheduling/jobs.py` | 839 | — (module-level job functions) |
-| `web/routes/schedules.py` | 720 | — (schedule CRUD, history, notifications) |
+| `platform/scheduling/jobs.py` | 894 | — (module-level job functions) |
+| `utils/post_sync.py` | 549 | — (post-sync hooks + sync notification) |
+| `web/routes/schedules.py` | 859 | — (schedule CRUD, history, notifications, webhook CRUD) |
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ dango/                          # Python package source
 │   ├── data_validation.py      # Data validation utilities
 │   ├── env_file.py             # .env file parsing and serialization
 │   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
-│   ├── post_sync.py            # Post-sync hook dispatcher (~549 lines)
+│   ├── post_sync.py            # Post-sync hook dispatcher (~553 lines)
 │   └── git_info.py             # Git repository info + deployment guardrails
 │
 ├── migrations/                 # Level 0 — Database migration framework
@@ -343,8 +343,8 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 867 | — |
-| `platform/scheduling/jobs.py` | 894 | — (module-level job functions) |
-| `utils/post_sync.py` | 549 | — (post-sync hooks + sync notification) |
+| `platform/scheduling/jobs.py` | 895 | — (module-level job functions) |
+| `utils/post_sync.py` | 553 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 859 | — (schedule CRUD, history, notifications, webhook CRUD) |
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |

--- a/dango/analysis/templates.py
+++ b/dango/analysis/templates.py
@@ -8,6 +8,7 @@ so analysis starts working automatically from the first sync.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from dango.analysis.models import ComparisonType, MetricConfig
@@ -41,9 +42,10 @@ def generate_metrics_for_source(
         "csv": lambda name: _csv_metrics(name),
     }
     generator = generators.get(source_type)
-    if generator is None:
-        return []
-    return generator(source_name)
+    if generator is not None:
+        return generator(source_name)
+    # Fallback: auto-discover tables and generate generic metrics
+    return _generic_metrics(source_name, project_root)
 
 
 # ---------------------------------------------------------------------------
@@ -146,6 +148,82 @@ def _csv_metrics(name: str) -> list[MetricConfig]:
     Add metrics manually after first sync via 'dango db status'.
     """
     return []
+
+
+def _generic_metrics(name: str, project_root: Path | None) -> list[MetricConfig]:
+    """Generate generic row-count and freshness metrics by discovering tables.
+
+    Queries ``information_schema.tables`` for the ``raw_{name}`` schema,
+    skipping dlt internal tables.  For each user table, creates:
+
+    - ``{name}_{table}_row_count`` — ``COUNT(*)`` with week-over-week comparison
+    - ``{name}_{table}_freshness`` — ``MAX(_dlt_load_id)`` cast to BIGINT
+      (only if the table has a ``_dlt_load_id`` column)
+    """
+    if project_root is None:
+        return []
+    db_path = project_root / "data" / "warehouse.duckdb"
+    if not db_path.exists():
+        return []
+    schema = f"raw_{name}"
+    try:
+        import duckdb
+
+        conn = duckdb.connect(str(db_path), read_only=True)
+        try:
+            tables = conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = ? AND table_name NOT LIKE '_dlt_%' "
+                "ORDER BY table_name",
+                [schema],
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return []
+
+    if not tables:
+        return []
+
+    metrics: list[MetricConfig] = []
+    for (table_name,) in tables:
+        sanitized = _sanitize_table_name(table_name)
+        metrics.append(
+            MetricConfig(
+                name=f"{name}_{sanitized}_row_count",
+                source_table=f"{schema}.{table_name}",
+                value_expression="COUNT(*)",
+                compare=ComparisonType.week_over_week,
+                warn_threshold=25.0,
+            )
+        )
+        # Add freshness metric only if _dlt_load_id column exists
+        columns = _get_table_columns(schema, table_name, project_root)
+        if "_dlt_load_id" in columns:
+            metrics.append(
+                MetricConfig(
+                    name=f"{name}_{sanitized}_freshness",
+                    source_table=f"{schema}.{table_name}",
+                    value_expression="CAST(MAX(_dlt_load_id) AS BIGINT)",
+                    compare=ComparisonType.week_over_week,
+                    warn_threshold=25.0,
+                )
+            )
+    return metrics
+
+
+_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
+_LEADING_DIGITS_RE = re.compile(r"^[0-9]+")
+
+
+def _sanitize_table_name(table_name: str) -> str:
+    """Sanitize a table name for use in a metric name.
+
+    Replaces non-alphanumeric characters with ``_`` and strips leading digits.
+    """
+    result = _SANITIZE_RE.sub("_", table_name)
+    result = _LEADING_DIGITS_RE.sub("", result)
+    return result.strip("_") or "table"
 
 
 # ---------------------------------------------------------------------------

--- a/dango/analysis/templates.py
+++ b/dango/analysis/templates.py
@@ -157,8 +157,10 @@ def _generic_metrics(name: str, project_root: Path | None) -> list[MetricConfig]
     skipping dlt internal tables.  For each user table, creates:
 
     - ``{name}_{table}_row_count`` — ``COUNT(*)`` with week-over-week comparison
-    - ``{name}_{table}_freshness`` — ``MAX(_dlt_load_id)`` cast to BIGINT
+    - ``{name}_{table}_freshness`` — ``MAX(_dlt_load_id)``
       (only if the table has a ``_dlt_load_id`` column)
+
+    Uses a single DuckDB connection for all queries to avoid N+1 overhead.
     """
     if project_root is None:
         return []
@@ -177,12 +179,19 @@ def _generic_metrics(name: str, project_root: Path | None) -> list[MetricConfig]
                 "ORDER BY table_name",
                 [schema],
             ).fetchall()
+            if not tables:
+                return []
+
+            # Batch-fetch columns for all tables to check for _dlt_load_id
+            cols_rows = conn.execute(
+                "SELECT table_name, column_name FROM information_schema.columns "
+                "WHERE table_schema = ? AND column_name = '_dlt_load_id'",
+                [schema],
+            ).fetchall()
+            tables_with_load_id = {r[0] for r in cols_rows}
         finally:
             conn.close()
     except Exception:
-        return []
-
-    if not tables:
         return []
 
     metrics: list[MetricConfig] = []
@@ -198,13 +207,12 @@ def _generic_metrics(name: str, project_root: Path | None) -> list[MetricConfig]
             )
         )
         # Add freshness metric only if _dlt_load_id column exists
-        columns = _get_table_columns(schema, table_name, project_root)
-        if "_dlt_load_id" in columns:
+        if table_name in tables_with_load_id:
             metrics.append(
                 MetricConfig(
                     name=f"{name}_{sanitized}_freshness",
                     source_table=f"{schema}.{table_name}",
-                    value_expression="CAST(MAX(_dlt_load_id) AS BIGINT)",
+                    value_expression="MAX(_dlt_load_id)",
                     compare=ComparisonType.week_over_week,
                     warn_threshold=25.0,
                 )

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2173,6 +2173,8 @@ def run_sync(
     limit: int | None = None,
     skip_dbt: bool = False,
     allow_schema_changes: bool = False,
+    *,
+    skip_sync_notification: bool = False,
 ) -> dict[str, Any]:
     """
     Sync multiple sources and return summary
@@ -2382,19 +2384,7 @@ def run_sync(
         else:
             console.print("[dim]⏭  Skipping dbt run (will be coalesced)[/dim]\n")
 
-    # Post-sync hooks (profiling, drift detection, PII scanning, analysis)
-    if success_sources:
-        try:
-            from dango.utils.post_sync import dispatch_post_sync_hooks
-
-            dispatch_post_sync_hooks(project_root=project_root, sources=success_sources)
-        except Exception:
-            import logging as _logging
-
-            _logging.getLogger(__name__).debug("post_sync_hooks_failed", exc_info=True)
-            console.print("[dim]Post-sync hooks skipped (non-critical)[/dim]")
-
-    return {
+    summary = {
         "success_count": len(success_sources),
         "failed_count": len(failed_sources),
         "skipped_count": len(skipped_sources),
@@ -2404,3 +2394,22 @@ def run_sync(
         "results": results,
         "oauth_warnings": oauth_warnings,  # For display at very end of sync
     }
+
+    # Post-sync hooks (profiling, drift detection, PII scanning, analysis, notifications)
+    if success_sources:
+        try:
+            from dango.utils.post_sync import dispatch_post_sync_hooks
+
+            dispatch_post_sync_hooks(
+                project_root=project_root,
+                sources=success_sources,
+                sync_result=summary,
+                skip_sync_notification=skip_sync_notification,
+            )
+        except Exception:
+            import logging as _logging
+
+            _logging.getLogger(__name__).debug("post_sync_hooks_failed", exc_info=True)
+            console.print("[dim]Post-sync hooks skipped (non-critical)[/dim]")
+
+    return summary

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2188,6 +2188,8 @@ def run_sync(
         limit: Max rows per source (dev testing)
         skip_dbt: If True, skip dbt run/docs/Metabase refresh (caller handles separately)
         allow_schema_changes: If True, allow CSV schema evolution (add cols, NULL missing)
+        skip_sync_notification: If True, skip sending sync webhooks in post-sync hooks
+            (used by scheduler which sends its own notifications)
 
     Returns:
         Summary dictionary with success/failed counts

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,7 +12,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (430 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (211 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (839 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `jobs.py` (894 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `sync_trigger.py` (147 lines) | Server-side manual sync runner invoked via SSH from `dango remote sync` | `main()`, `_run_sync()` |
 
 ## Key Conventions

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,7 +12,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (430 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (211 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (894 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `jobs.py` (895 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `sync_trigger.py` (147 lines) | Server-side manual sync runner invoked via SSH from `dango remote sync` | `main()`, `_run_sync()` |
 
 ## Key Conventions

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -79,6 +79,8 @@ def _notify(
     error: str | None = None,
     duration_seconds: float | None = None,
     stale_hours: float | None = None,
+    rows_loaded: int | None = None,
+    dashboard_url: str | None = None,
 ) -> None:
     """Bridge a webhook notification (fire-and-forget).  Never raises."""
     try:
@@ -91,6 +93,8 @@ def _notify(
             error=error,
             duration_seconds=duration_seconds,
             stale_hours=stale_hours,
+            rows_loaded=rows_loaded,
+            dashboard_url=dashboard_url,
         )
         asyncio.run_coroutine_threadsafe(coro, _event_loop)
     except Exception:  # noqa: BLE001
@@ -475,12 +479,24 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         from dango.utils.sync_history import save_sync_history_entry
 
         job_id = f"schedule:{schedule_name}"
+        total_rows = 0
         # Sync each source with skip_dbt=True (dbt coalesced after all sources)
         for src in resolved:
             if _scheduler_service is not None and _scheduler_service.is_cancelled(job_id):
                 raise JobCancelledError(f"Sync cancelled between sources for {schedule_name}")
             src_t0 = time.monotonic()
-            run_sync(project_root, [src], full_refresh=full_refresh, skip_dbt=True)
+            sync_result = run_sync(
+                project_root,
+                [src],
+                full_refresh=full_refresh,
+                skip_dbt=True,
+                skip_sync_notification=True,
+            )
+            total_rows += sum(
+                r.get("rows_loaded", 0)
+                for r in sync_result.get("results", [])
+                if isinstance(r, dict)
+            )
             save_sync_history_entry(
                 project_root,
                 src.name,
@@ -510,6 +526,15 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
 
         elapsed = time.monotonic() - t0
 
+        # Build dashboard URL from project config
+        try:
+            from dango.config.helpers import load_config
+
+            _cfg = load_config(project_root)
+            dashboard_url: str | None = f"http://localhost:{_cfg.platform.port}"
+        except Exception:  # noqa: BLE001
+            dashboard_url = None
+
         _try_finish_record(project_root, schedule_name, record_id, "record_completion")
 
         _log_execution_event(
@@ -534,6 +559,8 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             schedule_name=schedule_name,
             sources=source_names,
             duration_seconds=round(elapsed, 2),
+            rows_loaded=total_rows or None,
+            dashboard_url=dashboard_url,
         )
         _check_freshness(project_root, schedule_name, source_names, sender)
 
@@ -725,6 +752,15 @@ def run_scheduled_dbt(
         success, output = run_dbt_models(project_root, select=dbt_command)
         elapsed = time.monotonic() - t0
 
+        # Build dashboard URL from project config
+        try:
+            from dango.config.helpers import load_config as _load_cfg
+
+            _dbt_cfg = _load_cfg(project_root)
+            dbt_dashboard_url: str | None = f"http://localhost:{_dbt_cfg.platform.port}"
+        except Exception:  # noqa: BLE001
+            dbt_dashboard_url = None
+
         if success:
             _try_finish_record(project_root, schedule_name, record_id, "record_completion")
             _log_execution_event(
@@ -746,6 +782,7 @@ def run_scheduled_dbt(
                 event_type=EventType.SYNC_COMPLETED,
                 schedule_name=schedule_name,
                 duration_seconds=round(elapsed, 2),
+                dashboard_url=dbt_dashboard_url,
             )
         else:
             _try_finish_record(

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -106,6 +106,21 @@ def _ts() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
+def _build_dashboard_url(project_root: Path) -> str | None:
+    """Build the dashboard URL, preferring domain over localhost.  Never raises."""
+    try:
+        from dango.config import ConfigLoader
+
+        loader = ConfigLoader(project_root)
+        cloud = loader.load_cloud_config()
+        if cloud is not None and cloud.domain:
+            return f"https://{cloud.domain}"
+        config = loader.load_config()
+        return f"http://localhost:{config.platform.port}"
+    except Exception:  # noqa: BLE001
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Source resolution
 # ---------------------------------------------------------------------------
@@ -526,14 +541,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
 
         elapsed = time.monotonic() - t0
 
-        # Build dashboard URL from project config
-        try:
-            from dango.config.helpers import load_config
-
-            _cfg = load_config(project_root)
-            dashboard_url: str | None = f"http://localhost:{_cfg.platform.port}"
-        except Exception:  # noqa: BLE001
-            dashboard_url = None
+        dashboard_url = _build_dashboard_url(project_root)
 
         _try_finish_record(project_root, schedule_name, record_id, "record_completion")
 
@@ -559,7 +567,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             schedule_name=schedule_name,
             sources=source_names,
             duration_seconds=round(elapsed, 2),
-            rows_loaded=total_rows or None,
+            rows_loaded=total_rows,
             dashboard_url=dashboard_url,
         )
         _check_freshness(project_root, schedule_name, source_names, sender)
@@ -752,14 +760,7 @@ def run_scheduled_dbt(
         success, output = run_dbt_models(project_root, select=dbt_command)
         elapsed = time.monotonic() - t0
 
-        # Build dashboard URL from project config
-        try:
-            from dango.config.helpers import load_config as _load_cfg
-
-            _dbt_cfg = _load_cfg(project_root)
-            dbt_dashboard_url: str | None = f"http://localhost:{_dbt_cfg.platform.port}"
-        except Exception:  # noqa: BLE001
-            dbt_dashboard_url = None
+        dbt_dashboard_url = _build_dashboard_url(project_root)
 
         if success:
             _try_finish_record(project_root, schedule_name, record_id, "record_completion")

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -20,7 +20,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~549 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_ga4_metrics()`, `_send_sync_notification()` |
+| `post_sync.py` (~553 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_ga4_metrics()`, `_send_sync_notification()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -20,7 +20,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~481 lines) | Post-sync hook dispatcher (drift moved to pre-dbt) | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_ga4_metrics()` |
+| `post_sync.py` (~549 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_ga4_metrics()`, `_send_sync_notification()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -287,6 +287,7 @@ def dispatch_post_sync_hooks(
     *,
     sync_result: dict[str, Any] | None = None,
     skip_sync_notification: bool = False,
+    trigger: str = "cli",
 ) -> None:
     """Run post-sync hooks for successfully synced sources.
 
@@ -299,6 +300,7 @@ def dispatch_post_sync_hooks(
         sync_result: Summary dict from ``run_sync()`` (used for notifications).
         skip_sync_notification: If True, skip sending sync webhooks
             (e.g. when the scheduler sends its own notifications).
+        trigger: Label for the sync trigger (e.g. ``"cli"``, ``"web"``).
     """
     if not sources:
         return
@@ -310,7 +312,7 @@ def dispatch_post_sync_hooks(
     _run_analysis(project_root, sources)
 
     if not skip_sync_notification and sync_result is not None:
-        _send_sync_notification(project_root, sources, sync_result)
+        _send_sync_notification(project_root, sources, sync_result, trigger=trigger)
 
     logger.info("post_sync_hooks_complete", sources=sources)
 
@@ -448,11 +450,11 @@ def _deliver_to_webhooks(
                     "event": payload.event_type.value,
                     "schedule": payload.schedule_name,
                     "sources": payload.sources,
-                    "error": getattr(payload, "error", None),
-                    "duration_seconds": getattr(payload, "duration_seconds", None),
-                    "rows_loaded": getattr(payload, "rows_loaded", None),
-                    "dashboard_url": getattr(payload, "dashboard_url", None),
-                    "metadata": getattr(payload, "metadata", None),
+                    "error": payload.error,
+                    "duration_seconds": payload.duration_seconds,
+                    "rows_loaded": payload.rows_loaded,
+                    "dashboard_url": payload.dashboard_url,
+                    "metadata": payload.metadata,
                     "timestamp": payload.occurred_at.isoformat() if payload.occurred_at else None,
                 }
             with httpx.Client(timeout=10.0) as client:
@@ -506,6 +508,8 @@ def _send_sync_notification(
     project_root: Path,
     sources: list[str],
     sync_result: dict[str, Any],
+    *,
+    trigger: str = "cli",
 ) -> None:
     """Send sync completed/failed webhook notification.  Never raises."""
     try:
@@ -537,9 +541,9 @@ def _send_sync_notification(
 
         payload = WebhookPayload(
             event_type=event_type,
-            schedule_name="cli_sync",
+            schedule_name=f"{trigger}_sync",
             sources=sources,
-            rows_loaded=total_rows or None,
+            rows_loaded=total_rows,
             error=error_msg,
             occurred_at=datetime.now(tz=timezone.utc),
         )

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -284,15 +284,21 @@ def _cache_stats(
 def dispatch_post_sync_hooks(
     project_root: Path,
     sources: list[str],
+    *,
+    sync_result: dict[str, Any] | None = None,
+    skip_sync_notification: bool = False,
 ) -> None:
     """Run post-sync hooks for successfully synced sources.
 
-    Invokes each hook in order: profiling, drift detection, PII scanning,
-    analysis.
+    Invokes each hook in order: profiling, PII scanning, analysis,
+    and (optionally) sync notification.
 
     Args:
         project_root: Path to the Dango project root.
         sources: Names of sources that synced successfully.
+        sync_result: Summary dict from ``run_sync()`` (used for notifications).
+        skip_sync_notification: If True, skip sending sync webhooks
+            (e.g. when the scheduler sends its own notifications).
     """
     if not sources:
         return
@@ -302,6 +308,9 @@ def dispatch_post_sync_hooks(
     _run_profiling(project_root, sources)
     _run_pii_scan(project_root, sources)
     _run_analysis(project_root, sources)
+
+    if not skip_sync_notification and sync_result is not None:
+        _send_sync_notification(project_root, sources, sync_result)
 
     logger.info("post_sync_hooks_complete", sources=sources)
 
@@ -417,6 +426,42 @@ def _ensure_ga4_metrics(project_root: Path, sources: list[str]) -> None:
         logger.debug("ga4_metrics_auto_generate_skipped", exc_info=True)
 
 
+def _deliver_to_webhooks(
+    webhooks: list[Any],
+    payload: Any,
+) -> None:
+    """Deliver a ``WebhookPayload`` to a list of webhook configs.
+
+    Formats each webhook (Slack vs generic) and sends via synchronous httpx.
+    Never raises — individual delivery errors are logged and skipped.
+    """
+    import httpx
+
+    for webhook in webhooks:
+        try:
+            if webhook.format == "slack":
+                from dango.platform.notifications.slack import format_slack_message
+
+                json_payload: dict[str, Any] = format_slack_message(payload)
+            else:
+                json_payload = {
+                    "event": payload.event_type.value,
+                    "schedule": payload.schedule_name,
+                    "sources": payload.sources,
+                    "error": getattr(payload, "error", None),
+                    "duration_seconds": getattr(payload, "duration_seconds", None),
+                    "rows_loaded": getattr(payload, "rows_loaded", None),
+                    "dashboard_url": getattr(payload, "dashboard_url", None),
+                    "metadata": getattr(payload, "metadata", None),
+                    "timestamp": payload.occurred_at.isoformat() if payload.occurred_at else None,
+                }
+            with httpx.Client(timeout=10.0) as client:
+                resp = client.post(webhook.url, json=json_payload)
+            logger.info("webhook_delivered", webhook=webhook.name, status=resp.status_code)
+        except Exception:
+            logger.warning("webhook_delivery_error", webhook=webhook.name, exc_info=True)
+
+
 def _send_analysis_webhook(
     project_root: Path,
     sources: list[str],
@@ -452,30 +497,53 @@ def _send_analysis_webhook(
             occurred_at=datetime.now(tz=timezone.utc),
         )
 
-        import httpx
-
-        for webhook in config.webhooks:
-            try:
-                if webhook.format == "slack":
-                    from dango.platform.notifications.slack import format_slack_message
-
-                    json_payload: dict[str, Any] = format_slack_message(payload)
-                else:
-                    json_payload = {
-                        "event": payload.event_type.value,
-                        "schedule": payload.schedule_name,
-                        "sources": payload.sources,
-                        "metadata": payload.metadata,
-                        "timestamp": payload.occurred_at.isoformat()
-                        if payload.occurred_at
-                        else None,
-                    }
-                with httpx.Client(timeout=10.0) as client:
-                    resp = client.post(webhook.url, json=json_payload)
-                logger.info(
-                    "analysis_webhook_delivered", webhook=webhook.name, status=resp.status_code
-                )
-            except Exception:
-                logger.warning("analysis_webhook_error", webhook=webhook.name, exc_info=True)
+        _deliver_to_webhooks(config.webhooks, payload)
     except Exception:
         logger.warning("analysis_webhook_outer_error", exc_info=True)
+
+
+def _send_sync_notification(
+    project_root: Path,
+    sources: list[str],
+    sync_result: dict[str, Any],
+) -> None:
+    """Send sync completed/failed webhook notification.  Never raises."""
+    try:
+        from dango.platform.notifications.webhook import (
+            EventType,
+            WebhookPayload,
+            load_notification_config,
+            should_notify,
+        )
+
+        config = load_notification_config(project_root)
+        if config is None or not config.webhooks:
+            return
+
+        failed = sync_result.get("failed_count", 0)
+        event_type = EventType.SYNC_FAILED if failed > 0 else EventType.SYNC_COMPLETED
+        if not should_notify(event_type, config):
+            return
+
+        # Compute total rows loaded
+        total_rows = sum(
+            r.get("rows_loaded", 0) for r in sync_result.get("results", []) if isinstance(r, dict)
+        )
+
+        error_msg: str | None = None
+        if failed > 0:
+            failed_names = [f.get("name", "?") for f in sync_result.get("failed_sources", [])]
+            error_msg = f"Failed sources: {', '.join(failed_names)}"
+
+        payload = WebhookPayload(
+            event_type=event_type,
+            schedule_name="cli_sync",
+            sources=sources,
+            rows_loaded=total_rows or None,
+            error=error_msg,
+            occurred_at=datetime.now(tz=timezone.utc),
+        )
+
+        _deliver_to_webhooks(config.webhooks, payload)
+    except Exception:
+        logger.warning("sync_notification_error", exc_info=True)

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -43,7 +43,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/metabase_proxy.py` | All Metabase proxy routes + SSO session state | `proxy_to_metabase()`, `get_metabase_session()` |
 | `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
-| `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, `/schedules` page (~720 lines) | `router` |
+| `routes/schedules.py` | Schedule CRUD, trigger, reload, cancel, history, notification config/test, webhook CRUD, `/schedules` page (~859 lines) | `router` |
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~490 lines) | `router` |
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1157 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -7,10 +7,12 @@ unscheduled-source discovery, and paginated execution history.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import yaml
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import ValidationError
@@ -171,6 +173,143 @@ async def test_notification(
     )
 
     return JSONResponse(content={"status": "sent"})
+
+
+_WEBHOOK_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _read_schedules_yaml(project_root: Path) -> dict[str, Any]:
+    """Read the full schedules.yml as a raw dict."""
+    path = project_root / ".dango" / "schedules.yml"
+    if not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _write_schedules_yaml(project_root: Path, data: dict[str, Any]) -> None:
+    """Write the full schedules.yml dict back to disk."""
+    path = project_root / ".dango" / "schedules.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+@router.post("/api/notifications/webhooks")
+async def add_webhook(
+    request: Request,
+    user: User = Depends(require_permission("scheduler.manage")),
+) -> JSONResponse:
+    """Add a new webhook to the notification config."""
+    project_root = get_project_root()
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            status_code=400,
+            content={"error_code": "DANGO-S009", "message": "Invalid JSON body."},
+        )
+
+    name = body.get("name", "")
+    url = body.get("url", "")
+    fmt = body.get("format", "generic")
+
+    if not _WEBHOOK_NAME_RE.match(name):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S009",
+                "message": "Webhook name must match ^[a-z][a-z0-9_]*$.",
+            },
+        )
+    if not url.startswith(("http://", "https://")):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S009",
+                "message": "Webhook URL must start with http:// or https://.",
+            },
+        )
+    if fmt not in ("generic", "slack"):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "DANGO-S009",
+                "message": "Webhook format must be 'generic' or 'slack'.",
+            },
+        )
+
+    data = _read_schedules_yaml(project_root)
+    notifications = data.setdefault("notifications", {})
+    webhooks = notifications.setdefault("webhooks", [])
+
+    # Check duplicate
+    if any(wh.get("name") == name for wh in webhooks):
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error_code": "DANGO-S010",
+                "message": f"Webhook {name!r} already exists.",
+            },
+        )
+
+    webhooks.append({"name": name, "url": url, "format": fmt})
+    _write_schedules_yaml(project_root, data)
+
+    _audit(
+        AuditEvent.SCHEDULE_UPDATED,
+        user,
+        request,
+        project_root,
+        action="webhook_added",
+        webhook_name=name,
+    )
+
+    return JSONResponse(
+        status_code=201,
+        content={"status": "created", "name": name},
+    )
+
+
+@router.delete("/api/notifications/webhooks/{name}")
+async def delete_webhook(
+    name: str,
+    request: Request,
+    user: User = Depends(require_permission("scheduler.manage")),
+) -> JSONResponse:
+    """Remove a webhook from the notification config."""
+    project_root = get_project_root()
+    data = _read_schedules_yaml(project_root)
+    notifications = data.get("notifications", {})
+    webhooks = notifications.get("webhooks", [])
+
+    original_len = len(webhooks)
+    webhooks = [wh for wh in webhooks if wh.get("name") != name]
+
+    if len(webhooks) == original_len:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error_code": "DANGO-S011",
+                "message": f"Webhook {name!r} not found.",
+            },
+        )
+
+    notifications["webhooks"] = webhooks
+    data["notifications"] = notifications
+    _write_schedules_yaml(project_root, data)
+
+    _audit(
+        AuditEvent.SCHEDULE_UPDATED,
+        user,
+        request,
+        project_root,
+        action="webhook_removed",
+        webhook_name=name,
+    )
+
+    return JSONResponse(content={"status": "deleted", "name": name})
 
 
 @router.get("/api/schedules/history/recent")

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -182,11 +182,17 @@
                                         <span class="text-sm font-medium text-gray-700" x-text="wh.name"></span>
                                         <span class="ml-2 text-xs text-gray-400" x-text="wh.format"></span>
                                     </div>
-                                    <span class="text-xs text-gray-500 truncate max-w-xs" x-text="wh.url"></span>
+                                    <div class="flex items-center space-x-3">
+                                        <span class="text-xs text-gray-500 truncate max-w-xs" x-text="wh.url"></span>
+                                        <template x-if="isEditorPlus">
+                                            <button @click="deleteWebhook(wh.name)"
+                                                    class="text-red-500 hover:text-red-700 text-xs font-medium">Remove</button>
+                                        </template>
+                                    </div>
                                 </li>
                             </template>
                         </ul>
-                        <div class="flex items-center space-x-4 text-xs text-gray-500">
+                        <div class="flex items-center space-x-4 text-xs text-gray-500 mb-3">
                             <span :class="notifConfig.on_failure ? 'text-green-600' : 'text-gray-400'">
                                 Failures: <span x-text="notifConfig.on_failure ? 'On' : 'Off'"></span>
                             </span>
@@ -197,10 +203,62 @@
                                 Stale: <span x-text="notifConfig.on_stale ? 'On' : 'Off'"></span>
                             </span>
                         </div>
+                        <template x-if="isEditorPlus">
+                            <div class="flex items-center space-x-2">
+                                <button @click="testNotification()" :disabled="testingNotif"
+                                        class="px-3 py-1.5 text-xs font-medium text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">
+                                    <span x-show="!testingNotif">Test Notification</span>
+                                    <span x-show="testingNotif" x-cloak>Sending...</span>
+                                </button>
+                            </div>
+                        </template>
                     </div>
                 </template>
             </div>
         </div>
+
+        <!-- Add Webhook (editor+ only) -->
+        <template x-if="isEditorPlus">
+            <div class="bg-white shadow rounded-lg overflow-hidden mb-6">
+                <button @click="showAddWebhook = !showAddWebhook"
+                        class="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-gray-50">
+                    <span class="text-sm font-medium text-gray-700">+ Add Webhook</span>
+                    <svg class="h-5 w-5 text-gray-400 transition-transform" :class="showAddWebhook && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                    </svg>
+                </button>
+                <div x-show="showAddWebhook" x-cloak class="border-t border-gray-200 px-6 py-4">
+                    <form @submit.prevent="addWebhook()">
+                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 mb-1">Name</label>
+                                <input type="text" x-model="newWebhook.name" placeholder="my_webhook" required
+                                       pattern="^[a-z][a-z0-9_]*$"
+                                       class="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 mb-1">URL</label>
+                                <input type="url" x-model="newWebhook.url" placeholder="https://hooks.slack.com/..." required
+                                       class="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700 mb-1">Format</label>
+                                <select x-model="newWebhook.format"
+                                        class="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
+                                    <option value="generic">Generic</option>
+                                    <option value="slack">Slack</option>
+                                </select>
+                            </div>
+                        </div>
+                        <button type="submit" :disabled="addingWebhook"
+                                class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">
+                            <span x-show="!addingWebhook">Add Webhook</span>
+                            <span x-show="addingWebhook" x-cloak>Adding...</span>
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </template>
 
         <!-- Trigger / Re-run Modal -->
         <div x-show="showTriggerModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
@@ -265,6 +323,12 @@ function schedulesPage() {
         historyItems: [],
         historyLoading: false,
 
+        // Notifications
+        testingNotif: false,
+        showAddWebhook: false,
+        addingWebhook: false,
+        newWebhook: { name: '', url: '', format: 'generic' },
+
         // Trigger modal
         showTriggerModal: false,
         triggerTarget: null,
@@ -305,6 +369,46 @@ function schedulesPage() {
                 const res = await fetch('/api/notifications/config', { headers });
                 if (res.ok) this.notifConfig = await res.json();
             } catch (e) { /* ignore */ }
+        },
+
+        // --- Webhook management ---
+        async testNotification() {
+            this.testingNotif = true; this.error = '';
+            try {
+                const res = await fetch('/api/notifications/test', { method: 'POST', headers });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to send test notification'; }
+                else { this.success = 'Test notification sent.'; setTimeout(() => this.success = '', 3000); }
+            } catch (e) { this.error = 'Failed to send test notification'; }
+            this.testingNotif = false;
+        },
+        async addWebhook() {
+            this.addingWebhook = true; this.error = '';
+            try {
+                const res = await fetch('/api/notifications/webhooks', {
+                    method: 'POST', headers, body: JSON.stringify(this.newWebhook)
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to add webhook'; this.addingWebhook = false; return; }
+                this.newWebhook = { name: '', url: '', format: 'generic' };
+                this.showAddWebhook = false;
+                this.success = 'Webhook added.'; setTimeout(() => this.success = '', 3000);
+                await this.loadNotifConfig();
+            } catch (e) { this.error = 'Failed to add webhook'; }
+            this.addingWebhook = false;
+        },
+        async deleteWebhook(name) {
+            if (!confirm('Remove webhook "' + name + '"?')) return;
+            this.error = '';
+            try {
+                const res = await fetch('/api/notifications/webhooks/' + encodeURIComponent(name), {
+                    method: 'DELETE', headers
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to remove webhook'; return; }
+                this.success = 'Webhook removed.'; setTimeout(() => this.success = '', 3000);
+                await this.loadNotifConfig();
+            } catch (e) { this.error = 'Failed to remove webhook'; }
         },
 
         // --- Trigger ---

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -398,7 +398,7 @@ function schedulesPage() {
             this.addingWebhook = false;
         },
         async deleteWebhook(name) {
-            if (!confirm('Remove webhook "' + name + '"?')) return;
+            if (!confirm(`Remove webhook "${name}"?`)) return;
             this.error = '';
             try {
                 const res = await fetch('/api/notifications/webhooks/' + encodeURIComponent(name), {

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -243,7 +243,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py
-    lines: 894
+    lines: 895
     category: exempt
     reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. R9-I added rows_loaded/dashboard_url to _notify + sync result accumulation. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
     review_by: "v1.1"
@@ -297,9 +297,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_sync_jobs.py
-    lines: 569
+    lines: 685
     category: exempt
-    reason: "TASK-041: 25 tests across 6 classes covering configure_jobs, _broadcast, _notify, run_scheduled_sync (8 tests incl. lock failure, no sources, exception), run_scheduled_dbt (6 tests incl. lock failure, exception), and _check_freshness. Each test requires isolated mock setup for lazy-import patching."
+    reason: "TASK-041+R9-I: 30 tests across 8 classes covering configure_jobs, _broadcast, _notify (incl. rows_loaded/dashboard_url), _build_dashboard_url (domain/localhost/error), run_scheduled_sync, run_scheduled_dbt, and _check_freshness. Each test requires isolated mock setup for lazy-import patching."
     review_by: "v1.1"
 
   - file: tests/unit/test_scheduler.py
@@ -311,7 +311,7 @@ exemptions:
   # --- Phase 4 scheduling ---
 
   - file: dango/utils/post_sync.py
-    lines: 549
+    lines: 553
     category: exempt
     reason: "R9-I: Added _deliver_to_webhooks shared helper and _send_sync_notification for CLI sync webhook delivery. Marginally over limit."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -124,9 +124,9 @@ exemptions:
 
   # --- Exempt (stable, not modified in v1) ---
   - file: dango/ingestion/dlt_runner.py
-    lines: 2373
+    lines: 2415
     category: exempt
-    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000. P5c grew +480 lines (credential unification, resource selection, local_files routing). P8-001 added headers/data_selector/params passthrough (+8 lines)."
+    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000. P5c grew +480 lines (credential unification, resource selection, local_files routing). P8-001 added headers/data_selector/params passthrough (+8 lines). R9-I added skip_sync_notification param + sync_result passthrough to post_sync hooks."
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
@@ -243,9 +243,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py
-    lines: 839
+    lines: 894
     category: exempt
-    reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
+    reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. R9-I added rows_loaded/dashboard_url to _notify + sync result accumulation. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/digitalocean.py
@@ -310,10 +310,16 @@ exemptions:
 
   # --- Phase 4 scheduling ---
 
-  - file: dango/web/routes/schedules.py
-    lines: 720
+  - file: dango/utils/post_sync.py
+    lines: 549
     category: exempt
-    reason: "TASK-037+038+045b: 14 endpoints (history×2, CRUD×5, trigger, reload, cancel, unscheduled, page route, notification config/test). Single router file — split would scatter schedule logic across files."
+    reason: "R9-I: Added _deliver_to_webhooks shared helper and _send_sync_notification for CLI sync webhook delivery. Marginally over limit."
+    review_by: "v1.1"
+
+  - file: dango/web/routes/schedules.py
+    lines: 859
+    category: exempt
+    reason: "TASK-037+038+045b: 16 endpoints (history×2, CRUD×5, trigger, reload, cancel, unscheduled, page route, notification config/test, webhook add/delete). R9-I added webhook CRUD endpoints. Single router file — split would scatter schedule logic across files."
     review_by: "v1.1"
 
   - file: dango/web/routes/sync.py

--- a/tests/unit/test_analysis_templates.py
+++ b/tests/unit/test_analysis_templates.py
@@ -11,7 +11,10 @@ from unittest.mock import patch
 import duckdb
 import pytest
 
-from dango.analysis.templates import generate_metrics_for_source
+from dango.analysis.templates import (
+    _sanitize_table_name,
+    generate_metrics_for_source,
+)
 
 _MOD = "dango.analysis.templates"
 
@@ -197,3 +200,147 @@ class TestGA4DynamicMetrics:
             metrics = generate_metrics_for_source("google_analytics", "ga", project_root=tmp_path)
 
         assert len(metrics) == 0
+
+
+# ---------------------------------------------------------------------------
+# Generic metric templates (BUG-148)
+# ---------------------------------------------------------------------------
+
+
+def _create_generic_warehouse(
+    tmp_path: Path,
+    source_name: str,
+    tables: dict[str, list[str]],
+) -> Path:
+    """Create a DuckDB warehouse with arbitrary tables.
+
+    Args:
+        tables: Mapping of table_name → list of column names.
+    """
+    db_path = tmp_path / "data" / "warehouse.duckdb"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    schema = f"raw_{source_name}"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+    for table_name, cols in tables.items():
+        col_defs = ", ".join(f'"{c}" VARCHAR' for c in cols)
+        conn.execute(f'CREATE TABLE {schema}."{table_name}" ({col_defs})')
+    conn.close()
+    return db_path
+
+
+@pytest.mark.unit
+class TestGenericMetrics:
+    """Tests for the generic metric fallback (unknown source types)."""
+
+    def test_no_project_root_returns_empty(self) -> None:
+        metrics = generate_metrics_for_source("hubspot", "hs")
+        assert metrics == []
+
+    def test_no_warehouse_returns_empty(self, tmp_path: Path) -> None:
+        metrics = generate_metrics_for_source("hubspot", "hs", project_root=tmp_path)
+        assert metrics == []
+
+    def test_no_tables_returns_empty(self, tmp_path: Path) -> None:
+        """Schema exists but has no user tables."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True)
+        conn = duckdb.connect(str(db_path))
+        conn.execute("CREATE SCHEMA IF NOT EXISTS raw_empty")
+        conn.close()
+
+        metrics = generate_metrics_for_source("hubspot", "empty", project_root=tmp_path)
+        assert metrics == []
+
+    def test_generates_row_count_per_table(self, tmp_path: Path) -> None:
+        _create_generic_warehouse(
+            tmp_path,
+            "hs",
+            {
+                "contact": ["id", "email"],
+                "deal": ["id", "amount"],
+            },
+        )
+
+        metrics = generate_metrics_for_source("hubspot", "hs", project_root=tmp_path)
+
+        row_count_metrics = [m for m in metrics if "row_count" in m.name]
+        assert len(row_count_metrics) == 2
+        names = {m.name for m in row_count_metrics}
+        assert "hs_contact_row_count" in names
+        assert "hs_deal_row_count" in names
+
+    def test_freshness_only_when_dlt_load_id_exists(self, tmp_path: Path) -> None:
+        _create_generic_warehouse(
+            tmp_path,
+            "src",
+            {
+                "with_load_id": ["id", "_dlt_load_id"],
+                "without_load_id": ["id", "name"],
+            },
+        )
+
+        metrics = generate_metrics_for_source("salesforce", "src", project_root=tmp_path)
+
+        freshness_metrics = [m for m in metrics if "freshness" in m.name]
+        assert len(freshness_metrics) == 1
+        assert freshness_metrics[0].name == "src_with_load_id_freshness"
+        assert "MAX(_dlt_load_id)" in freshness_metrics[0].value_expression
+
+    def test_skips_dlt_internal_tables(self, tmp_path: Path) -> None:
+        _create_generic_warehouse(
+            tmp_path,
+            "src",
+            {
+                "user_table": ["id"],
+                "_dlt_loads": ["load_id"],
+                "_dlt_version": ["version"],
+            },
+        )
+
+        metrics = generate_metrics_for_source("salesforce", "src", project_root=tmp_path)
+
+        metric_tables = {m.source_table for m in metrics}
+        assert "raw_src.user_table" in metric_tables
+        assert all("_dlt_" not in t for t in metric_tables)
+
+    def test_unique_metric_names(self, tmp_path: Path) -> None:
+        _create_generic_warehouse(
+            tmp_path,
+            "src",
+            {
+                "table_a": ["id", "_dlt_load_id"],
+                "table_b": ["id", "_dlt_load_id"],
+            },
+        )
+
+        metrics = generate_metrics_for_source("salesforce", "src", project_root=tmp_path)
+
+        names = [m.name for m in metrics]
+        assert len(names) == len(set(names))
+
+
+@pytest.mark.unit
+class TestSanitizeTableName:
+    """Tests for _sanitize_table_name()."""
+
+    def test_basic_name(self) -> None:
+        assert _sanitize_table_name("users") == "users"
+
+    def test_hyphens_replaced(self) -> None:
+        assert _sanitize_table_name("my-table") == "my_table"
+
+    def test_dots_replaced(self) -> None:
+        assert _sanitize_table_name("my.table") == "my_table"
+
+    def test_leading_digits_stripped(self) -> None:
+        assert _sanitize_table_name("123abc") == "abc"
+
+    def test_all_special_chars_returns_table(self) -> None:
+        assert _sanitize_table_name("---") == "table"
+
+    def test_all_digits_returns_table(self) -> None:
+        assert _sanitize_table_name("123") == "table"
+
+    def test_mixed_special_chars(self) -> None:
+        assert _sanitize_table_name("my table (v2)") == "my_table__v2"

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -505,6 +505,105 @@ class TestNotifyHelper:
         finally:
             jobs_mod._event_loop = old
 
+    def test_passes_rows_loaded_and_dashboard_url(self):
+        """_notify passes rows_loaded and dashboard_url to sender.send()."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod._event_loop = loop
+
+            sender = MagicMock()
+            sender.is_configured = True
+
+            jobs_mod._notify(
+                sender,
+                event_type="TEST",
+                schedule_name="daily",
+                rows_loaded=42,
+                dashboard_url="https://example.com",
+            )
+
+            sender.send.assert_called_once()
+            call_kwargs = sender.send.call_args[1]
+            assert call_kwargs["rows_loaded"] == 42
+            assert call_kwargs["dashboard_url"] == "https://example.com"
+        finally:
+            jobs_mod._event_loop = old
+
+    def test_rows_loaded_zero_is_preserved(self):
+        """_notify should pass rows_loaded=0, not convert it to None."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        old = jobs_mod._event_loop
+        try:
+            jobs_mod._event_loop = loop
+
+            sender = MagicMock()
+            sender.is_configured = True
+
+            jobs_mod._notify(
+                sender,
+                event_type="TEST",
+                schedule_name="daily",
+                rows_loaded=0,
+            )
+
+            call_kwargs = sender.send.call_args[1]
+            assert call_kwargs["rows_loaded"] == 0
+        finally:
+            jobs_mod._event_loop = old
+
+
+# ---------------------------------------------------------------------------
+# _build_dashboard_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildDashboardUrl:
+    """Test _build_dashboard_url() domain detection."""
+
+    def test_returns_domain_when_cloud_config_has_domain(self, tmp_path):
+        """Cloud domain takes precedence over localhost."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        mock_loader = MagicMock()
+        mock_cloud = MagicMock()
+        mock_cloud.domain = "app.example.com"
+        mock_loader.return_value.load_cloud_config.return_value = mock_cloud
+
+        with patch("dango.config.ConfigLoader", mock_loader):
+            url = jobs_mod._build_dashboard_url(tmp_path)
+
+        assert url == "https://app.example.com"
+
+    def test_returns_localhost_when_no_cloud_config(self, tmp_path):
+        """Falls back to localhost when no cloud config."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        mock_loader = MagicMock()
+        mock_loader.return_value.load_cloud_config.return_value = None
+        mock_config = MagicMock()
+        mock_config.platform.port = 8800
+        mock_loader.return_value.load_config.return_value = mock_config
+
+        with patch("dango.config.ConfigLoader", mock_loader):
+            url = jobs_mod._build_dashboard_url(tmp_path)
+
+        assert url == "http://localhost:8800"
+
+    def test_returns_none_on_error(self, tmp_path):
+        """Returns None when config loading fails."""
+        import dango.platform.scheduling.jobs as jobs_mod
+
+        with patch("dango.config.ConfigLoader", side_effect=Exception("boom")):
+            url = jobs_mod._build_dashboard_url(tmp_path)
+
+        assert url is None
+
 
 # ---------------------------------------------------------------------------
 # _check_freshness

--- a/tests/unit/test_webhook_crud_api.py
+++ b/tests/unit/test_webhook_crud_api.py
@@ -1,0 +1,261 @@
+"""tests/unit/test_webhook_crud_api.py
+
+Tests for webhook CRUD API endpoints (POST/DELETE /api/notifications/webhooks)
+added by R9-I (BUG-146).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+from starlette.testclient import TestClient
+
+from dango.auth.models import Role, User
+
+_PATCH_ROOT = "dango.web.routes.schedules"
+
+
+def _make_admin_user() -> User:
+    return User(id="admin-id", email="admin@test.com", role=Role.ADMIN, is_active=True)
+
+
+def _make_viewer_user() -> User:
+    return User(id="viewer-id", email="viewer@test.com", role=Role.VIEWER, is_active=True)
+
+
+def _make_app(tmp_path: Path, user: User | None = None) -> Any:
+    """Build a minimal FastAPI app with schedules router and injected user."""
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+
+    from dango.exceptions import AuthorizationError
+    from dango.web.routes.schedules import router
+
+    app = FastAPI()
+    app.state.project_root = tmp_path
+    app.include_router(router)
+
+    test_user = user or _make_admin_user()
+
+    @app.middleware("http")
+    async def inject_user(request: Any, call_next: Any) -> Any:
+        request.state.user = test_user
+        return await call_next(request)
+
+    @app.exception_handler(AuthorizationError)
+    async def auth_error_handler(request: Any, exc: AuthorizationError) -> Any:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
+    return app
+
+
+def _write_schedules_yml(
+    tmp_path: Path,
+    webhooks: list[dict[str, Any]] | None = None,
+    schedules: list[dict[str, Any]] | None = None,
+) -> None:
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {"schedules": schedules or []}
+    if webhooks is not None:
+        data["notifications"] = {"webhooks": webhooks}
+    with open(dango_dir / "schedules.yml", "w") as f:
+        yaml.dump(data, f)
+
+
+def _read_webhooks(tmp_path: Path) -> list[dict[str, Any]]:
+    path = tmp_path / ".dango" / "schedules.yml"
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    result: list[dict[str, Any]] = data.get("notifications", {}).get("webhooks", [])
+    return result
+
+
+# ---------------------------------------------------------------------------
+# POST /api/notifications/webhooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAddWebhook:
+    """Tests for the add webhook endpoint."""
+
+    def test_add_webhook_success(self, tmp_path: Path) -> None:
+        _write_schedules_yml(tmp_path, webhooks=[])
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/notifications/webhooks",
+                json={
+                    "name": "slack_alerts",
+                    "url": "https://hooks.slack.com/xxx",
+                    "format": "slack",
+                },
+            )
+
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "slack_alerts"
+        webhooks = _read_webhooks(tmp_path)
+        assert len(webhooks) == 1
+        assert webhooks[0]["name"] == "slack_alerts"
+
+    def test_add_webhook_creates_notifications_section(self, tmp_path: Path) -> None:
+        """Adding a webhook when no notifications section exists creates it."""
+        _write_schedules_yml(tmp_path)  # No webhooks key
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/notifications/webhooks",
+                json={"name": "alerts", "url": "https://example.com/hook", "format": "generic"},
+            )
+
+        assert resp.status_code == 201
+        webhooks = _read_webhooks(tmp_path)
+        assert len(webhooks) == 1
+
+    def test_add_webhook_preserves_existing_schedules(self, tmp_path: Path) -> None:
+        """Adding a webhook must not clobber the schedules section."""
+        schedules = [{"name": "daily", "type": "sync", "cron": "0 6 * * *", "sources": ["src"]}]
+        _write_schedules_yml(tmp_path, webhooks=[], schedules=schedules)
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            client.post(
+                "/api/notifications/webhooks",
+                json={"name": "alerts", "url": "https://example.com/hook", "format": "generic"},
+            )
+
+        path = tmp_path / ".dango" / "schedules.yml"
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert len(data["schedules"]) == 1
+        assert data["schedules"][0]["name"] == "daily"
+
+    def test_add_webhook_duplicate_returns_409(self, tmp_path: Path) -> None:
+        _write_schedules_yml(
+            tmp_path,
+            webhooks=[{"name": "existing", "url": "https://example.com", "format": "generic"}],
+        )
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/notifications/webhooks",
+                json={"name": "existing", "url": "https://example.com/new", "format": "generic"},
+            )
+
+        assert resp.status_code == 409
+
+    def test_add_webhook_invalid_name(self, tmp_path: Path) -> None:
+        _write_schedules_yml(tmp_path, webhooks=[])
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/notifications/webhooks",
+                json={"name": "Bad-Name!", "url": "https://example.com", "format": "generic"},
+            )
+
+        assert resp.status_code == 400
+
+    def test_add_webhook_invalid_url(self, tmp_path: Path) -> None:
+        _write_schedules_yml(tmp_path, webhooks=[])
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/notifications/webhooks",
+                json={"name": "valid_name", "url": "ftp://bad-protocol.com", "format": "generic"},
+            )
+
+        assert resp.status_code == 400
+
+    def test_add_webhook_invalid_format(self, tmp_path: Path) -> None:
+        _write_schedules_yml(tmp_path, webhooks=[])
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/notifications/webhooks",
+                json={"name": "valid_name", "url": "https://example.com", "format": "teams"},
+            )
+
+        assert resp.status_code == 400
+
+    def test_add_webhook_viewer_forbidden(self, tmp_path: Path) -> None:
+        _write_schedules_yml(tmp_path, webhooks=[])
+        app = _make_app(tmp_path, user=_make_viewer_user())
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.post(
+                "/api/notifications/webhooks",
+                json={"name": "test", "url": "https://example.com", "format": "generic"},
+            )
+
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/notifications/webhooks/{name}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeleteWebhook:
+    """Tests for the delete webhook endpoint."""
+
+    def test_delete_webhook_success(self, tmp_path: Path) -> None:
+        _write_schedules_yml(
+            tmp_path,
+            webhooks=[
+                {"name": "alerts", "url": "https://example.com", "format": "generic"},
+                {"name": "keep_me", "url": "https://other.com", "format": "slack"},
+            ],
+        )
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.delete("/api/notifications/webhooks/alerts")
+
+        assert resp.status_code == 200
+        webhooks = _read_webhooks(tmp_path)
+        assert len(webhooks) == 1
+        assert webhooks[0]["name"] == "keep_me"
+
+    def test_delete_webhook_not_found(self, tmp_path: Path) -> None:
+        _write_schedules_yml(tmp_path, webhooks=[])
+        app = _make_app(tmp_path)
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.delete("/api/notifications/webhooks/nonexistent")
+
+        assert resp.status_code == 404
+
+    def test_delete_webhook_viewer_forbidden(self, tmp_path: Path) -> None:
+        _write_schedules_yml(
+            tmp_path,
+            webhooks=[{"name": "alerts", "url": "https://example.com", "format": "generic"}],
+        )
+        app = _make_app(tmp_path, user=_make_viewer_user())
+        client = TestClient(app)
+
+        with patch(f"{_PATCH_ROOT}.get_project_root", return_value=tmp_path):
+            resp = client.delete("/api/notifications/webhooks/alerts")
+
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary

- **BUG-148:** Generic metric templates — `generate_metrics_for_source()` now auto-discovers tables in `raw_{source}` schema and generates `row_count` + `freshness` metrics for any source without specific templates (previously returned empty for non-stripe/ga4/csv)
- **BUG-147:** Scheduled sync webhooks now include `rows_loaded` and `dashboard_url` (were null) — `_notify()` accepts new params, `run_scheduled_sync` accumulates rows from `run_sync` results
- **BUG-145:** CLI `dango sync` now sends `sync_completed`/`sync_failed` webhooks via `_send_sync_notification()` in `post_sync.py` — scheduler passes `skip_sync_notification=True` to prevent double-notification
- **BUG-146:** Schedules page webhook management — Test Notification button, Add Webhook form (name/URL/format), per-webhook Remove button. New `POST/DELETE /api/notifications/webhooks` endpoints with full YAML read/write to preserve notification config

## Files changed (11)

- `dango/analysis/templates.py` — `_generic_metrics()` + `_sanitize_table_name()` fallback
- `dango/platform/scheduling/jobs.py` — `rows_loaded`/`dashboard_url` in `_notify()`, sync result accumulation
- `dango/utils/post_sync.py` — `_deliver_to_webhooks()` shared helper, `_send_sync_notification()`, updated `dispatch_post_sync_hooks()` signature
- `dango/ingestion/dlt_runner.py` — `skip_sync_notification` param, `sync_result` passthrough
- `dango/web/routes/schedules.py` — webhook CRUD endpoints + YAML helpers
- `dango/web/templates/schedules.html` — Test/Add/Remove webhook UI
- `docs/file-exemptions.yml` — updated line counts, added `post_sync.py` exemption
- 4 CLAUDE.md files — line count updates

## Test plan

- [x] `pytest tests/ -x` — 3257 passed, 31 skipped
- [x] `ruff check dango/` + `ruff format --check dango/` — clean
- [x] All pre-commit hooks pass (mypy, file-size, headers, docstrings)
- [x] `wc -l` verified for all exempt files

🤖 Generated with [Claude Code](https://claude.com/claude-code)