### PR TITLE
R9-K: Add workflow guard rails for sync and start commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,9 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (985 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (1011 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (757 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (785 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
@@ -338,7 +338,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `visualization/metabase.py` | 1151 | — |
 | `cli/init.py` | 1324 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/commands/platform.py` | 985 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 1011 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
@@ -349,7 +349,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 757 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 785 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 595 | — (push deploy workflow + deploy lock + journal) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,8 +13,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (750 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (985 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/source.py` (785 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/platform.py` (1011 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -125,8 +125,9 @@ def _check_docker_ports(platform_config: object) -> None:
 
 
 @click.command()
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
 @click.pass_context
-def start(ctx: click.Context) -> None:
+def start(ctx: click.Context, yes: bool) -> None:
     """
     Start all Dango data platform services.
 
@@ -160,11 +161,36 @@ def start(ctx: click.Context) -> None:
     try:
         project_root = require_project_context(ctx)
 
+        # Guard rail: inform if this looks like a cloned project
+        sources_file = project_root / ".dango" / "sources.yml"
+        dango_db = project_root / ".dango" / "dango.db"
+        warehouse = project_root / "data" / "warehouse.duckdb"
+        if sources_file.exists() and not dango_db.exists() and not warehouse.exists():
+            console.print(
+                "[yellow]  This looks like a cloned project. "
+                "Run `dango sync` to load data before starting.[/yellow]"
+            )
+            console.print()
+
         # Load project config
         config_loader = ConfigLoader(project_root)
         config = config_loader.load_config()
         project_name = config.project.name
         platform_config = config.platform
+
+        # Guard rail: warn if project is deployed to cloud
+        if not yes:
+            cloud_cfg = config_loader.load_cloud_config()
+            if cloud_cfg and cloud_cfg.droplet_ip:
+                target = cloud_cfg.domain or cloud_cfg.droplet_ip
+                console.print(f"[yellow]  This project is deployed to {target}.[/yellow]")
+                console.print(
+                    "[yellow]   Starting locally will run a SEPARATE instance. "
+                    "Your cloud server is unaffected.[/yellow]"
+                )
+                if not click.confirm("Continue?", default=True):
+                    raise click.Abort()
+                console.print()
 
         # Version alignment check — abort early if Python DuckDB ≠ driver major.minor
         # Must run BEFORE any DuckDB write operations (migrations, schema setup)

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -528,7 +528,7 @@ def sync(
     """
     from datetime import datetime, timedelta
 
-    from dango.config import get_config
+    from dango.config import ConfigLoader, get_config
     from dango.ingestion import run_sync
     from dango.utils import DbtLock, DbtLockError
 
@@ -543,9 +543,8 @@ def sync(
         project_root = require_project_context(ctx)
 
         # Guard rail: warn if project is deployed to cloud
+        # Placed before lock so user doesn't wait for lock if they'll cancel.
         if not yes:
-            from dango.config import ConfigLoader
-
             cloud_cfg = ConfigLoader(project_root).load_cloud_config()
             if cloud_cfg and cloud_cfg.droplet_ip:
                 target = cloud_cfg.domain or cloud_cfg.droplet_ip
@@ -558,32 +557,7 @@ def sync(
                     raise click.Abort()
                 console.print()
 
-        # Try to acquire lock before running sync (which includes dbt)
-        try:
-            lock = DbtLock(
-                project_root=project_root,
-                source="cli",
-                operation=f"sync {source if source else 'all sources'}",
-            )
-            lock.acquire()
-        except DbtLockError as e:
-            console.print(f"[red]Error:[/red] {str(e)}")
-            raise click.Abort() from e
-
-        # Check git branch (gentle reminder if on main/master)
-        from ..utils import check_git_branch_warning
-
-        check_git_branch_warning(project_root)
-
-        # Load configuration
-        config = get_config(project_root)
-
-        # Check for unreferenced custom sources
-        unreferenced = check_unreferenced_custom_sources(project_root, config.sources)
-        if unreferenced:
-            console.print(format_unreferenced_sources_warning(unreferenced))
-
-        # --- Validate option conflicts ---
+        # --- Validate option conflicts (before lock — fast failures) ---
         if backfill and (since or until):
             console.print(
                 "[red]Error:[/red] --backfill conflicts with --since/--until. Use one or the other."
@@ -594,7 +568,7 @@ def sync(
             console.print("[red]Error:[/red] --limit must be a positive integer.")
             raise click.Abort()
 
-        # --- Resolve dates ---
+        # --- Resolve dates (before lock — fast failures) ---
         start_date_obj = None
         end_date_obj = None
 
@@ -622,6 +596,14 @@ def sync(
             console.print("[red]Error:[/red] --since must be before --until.")
             raise click.Abort()
 
+        # Load configuration (before lock — needed for source resolution + first-sync check)
+        config = get_config(project_root)
+
+        # Check for unreferenced custom sources
+        unreferenced = check_unreferenced_custom_sources(project_root, config.sources)
+        if unreferenced:
+            console.print(format_unreferenced_sources_warning(unreferenced))
+
         # Get sources to sync
         if source:
             # Sync specific source
@@ -647,6 +629,7 @@ def sync(
             console.print(f"Syncing {len(sources_to_sync)} enabled source(s)")
 
         # Guard rail: on first sync, confirm scope
+        # Placed before lock so user doesn't wait for lock if they'll cancel.
         if not yes and not dry_run:
             warehouse_path = project_root / "data" / "warehouse.duckdb"
             if not warehouse_path.exists():
@@ -655,6 +638,23 @@ def sync(
                     default=True,
                 ):
                     raise click.Abort()
+
+        # Try to acquire lock before running sync (which includes dbt)
+        try:
+            lock = DbtLock(
+                project_root=project_root,
+                source="cli",
+                operation=f"sync {source if source else 'all sources'}",
+            )
+            lock.acquire()
+        except DbtLockError as e:
+            console.print(f"[red]Error:[/red] {str(e)}")
+            raise click.Abort() from e
+
+        # Check git branch (gentle reminder if on main/master)
+        from ..utils import check_git_branch_warning
+
+        check_git_branch_warning(project_root)
 
         if full_refresh:
             console.print("[yellow]⚠️  Full refresh mode: existing data will be dropped[/yellow]")

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -495,6 +495,7 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
     is_flag=True,
     help="Allow CSV schema changes (add columns, treat missing as NULL)",
 )
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
 @click.pass_context
 def sync(
     ctx: click.Context,
@@ -506,6 +507,7 @@ def sync(
     full_refresh: bool,
     dry_run: bool,
     allow_schema_changes: bool,
+    yes: bool,
 ) -> None:
     """
     Load data from all sources (or specific source).
@@ -539,6 +541,22 @@ def sync(
     try:
         # Get project context
         project_root = require_project_context(ctx)
+
+        # Guard rail: warn if project is deployed to cloud
+        if not yes:
+            from dango.config import ConfigLoader
+
+            cloud_cfg = ConfigLoader(project_root).load_cloud_config()
+            if cloud_cfg and cloud_cfg.droplet_ip:
+                target = cloud_cfg.domain or cloud_cfg.droplet_ip
+                console.print(f"[yellow]  This project is deployed to {target}.[/yellow]")
+                console.print(
+                    "[yellow]   `dango sync` syncs data LOCALLY, not on your cloud server.[/yellow]"
+                )
+                console.print("[yellow]   Use `dango remote sync` for cloud.[/yellow]")
+                if not click.confirm("Continue?", default=False):
+                    raise click.Abort()
+                console.print()
 
         # Try to acquire lock before running sync (which includes dbt)
         try:
@@ -627,6 +645,16 @@ def sync(
                 return
 
             console.print(f"Syncing {len(sources_to_sync)} enabled source(s)")
+
+        # Guard rail: on first sync, confirm scope
+        if not yes and not dry_run:
+            warehouse_path = project_root / "data" / "warehouse.duckdb"
+            if not warehouse_path.exists():
+                if not click.confirm(
+                    f"This will sync {len(sources_to_sync)} source(s). Continue?",
+                    default=True,
+                ):
+                    raise click.Abort()
 
         if full_refresh:
             console.print("[yellow]⚠️  Full refresh mode: existing data will be dropped[/yellow]")

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -81,7 +81,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 985
+    lines: 1011
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
@@ -93,7 +93,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 757
+    lines: 785
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"

--- a/tests/unit/test_cli_start_guardrails.py
+++ b/tests/unit/test_cli_start_guardrails.py
@@ -1,0 +1,120 @@
+"""tests/unit/test_cli_start_guardrails.py
+
+Unit tests for `dango start` guard rails (cloned project info, cloud warning).
+"""
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.platform import start
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _make_cloud_config(droplet_ip: str = "1.2.3.4", domain: str | None = None) -> MagicMock:
+    """Create a mock CloudConfig."""
+    cfg = MagicMock()
+    cfg.droplet_ip = droplet_ip
+    cfg.domain = domain
+    return cfg
+
+
+def _make_config_loader(cloud_config: MagicMock | None = None) -> MagicMock:
+    """Create a mock ConfigLoader that returns the given cloud config."""
+    mock_loader = MagicMock()
+    mock_loader.return_value.load_config.return_value = MagicMock()
+    mock_loader.return_value.load_config.return_value.project.name = "test-project"
+    mock_loader.return_value.load_config.return_value.project.organization = None
+    mock_loader.return_value.load_config.return_value.platform.port = 8800
+    mock_loader.return_value.load_config.return_value.platform.metabase_port = 3000
+    mock_loader.return_value.load_config.return_value.platform.dbt_docs_port = 8081
+    mock_loader.return_value.load_config.return_value.platform.auto_sync = False
+    mock_loader.return_value.load_cloud_config.return_value = cloud_config
+    return mock_loader
+
+
+@pytest.mark.unit
+class TestStartGuardRails:
+    """Tests for start command guard rails."""
+
+    def test_cloned_project_message_shown(self, tmp_path: Path) -> None:
+        """Cloned project message shown when sources.yml exists but no dango.db/warehouse."""
+        # Set up cloned project state
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "sources.yml").write_text("sources: []")
+        # No dango.db, no data/warehouse.duckdb
+
+        mock_loader = _make_config_loader()
+        runner = CliRunner()
+        with (
+            patch("dango.cli.utils.require_project_context", return_value=tmp_path),
+            patch("dango.config.ConfigLoader", mock_loader),
+            patch("dango.platform.common.startup.check_duckdb_version_alignment"),
+        ):
+            # Abort after cloud check by injecting an error in version check
+            mock_loader.return_value.load_cloud_config.return_value = None
+            # Let it fail on the next step (version alignment already patched)
+            # We just need to see the cloned project message in output
+            result = runner.invoke(start, ["--yes"], obj={"project_root": str(tmp_path)})
+
+        plain = _ANSI_RE.sub("", result.output)
+        assert "cloned project" in plain.lower()
+        assert "dango sync" in plain
+
+    def test_cloned_project_message_not_shown_when_warehouse_exists(self, tmp_path: Path) -> None:
+        """Cloned project message NOT shown when warehouse.duckdb exists."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "sources.yml").write_text("sources: []")
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "warehouse.duckdb").touch()
+
+        mock_loader = _make_config_loader()
+        runner = CliRunner()
+        with (
+            patch("dango.cli.utils.require_project_context", return_value=tmp_path),
+            patch("dango.config.ConfigLoader", mock_loader),
+            patch("dango.platform.common.startup.check_duckdb_version_alignment"),
+        ):
+            mock_loader.return_value.load_cloud_config.return_value = None
+            result = runner.invoke(start, ["--yes"], obj={"project_root": str(tmp_path)})
+
+        plain = _ANSI_RE.sub("", result.output)
+        assert "cloned project" not in plain.lower()
+
+    def test_cloud_warning_shown_and_cancelled(self, tmp_path: Path) -> None:
+        """Cloud warning is shown and start aborts when user says 'n'."""
+        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
+        mock_loader = _make_config_loader(cloud_config=cloud_cfg)
+        runner = CliRunner()
+        with (
+            patch("dango.cli.utils.require_project_context", return_value=tmp_path),
+            patch("dango.config.ConfigLoader", mock_loader),
+        ):
+            result = runner.invoke(start, [], obj={"project_root": str(tmp_path)}, input="n\n")
+
+        plain = _ANSI_RE.sub("", result.output)
+        assert "deployed to 1.2.3.4" in plain
+        assert "SEPARATE instance" in plain
+        assert result.exit_code != 0
+
+    def test_cloud_warning_skipped_with_yes(self, tmp_path: Path) -> None:
+        """Cloud warning is skipped with --yes flag."""
+        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
+        mock_loader = _make_config_loader(cloud_config=cloud_cfg)
+        runner = CliRunner()
+        with (
+            patch("dango.cli.utils.require_project_context", return_value=tmp_path),
+            patch("dango.config.ConfigLoader", mock_loader),
+            patch("dango.platform.common.startup.check_duckdb_version_alignment"),
+        ):
+            result = runner.invoke(start, ["--yes"], obj={"project_root": str(tmp_path)})
+
+        plain = _ANSI_RE.sub("", result.output)
+        assert "deployed to" not in plain

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -4,6 +4,7 @@ Unit tests for dango sync CLI backfill and dev-sync options.
 """
 
 import re
+import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -196,7 +197,7 @@ class TestSyncBackfillValidation:
         assert mock_run_sync.call_args.kwargs["limit"] == 500
 
 
-def _make_cloud_config(droplet_ip: str = "1.2.3.4", domain: str | None = None):
+def _make_cloud_config(droplet_ip: str = "1.2.3.4", domain: str | None = None) -> MagicMock:
     """Create a mock CloudConfig."""
     cfg = MagicMock()
     cfg.droplet_ip = droplet_ip
@@ -208,7 +209,12 @@ def _make_cloud_config(droplet_ip: str = "1.2.3.4", domain: str | None = None):
 class TestSyncGuardRails:
     """Tests for sync command guard rails (cloud warning, first-sync confirmation)."""
 
-    def _invoke(self, args: list[str], cloud_config=None, extra_patches=None):
+    def _invoke(
+        self,
+        args: list[str],
+        cloud_config: MagicMock | None = None,
+        extra_patches: list[patch] | None = None,
+    ) -> click.testing.Result:
         runner = CliRunner()
         patches = _patch_sync_prereqs(cloud_config=cloud_config)
         if extra_patches:
@@ -216,16 +222,18 @@ class TestSyncGuardRails:
         for p in patches:
             p.start()
         try:
-            return runner.invoke(
-                sync, args, obj={"project_root": "/tmp"}, input=args[-1] if False else None
-            )
+            return runner.invoke(sync, args, obj={"project_root": "/tmp"})
         finally:
             for p in patches:
                 p.stop()
 
     def _invoke_with_input(
-        self, args: list[str], input_text: str, cloud_config=None, extra_patches=None
-    ):
+        self,
+        args: list[str],
+        input_text: str,
+        cloud_config: MagicMock | None = None,
+        extra_patches: list[patch] | None = None,
+    ) -> click.testing.Result:
         runner = CliRunner()
         patches = _patch_sync_prereqs(cloud_config=cloud_config)
         if extra_patches:
@@ -271,13 +279,6 @@ class TestSyncGuardRails:
 
     def test_first_sync_shown_when_no_warehouse(self) -> None:
         """First-sync confirmation shown when warehouse.duckdb doesn't exist."""
-        with patch("pathlib.Path.exists", side_effect=lambda self=None: False):
-            # Need more targeted patching — patch just the warehouse path check
-            pass
-
-        # Use a tmp dir where warehouse.duckdb won't exist
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             patches = _patch_sync_prereqs()
@@ -293,12 +294,10 @@ class TestSyncGuardRails:
                     p.stop()
 
             plain = _ANSI_RE.sub("", result.output)
-            assert "sync 1 source(s)" in plain.lower() or "This will sync" in plain
+            assert "This will sync" in plain
 
     def test_first_sync_skipped_when_warehouse_exists(self) -> None:
         """First-sync confirmation skipped when warehouse.duckdb exists."""
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             # Create the warehouse file
@@ -322,8 +321,6 @@ class TestSyncGuardRails:
 
     def test_first_sync_skipped_with_yes(self) -> None:
         """First-sync confirmation skipped with --yes flag."""
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             patches = _patch_sync_prereqs()
@@ -344,8 +341,6 @@ class TestSyncGuardRails:
 
     def test_first_sync_skipped_in_dry_run(self) -> None:
         """First-sync confirmation skipped in --dry-run mode."""
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             patches = _patch_sync_prereqs()

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -88,7 +88,7 @@ def _make_mock_source(name: str = "test_src", source_type: str = "stripe"):
     return mock_src
 
 
-def _patch_sync_prereqs(sources=None):
+def _patch_sync_prereqs(sources=None, cloud_config=None):
     """Stack patches for all sync prerequisites (lazy imports)."""
     if sources is None:
         sources = [_make_mock_source()]
@@ -99,6 +99,9 @@ def _patch_sync_prereqs(sources=None):
     mock_config = MagicMock()
     mock_config.sources = mock_sources_cfg
 
+    mock_config_loader = MagicMock()
+    mock_config_loader.return_value.load_cloud_config.return_value = cloud_config
+
     return [
         patch("dango.cli.utils.require_project_context", return_value=Path("/tmp/fake")),
         patch("dango.utils.DbtLock"),
@@ -108,6 +111,7 @@ def _patch_sync_prereqs(sources=None):
             "dango.cli.commands.source.check_unreferenced_custom_sources",
             return_value=[],
         ),
+        patch("dango.config.ConfigLoader", mock_config_loader),
     ]
 
 
@@ -180,7 +184,7 @@ class TestSyncBackfillValidation:
         )
         mock_validate = patch("dango.oauth.validation.validate_before_sync")
         result = self._invoke(
-            ["--limit", "500"],
+            ["--limit", "500", "--yes"],
             extra_patches=[
                 patch("dango.ingestion.run_sync", mock_run_sync),
                 mock_metabase,
@@ -190,3 +194,170 @@ class TestSyncBackfillValidation:
         assert result.exit_code == 0, result.output
         mock_run_sync.assert_called_once()
         assert mock_run_sync.call_args.kwargs["limit"] == 500
+
+
+def _make_cloud_config(droplet_ip: str = "1.2.3.4", domain: str | None = None):
+    """Create a mock CloudConfig."""
+    cfg = MagicMock()
+    cfg.droplet_ip = droplet_ip
+    cfg.domain = domain
+    return cfg
+
+
+@pytest.mark.unit
+class TestSyncGuardRails:
+    """Tests for sync command guard rails (cloud warning, first-sync confirmation)."""
+
+    def _invoke(self, args: list[str], cloud_config=None, extra_patches=None):
+        runner = CliRunner()
+        patches = _patch_sync_prereqs(cloud_config=cloud_config)
+        if extra_patches:
+            patches.extend(extra_patches)
+        for p in patches:
+            p.start()
+        try:
+            return runner.invoke(
+                sync, args, obj={"project_root": "/tmp"}, input=args[-1] if False else None
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+    def _invoke_with_input(
+        self, args: list[str], input_text: str, cloud_config=None, extra_patches=None
+    ):
+        runner = CliRunner()
+        patches = _patch_sync_prereqs(cloud_config=cloud_config)
+        if extra_patches:
+            patches.extend(extra_patches)
+        for p in patches:
+            p.start()
+        try:
+            return runner.invoke(sync, args, obj={"project_root": "/tmp"}, input=input_text)
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_cloud_warning_shown_and_cancelled(self) -> None:
+        """Cloud warning is shown and sync aborts when user says 'n'."""
+        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
+        result = self._invoke_with_input(["--dry-run"], input_text="n\n", cloud_config=cloud_cfg)
+        plain = _ANSI_RE.sub("", result.output)
+        assert "deployed to 1.2.3.4" in plain
+        assert "dango remote sync" in plain
+        assert result.exit_code != 0
+
+    def test_cloud_warning_shows_domain(self) -> None:
+        """Cloud warning shows domain when configured."""
+        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4", domain="data.example.com")
+        result = self._invoke_with_input(["--dry-run"], input_text="n\n", cloud_config=cloud_cfg)
+        plain = _ANSI_RE.sub("", result.output)
+        assert "deployed to data.example.com" in plain
+
+    def test_cloud_warning_skipped_with_yes(self) -> None:
+        """Cloud warning is skipped with --yes flag."""
+        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
+        result = self._invoke(["--dry-run", "--yes"], cloud_config=cloud_cfg)
+        plain = _ANSI_RE.sub("", result.output)
+        assert "deployed to" not in plain
+        assert result.exit_code == 0
+
+    def test_cloud_warning_not_shown_without_cloud(self) -> None:
+        """No cloud warning when project is not deployed."""
+        result = self._invoke(["--dry-run"], cloud_config=None)
+        plain = _ANSI_RE.sub("", result.output)
+        assert "deployed to" not in plain
+        assert result.exit_code == 0
+
+    def test_first_sync_shown_when_no_warehouse(self) -> None:
+        """First-sync confirmation shown when warehouse.duckdb doesn't exist."""
+        with patch("pathlib.Path.exists", side_effect=lambda self=None: False):
+            # Need more targeted patching — patch just the warehouse path check
+            pass
+
+        # Use a tmp dir where warehouse.duckdb won't exist
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            patches = _patch_sync_prereqs()
+            # Override require_project_context to use our tmpdir
+            patches[0] = patch("dango.cli.utils.require_project_context", return_value=tmp_path)
+            runner = CliRunner()
+            for p in patches:
+                p.start()
+            try:
+                result = runner.invoke(sync, [], obj={"project_root": str(tmp_path)}, input="n\n")
+            finally:
+                for p in patches:
+                    p.stop()
+
+            plain = _ANSI_RE.sub("", result.output)
+            assert "sync 1 source(s)" in plain.lower() or "This will sync" in plain
+
+    def test_first_sync_skipped_when_warehouse_exists(self) -> None:
+        """First-sync confirmation skipped when warehouse.duckdb exists."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            # Create the warehouse file
+            data_dir = tmp_path / "data"
+            data_dir.mkdir()
+            (data_dir / "warehouse.duckdb").touch()
+
+            patches = _patch_sync_prereqs()
+            patches[0] = patch("dango.cli.utils.require_project_context", return_value=tmp_path)
+            runner = CliRunner()
+            for p in patches:
+                p.start()
+            try:
+                result = runner.invoke(sync, ["--dry-run"], obj={"project_root": str(tmp_path)})
+            finally:
+                for p in patches:
+                    p.stop()
+
+            plain = _ANSI_RE.sub("", result.output)
+            assert "This will sync" not in plain
+
+    def test_first_sync_skipped_with_yes(self) -> None:
+        """First-sync confirmation skipped with --yes flag."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            patches = _patch_sync_prereqs()
+            patches[0] = patch("dango.cli.utils.require_project_context", return_value=tmp_path)
+            runner = CliRunner()
+            for p in patches:
+                p.start()
+            try:
+                result = runner.invoke(
+                    sync, ["--yes", "--dry-run"], obj={"project_root": str(tmp_path)}
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+            plain = _ANSI_RE.sub("", result.output)
+            assert "This will sync" not in plain
+
+    def test_first_sync_skipped_in_dry_run(self) -> None:
+        """First-sync confirmation skipped in --dry-run mode."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            patches = _patch_sync_prereqs()
+            patches[0] = patch("dango.cli.utils.require_project_context", return_value=tmp_path)
+            runner = CliRunner()
+            for p in patches:
+                p.start()
+            try:
+                result = runner.invoke(sync, ["--dry-run"], obj={"project_root": str(tmp_path)})
+            finally:
+                for p in patches:
+                    p.stop()
+
+            plain = _ANSI_RE.sub("", result.output)
+            assert "This will sync" not in plain


### PR DESCRIPTION
## Summary
- Add `--yes`/`-y` flag to `dango sync` and `dango start` to skip confirmation prompts
- `dango sync`: warn if project is deployed to cloud (suggests `dango remote sync`), confirm scope on first sync when no `warehouse.duckdb` exists
- `dango start`: informational message when project looks cloned (has `sources.yml` but no data), warn if project is deployed to cloud (local instance is separate)
- 12 new tests across `test_cli_sync.py` and `test_cli_start_guardrails.py`
- Line counts updated in all three locations

## Test plan
- [x] `pytest tests/unit/test_cli_sync.py tests/unit/test_cli_start_guardrails.py -v` — 32 passed
- [x] `pytest tests/ -x` — 3269 passed, 31 skipped
- [x] `ruff check` — all checks passed
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, file-size, docstrings, CLAUDE.md staleness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)