### PR TITLE
R9-P: Remove remaining admin@dango.local references (BUG-021)

### DIFF
--- a/dango/auth/metabase_sync.py
+++ b/dango/auth/metabase_sync.py
@@ -542,11 +542,7 @@ def sync_all_users_to_metabase(
                 errors.append(f"Error syncing {user.email}")
 
         for email, mb_u in mb_by_email.items():
-            if (
-                email != "admin@dango.local"
-                and email not in dango_emails
-                and mb_u.get("is_active", True)
-            ):
+            if email not in dango_emails and mb_u.get("is_active", True):
                 warnings.append(f"Metabase user '{email}' not found in Dango")
 
     except Exception:

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -242,10 +242,7 @@ def setup_metabase_if_needed(
             if db_path.exists():
                 users = list_users(db_path, active_only=True)
                 admins = [u for u in users if u.role == Role.ADMIN]
-                if admins and admins[0].email not in (
-                    "admin@dango.local",
-                    "admin@localhost",
-                ):
+                if admins and admins[0].email != "admin@localhost":
                     admin_email = admins[0].email
         except Exception:
             pass

--- a/tests/unit/test_metabase_sync.py
+++ b/tests/unit/test_metabase_sync.py
@@ -390,7 +390,6 @@ class TestSyncAllUsers:
 
         mb_users = [
             {"id": 10, "email": "synced@example.com", "is_active": True},
-            {"id": 1, "email": "admin@dango.local", "is_active": True},
             {"id": 99, "email": "orphan@example.com", "is_active": True},
         ]
 
@@ -421,7 +420,6 @@ class TestSyncAllUsers:
         result = sync_all_users_to_metabase(db, root, MB_URL)
         assert result["synced"] >= 1 and result["created"] >= 1
         assert any("orphan" in w for w in result["warnings"])
-        assert not any("admin@dango.local" in w for w in result["warnings"])
 
     @patch("dango.auth.metabase_sync.requests")
     def test_auth_failure(self, mock_req: MagicMock, tmp_path: Path) -> None:

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -269,7 +269,7 @@ class TestSetupMetabaseIfNeeded:
         assert result["success"] is True
 
     def test_skips_admin_at_localhost(self, tmp_path, monkeypatch):
-        """BUG-100: admin@localhost is filtered like admin@dango.local."""
+        """BUG-100: admin@localhost is filtered out for Metabase setup."""
         monkeypatch.delenv("DANGO_ADMIN_EMAIL", raising=False)
         # Create auth DB with admin@localhost
         from dango.auth.admin import get_auth_db_path


### PR DESCRIPTION
## Summary
- **BUG-021:** Remove last 2 source references to `admin@dango.local` (in `startup.py` email filter and `metabase_sync.py` orphan warning exclusion). No code creates this email anymore, so any such Metabase user is a legitimate orphan.
- **BUG-058** (password = email check) and **BUG-027** (spaCy model download) were already fully implemented — no changes needed.
- Updated corresponding tests and docstrings.

## Test plan
- [x] 63 affected tests pass (`test_platform_startup.py` + `test_metabase_sync.py`)
- [x] Zero `dango.local` references remain in `dango/` source
- [x] Ruff + mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)