### PR TITLE
R9-O: Add role badge to nav bar and fix metabase save docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ dango/                          # Python package source
 │
 ├── visualization/              # Level 2 — Metabase integration
 │   ├── metabase.py             # Metabase API (1152 lines)
-│   └── dashboard_manager.py    # Dashboard export/import (1113 lines)
+│   └── dashboard_manager.py    # Dashboard export/import (1112 lines)
 │
 ├── platform/                   # Level 2 — Docker, network, file watcher, scheduling
 │   ├── __main__.py             # Platform CLI entry point
@@ -337,7 +337,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/source_wizard.py` | 2288 | — |
 | `visualization/metabase.py` | 1151 | — |
 | `cli/init.py` | 1324 | — |
-| `visualization/dashboard_manager.py` | 1113 | — |
+| `visualization/dashboard_manager.py` | 1112 | — |
 | `cli/commands/platform.py` | 1011 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -22,7 +22,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/upgrade.py` (236 lines) | `upgrade` command — local Dango upgrade via pip + migrations | `upgrade()`, `get_latest_version_cached()` |
 | `commands/data.py` (360 lines) | `db` group (`status`, `clean`) + `validate` | `db`, `validate()` |
 | `commands/config_cmd.py` (179 lines) | `config` group (`validate`, `show`) | `config` |
-| `commands/metabase_cmd.py` (431 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
+| `commands/metabase_cmd.py` (412 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
 | `commands/remote.py` (698 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |

--- a/dango/cli/commands/metabase_cmd.py
+++ b/dango/cli/commands/metabase_cmd.py
@@ -26,7 +26,7 @@ def metabase(ctx: click.Context) -> None:
     "--all",
     "include_personal",
     is_flag=True,
-    help="Include personal collections (default: only shared/team)",
+    help="Include personal collections (currently a no-op; default: 'Shared' only)",
 )
 @click.option("--collections", help="Specific collections to export (comma-separated)")
 @click.pass_context
@@ -35,12 +35,13 @@ def metabase_save(ctx: click.Context, include_personal: bool, collections: str |
     Save Metabase dashboards and questions to files.
 
     Exports to metabase/ directory in YAML format.
-    By default, excludes personal collections (only exports shared/team assets).
+    By default, only exports the "Shared" collection.
 
     What this does:
     - Exports dashboards from Metabase to metabase/dashboards/ (YAML files)
     - Exports questions from Metabase to metabase/questions/ (YAML files)
-    - Excludes personal collections by default
+    - Only exports the "Shared" collection by default
+    - Use --collections to include other root collections
     - Files can optionally be committed to git for version control
 
     Workflow:
@@ -49,9 +50,9 @@ def metabase_save(ctx: click.Context, include_personal: bool, collections: str |
       3. (Optional) Commit to git: git add metabase/ && git commit -m "Update dashboards"
 
     Examples:
-      dango metabase save                          # Export shared/team collections
-      dango metabase save --all                    # Include personal collections
-      dango metabase save --collections "Shared,Marketing"  # Specific collections
+      dango metabase save                                    # Export "Shared" collection only
+      dango metabase save --collections "Our analytics"      # Export a specific root collection
+      dango metabase save --collections "Shared,Marketing"   # Export multiple collections
     """
     from dango.visualization.dashboard_manager import DashboardManager
 

--- a/dango/visualization/dashboard_manager.py
+++ b/dango/visualization/dashboard_manager.py
@@ -588,7 +588,7 @@ class DashboardManager:
 
         Args:
             include_personal: Include personal collections (default: False)
-            collections: Specific collections to export (default: all non-personal)
+            collections: Specific collections to export (default: 'Shared' collection only)
 
         Returns:
             Summary with exported items
@@ -632,7 +632,13 @@ class DashboardManager:
             ]
 
         if not collections_to_export:
-            summary["errors"].append("No collections to export")
+            if collections:
+                summary["errors"].append(f"No matching collections found: {', '.join(collections)}")
+            else:
+                summary["errors"].append(
+                    "No 'Shared' collection found. Create one in Metabase, "
+                    "or use --collections to specify a collection name."
+                )
             return summary
 
         # Create metabase/ directory structure

--- a/dango/visualization/dashboard_manager.py
+++ b/dango/visualization/dashboard_manager.py
@@ -581,7 +581,7 @@ class DashboardManager:
         Save Metabase assets to files (simplified export for version control)
 
         Exports dashboards and questions to metabase/ directory in YAML format.
-        By default, excludes personal collections (only exports team/shared assets).
+        By default, only exports the "Shared" collection.
 
         Files can optionally be committed to git for version control, but this
         command works independently of git.

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -77,6 +77,10 @@
                 <div class="flex items-center space-x-2 ml-auto">
                     {% if request.state.user %}
                     <span class="text-xs text-gray-400 hidden lg:inline mr-2">{{ request.state.user.email }}</span>
+                    <span class="text-xs px-1.5 py-0.5 rounded-full hidden lg:inline mr-1
+                        {% if request.state.user.role.value == 'admin' %}bg-red-100 text-red-800
+                        {% elif request.state.user.role.value == 'editor' %}bg-blue-100 text-blue-800
+                        {% else %}bg-gray-100 text-gray-800{% endif %}">{{ request.state.user.role.value }}</span>
                     <!-- Settings gear dropdown -->
                     <div class="relative">
                         <button @click="settingsOpen = !settingsOpen"
@@ -132,6 +136,13 @@
             </div>
             {% if request.state.user %}
             <div class="border-t border-gray-700 px-2 pt-2 pb-3 space-y-1">
+                <div class="px-3 py-2 text-sm text-gray-400 flex items-center space-x-2">
+                    <span>{{ request.state.user.email }}</span>
+                    <span class="text-xs px-1.5 py-0.5 rounded-full
+                        {% if request.state.user.role.value == 'admin' %}bg-red-100 text-red-800
+                        {% elif request.state.user.role.value == 'editor' %}bg-blue-100 text-blue-800
+                        {% else %}bg-gray-100 text-gray-800{% endif %}">{{ request.state.user.role.value }}</span>
+                </div>
                 <a href="/settings/account" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Account Settings</a>
                 {% if request.state.user.role.value == 'admin' %}
                 <a href="/settings/users" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">User Management</a>

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -148,7 +148,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/visualization/dashboard_manager.py
-    lines: 1117
+    lines: 1112
     category: exempt
     reason: "Dashboard export/import operations. Tightly coupled to metabase.py API surface."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary

- **BUG-057**: Add color-coded role badge (admin/editor/viewer) next to user email in both desktop and mobile navigation
- **BUG-034**: Fix misleading `dango metabase save` docs — said "all non-personal" but code only exports "Shared" collection. Improved error messages and CLI help text.

## Test plan

- [x] `ruff check` — passes
- [x] `ruff format --check` — passes
- [x] `mypy` on changed Python files — passes
- [x] Unit tests (29 targeted + full suite) — all pass
- [x] All pre-commit hooks pass
- [x] `wc -l` verified, line counts updated in `file-exemptions.yml`, `CLAUDE.md`, `cli/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)