### PR TITLE
R9-H: Fix 5 notebook bugs (BUG-140 through BUG-144)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (970 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (985 lines)
 │   │   ├── project.py          # init/rename/info
 │   │   ├── source.py           # source group (add/list/remove) + sync (757 lines)
 │   │   ├── transform.py        # run/docs/generate
@@ -338,7 +338,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `visualization/metabase.py` | 1151 | — |
 | `cli/init.py` | 1324 | — |
 | `visualization/dashboard_manager.py` | 1113 | — |
-| `cli/commands/platform.py` | 970 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 985 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -14,7 +14,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
 | `commands/source.py` (750 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (970 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/platform.py` (985 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |

--- a/dango/cli/commands/notebook.py
+++ b/dango/cli/commands/notebook.py
@@ -153,7 +153,7 @@ def notebook_open(ctx: click.Context, name: str) -> None:
         status = get_marimo_status(project_root)
 
     port = status.get("port") or 7805
-    url = f"http://localhost:{port}/@file/{name}.py"
+    url = f"http://localhost:{port}/?file={name}.py"
     console.print(f"\n  [bold]Open in browser:[/bold] {url}\n")
 
 

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -714,8 +714,9 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
             console.print("[yellow]⚠[/yellow] Failed to stop file watcher")
 
         # Stop Marimo notebook server
-        from dango.notebooks.manager import get_marimo_status, stop_marimo
+        from dango.notebooks.manager import get_marimo_status, stop_idle_checker, stop_marimo
 
+        stop_idle_checker()
         marimo_was_running = get_marimo_status(project_root)["running"]
         marimo_stopped = stop_marimo(project_root)
         if marimo_was_running and not marimo_stopped:

--- a/dango/notebooks/CLAUDE.md
+++ b/dango/notebooks/CLAUDE.md
@@ -9,7 +9,7 @@ Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking
 | File | Lines | Purpose | Key Exports |
 |------|-------|---------|-------------|
 | `__init__.py` | ~45 | Re-exports public symbols | All public API |
-| `manager.py` | ~197 | Marimo process lifecycle (PID file, start/stop/status) | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()` |
+| `manager.py` | ~262 | Marimo process lifecycle (PID file, start/stop/status) + idle auto-shutdown | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()`, `start_idle_checker()`, `stop_idle_checker()` |
 | `snapshot.py` | ~143 | DuckDB snapshot management | `create_snapshot()`, `list_snapshots()`, `cleanup_snapshots()` |
 | `locking.py` | ~249 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
 | `proxy.py` | ~186 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |

--- a/dango/notebooks/__init__.py
+++ b/dango/notebooks/__init__.py
@@ -16,7 +16,9 @@ from dango.notebooks.locking import (
 from dango.notebooks.manager import (
     get_marimo_pid_file_path,
     get_marimo_status,
+    start_idle_checker,
     start_marimo,
+    stop_idle_checker,
     stop_marimo,
 )
 from dango.notebooks.snapshot import (
@@ -31,6 +33,8 @@ __all__ = [
     "start_marimo",
     "stop_marimo",
     "get_marimo_status",
+    "start_idle_checker",
+    "stop_idle_checker",
     # snapshot
     "create_snapshot",
     "list_snapshots",

--- a/dango/notebooks/locking.py
+++ b/dango/notebooks/locking.py
@@ -203,8 +203,8 @@ def get_lock_info(project_root: Path, notebook_id: str) -> dict[str, str] | None
 
         return {
             "locked_by": row["locked_by"],
-            "locked_at": row["locked_at"],
-            "expires_at": row["expires_at"],
+            "locked_at": row["locked_at"].replace(" ", "T") + "Z",
+            "expires_at": row["expires_at"].replace(" ", "T") + "Z",
         }
 
 

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -224,24 +224,24 @@ def _release_all_locks(project_root: Path) -> None:
 
 async def _idle_check_loop(project_root: Path) -> None:
     """Background loop: shut down Marimo when idle for ``_IDLE_TIMEOUT`` seconds."""
-    idle_since: float | None = None
+    idle_since: float = time.monotonic()
 
     while True:
         await asyncio.sleep(_IDLE_CHECK_INTERVAL)
 
         has_locks = await asyncio.to_thread(_has_active_locks, project_root)
         if has_locks:
-            idle_since = None
+            idle_since = 0.0  # reset — will be set on next no-lock check
             continue
 
-        now = time.monotonic()
-        if idle_since is None:
-            idle_since = now
-            continue
+        if idle_since == 0.0:
+            idle_since = time.monotonic()
 
-        if now - idle_since >= _IDLE_TIMEOUT:
+        if time.monotonic() - idle_since >= _IDLE_TIMEOUT:
             logger.info("Marimo idle for %ds — shutting down", _IDLE_TIMEOUT)
-            await asyncio.to_thread(_release_all_locks, project_root)
+            # Clean up any locks created in the narrow window since last check
+            if await asyncio.to_thread(_has_active_locks, project_root):
+                await asyncio.to_thread(_release_all_locks, project_root)
             await asyncio.to_thread(stop_marimo, project_root)
             break
 
@@ -251,7 +251,7 @@ def start_idle_checker(project_root: Path) -> None:
     global _idle_checker_task  # noqa: PLW0603
     if _idle_checker_task is not None and not _idle_checker_task.done():
         return
-    _idle_checker_task = asyncio.get_event_loop().create_task(_idle_check_loop(project_root))
+    _idle_checker_task = asyncio.get_running_loop().create_task(_idle_check_loop(project_root))
 
 
 def stop_idle_checker() -> None:

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -1,18 +1,26 @@
 """dango/notebooks/manager.py
 
-Marimo notebook server process lifecycle (start, stop, status).
+Marimo notebook server process lifecycle (start, stop, status) and idle
+auto-shutdown.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import subprocess
 import time
 from pathlib import Path
 
+from dango.utils.dango_db import connect
 from dango.utils.process import is_process_running, kill_process
 
 logger = logging.getLogger(__name__)
+
+# --- Idle auto-shutdown state ---
+_idle_checker_task: asyncio.Task[None] | None = None
+_IDLE_CHECK_INTERVAL = 300  # 5 minutes
+_IDLE_TIMEOUT = 900  # 15 minutes
 
 
 def get_marimo_pid_file_path(project_root: Path) -> Path:
@@ -195,3 +203,60 @@ def get_marimo_status(project_root: Path) -> dict[str, bool | int | Path | None]
             pass
 
     return status
+
+
+def _has_active_locks(project_root: Path) -> bool:
+    """Check if any non-expired notebook locks exist."""
+    with connect(project_root) as conn:
+        conn.execute("DELETE FROM notebook_locks WHERE expires_at < datetime('now')")
+        conn.commit()
+        row = conn.execute("SELECT COUNT(*) AS cnt FROM notebook_locks").fetchone()
+        return bool(row and row["cnt"] > 0)
+
+
+def _release_all_locks(project_root: Path) -> None:
+    """Delete all notebook locks (used during idle shutdown)."""
+    with connect(project_root) as conn:
+        conn.execute("DELETE FROM notebook_locks")
+        conn.commit()
+    logger.info("Released all notebook locks (idle shutdown)")
+
+
+async def _idle_check_loop(project_root: Path) -> None:
+    """Background loop: shut down Marimo when idle for ``_IDLE_TIMEOUT`` seconds."""
+    idle_since: float | None = None
+
+    while True:
+        await asyncio.sleep(_IDLE_CHECK_INTERVAL)
+
+        has_locks = await asyncio.to_thread(_has_active_locks, project_root)
+        if has_locks:
+            idle_since = None
+            continue
+
+        now = time.monotonic()
+        if idle_since is None:
+            idle_since = now
+            continue
+
+        if now - idle_since >= _IDLE_TIMEOUT:
+            logger.info("Marimo idle for %ds — shutting down", _IDLE_TIMEOUT)
+            await asyncio.to_thread(_release_all_locks, project_root)
+            await asyncio.to_thread(stop_marimo, project_root)
+            break
+
+
+def start_idle_checker(project_root: Path) -> None:
+    """Start the idle-shutdown background task (idempotent)."""
+    global _idle_checker_task  # noqa: PLW0603
+    if _idle_checker_task is not None and not _idle_checker_task.done():
+        return
+    _idle_checker_task = asyncio.get_event_loop().create_task(_idle_check_loop(project_root))
+
+
+def stop_idle_checker() -> None:
+    """Cancel the idle-shutdown background task if running."""
+    global _idle_checker_task  # noqa: PLW0603
+    if _idle_checker_task is not None and not _idle_checker_task.done():
+        _idle_checker_task.cancel()
+    _idle_checker_task = None

--- a/dango/notebooks/templates/explore.py
+++ b/dango/notebooks/templates/explore.py
@@ -20,12 +20,12 @@ def setup():
 @app.cell
 def list_tables(conn):
     """List all user-created tables across schemas."""
-    tables = conn.execute(
+    tables = conn.sql(
         "SELECT table_schema, table_name "
         "FROM information_schema.tables "
         "WHERE table_schema NOT IN ('information_schema', 'pg_catalog') "
         "ORDER BY table_schema, table_name"
-    ).fetchdf()
+    )
     return (tables,)
 
 
@@ -33,5 +33,5 @@ def list_tables(conn):
 def sample_query(conn):
     """Run an ad-hoc query — edit the SQL below to explore your data."""
     # Edit the query below to explore your data
-    result = conn.execute("SELECT 1 AS hello").fetchdf()
+    result = conn.sql("SELECT 1 AS hello")
     return (result,)

--- a/dango/notebooks/templates/quality.py
+++ b/dango/notebooks/templates/quality.py
@@ -30,21 +30,18 @@ def row_counts(conn):
     for schema, table in tables:
         n = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()[0]
         counts.append({"schema": schema, "table": table, "row_count": n})
-    import pandas as pd
-
-    counts_df = pd.DataFrame(counts)
-    return (counts_df,)
+    return (counts,)
 
 
 @app.cell
 def null_analysis(conn):
     """Show column metadata for a target table — edit the WHERE clause."""
     # Replace with your target table
-    result = conn.execute(
+    result = conn.sql(
         "SELECT column_name, data_type "
         "FROM information_schema.columns "
         "WHERE table_schema = 'raw' "
         "ORDER BY ordinal_position "
         "LIMIT 20"
-    ).fetchdf()
+    )
     return (result,)

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -29,7 +29,7 @@ from dango.notebooks.locking import (
     refresh_lock,
     release_lock,
 )
-from dango.notebooks.manager import get_marimo_status, start_marimo
+from dango.notebooks.manager import get_marimo_status, start_idle_checker, start_marimo
 from dango.utils.dango_db import connect
 from dango.validation import validate_identifier
 from dango.web.helpers import get_project_root
@@ -384,7 +384,9 @@ async def lock_notebook(
 
     port = status.get("port") or _DEFAULT_MARIMO_PORT  # type: ignore[assignment]
 
-    marimo_url = f"http://localhost:{port}/@file/{name}.py"
+    marimo_url = f"http://localhost:{port}/?file={name}.py"
+
+    start_idle_checker(project_root)
 
     return JSONResponse(content={"locked": True, "marimo_url": marimo_url})
 

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -89,7 +89,7 @@
                                         <button @click="copyNotebook(nb)"
                                                 class="text-gray-600 hover:text-gray-800 text-xs font-medium">Copy</button>
                                     </template>
-                                    <template x-if="canManage && nb.lock">
+                                    <template x-if="canManage && nb.lock && nb.lock.locked_by !== userEmail">
                                         <button @click="forceReleaseLock(nb)"
                                                 class="text-orange-600 hover:text-orange-800 text-xs font-medium">Force Unlock</button>
                                     </template>

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -81,6 +81,10 @@
                                         <button @click="openNotebook(nb)"
                                                 class="text-blue-600 hover:text-blue-800 text-xs font-medium">Open</button>
                                     </template>
+                                    <template x-if="canExecute && nb.lock && nb.lock.locked_by === userEmail">
+                                        <button @click="releaseOwnLock(nb)"
+                                                class="text-yellow-600 hover:text-yellow-800 text-xs font-medium">Release Lock</button>
+                                    </template>
                                     <template x-if="canExecute && nb.lock && nb.lock.locked_by !== userEmail">
                                         <button @click="copyNotebook(nb)"
                                                 class="text-gray-600 hover:text-gray-800 text-xs font-medium">Copy</button>
@@ -299,6 +303,22 @@ function notebooksPage() {
                 await this.loadNotebooks();
             } catch (e) { this.error = 'Failed to delete notebook'; }
             this.deleteLoading = false;
+        },
+
+        async releaseOwnLock(nb) {
+            this.error = '';
+            try {
+                const res = await fetch(`/api/notebooks/${nb.name}/release`, {
+                    method: 'POST', headers, body: '{}'
+                });
+                const data = await res.json();
+                if (!res.ok) { this.error = data.message || 'Failed to release lock'; return; }
+                this.stopHeartbeat();
+                this.activeNotebook = null;
+                this.success = 'Lock released.';
+                setTimeout(() => this.success = '', 3000);
+                await this.loadNotebooks();
+            } catch (e) { this.error = 'Failed to release lock'; }
         },
 
         async forceReleaseLock(nb) {

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -81,7 +81,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 970
+    lines: 985
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
@@ -347,7 +347,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_web_notebooks.py
-    lines: 506
+    lines: 515
     category: exempt
     reason: "TEST-030: 7 test classes covering page, list, create, delete, lock, heartbeat, release, force-release, copy. Marginally over limit after locked_at test addition."
     review_by: "v1.1"

--- a/tests/unit/test_notebook_cli.py
+++ b/tests/unit/test_notebook_cli.py
@@ -186,6 +186,11 @@ class TestNotebookOpen:
                 result = runner.invoke(notebook, ["open", "test"])
 
             assert "localhost:7805" in result.output
+            # Rich inserts ANSI escape codes in URLs; strip before checking
+            import re
+
+            plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+            assert "?file=test.py" in plain
 
     def test_open_nonexistent_notebook(self):
         runner = CliRunner()

--- a/tests/unit/test_notebook_locking.py
+++ b/tests/unit/test_notebook_locking.py
@@ -137,6 +137,18 @@ class TestGetLockInfo:
 
         assert get_lock_info(tmp_path, "nb1") is None
 
+    def test_timestamps_are_iso_utc(self, tmp_path):
+        """Timestamps use ISO 8601 format with Z suffix for UTC."""
+        from dango.notebooks.locking import acquire_lock, get_lock_info
+
+        acquire_lock(tmp_path, "nb1", "alice")
+        info = get_lock_info(tmp_path, "nb1")
+        assert info is not None
+        assert "T" in info["locked_at"]
+        assert info["locked_at"].endswith("Z")
+        assert "T" in info["expires_at"]
+        assert info["expires_at"].endswith("Z")
+
 
 @pytest.mark.unit
 class TestCopyLockedNotebook:

--- a/tests/unit/test_notebook_manager.py
+++ b/tests/unit/test_notebook_manager.py
@@ -1,13 +1,16 @@
 """tests/unit/test_notebook_manager.py
 
-Tests for dango.notebooks.manager — Marimo process lifecycle.
+Tests for dango.notebooks.manager — Marimo process lifecycle and idle shutdown.
 """
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from dango.utils.dango_db import _schema_initialized, connect
 
 
 @pytest.mark.unit
@@ -162,3 +165,126 @@ class TestGetMarimoStatus:
         assert status["running"] is True
         assert status["pid"] == 12345
         assert status["port"] == 7805
+
+
+def _init_db(tmp_path):
+    """Initialize dango.db schema for tests."""
+    _schema_initialized.clear()
+    with connect(tmp_path):
+        pass
+
+
+def _seed_lock(tmp_path, notebook_id="nb1", user="alice"):
+    """Insert a non-expired lock row."""
+    with connect(tmp_path) as conn:
+        conn.execute(
+            "INSERT INTO notebook_locks (notebook_id, locked_by, locked_at, expires_at) "
+            "VALUES (?, ?, datetime('now'), datetime('now', '+15 minutes'))",
+            (notebook_id, user),
+        )
+        conn.commit()
+
+
+@pytest.mark.unit
+class TestHasActiveLocks:
+    def test_true_when_locks_exist(self, tmp_path):
+        _init_db(tmp_path)
+        _seed_lock(tmp_path)
+
+        from dango.notebooks.manager import _has_active_locks
+
+        assert _has_active_locks(tmp_path) is True
+
+    def test_false_when_no_locks(self, tmp_path):
+        _init_db(tmp_path)
+
+        from dango.notebooks.manager import _has_active_locks
+
+        assert _has_active_locks(tmp_path) is False
+
+    def test_false_when_all_expired(self, tmp_path):
+        _init_db(tmp_path)
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "INSERT INTO notebook_locks (notebook_id, locked_by, locked_at, expires_at) "
+                "VALUES ('nb1', 'alice', datetime('now'), datetime('now', '-1 minute'))"
+            )
+            conn.commit()
+
+        from dango.notebooks.manager import _has_active_locks
+
+        assert _has_active_locks(tmp_path) is False
+
+
+@pytest.mark.unit
+class TestReleaseAllLocks:
+    def test_clears_all_locks(self, tmp_path):
+        _init_db(tmp_path)
+        _seed_lock(tmp_path, "nb1", "alice")
+        _seed_lock(tmp_path, "nb2", "bob")
+
+        from dango.notebooks.manager import _release_all_locks
+
+        _release_all_locks(tmp_path)
+
+        with connect(tmp_path) as conn:
+            count = conn.execute("SELECT COUNT(*) AS cnt FROM notebook_locks").fetchone()["cnt"]
+        assert count == 0
+
+
+@pytest.mark.unit
+class TestStartIdleChecker:
+    def test_creates_task(self, tmp_path):
+        import dango.notebooks.manager as mgr
+
+        _init_db(tmp_path)
+        loop = asyncio.new_event_loop()
+        try:
+            mgr._idle_checker_task = None
+            loop.run_until_complete(asyncio.sleep(0))
+
+            # Run start_idle_checker inside the loop
+            async def _run():
+                mgr.start_idle_checker(tmp_path)
+                assert mgr._idle_checker_task is not None
+                assert not mgr._idle_checker_task.done()
+                mgr._idle_checker_task.cancel()
+                try:
+                    await mgr._idle_checker_task
+                except asyncio.CancelledError:
+                    pass
+
+            loop.run_until_complete(_run())
+        finally:
+            mgr._idle_checker_task = None
+            loop.close()
+
+
+@pytest.mark.unit
+class TestStopIdleChecker:
+    def test_cancels_task(self):
+        import dango.notebooks.manager as mgr
+
+        loop = asyncio.new_event_loop()
+        try:
+
+            async def _run():
+                task = loop.create_task(asyncio.sleep(999))
+                mgr._idle_checker_task = task
+                mgr.stop_idle_checker()
+                assert mgr._idle_checker_task is None
+                # Let the cancellation propagate
+                await asyncio.sleep(0)
+                assert task.cancelled()
+
+            loop.run_until_complete(_run())
+        finally:
+            mgr._idle_checker_task = None
+            loop.close()
+
+    def test_noop_when_no_task(self):
+        import dango.notebooks.manager as mgr
+
+        mgr._idle_checker_task = None
+        mgr.stop_idle_checker()
+        assert mgr._idle_checker_task is None

--- a/tests/unit/test_web_notebooks.py
+++ b/tests/unit/test_web_notebooks.py
@@ -319,6 +319,7 @@ class TestDeleteNotebook:
 class TestLockNotebook:
     """Tests for POST /api/notebooks/{name}/lock."""
 
+    @patch(f"{_P}.start_idle_checker")
     @patch(f"{_P}.start_marimo")
     @patch(f"{_P}.get_marimo_status")
     @patch(f"{_P}.get_project_root")
@@ -327,9 +328,10 @@ class TestLockNotebook:
         mock_root: MagicMock,
         mock_status: MagicMock,
         mock_start: MagicMock,
+        mock_idle: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Acquires lock and returns Marimo URL."""
+        """Acquires lock and returns Marimo URL with ?file= query param."""
         mock_root.return_value = tmp_path
         mock_status.return_value = {"running": True, "port": 7805, "pid": 123, "log_file": None}
         _init_db(tmp_path)
@@ -337,7 +339,8 @@ class TestLockNotebook:
         resp = _client(tmp_path).post("/api/notebooks/test_nb/lock", json={})
         assert resp.status_code == 200
         assert resp.json()["locked"] is True
-        assert "test_nb.py" in resp.json()["marimo_url"]
+        assert "?file=test_nb.py" in resp.json()["marimo_url"]
+        mock_idle.assert_called_once_with(tmp_path)
 
     @patch(f"{_P}.get_project_root")
     def test_conflict(self, mock_root: MagicMock, tmp_path: Path) -> None:
@@ -367,11 +370,17 @@ class TestLockNotebook:
         resp = _client(tmp_path).post("/api/notebooks/no_file/lock", json={})
         assert resp.status_code == 404
 
+    @patch(f"{_P}.start_idle_checker")
     @patch(f"{_P}.start_marimo", side_effect=RuntimeError("already running"))
     @patch(f"{_P}.get_marimo_status")
     @patch(f"{_P}.get_project_root")
     def test_marimo_start_race_condition(
-        self, mock_root: MagicMock, mock_status: MagicMock, _ms: MagicMock, tmp_path: Path
+        self,
+        mock_root: MagicMock,
+        mock_status: MagicMock,
+        _ms: MagicMock,
+        _idle: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """Recovers when start_marimo raises RuntimeError (race condition)."""
         mock_root.return_value = tmp_path


### PR DESCRIPTION
## Summary

- **BUG-142**: Fix Marimo URL format — use `?file=` query param instead of `/@file/` path (Marimo 0.23.x)
- **BUG-141**: Fix lock timestamp timezone — append `T` and `Z` suffix so JS `new Date()` parses as UTC, not local time
- **BUG-143**: Remove pandas dependency from notebook templates — replace `fetchdf()` with `conn.sql()` (DuckDB Relation, rendered natively by Marimo)
- **BUG-140/BUG-144**: Add Marimo idle auto-shutdown (15min timeout after last lock expires) with lock cleanup, and "Release Lock" button for own locks in the web UI

## Test plan

- [x] `ruff check` + `ruff format --check` — all pass
- [x] `mypy` — 0 issues across 11 source files
- [x] 78 targeted notebook tests pass (locking, manager, web notebooks, CLI)
- [x] 3160 unit tests pass (7 skipped, 0 failures)
- [x] All 11 pre-commit hooks pass
- [x] File size exemptions updated (`platform.py` 985, `test_web_notebooks.py` 515)
- [ ] Manual: open notebook from web UI → URL uses `?file=`, templates run without pandas, lock timestamps show correct relative time, "Release Lock" button visible for own locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)