### PR TITLE
R9-M: Rename Insights → Monitoring (BUG-149)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for system diagram, data flow, and cross-
 | Auth / users / sessions | `dango/auth/` | [`dango/auth/CLAUDE.md`](dango/auth/CLAUDE.md) |
 | Notebooks | `dango/notebooks/` | [`dango/notebooks/CLAUDE.md`](dango/notebooks/CLAUDE.md) |
 | Data governance | `dango/governance/` | [`dango/governance/CLAUDE.md`](dango/governance/CLAUDE.md) |
-| Metric analysis / insights | `dango/analysis/` | [`dango/analysis/CLAUDE.md`](dango/analysis/CLAUDE.md) |
+| Monitoring / analysis | `dango/analysis/` | [`dango/analysis/CLAUDE.md`](dango/analysis/CLAUDE.md) |
 
 ## Don't Read First
 
@@ -101,7 +101,7 @@ dango/                          # Python package source
 │   │   ├── schedule.py         # schedule group (add/list/remove/status/enable/disable/webhook)
 │   │   ├── governance.py       # governance group (drift-report/pii-report)
 │   │   ├── notebook.py         # notebook group (new/open) + snapshot
-│   │   └── analyze.py          # analyze top-level command
+│   │   └── analyze.py          # monitor group + analyze alias
 │   ├── init.py                 # Project initialization wizard
 │   ├── wizard.py               # Interactive setup wizards
 │   ├── source_wizard.py        # Source configuration wizard
@@ -183,7 +183,7 @@ dango/                          # Python package source
 │   │   ├── oauth_connect.py    # Web-based OAuth connect/callback
 │   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact, models, search (1157 lines)
 │   │   ├── governance.py       # Schema drift + PII results API
-│   │   ├── insights.py         # Metric results, run trigger, history
+│   │   ├── monitoring.py        # Monitor results, run trigger, history
 │   │   ├── notebooks.py        # Notebook management API + page route
 │   │   └── initial_sync.py     # Initial data sync after first deploy
 │   ├── templates/              # Jinja2 page templates
@@ -196,7 +196,7 @@ dango/                          # Python package source
 │   │   ├── schedules.html      # Schedule management page
 │   │   ├── notebooks.html      # Notebook management page
 │   │   ├── catalog.html        # Data catalog page (495 lines)
-│   │   └── insights.html       # Insights/analysis page
+│   │   └── monitoring.html      # Monitoring page
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ dango/                          # Python package source
 │   │   ├── oauth_connect.py    # Web-based OAuth connect/callback
 │   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact, models, search (1157 lines)
 │   │   ├── governance.py       # Schema drift + PII results API
-│   │   ├── monitoring.py        # Monitor results, run trigger, history
+│   │   ├── monitoring.py       # Monitor results, run trigger, history
 │   │   ├── notebooks.py        # Notebook management API + page route
 │   │   └── initial_sync.py     # Initial data sync after first deploy
 │   ├── templates/              # Jinja2 page templates
@@ -196,7 +196,7 @@ dango/                          # Python package source
 │   │   ├── schedules.html      # Schedule management page
 │   │   ├── notebooks.html      # Notebook management page
 │   │   ├── catalog.html        # Data catalog page (495 lines)
-│   │   └── monitoring.html      # Monitoring page
+│   │   └── monitoring.html     # Monitoring page
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration

--- a/dango/analysis/CLAUDE.md
+++ b/dango/analysis/CLAUDE.md
@@ -2,19 +2,21 @@
 
 ## Purpose
 
-Automated metric monitoring and comparison engine. Executes user-defined metrics against DuckDB, stores results in SQLite (`metric_history`, `metric_results` tables in `.dango/dango.db`), and compares current values against historical baselines to detect changes and trends. Pre-built templates auto-generate metrics for common sources.
+Automated monitoring and comparison engine. Executes user-defined monitors against DuckDB, stores results in SQLite (`metric_history`, `metric_results` tables in `.dango/dango.db`), and compares current values against historical baselines to detect changes and trends. Pre-built templates auto-generate monitors for common sources.
+
+**Naming:** Config models use "monitor" terminology (`MonitorConfig`, `MonitorsConfig`, `.dango/monitors.yml`). Runtime models retain "metric" terminology (`MetricValue`, `ComparisonResult`). Old names (`MetricConfig`, `MetricsConfig`, `warn_threshold`, `metrics.yml`) are supported via backward-compatible aliases.
 
 ## Files
 
 | File | Purpose | Key Exports |
 |------|---------|-------------|
-| `__init__.py` | Public API re-exports | `run_analysis`, `load_metrics_config`, `save_metrics_config`, `add_metrics_to_config`, `generate_metrics_for_source`, `DimensionContributor`, `DrillDownDimension` |
-| `models.py` | Pydantic V2 models | `ComparisonType`, `MetricConfig`, `MetricsConfig`, `MetricValue`, `ComparisonResult`, `DimensionContributor`, `DrillDownDimension`, `AnalysisResult` |
-| `config.py` | YAML config load/save | `load_metrics_config()`, `save_metrics_config()`, `add_metrics_to_config()`, `get_metrics_file_path()` |
+| `__init__.py` | Public API re-exports | `run_analysis`, `load_monitors_config`, `save_monitors_config`, `add_monitors_to_config`, `generate_metrics_for_source`, `MonitorConfig`, `MonitorsConfig`, `DimensionContributor`, `DrillDownDimension` + backward-compat aliases |
+| `models.py` | Pydantic V2 models | `ComparisonType`, `MonitorConfig` (alias: `MetricConfig`), `MonitorsConfig` (alias: `MetricsConfig`), `MetricValue`, `ComparisonResult`, `DimensionContributor`, `DrillDownDimension`, `AnalysisResult` |
+| `config.py` | YAML config load/save | `load_monitors_config()`, `save_monitors_config()`, `add_monitors_to_config()`, `get_monitors_file_path()` + backward-compat aliases |
 | `comparisons.py` | Comparison engine + trend detection | `compute_comparison()`, `detect_trend()` |
 | `drilldown.py` | Drill-down engine: GROUP BY breakdown + contributor ranking | `run_drill_down()` |
 | `metrics.py` | Orchestration: execute → store → compare → drill-down | `run_analysis()` |
-| `templates.py` | Pre-built metric templates for common sources | `generate_metrics_for_source()` |
+| `templates.py` | Pre-built monitor templates for common sources | `generate_metrics_for_source()` |
 | `formatter.py` (144 lines) | Result categorization + display formatting | `categorize_results()`, status labels, trend direction |
 
 ## Common Tasks
@@ -22,9 +24,9 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
 | Add a new comparison type | `models.py` (`ComparisonType` enum) + `comparisons.py` (`_get_baseline`) | `pytest tests/unit/test_analysis_comparisons.py` |
-| Change metric validation | `models.py` (`MetricConfig` validators) | `pytest tests/unit/test_analysis_models.py` |
+| Change monitor validation | `models.py` (`MonitorConfig` validators) | `pytest tests/unit/test_analysis_models.py` |
 | Change config file format | `config.py` | `pytest tests/unit/test_analysis_config.py` |
-| Save/merge metrics config | `config.py` (`save_metrics_config`, `add_metrics_to_config`) | `pytest tests/unit/test_analysis_config.py` |
+| Save/merge monitors config | `config.py` (`save_monitors_config`, `add_monitors_to_config`) | `pytest tests/unit/test_analysis_config.py` |
 | Add source template | `templates.py` (add generator + register in dispatch dict) | `pytest tests/unit/test_analysis_templates.py` |
 | Modify trend detection | `comparisons.py` (`detect_trend`, `_linear_regression`) | `pytest tests/unit/test_analysis_comparisons.py` |
 | Change metric execution | `metrics.py` (`_execute_metric`, `_build_metric_sql`) | `pytest tests/unit/test_analysis_metrics.py` |
@@ -42,10 +44,10 @@ Automated metric monitoring and comparison engine. Executes user-defined metrics
 **Used by:**
 - `metrics.py` — calls `run_drill_down()` from `drilldown.py` when threshold exceeded
 - `utils/post_sync.py` — `_run_analysis()` calls `run_analysis` with `raw_`-prefixed source filter
-- `cli/source_wizard.py` — `generate_metrics_for_source()` + `add_metrics_to_config()` on source add
-- `cli/init.py` — `save_metrics_config()` + `generate_metrics_for_source()` on project init
-- `web/routes/insights.py` — GET /api/insights, POST /api/insights/run, GET /api/insights/history
-- `cli/commands/analyze.py` — `dango analyze` command
+- `cli/source_wizard.py` — `generate_metrics_for_source()` + `add_monitors_to_config()` on source add
+- `cli/init.py` — `save_monitors_config()` + `generate_metrics_for_source()` on project init
+- `web/routes/monitoring.py` — GET /api/monitoring, POST /api/monitoring/run, GET /api/monitoring/history
+- `cli/commands/analyze.py` — `dango monitor run` command (+ `dango analyze` alias)
 
 ## Testing
 
@@ -60,6 +62,6 @@ pytest tests/integration/test_analysis_integration.py -v
 
 | Item | Reason |
 |------|--------|
-| `models.py` field names | P7-010, P7-011, P7-012 depend on exact model shapes |
+| `models.py` runtime model field names | P7-010, P7-011, P7-012 depend on exact model shapes |
 | `ComparisonType` enum values | Stored in `metric_results.result_type` column |
 | `metric_history` / `metric_results` table schemas | Defined in `utils/dango_db.py`, shared across modules |

--- a/dango/analysis/__init__.py
+++ b/dango/analysis/__init__.py
@@ -1,21 +1,40 @@
 """dango/analysis/__init__.py
 
-Automated data analysis module.
+Automated data monitoring and analysis module.
 """
 
 from dango.analysis.config import (
     add_metrics_to_config,
+    add_monitors_to_config,
     load_metrics_config,
+    load_monitors_config,
     save_metrics_config,
+    save_monitors_config,
 )
 from dango.analysis.formatter import categorize_results, format_webhook_summary
 from dango.analysis.metrics import run_analysis
-from dango.analysis.models import DimensionContributor, DrillDownDimension
+from dango.analysis.models import (
+    DimensionContributor,
+    DrillDownDimension,
+    MetricConfig,
+    MetricsConfig,
+    MonitorConfig,
+    MonitorsConfig,
+)
 from dango.analysis.templates import generate_metrics_for_source
 
 __all__: list[str] = [
     "DimensionContributor",
     "DrillDownDimension",
+    # New names
+    "MonitorConfig",
+    "MonitorsConfig",
+    "add_monitors_to_config",
+    "load_monitors_config",
+    "save_monitors_config",
+    # Backward-compatible aliases
+    "MetricConfig",
+    "MetricsConfig",
     "add_metrics_to_config",
     "categorize_results",
     "format_webhook_summary",

--- a/dango/analysis/comparisons.py
+++ b/dango/analysis/comparisons.py
@@ -34,7 +34,7 @@ def compute_comparison(
     project_root: Path,
     metric_value: MetricValue,
     comparison_type: ComparisonType,
-    warn_threshold: float | None,
+    alert_threshold: float | None,
 ) -> ComparisonResult:
     """Compare a metric value against its historical baseline.
 
@@ -42,7 +42,7 @@ def compute_comparison(
         project_root: Path to the Dango project root.
         metric_value: The current metric value.
         comparison_type: Which comparison strategy to use.
-        warn_threshold: Percentage change threshold for warnings.
+        alert_threshold: Percentage change threshold for alerts.
 
     Returns:
         A ``ComparisonResult`` with computed change percentage and threshold flag.
@@ -59,11 +59,13 @@ def compute_comparison(
 
     change_pct = _compute_change_pct(current, baseline)
     exceeds = (
-        warn_threshold is not None and change_pct is not None and abs(change_pct) >= warn_threshold
+        alert_threshold is not None
+        and change_pct is not None
+        and abs(change_pct) >= alert_threshold
     )
 
     slope, direction, forecast_days = detect_trend(
-        project_root, metric_value.metric_name, warn_threshold
+        project_root, metric_value.metric_name, alert_threshold
     )
 
     return ComparisonResult(
@@ -82,7 +84,7 @@ def compute_comparison(
 def detect_trend(
     project_root: Path,
     metric_name: str,
-    warn_threshold: float | None = None,
+    alert_threshold: float | None = None,
 ) -> tuple[float | None, str | None, int | None]:
     """Detect a linear trend over the last 30 data points.
 
@@ -91,7 +93,7 @@ def detect_trend(
     Args:
         project_root: Path to the Dango project root.
         metric_name: Name of the metric to analyse.
-        warn_threshold: Optional threshold percentage for forecasting.
+        alert_threshold: Optional threshold percentage for forecasting.
 
     Returns:
         A tuple of ``(slope, direction, forecast_days)``.  All ``None`` if
@@ -124,7 +126,7 @@ def detect_trend(
     else:
         direction = "stable"
 
-    forecast_days = _forecast_threshold_days(ys[-1], slope, warn_threshold, mean_y)
+    forecast_days = _forecast_threshold_days(ys[-1], slope, alert_threshold, mean_y)
 
     return slope, direction, forecast_days
 
@@ -241,19 +243,19 @@ def _linear_regression(
 def _forecast_threshold_days(
     current_value: float,
     slope: float,
-    warn_threshold: float | None,
+    alert_threshold: float | None,
     mean_value: float,
 ) -> int | None:
-    """Estimate days until the warn_threshold percentage change is exceeded.
+    """Estimate days until the alert_threshold percentage change is exceeded.
 
     Returns ``None`` when forecasting is not applicable (no threshold,
     zero slope, or already exceeded).
     """
-    if warn_threshold is None or slope == 0 or mean_value == 0:
+    if alert_threshold is None or slope == 0 or mean_value == 0:
         return None
 
     # Threshold in absolute terms relative to mean
-    threshold_abs = abs(mean_value * warn_threshold / 100)
+    threshold_abs = abs(mean_value * alert_threshold / 100)
     distance = threshold_abs - abs(current_value - mean_value)
 
     if distance <= 0:

--- a/dango/analysis/config.py
+++ b/dango/analysis/config.py
@@ -1,10 +1,13 @@
 """dango/analysis/config.py
 
-Load, save, and validate the metrics configuration from ``.dango/metrics.yml``.
+Load, save, and validate the monitors configuration from ``.dango/monitors.yml``.
 
 Mirrors the ``load_schedules_config()`` pattern in ``dango/config/schedules.py``.
-Missing file → empty ``MetricsConfig``.  Invalid YAML or Pydantic errors →
+Missing file → empty ``MonitorsConfig``.  Invalid YAML or Pydantic errors →
 ``AnalysisConfigError``.
+
+Backward compatibility: falls back to ``.dango/metrics.yml`` if
+``.dango/monitors.yml`` does not exist.
 """
 
 from __future__ import annotations
@@ -14,42 +17,56 @@ from typing import Any
 
 import yaml
 
-from dango.analysis.models import MetricConfig, MetricsConfig
+from dango.analysis.models import MonitorConfig, MonitorsConfig
 from dango.exceptions import AnalysisConfigError
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-def get_metrics_file_path(project_root: Path) -> Path:
-    """Return the path to ``.dango/metrics.yml``.
+def get_monitors_file_path(project_root: Path) -> Path:
+    """Return the path to ``.dango/monitors.yml``.
+
+    If ``.dango/monitors.yml`` does not exist but ``.dango/metrics.yml`` does,
+    returns the legacy path for backward compatibility.  For new files,
+    returns the ``monitors.yml`` path.
 
     Args:
         project_root: Path to the Dango project root.
 
     Returns:
-        Absolute path to the metrics configuration file.
+        Absolute path to the monitors configuration file.
     """
-    return project_root / ".dango" / "metrics.yml"
+    monitors_path = project_root / ".dango" / "monitors.yml"
+    if monitors_path.exists():
+        return monitors_path
+    legacy_path = project_root / ".dango" / "metrics.yml"
+    if legacy_path.exists():
+        return legacy_path
+    return monitors_path  # default for new files
 
 
-def load_metrics_config(project_root: Path) -> MetricsConfig:
-    """Load metrics config from ``.dango/metrics.yml``.
+# Backward-compatible alias
+get_metrics_file_path = get_monitors_file_path
 
-    Returns an empty ``MetricsConfig`` if the file is missing.
+
+def load_monitors_config(project_root: Path) -> MonitorsConfig:
+    """Load monitors config from ``.dango/monitors.yml`` (or legacy ``metrics.yml``).
+
+    Returns an empty ``MonitorsConfig`` if the file is missing.
 
     Args:
         project_root: Path to the Dango project root.
 
     Returns:
-        Parsed metrics configuration.
+        Parsed monitors configuration.
 
     Raises:
         AnalysisConfigError: If the file exists but contains invalid data.
     """
-    path = get_metrics_file_path(project_root)
+    path = get_monitors_file_path(project_root)
     if not path.exists():
-        return MetricsConfig()
+        return MonitorsConfig()
 
     try:
         with open(path, encoding="utf-8") as f:
@@ -58,30 +75,34 @@ def load_metrics_config(project_root: Path) -> MetricsConfig:
         raise AnalysisConfigError(f"Invalid YAML in {path}:\n{e}") from e
 
     try:
-        return MetricsConfig(**data)
+        return MonitorsConfig(**data)
     except Exception as e:
-        raise AnalysisConfigError(f"Invalid metrics configuration in {path}:\n{e}") from e
+        raise AnalysisConfigError(f"Invalid monitors configuration in {path}:\n{e}") from e
 
 
-def save_metrics_config(
+# Backward-compatible alias
+load_metrics_config = load_monitors_config
+
+
+def save_monitors_config(
     project_root: Path,
-    config: MetricsConfig,
+    config: MonitorsConfig,
     *,
     header_comment: str | None = None,
 ) -> None:
-    """Serialize ``MetricsConfig`` to ``.dango/metrics.yml``.
+    """Serialize ``MonitorsConfig`` to ``.dango/monitors.yml``.
 
     Args:
         project_root: Path to the Dango project root.
-        config: The metrics configuration to save.
+        config: The monitors configuration to save.
         header_comment: Optional comment block prepended to the file.
     """
-    path = get_metrics_file_path(project_root)
+    path = project_root / ".dango" / "monitors.yml"
     path.parent.mkdir(parents=True, exist_ok=True)
 
     data: dict[str, Any] = {
         "enabled": config.enabled,
-        "metrics": [m.model_dump(exclude_none=True, mode="json") for m in config.metrics],
+        "monitors": [m.model_dump(exclude_none=True, mode="json") for m in config.monitors],
     }
 
     lines: list[str] = []
@@ -95,27 +116,35 @@ def save_metrics_config(
     path.write_text("\n".join(lines), encoding="utf-8")
 
 
-def add_metrics_to_config(
+# Backward-compatible alias
+save_metrics_config = save_monitors_config
+
+
+def add_monitors_to_config(
     project_root: Path,
-    new_metrics: list[MetricConfig],
+    new_monitors: list[MonitorConfig],
     *,
     header_comment: str | None = None,
-) -> MetricsConfig:
-    """Load existing config, append new metrics (dedup by name), and save.
+) -> MonitorsConfig:
+    """Load existing config, append new monitors (dedup by name), and save.
 
-    Existing metrics with the same name are preserved (not overwritten).
+    Existing monitors with the same name are preserved (not overwritten).
 
     Args:
         project_root: Path to the Dango project root.
-        new_metrics: Metrics to add.
+        new_monitors: Monitors to add.
         header_comment: Optional comment block prepended to the file.
 
     Returns:
-        The merged ``MetricsConfig``.
+        The merged ``MonitorsConfig``.
     """
-    existing = load_metrics_config(project_root)
-    existing_names = {m.name for m in existing.metrics}
-    merged = list(existing.metrics) + [m for m in new_metrics if m.name not in existing_names]
-    config = MetricsConfig(enabled=existing.enabled, metrics=merged)
-    save_metrics_config(project_root, config, header_comment=header_comment)
+    existing = load_monitors_config(project_root)
+    existing_names = {m.name for m in existing.monitors}
+    merged = list(existing.monitors) + [m for m in new_monitors if m.name not in existing_names]
+    config = MonitorsConfig(enabled=existing.enabled, monitors=merged)
+    save_monitors_config(project_root, config, header_comment=header_comment)
     return config
+
+
+# Backward-compatible alias
+add_metrics_to_config = add_monitors_to_config

--- a/dango/analysis/metrics.py
+++ b/dango/analysis/metrics.py
@@ -16,13 +16,13 @@ from pathlib import Path
 import duckdb
 
 from dango.analysis.comparisons import compute_comparison
-from dango.analysis.config import load_metrics_config
+from dango.analysis.config import load_monitors_config
 from dango.analysis.models import (
     AnalysisResult,
     ComparisonResult,
     DrillDownDimension,
-    MetricConfig,
     MetricValue,
+    MonitorConfig,
 )
 from dango.logging import get_logger
 from dango.utils.dango_db import connect
@@ -50,8 +50,8 @@ def run_analysis(
     Returns:
         A list of ``AnalysisResult`` objects, one per metric.
     """
-    config = load_metrics_config(project_root)
-    if not config.enabled or not config.metrics:
+    config = load_monitors_config(project_root)
+    if not config.enabled or not config.monitors:
         return []
 
     duckdb_path = project_root / "data" / "warehouse.duckdb"
@@ -61,7 +61,7 @@ def run_analysis(
 
     results: list[AnalysisResult] = []
 
-    for metric in config.metrics:
+    for metric in config.monitors:
         if source_filter is not None:
             source, _table = _parse_source_from_table(metric.source_table)
             if source and source not in source_filter:
@@ -76,7 +76,7 @@ def run_analysis(
                 project_root,
                 metric_value,
                 metric.compare,
-                metric.warn_threshold,
+                metric.alert_threshold,
             )
             _store_comparison_result(project_root, comparison)
 
@@ -111,7 +111,7 @@ def run_analysis(
 # ---------------------------------------------------------------------------
 
 
-def _execute_metric(duckdb_path: Path, metric: MetricConfig) -> MetricValue:
+def _execute_metric(duckdb_path: Path, metric: MonitorConfig) -> MetricValue:
     """Execute a single metric query against DuckDB.
 
     Args:
@@ -153,7 +153,7 @@ def _execute_metric(duckdb_path: Path, metric: MetricConfig) -> MetricValue:
     )
 
 
-def _build_metric_sql(metric: MetricConfig) -> str:
+def _build_metric_sql(metric: MonitorConfig) -> str:
     """Build the SQL query for a metric.
 
     Args:

--- a/dango/analysis/models.py
+++ b/dango/analysis/models.py
@@ -1,8 +1,8 @@
 """dango/analysis/models.py
 
-Pydantic V2 models for the metric engine, comparison system, and drill-down.
+Pydantic V2 models for the monitoring engine, comparison system, and drill-down.
 
-Defines configuration shapes (``MetricConfig``, ``MetricsConfig``), runtime
+Defines configuration shapes (``MonitorConfig``, ``MonitorsConfig``), runtime
 value containers (``MetricValue``, ``ComparisonResult``), drill-down models
 (``DimensionContributor``, ``DrillDownDimension``), and the top-level
 ``AnalysisResult`` that bundles a metric value with its comparison and
@@ -14,7 +14,7 @@ from __future__ import annotations
 import re
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -37,17 +37,20 @@ class ComparisonType(str, Enum):
 # ---------------------------------------------------------------------------
 
 
-class MetricConfig(BaseModel):
-    """Single metric definition from ``.dango/metrics.yml``."""
+class MonitorConfig(BaseModel):
+    """Single monitor definition from ``.dango/monitors.yml``."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
 
     name: str
     source_table: str
     value_expression: str
     filter: str | None = None
     compare: ComparisonType = ComparisonType.week_over_week
-    warn_threshold: float | None = None
+    alert_threshold: float | None = Field(
+        default=None,
+        validation_alias=AliasChoices("alert_threshold", "warn_threshold"),
+    )
     drill_down: list[str] = Field(default_factory=list)
 
     @field_validator("name")
@@ -55,7 +58,7 @@ class MetricConfig(BaseModel):
     def _name_is_slug(cls, v: str) -> str:
         if not _SLUG_RE.match(v):
             msg = (
-                f"Metric name must be lowercase alphanumeric with underscores, "
+                f"Monitor name must be lowercase alphanumeric with underscores, "
                 f"starting with a letter: {v!r}"
             )
             raise ValueError(msg)
@@ -77,22 +80,33 @@ class MetricConfig(BaseModel):
             raise ValueError(msg)
         return v
 
-    @field_validator("warn_threshold")
+    @field_validator("alert_threshold")
     @classmethod
-    def _warn_threshold_positive(cls, v: float | None) -> float | None:
+    def _alert_threshold_positive(cls, v: float | None) -> float | None:
         if v is not None and v <= 0:
-            msg = f"warn_threshold must be positive: {v}"
+            msg = f"alert_threshold must be positive: {v}"
             raise ValueError(msg)
         return v
 
 
-class MetricsConfig(BaseModel):
-    """Top-level metrics configuration from ``.dango/metrics.yml``."""
+# Backward-compatible aliases
+MetricConfig = MonitorConfig
 
-    model_config = ConfigDict(frozen=True)
 
-    metrics: list[MetricConfig] = Field(default_factory=list)
+class MonitorsConfig(BaseModel):
+    """Top-level monitors configuration from ``.dango/monitors.yml``."""
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    monitors: list[MonitorConfig] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("monitors", "metrics"),
+    )
     enabled: bool = True
+
+
+# Backward-compatible alias
+MetricsConfig = MonitorsConfig
 
 
 # ---------------------------------------------------------------------------

--- a/dango/analysis/templates.py
+++ b/dango/analysis/templates.py
@@ -2,7 +2,7 @@
 
 Pre-built metric templates for common data sources.
 
-Generates sensible default ``MetricConfig`` objects when users add a new source,
+Generates sensible default ``MonitorConfig`` objects when users add a new source,
 so analysis starts working automatically from the first sync.
 """
 
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from dango.analysis.models import ComparisonType, MetricConfig
+from dango.analysis.models import ComparisonType, MonitorConfig
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -23,7 +23,7 @@ def generate_metrics_for_source(
     source_name: str,
     *,
     project_root: Path | None = None,
-) -> list[MetricConfig]:
+) -> list[MonitorConfig]:
     """Generate pre-built metric templates for a data source.
 
     Args:
@@ -33,7 +33,7 @@ def generate_metrics_for_source(
             When provided, GA4 templates use actual column names from the warehouse.
 
     Returns:
-        A list of ``MetricConfig`` objects.  Empty if the source type has no
+        A list of ``MonitorConfig`` objects.  Empty if the source type has no
         pre-built templates or if the warehouse hasn't been synced yet.
     """
     generators = {
@@ -53,40 +53,40 @@ def generate_metrics_for_source(
 # ---------------------------------------------------------------------------
 
 
-def _stripe_metrics(name: str) -> list[MetricConfig]:
+def _stripe_metrics(name: str) -> list[MonitorConfig]:
     """Stripe metrics: revenue, customers, refund rate, AOV."""
     schema = f"raw_{name}"
     return [
-        MetricConfig(
+        MonitorConfig(
             name=f"{name}_daily_revenue",
             source_table=f"{schema}.charge",
             value_expression="SUM(amount) / 100.0",
             filter="status = 'succeeded'",
             compare=ComparisonType.week_over_week,
-            warn_threshold=20.0,
+            alert_threshold=20.0,
             drill_down=["currency"],
         ),
-        MetricConfig(
+        MonitorConfig(
             name=f"{name}_new_customers",
             source_table=f"{schema}.customer",
             value_expression="COUNT(*)",
             compare=ComparisonType.week_over_week,
-            warn_threshold=25.0,
+            alert_threshold=25.0,
         ),
-        MetricConfig(
+        MonitorConfig(
             name=f"{name}_refund_rate",
             source_table=f"{schema}.charge",
             value_expression=("COUNT(CASE WHEN refunded THEN 1 END) * 100.0 / NULLIF(COUNT(*), 0)"),
             compare=ComparisonType.rolling_7day_avg,
-            warn_threshold=50.0,
+            alert_threshold=50.0,
         ),
-        MetricConfig(
+        MonitorConfig(
             name=f"{name}_avg_order_value",
             source_table=f"{schema}.charge",
             value_expression="AVG(amount) / 100.0",
             filter="status = 'succeeded'",
             compare=ComparisonType.rolling_7day_avg,
-            warn_threshold=15.0,
+            alert_threshold=15.0,
         ),
     ]
 
@@ -104,7 +104,7 @@ def _google_analytics_metrics(
     name: str,
     *,
     project_root: Path | None = None,
-) -> list[MetricConfig]:
+) -> list[MonitorConfig]:
     """Google Analytics metrics using actual DuckDB column names.
 
     When ``project_root`` is provided and the warehouse contains the GA4 traffic
@@ -122,26 +122,26 @@ def _google_analytics_metrics(
     # Find drill-down column for sessions (any column containing "source")
     source_col = next((c for c in columns if "source" in c.lower()), None)
 
-    metrics: list[MetricConfig] = []
+    metrics: list[MonitorConfig] = []
     for keyword, exclude, suffix, agg, compare, threshold in _GA4_METRIC_DEFS:
         col = _find_column(columns, keyword, exclude)
         if col is None:
             continue
         drill = [source_col] if source_col and suffix == "daily_sessions" else []
         metrics.append(
-            MetricConfig(
+            MonitorConfig(
                 name=f"{name}_{suffix}",
                 source_table=f"{schema}.{table}",
                 value_expression=f"{agg}({col})",
                 compare=compare,
-                warn_threshold=threshold,
+                alert_threshold=threshold,
                 drill_down=drill,
             )
         )
     return metrics
 
 
-def _csv_metrics(name: str) -> list[MetricConfig]:
+def _csv_metrics(name: str) -> list[MonitorConfig]:
     """CSV metrics: skipped — table name unknown until first sync.
 
     CSV table names derive from filenames, unknown at source-add time.
@@ -150,7 +150,7 @@ def _csv_metrics(name: str) -> list[MetricConfig]:
     return []
 
 
-def _generic_metrics(name: str, project_root: Path | None) -> list[MetricConfig]:
+def _generic_metrics(name: str, project_root: Path | None) -> list[MonitorConfig]:
     """Generate generic row-count and freshness metrics by discovering tables.
 
     Queries ``information_schema.tables`` for the ``raw_{name}`` schema,
@@ -194,27 +194,27 @@ def _generic_metrics(name: str, project_root: Path | None) -> list[MetricConfig]
     except Exception:
         return []
 
-    metrics: list[MetricConfig] = []
+    metrics: list[MonitorConfig] = []
     for (table_name,) in tables:
         sanitized = _sanitize_table_name(table_name)
         metrics.append(
-            MetricConfig(
+            MonitorConfig(
                 name=f"{name}_{sanitized}_row_count",
                 source_table=f"{schema}.{table_name}",
                 value_expression="COUNT(*)",
                 compare=ComparisonType.week_over_week,
-                warn_threshold=25.0,
+                alert_threshold=25.0,
             )
         )
         # Add freshness metric only if _dlt_load_id column exists
         if table_name in tables_with_load_id:
             metrics.append(
-                MetricConfig(
+                MonitorConfig(
                     name=f"{name}_{sanitized}_freshness",
                     source_table=f"{schema}.{table_name}",
                     value_expression="MAX(_dlt_load_id)",
                     compare=ComparisonType.week_over_week,
-                    warn_threshold=25.0,
+                    alert_threshold=25.0,
                 )
             )
     return metrics

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -67,7 +67,8 @@ class AuditEvent(str, Enum):
     GOVERNANCE_DRIFT_VIEWED      = "governance_drift_viewed"
     GOVERNANCE_PII_VIEWED        = "governance_pii_viewed"
     CATALOG_VIEWED               = "catalog_viewed"
-    INSIGHTS_VIEWED              = "insights_viewed"
+    MONITORING_VIEWED             = "monitoring_viewed"
+    INSIGHTS_VIEWED              = "monitoring_viewed"  # deprecated alias
     AI_CATALOG_VIEWED            = "ai_catalog_viewed"
     DEPLOYMENT_HISTORY_VIEWED    = "deployment_history_viewed"
     GOVERNANCE_PII_OVERRIDE_SET     = "governance_pii_override_set"

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -38,7 +38,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/schedule.py` (743 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/governance.py` (208 lines) | `governance` group (drift-report, pii-report, pii-set, pii-list) | `governance`, `drift_report()`, `pii_report()`, `pii_set()`, `pii_list()` |
 | `commands/notebook.py` (179 lines) | `notebook` group (new, open) + `snapshot` top-level | `notebook`, `notebook_new()`, `notebook_open()`, `snapshot()` |
-| `commands/analyze.py` (81 lines) | `analyze` top-level command | `analyze()` |
+| `commands/analyze.py` (~95 lines) | `monitor` group + `analyze` alias | `monitor` (group), `monitor_run()`, `analyze()` |
 | `commands/web.py` (66 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
 | `init.py` (1324 lines) | Project initialization wizard | `ProjectInitializer` |
@@ -108,7 +108,9 @@ dango (top-level group)
 │   ├── (default)  interactive wizard (DO or BYOS) → deploy_wizard.py + deploy_provision.py
 │   ├── --byos     deploy to existing server (any provider)
 │   └── destroy    tear down cloud infrastructure (DO resources or BYOS config)
-├── analyze                     ← commands/analyze.py
+├── analyze                     ← commands/analyze.py (alias for monitor run)
+├── monitor (group)             ← commands/analyze.py
+│   ├── run
 ├── snapshot                    ← commands/notebook.py
 ├── governance (group)          ← commands/governance.py
 │   ├── drift-report, pii-report, pii-set, pii-list

--- a/dango/cli/commands/analyze.py
+++ b/dango/cli/commands/analyze.py
@@ -1,6 +1,9 @@
 """dango/cli/commands/analyze.py
 
-CLI command for running metric analysis and displaying results.
+CLI commands for running monitor analysis and displaying results.
+
+Provides ``dango monitor run`` as the canonical command and
+``dango analyze`` as a backward-compatible alias.
 """
 
 from __future__ import annotations
@@ -10,11 +13,16 @@ import click
 from dango.cli import console
 
 
-@click.command("analyze")
+@click.group("monitor")
+def monitor() -> None:
+    """Monitor data quality."""
+
+
+@monitor.command("run")
 @click.option("--source", default=None, help="Filter by source name.")
 @click.pass_context
-def analyze(ctx: click.Context, source: str | None) -> None:
-    """Run metric analysis and display results."""
+def monitor_run(ctx: click.Context, source: str | None) -> None:
+    """Run monitor analysis and display results."""
     from rich.table import Table
 
     from dango.analysis.formatter import categorize_results
@@ -33,14 +41,14 @@ def analyze(ctx: click.Context, source: str | None) -> None:
     results = run_analysis(project_root, source_filter=source_filter)
 
     if not results:
-        console.print("[dim]No metrics configured or no data available.[/dim]")
+        console.print("[dim]No monitors configured or no data available.[/dim]")
         return
 
     categorized = categorize_results(results)
 
-    tbl = Table(title="Metric Analysis")
+    tbl = Table(title="Monitor Results")
     tbl.add_column("Status")
-    tbl.add_column("Metric", style="bold")
+    tbl.add_column("Monitor", style="bold")
     tbl.add_column("Value", justify="right")
     tbl.add_column("Change", justify="right")
     tbl.add_column("Trend")
@@ -79,3 +87,11 @@ def analyze(ctx: click.Context, source: str | None) -> None:
                     f"{contrib['change_pct']:+.1f}%" if contrib["change_pct"] is not None else "-"
                 )
                 console.print(f"      {group}: {cpct}")
+
+
+@click.command("analyze")
+@click.option("--source", default=None, help="Filter by source name.")
+@click.pass_context
+def analyze(ctx: click.Context, source: str | None) -> None:
+    """Run monitor analysis and display results (alias for 'monitor run')."""
+    ctx.invoke(monitor_run, source=source)

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -65,8 +65,8 @@ class ProjectInitializer:
             # Save configuration
             self.loader.save_config(config)
 
-            # Create metrics config
-            self._create_metrics_config(force=force)
+            # Create monitors config
+            self._create_monitors_config(force=force)
 
             # Create default .gitignore
             self._create_gitignore()
@@ -152,27 +152,27 @@ class ProjectInitializer:
 
         return DangoConfig(project=project, sources=sources)
 
-    def _create_metrics_config(self, *, force: bool = False) -> None:
-        """Create ``.dango/metrics.yml`` with default analysis metrics.
+    def _create_monitors_config(self, *, force: bool = False) -> None:
+        """Create ``.dango/monitors.yml`` with default monitors.
 
         Fresh init creates an empty config.  ``--force`` re-init with existing
         sources generates templates for configured source types by reading
         the on-disk ``sources.yml`` (not the wizard config, which is blank).
         """
         try:
-            from dango.analysis.config import save_metrics_config
-            from dango.analysis.models import MetricsConfig
+            from dango.analysis.config import save_monitors_config
+            from dango.analysis.models import MonitorsConfig
             from dango.analysis.templates import generate_metrics_for_source
 
-            all_metrics = []  # type: ignore[var-annotated]
+            all_monitors = []  # type: ignore[var-annotated]
             if force:
                 existing_config = self.loader.load_config()
                 if existing_config.sources and existing_config.sources.sources:
                     for src in existing_config.sources.sources:
-                        all_metrics.extend(generate_metrics_for_source(src.type, src.name))
+                        all_monitors.extend(generate_metrics_for_source(src.type, src.name))
 
-            metrics_config = MetricsConfig(enabled=True, metrics=all_metrics)
-            save_metrics_config(self.project_dir, metrics_config)
+            monitors_config = MonitorsConfig(enabled=True, monitors=all_monitors)
+            save_monitors_config(self.project_dir, monitors_config)
         except Exception:
             pass  # Non-critical — never block init
 

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -9,7 +9,7 @@ top-level ``cli`` group with version info and project-root discovery.
 import click
 
 from dango import __version__
-from dango.cli.commands.analyze import analyze
+from dango.cli.commands.analyze import analyze, monitor
 from dango.cli.commands.auth import auth
 from dango.cli.commands.cleanup import cleanup
 from dango.cli.commands.config_cmd import config
@@ -110,6 +110,7 @@ cli.add_command(notebook)
 cli.add_command(schedule)
 cli.add_command(deploy)
 cli.add_command(governance)
+cli.add_command(monitor)
 
 
 def main() -> None:

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -307,7 +307,7 @@ class SourceWizard:
                         "\n[bold]Enable automatic analysis?[/bold]",
                         default=True,
                     ):
-                        from dango.analysis.config import add_metrics_to_config
+                        from dango.analysis.config import add_monitors_to_config
 
                         header = None
                         if source_type in ("csv", "local_files"):
@@ -316,10 +316,10 @@ class SourceWizard:
                                 f" schema. Replace 'your_table' with your actual"
                                 f" table name after first sync."
                             )
-                        add_metrics_to_config(self.project_root, templates, header_comment=header)
+                        add_monitors_to_config(self.project_root, templates, header_comment=header)
                         console.print(
                             f"[green]✅ Added {len(templates)} analysis"
-                            f" metric(s) to metrics.yml[/green]"
+                            f" monitor(s) to monitors.yml[/green]"
                         )
             except Exception:
                 pass  # Never block source add

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -405,12 +405,12 @@ def _run_analysis(project_root: Path, sources: list[str]) -> None:
 def _ensure_ga4_metrics(project_root: Path, sources: list[str]) -> None:
     """Generate GA4 metric templates if not already present.  Never raises."""
     try:
-        from dango.analysis.config import add_metrics_to_config, load_metrics_config
+        from dango.analysis.config import add_monitors_to_config, load_monitors_config
         from dango.analysis.templates import generate_metrics_for_source
         from dango.config import get_config
 
         config = get_config(project_root)
-        existing_names = {m.name for m in load_metrics_config(project_root).metrics}
+        existing_names = {m.name for m in load_monitors_config(project_root).monitors}
         for source in config.sources.sources:
             if source.type.value != "google_analytics" or source.name not in sources:
                 continue
@@ -422,7 +422,7 @@ def _ensure_ga4_metrics(project_root: Path, sources: list[str]) -> None:
                 if m.name not in existing_names
             ]
             if new:
-                add_metrics_to_config(project_root, new)
+                add_monitors_to_config(project_root, new)
                 logger.info("ga4_metrics_auto_generated", source=source.name, count=len(new))
     except Exception:
         logger.debug("ga4_metrics_auto_generate_skipped", exc_info=True)

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -14,7 +14,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `__init__.py` | Public exports | `app` module |
 | `middleware/auth.py` | Session/API key auth + CSRF check on every request (~325 lines) | `AuthMiddleware`, `is_secure_request()`, `COOKIE_NAME` |
 | `middleware/rate_limit.py` | Rate limiting (login 10/min, API 200/min, localhost exempt, ~212 lines) | `RateLimitMiddleware` |
-| `templates/base.html` | Shared Jinja2 layout: head (compiled Tailwind CSS), header, nav bar (9-item flat: Overview/Sources/Models/Schedules/Catalog/Query/Dashboards/Notebooks/Insights + gear dropdown), responsive hamburger menu, footer, script blocks | Blocks: `title`, `subtitle_attrs`, `header_right`, `nav`, `content`, `footer`, `scripts` |
+| `templates/base.html` | Shared Jinja2 layout: head (compiled Tailwind CSS), header, nav bar (9-item flat: Overview/Sources/Models/Schedules/Catalog/Query/Dashboards/Notebooks/Monitoring + gear dropdown), responsive hamburger menu, footer, script blocks | Blocks: `title`, `subtitle_attrs`, `header_right`, `nav`, `content`, `footer`, `scripts` |
 | `templates/error.html` | HTML error page (extends `base.html`) — status code, title, message, back/home links | Rendered by `dango_error_handler()` for browser 401/403 requests |
 | `templates/dashboard.html` | Overview page (extends `base.html`) — health widget, service cards, activity log | Loads `app.js` |
 | `templates/sources.html` | Sources page (extends `base.html`) — source table, sync controls, upload/detail modals | Loads `app.js` |
@@ -47,13 +47,13 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~490 lines) | `router` |
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1286 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
-| `routes/insights.py` | Metric results, run trigger, history (~272 lines) | `router` |
+| `routes/monitoring.py` | Monitor results, run trigger, history + backward-compat redirects for old `/api/insights*` paths (~295 lines) | `router` |
 | `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~496 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |
 | `templates/catalog.html` | Data catalog page (extends `base.html`) — model browser, search, detail view, code view, profiling, lineage (872 lines) | Alpine.js `catalogPage()` component |
-| `templates/insights.html` | Insights/analysis page (extends `base.html`) — metric results, trends (~153 lines) | Alpine.js `insightsPage()` component |
+| `templates/monitoring.html` | Monitoring page (extends `base.html`) — monitor results, trends (~153 lines) | Alpine.js `monitoringPage()` component |
 | `static/` | CSS and JS assets (`css/tailwind.min.css` (compiled), `css/main.css`, `css/catalog.css`, `css/input.css` (Tailwind source), `js/app.js`, `js/logs.js`, `js/lineage.js`, `js/catalog.js`) | — |
 
 ## Architecture

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -399,9 +399,9 @@ from dango.web.routes.dbt import router as dbt_router  # noqa: E402
 from dango.web.routes.governance import router as governance_router  # noqa: E402
 from dango.web.routes.health import router as health_router  # noqa: E402
 from dango.web.routes.initial_sync import router as initial_sync_router  # noqa: E402
-from dango.web.routes.insights import router as insights_router  # noqa: E402
 from dango.web.routes.logs import router as logs_router  # noqa: E402
 from dango.web.routes.metabase_proxy import router as metabase_proxy_router  # noqa: E402
+from dango.web.routes.monitoring import router as monitoring_router  # noqa: E402
 from dango.web.routes.notebooks import router as notebooks_router  # noqa: E402
 from dango.web.routes.oauth_connect import router as oauth_connect_router  # noqa: E402
 from dango.web.routes.query import router as query_router  # noqa: E402
@@ -432,7 +432,7 @@ app.include_router(schedules_router)
 app.include_router(catalog_router)
 app.include_router(governance_router)
 app.include_router(query_router)
-app.include_router(insights_router)
+app.include_router(monitoring_router)
 app.include_router(ai_router)
 app.include_router(notebooks_router)
 app.include_router(websocket_router)

--- a/dango/web/routes/monitoring.py
+++ b/dango/web/routes/monitoring.py
@@ -287,18 +287,24 @@ async def get_metric_history(
 
 
 @router.get("/api/insights")
-async def redirect_insights_get() -> RedirectResponse:
+async def redirect_insights_get(
+    user: User = Depends(require_permission("governance.view")),
+) -> RedirectResponse:
     """Redirect old GET /api/insights to /api/monitoring."""
     return RedirectResponse(url="/api/monitoring", status_code=301)
 
 
 @router.post("/api/insights/run")
-async def redirect_insights_run() -> RedirectResponse:
+async def redirect_insights_run(
+    user: User = Depends(require_permission("governance.view")),
+) -> RedirectResponse:
     """Redirect old POST /api/insights/run to /api/monitoring/run."""
     return RedirectResponse(url="/api/monitoring/run", status_code=307)
 
 
 @router.get("/api/insights/history")
-async def redirect_insights_history() -> RedirectResponse:
+async def redirect_insights_history(
+    user: User = Depends(require_permission("governance.view")),
+) -> RedirectResponse:
     """Redirect old GET /api/insights/history to /api/monitoring/history."""
     return RedirectResponse(url="/api/monitoring/history", status_code=301)

--- a/dango/web/routes/monitoring.py
+++ b/dango/web/routes/monitoring.py
@@ -1,6 +1,6 @@
-"""dango/web/routes/insights.py
+"""dango/web/routes/monitoring.py
 
-Automated insights API endpoints.
+Automated monitoring API endpoints.
 
 Provides read access to cached analysis results, on-demand analysis execution,
 and metric history queries.
@@ -15,6 +15,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, ConfigDict
+from starlette.responses import RedirectResponse
 
 from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
@@ -25,7 +26,7 @@ from dango.web.helpers import get_project_root
 
 logger = get_logger(__name__)
 
-router = APIRouter(tags=["insights"])
+router = APIRouter(tags=["monitoring"])
 
 
 # ---------------------------------------------------------------------------
@@ -33,8 +34,8 @@ router = APIRouter(tags=["insights"])
 # ---------------------------------------------------------------------------
 
 
-class InsightMetric(BaseModel):
-    """A single metric in the insights response."""
+class MonitorMetric(BaseModel):
+    """A single metric in the monitoring response."""
 
     model_config = ConfigDict(frozen=True)
 
@@ -53,14 +54,22 @@ class InsightMetric(BaseModel):
     error: str | None = None
 
 
-class InsightsResponse(BaseModel):
-    """Response for insights endpoints."""
+# Backward-compatible alias
+InsightMetric = MonitorMetric
+
+
+class MonitoringResponse(BaseModel):
+    """Response for monitoring endpoints."""
 
     model_config = ConfigDict(frozen=True)
 
-    metrics: list[InsightMetric]
+    metrics: list[MonitorMetric]
     total: int
     flagged: int
+
+
+# Backward-compatible alias
+InsightsResponse = MonitoringResponse
 
 
 class HistoryPoint(BaseModel):
@@ -87,18 +96,18 @@ class MetricHistoryResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _build_insights_response(categorized: list[dict]) -> InsightsResponse:  # type: ignore[type-arg]
-    """Build an ``InsightsResponse`` from categorised result dicts.
+def _build_monitoring_response(categorized: list[dict]) -> MonitoringResponse:  # type: ignore[type-arg]
+    """Build a ``MonitoringResponse`` from categorised result dicts.
 
     Args:
         categorized: Output of ``categorize_results()``.
 
     Returns:
-        An ``InsightsResponse`` with metric list, total, and flagged count.
+        A ``MonitoringResponse`` with metric list, total, and flagged count.
     """
-    metrics = [InsightMetric(**m) for m in categorized]
+    metrics = [MonitorMetric(**m) for m in categorized]
     flagged_count = sum(1 for m in metrics if m.status == "flagged")
-    return InsightsResponse(metrics=metrics, total=len(metrics), flagged=flagged_count)
+    return MonitoringResponse(metrics=metrics, total=len(metrics), flagged=flagged_count)
 
 
 def _read_cached_results(project_root: Path) -> list[dict[str, Any]]:
@@ -106,7 +115,7 @@ def _read_cached_results(project_root: Path) -> list[dict[str, Any]]:
 
     Queries ``metric_history`` for latest values and ``metric_results`` for
     latest comparison data per metric.  Returns categorised dicts ready for
-    ``_build_insights_response()``.
+    ``_build_monitoring_response()``.
 
     Args:
         project_root: Path to the Dango project root.
@@ -197,32 +206,32 @@ def _read_cached_results(project_root: Path) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/insights")
-async def get_insights(
+@router.get("/api/monitoring")
+async def get_monitoring(
     user: User = Depends(require_permission("governance.view")),
-) -> InsightsResponse:
+) -> MonitoringResponse:
     """Read latest cached analysis results.
 
     Returns categorised metrics from the most recent analysis run.
-    Does not execute new analysis — use ``POST /api/insights/run`` for that.
+    Does not execute new analysis — use ``POST /api/monitoring/run`` for that.
     """
-    log_auth_event(AuditEvent.INSIGHTS_VIEWED, user_id=user.id, email=user.email)
+    log_auth_event(AuditEvent.MONITORING_VIEWED, user_id=user.id, email=user.email)
 
     project_root = get_project_root()
     categorized = await asyncio.to_thread(_read_cached_results, project_root)
-    return _build_insights_response(categorized)
+    return _build_monitoring_response(categorized)
 
 
-@router.post("/api/insights/run")
-async def run_insights(
+@router.post("/api/monitoring/run")
+async def run_monitoring(
     source: str | None = Query(None, description="Filter by source name"),
     user: User = Depends(require_permission("governance.view")),
-) -> InsightsResponse:
+) -> MonitoringResponse:
     """Execute a fresh analysis run (state-mutating).
 
     Optionally filter by source name.
     """
-    log_auth_event(AuditEvent.INSIGHTS_VIEWED, user_id=user.id, email=user.email)
+    log_auth_event(AuditEvent.MONITORING_VIEWED, user_id=user.id, email=user.email)
 
     project_root = get_project_root()
 
@@ -236,10 +245,10 @@ async def run_insights(
 
     results = await asyncio.to_thread(run_analysis, project_root, source_filter=source_filter)
     categorized = categorize_results(results)
-    return _build_insights_response(categorized)
+    return _build_monitoring_response(categorized)
 
 
-@router.get("/api/insights/history")
+@router.get("/api/monitoring/history")
 async def get_metric_history(
     metric: str = Query(..., description="Metric name"),
     days: int = Query(30, ge=1, le=365, description="Days of history"),
@@ -249,7 +258,7 @@ async def get_metric_history(
 
     Returns up to ``days`` worth of historical data points.
     """
-    log_auth_event(AuditEvent.INSIGHTS_VIEWED, user_id=user.id, email=user.email)
+    log_auth_event(AuditEvent.MONITORING_VIEWED, user_id=user.id, email=user.email)
 
     validated_metric = validate_identifier(metric)
     project_root = get_project_root()
@@ -270,3 +279,26 @@ async def get_metric_history(
 
     data_points = await asyncio.to_thread(_query_history)
     return MetricHistoryResponse(metric=validated_metric, days=days, data_points=data_points)
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible redirects for old /api/insights* paths
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/insights")
+async def redirect_insights_get() -> RedirectResponse:
+    """Redirect old GET /api/insights to /api/monitoring."""
+    return RedirectResponse(url="/api/monitoring", status_code=301)
+
+
+@router.post("/api/insights/run")
+async def redirect_insights_run() -> RedirectResponse:
+    """Redirect old POST /api/insights/run to /api/monitoring/run."""
+    return RedirectResponse(url="/api/monitoring/run", status_code=307)
+
+
+@router.get("/api/insights/history")
+async def redirect_insights_history() -> RedirectResponse:
+    """Redirect old GET /api/insights/history to /api/monitoring/history."""
+    return RedirectResponse(url="/api/monitoring/history", status_code=301)

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -169,26 +169,32 @@ async def catalog_page(
     )
 
 
-@router.get("/insights")
-async def insights_page(
+@router.get("/monitoring")
+async def monitoring_page(
     request: Request,
     user: User = Depends(require_permission("governance.view")),
 ) -> HTMLResponse:
-    """Serve the insights page."""
+    """Serve the monitoring page."""
     log_auth_event(
-        AuditEvent.INSIGHTS_VIEWED,
+        AuditEvent.MONITORING_VIEWED,
         user_id=user.id,
         email=user.email,
     )
     return _render_template(
         request,
-        "insights.html",
+        "monitoring.html",
         {
             "version": dango.__version__,
-            "current_page": "insights",
-            "subtitle": "Insights",
+            "current_page": "monitoring",
+            "subtitle": "Monitoring",
         },
     )
+
+
+@router.get("/insights")
+async def insights_redirect() -> RedirectResponse:
+    """Redirect old /insights to /monitoring."""
+    return RedirectResponse(url="/monitoring", status_code=301)
 
 
 @router.get("/api")

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -68,8 +68,8 @@
                     <a href="/notebooks" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'notebooks' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
                         Notebooks
                     </a>
-                    <a href="/insights" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'insights' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
-                        Insights
+                    <a href="/monitoring" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'monitoring' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
+                        Monitoring
                     </a>
                 </div>
 
@@ -132,7 +132,7 @@
                 <a href="/metabase/question/new" target="_blank" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Query</a>
                 <a href="/metabase" target="_blank" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Dashboards</a>
                 <a href="/notebooks" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'notebooks' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Notebooks</a>
-                <a href="/insights" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'insights' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Insights</a>
+                <a href="/monitoring" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'monitoring' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Monitoring</a>
             </div>
             {% if request.state.user %}
             <div class="border-t border-gray-700 px-2 pt-2 pb-3 space-y-1">

--- a/dango/web/templates/monitoring.html
+++ b/dango/web/templates/monitoring.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
-{% block title %}Insights - Dango{% endblock %}
+{% block title %}Monitoring - Dango{% endblock %}
 {% block content %}
 <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
-    <div x-data="insightsPage()" x-init="init()" x-cloak>
+    <div x-data="monitoringPage()" x-init="init()" x-cloak>
         <div x-show="error" x-cloak class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
             <p class="text-sm text-red-700" x-text="error"></p>
         </div>
         <!-- Header -->
         <div class="flex items-center justify-between mb-6">
             <div>
-                <h2 class="text-xl font-bold text-gray-900">Insights</h2>
+                <h2 class="text-xl font-bold text-gray-900">Monitoring</h2>
                 <p class="text-sm text-gray-500 mt-1">
-                    <span x-text="metrics.length"></span> metrics<template x-if="flaggedCount > 0">, <span class="text-red-600 font-medium" x-text="flaggedCount + ' flagged'"></span></template>
+                    <span x-text="metrics.length"></span> monitors<template x-if="flaggedCount > 0">, <span class="text-red-600 font-medium" x-text="flaggedCount + ' flagged'"></span></template>
                 </p>
             </div>
             <button @click="runAnalysis()" :disabled="running"
@@ -21,12 +21,12 @@
             </button>
         </div>
         <div x-show="loading" x-cloak class="flex items-center justify-center py-12">
-            <div class="text-gray-400 text-sm">Loading insights...</div>
+            <div class="text-gray-400 text-sm">Loading monitors...</div>
         </div>
         <!-- No data -->
         <template x-if="!loading && metrics.length === 0">
             <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
-                No metrics configured or no data available. Configure metrics in <code>.dango/metrics.yml</code>.
+                No monitors configured or no data available. Configure monitors in <code>.dango/monitors.yml</code>.
             </div>
         </template>
         <!-- Metric cards -->
@@ -103,25 +103,25 @@
 {% endblock %}
 {% block scripts %}
 <script>
-function insightsPage() {
+function monitoringPage() {
     return {
         metrics: [], flaggedCount: 0, loading: true, running: false, error: null,
         historyMetric: null, historyData: [], historyLoading: false,
         async init() {
             try {
-                const res = await fetch('/api/insights', {headers: {'X-Requested-With': 'XMLHttpRequest'}});
+                const res = await fetch('/api/monitoring', {headers: {'X-Requested-With': 'XMLHttpRequest'}});
                 if (res.ok) {
                     const data = await res.json();
                     this.metrics = data.metrics.map(m => ({...m, _expanded: false}));
                     this.flaggedCount = data.flagged;
-                } else { this.error = 'Failed to load insights.'; }
-            } catch (e) { this.error = 'Failed to load insights.'; }
+                } else { this.error = 'Failed to load monitors.'; }
+            } catch (e) { this.error = 'Failed to load monitors.'; }
             finally { this.loading = false; }
         },
         async runAnalysis() {
             this.running = true; this.error = null;
             try {
-                const res = await fetch('/api/insights/run', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}});
+                const res = await fetch('/api/monitoring/run', {method: 'POST', headers: {'X-Requested-With': 'XMLHttpRequest'}});
                 if (res.ok) {
                     const data = await res.json();
                     this.metrics = data.metrics.map(m => ({...m, _expanded: false}));
@@ -134,7 +134,7 @@ function insightsPage() {
             if (this.historyMetric === metricName) { this.historyMetric = null; this.historyData = []; return; }
             this.historyMetric = metricName; this.historyLoading = true; this.historyData = [];
             try {
-                const res = await fetch('/api/insights/history?metric=' + encodeURIComponent(metricName) + '&days=30', {headers: {'X-Requested-With': 'XMLHttpRequest'}});
+                const res = await fetch('/api/monitoring/history?metric=' + encodeURIComponent(metricName) + '&days=30', {headers: {'X-Requested-With': 'XMLHttpRequest'}});
                 if (res.ok) { const data = await res.json(); this.historyData = data.data_points; }
             } catch (e) { /* silent */ }
             finally { this.historyLoading = false; }

--- a/tests/integration/test_analysis_integration.py
+++ b/tests/integration/test_analysis_integration.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import duckdb
 import pytest
 
-from dango.analysis.config import save_metrics_config
-from dango.analysis.models import ComparisonType, MetricConfig, MetricsConfig
+from dango.analysis.config import save_monitors_config
+from dango.analysis.models import ComparisonType, MonitorConfig, MonitorsConfig
 from dango.utils.dango_db import _schema_initialized, connect
 from dango.utils.post_sync import dispatch_post_sync_hooks
 
@@ -58,21 +58,21 @@ class TestAnalysisHookIntegration:
         _clear_schema_cache()
         _create_test_warehouse(tmp_path)
 
-        # Create metrics config
-        config = MetricsConfig(
+        # Create monitors config
+        config = MonitorsConfig(
             enabled=True,
-            metrics=[
-                MetricConfig(
+            monitors=[
+                MonitorConfig(
                     name="testshop_order_total",
                     source_table="raw_testshop.orders",
                     value_expression="SUM(total)",
                     filter="status = 'succeeded'",
                     compare=ComparisonType.week_over_week,
-                    warn_threshold=20.0,
+                    alert_threshold=20.0,
                 ),
             ],
         )
-        save_metrics_config(tmp_path, config)
+        save_monitors_config(tmp_path, config)
 
         # Run via dispatcher (full hook boundary)
         dispatch_post_sync_hooks(tmp_path, ["testshop"])

--- a/tests/integration/test_phase7_gate.py
+++ b/tests/integration/test_phase7_gate.py
@@ -18,9 +18,9 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-from dango.analysis.config import save_metrics_config
+from dango.analysis.config import save_monitors_config
 from dango.analysis.drilldown import run_drill_down
-from dango.analysis.models import ComparisonType, MetricConfig, MetricsConfig
+from dango.analysis.models import ComparisonType, MonitorConfig, MonitorsConfig
 from dango.exceptions import (
     AuthenticationError,
     DangoError,
@@ -119,7 +119,7 @@ class TestRouteRegistration:
             "/api/catalog/{source}/{table}/columns",
             "/api/governance/schema-drift",
             "/api/governance/pii",
-            "/api/insights",
+            "/api/monitoring",
             "/api/notebooks",
         ]
         for path in expected:
@@ -135,11 +135,12 @@ class TestCLIRegistration:
     """Phase 7 CLI commands are registered."""
 
     def test_cli_commands_registered(self) -> None:
-        """governance, notebook, and analyze commands exist."""
+        """governance, notebook, monitor, and analyze commands exist."""
         from dango.cli.main import cli
 
         assert "governance" in cli.commands
         assert "notebook" in cli.commands
+        assert "monitor" in cli.commands
         assert "analyze" in cli.commands
 
 
@@ -157,21 +158,21 @@ class TestFullPipelineEndToEnd:
         _clear_schema_cache()
         _create_test_warehouse(tmp_path)
 
-        # Set up metrics config so the analysis hook has work to do
-        config = MetricsConfig(
+        # Set up monitors config so the analysis hook has work to do
+        config = MonitorsConfig(
             enabled=True,
-            metrics=[
-                MetricConfig(
+            monitors=[
+                MonitorConfig(
                     name="gate_order_total",
                     source_table="raw_testshop.orders",
                     value_expression="SUM(total)",
                     filter="status = 'succeeded'",
                     compare=ComparisonType.week_over_week,
-                    warn_threshold=20.0,
+                    alert_threshold=20.0,
                 ),
             ],
         )
-        save_metrics_config(tmp_path, config)
+        save_monitors_config(tmp_path, config)
 
         # Run the full hook chain — mock PII analyzer to avoid spaCy
         with patch("dango.governance.pii_detector._get_analyzer", return_value=None):
@@ -224,17 +225,17 @@ class TestAnalysisWithDrillDown:
         _clear_schema_cache()
         db_path = _create_test_warehouse(tmp_path)
 
-        # Set up metrics with a drill-down dimension
-        metric = MetricConfig(
+        # Set up monitors with a drill-down dimension
+        metric = MonitorConfig(
             name="gate_drilldown_total",
             source_table="raw_testshop.orders",
             value_expression="SUM(total)",
             compare=ComparisonType.week_over_week,
-            warn_threshold=20.0,
+            alert_threshold=20.0,
             drill_down=["status"],
         )
-        config = MetricsConfig(enabled=True, metrics=[metric])
-        save_metrics_config(tmp_path, config)
+        config = MonitorsConfig(enabled=True, monitors=[metric])
+        save_monitors_config(tmp_path, config)
 
         # Run analysis via public API
         from dango.analysis import run_analysis
@@ -277,7 +278,7 @@ class TestRBACEnforcement:
         """FastAPI test client with auth middleware + Phase 7 routers."""
         from dango.web.routes.catalog import router as catalog_router
         from dango.web.routes.governance import router as governance_router
-        from dango.web.routes.insights import router as insights_router
+        from dango.web.routes.monitoring import router as monitoring_router
         from dango.web.routes.notebooks import router as notebooks_router
 
         # Set up auth database
@@ -294,7 +295,7 @@ class TestRBACEnforcement:
         app.add_middleware(AuthMiddleware, project_root=tmp_path, idle_timeout_minutes=60)
         app.include_router(catalog_router)
         app.include_router(governance_router)
-        app.include_router(insights_router)
+        app.include_router(monitoring_router)
         app.include_router(notebooks_router)
 
         @app.exception_handler(DangoError)
@@ -315,7 +316,7 @@ class TestRBACEnforcement:
         "path",
         [
             "/api/governance/schema-drift",
-            "/api/insights",
+            "/api/monitoring",
             "/api/catalog/test/test/columns",
             "/api/notebooks",
         ],

--- a/tests/unit/test_analysis_comparisons.py
+++ b/tests/unit/test_analysis_comparisons.py
@@ -97,7 +97,7 @@ class TestComputeComparison:
 
         mv = MetricValue(metric_name="revenue", value=110.0)
         result = compute_comparison(
-            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=15.0
+            tmp_path, mv, ComparisonType.week_over_week, alert_threshold=15.0
         )
         assert result.baseline_value == pytest.approx(100.0)
         assert result.change_pct == pytest.approx(10.0)
@@ -110,7 +110,7 @@ class TestComputeComparison:
 
         mv = MetricValue(metric_name="revenue", value=120.0)
         result = compute_comparison(
-            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=10.0
+            tmp_path, mv, ComparisonType.week_over_week, alert_threshold=10.0
         )
         assert result.exceeds_threshold is True
 
@@ -121,7 +121,7 @@ class TestComputeComparison:
 
         mv = MetricValue(metric_name="users", value=110.0)
         result = compute_comparison(
-            tmp_path, mv, ComparisonType.rolling_7day_avg, warn_threshold=None
+            tmp_path, mv, ComparisonType.rolling_7day_avg, alert_threshold=None
         )
         assert result.baseline_value is not None
         assert result.baseline_value == pytest.approx(103.0)
@@ -133,7 +133,7 @@ class TestComputeComparison:
 
         mv = MetricValue(metric_name="orders", value=60.0)
         result = compute_comparison(
-            tmp_path, mv, ComparisonType.rolling_30day_avg, warn_threshold=None
+            tmp_path, mv, ComparisonType.rolling_30day_avg, alert_threshold=None
         )
         assert result.baseline_value == pytest.approx(50.0)
 
@@ -143,14 +143,14 @@ class TestComputeComparison:
         _insert_history(tmp_path, "signups", 90.0, days_ago=0)
 
         mv = MetricValue(metric_name="signups", value=90.0)
-        result = compute_comparison(tmp_path, mv, ComparisonType.prior_period, warn_threshold=None)
+        result = compute_comparison(tmp_path, mv, ComparisonType.prior_period, alert_threshold=None)
         assert result.baseline_value == pytest.approx(80.0)
 
     def test_no_history_returns_none_baseline(self, tmp_path):
         """First run — no history returns None baseline and change_pct."""
         mv = MetricValue(metric_name="new_metric", value=100.0)
         result = compute_comparison(
-            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=10.0
+            tmp_path, mv, ComparisonType.week_over_week, alert_threshold=10.0
         )
         assert result.baseline_value is None
         assert result.change_pct is None
@@ -160,7 +160,7 @@ class TestComputeComparison:
         """Metric with None value returns minimal ComparisonResult."""
         mv = MetricValue(metric_name="broken", value=None, error="query failed")
         result = compute_comparison(
-            tmp_path, mv, ComparisonType.week_over_week, warn_threshold=10.0
+            tmp_path, mv, ComparisonType.week_over_week, alert_threshold=10.0
         )
         assert result.current_value is None
         assert result.baseline_value is None

--- a/tests/unit/test_analysis_config.py
+++ b/tests/unit/test_analysis_config.py
@@ -1,6 +1,6 @@
 """tests/unit/test_analysis_config.py
 
-Tests for metrics config loading and saving (dango/analysis/config.py).
+Tests for monitors config loading and saving (dango/analysis/config.py).
 """
 
 from __future__ import annotations
@@ -8,56 +8,71 @@ from __future__ import annotations
 import pytest
 
 from dango.analysis.config import (
-    add_metrics_to_config,
-    get_metrics_file_path,
-    load_metrics_config,
-    save_metrics_config,
+    add_monitors_to_config,
+    get_monitors_file_path,
+    load_monitors_config,
+    save_monitors_config,
 )
-from dango.analysis.models import ComparisonType, MetricConfig, MetricsConfig
+from dango.analysis.models import ComparisonType, MonitorConfig, MonitorsConfig
 from dango.exceptions import AnalysisConfigError
 
 
 @pytest.mark.unit
-class TestGetMetricsFilePath:
-    """get_metrics_file_path returns the expected path."""
+class TestGetMonitorsFilePath:
+    """get_monitors_file_path returns the expected path."""
 
-    def test_returns_path(self, tmp_path):
-        """Path is .dango/metrics.yml under project root."""
-        assert get_metrics_file_path(tmp_path) == tmp_path / ".dango" / "metrics.yml"
+    def test_returns_monitors_path(self, tmp_path):
+        """Path is .dango/monitors.yml for new projects."""
+        assert get_monitors_file_path(tmp_path) == tmp_path / ".dango" / "monitors.yml"
+
+    def test_falls_back_to_metrics_yml(self, tmp_path):
+        """Falls back to .dango/metrics.yml if it exists."""
+        metrics_dir = tmp_path / ".dango"
+        metrics_dir.mkdir()
+        (metrics_dir / "metrics.yml").write_text("enabled: true\n")
+        assert get_monitors_file_path(tmp_path) == tmp_path / ".dango" / "metrics.yml"
+
+    def test_prefers_monitors_yml(self, tmp_path):
+        """Prefers monitors.yml when both exist."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "metrics.yml").write_text("enabled: true\n")
+        (dango_dir / "monitors.yml").write_text("enabled: true\n")
+        assert get_monitors_file_path(tmp_path) == tmp_path / ".dango" / "monitors.yml"
 
 
 @pytest.mark.unit
-class TestLoadMetricsConfig:
-    """load_metrics_config loading behaviour."""
+class TestLoadMonitorsConfig:
+    """load_monitors_config loading behaviour."""
 
     def test_missing_file_returns_empty(self, tmp_path):
-        """Missing file returns empty MetricsConfig."""
-        cfg = load_metrics_config(tmp_path)
-        assert cfg.metrics == []
+        """Missing file returns empty MonitorsConfig."""
+        cfg = load_monitors_config(tmp_path)
+        assert cfg.monitors == []
         assert cfg.enabled is True
 
     def test_empty_file_returns_empty(self, tmp_path):
-        """Empty YAML file returns empty MetricsConfig."""
-        metrics_dir = tmp_path / ".dango"
-        metrics_dir.mkdir()
-        (metrics_dir / "metrics.yml").write_text("")
-        cfg = load_metrics_config(tmp_path)
-        assert cfg.metrics == []
+        """Empty YAML file returns empty MonitorsConfig."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "monitors.yml").write_text("")
+        cfg = load_monitors_config(tmp_path)
+        assert cfg.monitors == []
 
     def test_valid_config(self, tmp_path):
         """Valid YAML loads correctly."""
-        metrics_dir = tmp_path / ".dango"
-        metrics_dir.mkdir()
-        (metrics_dir / "metrics.yml").write_text(
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "monitors.yml").write_text(
             """\
 enabled: true
-metrics:
+monitors:
   - name: daily_revenue
     source_table: raw_stripe.payments
     value_expression: "SUM(amount)"
     filter: "status = 'succeeded'"
     compare: week_over_week
-    warn_threshold: 10
+    alert_threshold: 10
     drill_down:
       - product_name
       - country
@@ -66,60 +81,77 @@ metrics:
     value_expression: "COUNT(*)"
 """
         )
-        cfg = load_metrics_config(tmp_path)
+        cfg = load_monitors_config(tmp_path)
         assert cfg.enabled is True
-        assert len(cfg.metrics) == 2
-        assert cfg.metrics[0].name == "daily_revenue"
-        assert cfg.metrics[0].compare == ComparisonType.week_over_week
-        assert cfg.metrics[0].warn_threshold == 10.0
-        assert cfg.metrics[0].drill_down == ["product_name", "country"]
-        assert cfg.metrics[1].name == "user_count"
-        assert cfg.metrics[1].filter is None
+        assert len(cfg.monitors) == 2
+        assert cfg.monitors[0].name == "daily_revenue"
+        assert cfg.monitors[0].compare == ComparisonType.week_over_week
+        assert cfg.monitors[0].alert_threshold == 10.0
+        assert cfg.monitors[0].drill_down == ["product_name", "country"]
+        assert cfg.monitors[1].name == "user_count"
+        assert cfg.monitors[1].filter is None
+
+    def test_legacy_metrics_yml_loads(self, tmp_path):
+        """Legacy .dango/metrics.yml with old field names loads correctly."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "metrics.yml").write_text(
+            """\
+enabled: true
+metrics:
+  - name: daily_revenue
+    source_table: raw_stripe.payments
+    value_expression: "SUM(amount)"
+    warn_threshold: 10
+"""
+        )
+        cfg = load_monitors_config(tmp_path)
+        assert len(cfg.monitors) == 1
+        assert cfg.monitors[0].alert_threshold == 10.0
 
     def test_disabled_config(self, tmp_path):
         """Config with enabled: false."""
-        metrics_dir = tmp_path / ".dango"
-        metrics_dir.mkdir()
-        (metrics_dir / "metrics.yml").write_text("enabled: false\nmetrics: []\n")
-        cfg = load_metrics_config(tmp_path)
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "monitors.yml").write_text("enabled: false\nmonitors: []\n")
+        cfg = load_monitors_config(tmp_path)
         assert cfg.enabled is False
 
     def test_invalid_yaml_raises(self, tmp_path):
         """Malformed YAML raises AnalysisConfigError."""
-        metrics_dir = tmp_path / ".dango"
-        metrics_dir.mkdir()
-        (metrics_dir / "metrics.yml").write_text("metrics: [invalid: yaml: content\n")
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "monitors.yml").write_text("monitors: [invalid: yaml: content\n")
         with pytest.raises(AnalysisConfigError, match="Invalid YAML"):
-            load_metrics_config(tmp_path)
+            load_monitors_config(tmp_path)
 
-    def test_invalid_metric_raises(self, tmp_path):
-        """Invalid metric config raises AnalysisConfigError."""
-        metrics_dir = tmp_path / ".dango"
-        metrics_dir.mkdir()
-        (metrics_dir / "metrics.yml").write_text(
+    def test_invalid_monitor_raises(self, tmp_path):
+        """Invalid monitor config raises AnalysisConfigError."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "monitors.yml").write_text(
             """\
-metrics:
+monitors:
   - name: BadName
     source_table: no_dot
     value_expression: "SUM(x)"
 """
         )
-        with pytest.raises(AnalysisConfigError, match="Invalid metrics configuration"):
-            load_metrics_config(tmp_path)
+        with pytest.raises(AnalysisConfigError, match="Invalid monitors configuration"):
+            load_monitors_config(tmp_path)
 
-    def test_no_metrics_key_returns_empty(self, tmp_path):
-        """YAML with unrelated keys returns empty MetricsConfig."""
-        metrics_dir = tmp_path / ".dango"
-        metrics_dir.mkdir()
-        (metrics_dir / "metrics.yml").write_text("some_other_key: true\n")
-        cfg = load_metrics_config(tmp_path)
-        # MetricsConfig accepts extra keys — metrics defaults to []
-        assert cfg.metrics == []
+    def test_no_monitors_key_returns_empty(self, tmp_path):
+        """YAML with unrelated keys returns empty MonitorsConfig."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "monitors.yml").write_text("some_other_key: true\n")
+        cfg = load_monitors_config(tmp_path)
+        assert cfg.monitors == []
 
 
-def _sample_metric(name: str = "test_metric") -> MetricConfig:
-    """Create a sample MetricConfig for testing."""
-    return MetricConfig(
+def _sample_monitor(name: str = "test_monitor") -> MonitorConfig:
+    """Create a sample MonitorConfig for testing."""
+    return MonitorConfig(
         name=name,
         source_table="raw_test.orders",
         value_expression="COUNT(*)",
@@ -127,64 +159,70 @@ def _sample_metric(name: str = "test_metric") -> MetricConfig:
 
 
 @pytest.mark.unit
-class TestSaveMetricsConfig:
-    """save_metrics_config serialization."""
+class TestSaveMonitorsConfig:
+    """save_monitors_config serialization."""
 
     def test_round_trip(self, tmp_path):
         """Save then load returns equivalent config."""
-        original = MetricsConfig(
+        original = MonitorsConfig(
             enabled=True,
-            metrics=[_sample_metric()],
+            monitors=[_sample_monitor()],
         )
-        save_metrics_config(tmp_path, original)
-        loaded = load_metrics_config(tmp_path)
+        save_monitors_config(tmp_path, original)
+        loaded = load_monitors_config(tmp_path)
         assert loaded.enabled is True
-        assert len(loaded.metrics) == 1
-        assert loaded.metrics[0].name == "test_metric"
+        assert len(loaded.monitors) == 1
+        assert loaded.monitors[0].name == "test_monitor"
 
     def test_creates_parent_dirs(self, tmp_path):
         """Creates .dango/ directory if missing."""
-        save_metrics_config(tmp_path, MetricsConfig())
-        assert (tmp_path / ".dango" / "metrics.yml").exists()
+        save_monitors_config(tmp_path, MonitorsConfig())
+        assert (tmp_path / ".dango" / "monitors.yml").exists()
 
     def test_header_comment(self, tmp_path):
         """Header comment is prepended to the file."""
-        save_metrics_config(
+        save_monitors_config(
             tmp_path,
-            MetricsConfig(),
+            MonitorsConfig(),
             header_comment="Replace your_table\nwith real name",
         )
-        content = (tmp_path / ".dango" / "metrics.yml").read_text()
+        content = (tmp_path / ".dango" / "monitors.yml").read_text()
         assert "# Replace your_table" in content
         assert "# with real name" in content
 
     def test_excludes_none_fields(self, tmp_path):
         """Fields with None values are excluded from YAML."""
-        save_metrics_config(tmp_path, MetricsConfig(metrics=[_sample_metric()]))
-        content = (tmp_path / ".dango" / "metrics.yml").read_text()
+        save_monitors_config(tmp_path, MonitorsConfig(monitors=[_sample_monitor()]))
+        content = (tmp_path / ".dango" / "monitors.yml").read_text()
         assert "filter:" not in content
-        assert "warn_threshold:" not in content
+        assert "alert_threshold:" not in content
+
+    def test_saves_as_monitors_yml(self, tmp_path):
+        """New saves always write to monitors.yml, not metrics.yml."""
+        save_monitors_config(tmp_path, MonitorsConfig())
+        assert (tmp_path / ".dango" / "monitors.yml").exists()
+        assert not (tmp_path / ".dango" / "metrics.yml").exists()
 
 
 @pytest.mark.unit
-class TestAddMetricsToConfig:
-    """add_metrics_to_config dedup and merge."""
+class TestAddMonitorsToConfig:
+    """add_monitors_to_config dedup and merge."""
 
-    def test_adds_new_metrics(self, tmp_path):
-        """New metrics are appended to empty config."""
-        result = add_metrics_to_config(tmp_path, [_sample_metric()])
-        assert len(result.metrics) == 1
+    def test_adds_new_monitors(self, tmp_path):
+        """New monitors are appended to empty config."""
+        result = add_monitors_to_config(tmp_path, [_sample_monitor()])
+        assert len(result.monitors) == 1
 
     def test_dedup_by_name(self, tmp_path):
-        """Existing metrics with same name are preserved, not overwritten."""
-        add_metrics_to_config(tmp_path, [_sample_metric("revenue")])
-        result = add_metrics_to_config(tmp_path, [_sample_metric("revenue")])
-        assert len(result.metrics) == 1
+        """Existing monitors with same name are preserved, not overwritten."""
+        add_monitors_to_config(tmp_path, [_sample_monitor("revenue")])
+        result = add_monitors_to_config(tmp_path, [_sample_monitor("revenue")])
+        assert len(result.monitors) == 1
 
     def test_merges_different_names(self, tmp_path):
-        """Metrics with different names are both kept."""
-        add_metrics_to_config(tmp_path, [_sample_metric("alpha")])
-        result = add_metrics_to_config(tmp_path, [_sample_metric("beta")])
-        assert len(result.metrics) == 2
-        names = {m.name for m in result.metrics}
+        """Monitors with different names are both kept."""
+        add_monitors_to_config(tmp_path, [_sample_monitor("alpha")])
+        result = add_monitors_to_config(tmp_path, [_sample_monitor("beta")])
+        assert len(result.monitors) == 2
+        names = {m.name for m in result.monitors}
         assert names == {"alpha", "beta"}

--- a/tests/unit/test_analysis_models.py
+++ b/tests/unit/test_analysis_models.py
@@ -15,6 +15,8 @@ from dango.analysis.models import (
     MetricConfig,
     MetricsConfig,
     MetricValue,
+    MonitorConfig,
+    MonitorsConfig,
 )
 
 
@@ -31,12 +33,12 @@ class TestComparisonType:
 
 
 @pytest.mark.unit
-class TestMetricConfig:
-    """MetricConfig validation."""
+class TestMonitorConfig:
+    """MonitorConfig validation."""
 
     def test_valid_config(self):
         """Valid config creates successfully."""
-        mc = MetricConfig(
+        mc = MonitorConfig(
             name="daily_revenue",
             source_table="raw_stripe.payments",
             value_expression="SUM(amount)",
@@ -47,23 +49,23 @@ class TestMetricConfig:
 
     def test_full_config(self):
         """Config with all optional fields."""
-        mc = MetricConfig(
+        mc = MonitorConfig(
             name="daily_revenue",
             source_table="raw_stripe.payments",
             value_expression="SUM(amount)",
             filter="status = 'succeeded'",
             compare=ComparisonType.rolling_7day_avg,
-            warn_threshold=10.0,
+            alert_threshold=10.0,
             drill_down=["product_name", "country"],
         )
         assert mc.filter == "status = 'succeeded'"
-        assert mc.warn_threshold == 10.0
+        assert mc.alert_threshold == 10.0
         assert mc.drill_down == ["product_name", "country"]
 
     def test_name_must_be_slug(self):
         """Name with uppercase or special chars is rejected."""
         with pytest.raises(ValidationError, match="lowercase alphanumeric"):
-            MetricConfig(
+            MonitorConfig(
                 name="DailyRevenue",
                 source_table="raw.t",
                 value_expression="SUM(x)",
@@ -72,7 +74,7 @@ class TestMetricConfig:
     def test_name_must_start_with_letter(self):
         """Name starting with digit is rejected."""
         with pytest.raises(ValidationError, match="lowercase alphanumeric"):
-            MetricConfig(
+            MonitorConfig(
                 name="1metric",
                 source_table="raw.t",
                 value_expression="SUM(x)",
@@ -81,7 +83,7 @@ class TestMetricConfig:
     def test_source_table_must_have_dot(self):
         """source_table without schema qualifier is rejected."""
         with pytest.raises(ValidationError, match="schema-qualified"):
-            MetricConfig(
+            MonitorConfig(
                 name="my_metric",
                 source_table="payments",
                 value_expression="SUM(amount)",
@@ -90,66 +92,102 @@ class TestMetricConfig:
     def test_value_expression_not_empty(self):
         """Empty value_expression is rejected."""
         with pytest.raises(ValidationError, match="must not be empty"):
-            MetricConfig(
+            MonitorConfig(
                 name="my_metric",
                 source_table="raw.t",
                 value_expression="   ",
             )
 
-    def test_warn_threshold_must_be_positive(self):
-        """Non-positive warn_threshold is rejected."""
+    def test_alert_threshold_must_be_positive(self):
+        """Non-positive alert_threshold is rejected."""
         with pytest.raises(ValidationError, match="must be positive"):
-            MetricConfig(
+            MonitorConfig(
                 name="my_metric",
                 source_table="raw.t",
                 value_expression="SUM(x)",
-                warn_threshold=-5.0,
+                alert_threshold=-5.0,
             )
 
-    def test_warn_threshold_zero_rejected(self):
-        """Zero warn_threshold is rejected."""
+    def test_alert_threshold_zero_rejected(self):
+        """Zero alert_threshold is rejected."""
         with pytest.raises(ValidationError, match="must be positive"):
-            MetricConfig(
+            MonitorConfig(
                 name="my_metric",
                 source_table="raw.t",
                 value_expression="SUM(x)",
-                warn_threshold=0,
+                alert_threshold=0,
             )
 
     def test_frozen(self):
-        """MetricConfig is immutable."""
-        mc = MetricConfig(name="m", source_table="s.t", value_expression="COUNT(*)")
+        """MonitorConfig is immutable."""
+        mc = MonitorConfig(name="m", source_table="s.t", value_expression="COUNT(*)")
         with pytest.raises(ValidationError):
             mc.name = "other"
 
 
 @pytest.mark.unit
-class TestMetricsConfig:
-    """MetricsConfig model."""
+class TestMonitorsConfig:
+    """MonitorsConfig model."""
 
     def test_empty_default(self):
-        """Empty config has no metrics and is enabled."""
-        cfg = MetricsConfig()
-        assert cfg.metrics == []
+        """Empty config has no monitors and is enabled."""
+        cfg = MonitorsConfig()
+        assert cfg.monitors == []
         assert cfg.enabled is True
 
-    def test_with_metrics(self):
-        """Config with a list of metrics."""
-        cfg = MetricsConfig(
-            metrics=[
-                MetricConfig(
+    def test_with_monitors(self):
+        """Config with a list of monitors."""
+        cfg = MonitorsConfig(
+            monitors=[
+                MonitorConfig(
                     name="m1",
                     source_table="s.t",
                     value_expression="COUNT(*)",
                 ),
             ],
         )
-        assert len(cfg.metrics) == 1
+        assert len(cfg.monitors) == 1
 
     def test_disabled(self):
         """Config can be disabled."""
-        cfg = MetricsConfig(enabled=False)
+        cfg = MonitorsConfig(enabled=False)
         assert cfg.enabled is False
+
+
+@pytest.mark.unit
+class TestBackwardCompatibility:
+    """Backward-compatible aliases work correctly."""
+
+    def test_metric_config_alias(self):
+        """MetricConfig is an alias for MonitorConfig."""
+        assert MetricConfig is MonitorConfig
+
+    def test_metrics_config_alias(self):
+        """MetricsConfig is an alias for MonitorsConfig."""
+        assert MetricsConfig is MonitorsConfig
+
+    def test_warn_threshold_accepted(self):
+        """Old ``warn_threshold`` field name is accepted via AliasChoices."""
+        mc = MonitorConfig(
+            name="test",
+            source_table="s.t",
+            value_expression="COUNT(*)",
+            warn_threshold=10.0,
+        )
+        assert mc.alert_threshold == 10.0
+
+    def test_metrics_key_accepted(self):
+        """Old ``metrics`` key is accepted via AliasChoices."""
+        cfg = MonitorsConfig(
+            metrics=[
+                MonitorConfig(
+                    name="m1",
+                    source_table="s.t",
+                    value_expression="COUNT(*)",
+                ),
+            ],
+        )
+        assert len(cfg.monitors) == 1
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cli_analyze.py
+++ b/tests/unit/test_cli_analyze.py
@@ -1,6 +1,6 @@
 """tests/unit/test_cli_analyze.py
 
-Tests for dango/cli/commands/analyze.py — CLI analyze command.
+Tests for dango/cli/commands/analyze.py — CLI monitor and analyze commands.
 """
 
 from __future__ import annotations
@@ -57,7 +57,7 @@ class TestAnalyzeCommand:
         runner = CliRunner()
         result = runner.invoke(cli, ["analyze"])
         assert result.exit_code == 0
-        assert "No metrics" in result.output
+        assert "No monitors" in result.output
 
     @patch("dango.analysis.metrics.run_analysis")
     @patch("dango.cli.utils.require_project_context")
@@ -94,3 +94,44 @@ class TestAnalyzeCommand:
         result = runner.invoke(cli, ["analyze"])
         assert result.exit_code == 0
         assert "broken" in result.output
+
+
+@pytest.mark.unit
+class TestMonitorRunCommand:
+    """Tests for ``dango monitor run``."""
+
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.cli.utils.require_project_context")
+    def test_no_results(self, mock_ctx: MagicMock, mock_run: MagicMock) -> None:
+        """Empty results show informational message."""
+        mock_ctx.return_value = Path("/fake/project")
+        mock_run.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["monitor", "run"])
+        assert result.exit_code == 0
+        assert "No monitors" in result.output
+
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.cli.utils.require_project_context")
+    def test_with_results(self, mock_ctx: MagicMock, mock_run: MagicMock) -> None:
+        """Results display in a Rich table."""
+        mock_ctx.return_value = Path("/fake/project")
+        mock_run.return_value = [_make_mock_result()]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["monitor", "run"])
+        assert result.exit_code == 0
+        assert "revenue" in result.output
+
+    @patch("dango.analysis.metrics.run_analysis")
+    @patch("dango.cli.utils.require_project_context")
+    def test_source_filter(self, mock_ctx: MagicMock, mock_run: MagicMock) -> None:
+        """--source flag passes source_filter to run_analysis."""
+        mock_ctx.return_value = Path("/fake/project")
+        mock_run.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["monitor", "run", "--source", "stripe"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(Path("/fake/project"), source_filter=["raw_stripe"])

--- a/tests/unit/test_web_monitoring.py
+++ b/tests/unit/test_web_monitoring.py
@@ -1,6 +1,6 @@
-"""tests/unit/test_web_insights.py
+"""tests/unit/test_web_monitoring.py
 
-Tests for dango/web/routes/insights.py — insights API endpoints.
+Tests for dango/web/routes/monitoring.py — monitoring API endpoints.
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from dango.exceptions import (
     DangoError,
     ValidationError,
 )
-from dango.web.routes.insights import router
+from dango.web.routes.monitoring import router
 
 # ---------------------------------------------------------------------------
 # Test infrastructure
@@ -41,7 +41,7 @@ def _make_user(role: Role = Role.ADMIN) -> User:
 
 
 def _make_app(project_root: Path) -> FastAPI:
-    """Create a minimal FastAPI app with the insights router."""
+    """Create a minimal FastAPI app with the monitoring router."""
     app = FastAPI()
     app.state.project_root = project_root
 
@@ -137,25 +137,25 @@ def _mock_connect_with_cache(
 
 
 # ---------------------------------------------------------------------------
-# GET /api/insights (reads cached results)
+# GET /api/monitoring (reads cached results)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestGetInsights:
-    """Tests for GET /api/insights."""
+    """Tests for GET /api/monitoring."""
 
-    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.web.routes.monitoring.get_project_root")
     @patch("dango.utils.dango_db.connect")
-    @patch("dango.web.routes.insights.log_auth_event")
-    def test_returns_cached_insights(
+    @patch("dango.web.routes.monitoring.log_auth_event")
+    def test_returns_cached_monitoring(
         self,
         mock_audit: MagicMock,
         mock_connect: MagicMock,
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """GET /api/insights returns cached metrics from SQLite."""
+        """GET /api/monitoring returns cached metrics from SQLite."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
 
@@ -173,7 +173,7 @@ class TestGetInsights:
             result_rows=[("revenue", comparison_json)],
         )
 
-        resp = client.get("/api/insights")
+        resp = client.get("/api/monitoring")
         assert resp.status_code == 200
         data = resp.json()
         assert "metrics" in data
@@ -182,9 +182,9 @@ class TestGetInsights:
         assert data["metrics"][0]["name"] == "revenue"
         assert data["metrics"][0]["status"] == "normal"
 
-    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.web.routes.monitoring.get_project_root")
     @patch("dango.utils.dango_db.connect")
-    @patch("dango.web.routes.insights.log_auth_event")
+    @patch("dango.web.routes.monitoring.log_auth_event")
     def test_empty_cache(
         self,
         mock_audit: MagicMock,
@@ -192,20 +192,20 @@ class TestGetInsights:
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """GET /api/insights with empty cache returns empty list."""
+        """GET /api/monitoring with empty cache returns empty list."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
         mock_connect.return_value = _mock_connect_with_cache(history_rows=[], result_rows=[])
 
-        resp = client.get("/api/insights")
+        resp = client.get("/api/monitoring")
         assert resp.status_code == 200
         data = resp.json()
         assert data["metrics"] == []
         assert data["total"] == 0
 
-    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.web.routes.monitoring.get_project_root")
     @patch("dango.utils.dango_db.connect")
-    @patch("dango.web.routes.insights.log_auth_event")
+    @patch("dango.web.routes.monitoring.log_auth_event")
     def test_flagged_metric_in_cache(
         self,
         mock_audit: MagicMock,
@@ -213,7 +213,7 @@ class TestGetInsights:
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """GET /api/insights returns flagged count from cached data."""
+        """GET /api/monitoring returns flagged count from cached data."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
 
@@ -231,15 +231,15 @@ class TestGetInsights:
             result_rows=[("revenue", comparison_json)],
         )
 
-        resp = client.get("/api/insights")
+        resp = client.get("/api/monitoring")
         assert resp.status_code == 200
         data = resp.json()
         assert data["flagged"] == 1
         assert data["metrics"][0]["status"] == "flagged"
 
-    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.web.routes.monitoring.get_project_root")
     @patch("dango.utils.dango_db.connect")
-    @patch("dango.web.routes.insights.log_auth_event")
+    @patch("dango.web.routes.monitoring.log_auth_event")
     def test_audit_logged(
         self,
         mock_audit: MagicMock,
@@ -247,27 +247,27 @@ class TestGetInsights:
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """GET /api/insights logs audit event."""
+        """GET /api/monitoring logs audit event."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
         mock_connect.return_value = _mock_connect_with_cache(history_rows=[], result_rows=[])
 
-        client.get("/api/insights")
+        client.get("/api/monitoring")
         mock_audit.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# POST /api/insights/run
+# POST /api/monitoring/run
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestRunInsights:
-    """Tests for POST /api/insights/run."""
+    """Tests for POST /api/monitoring/run."""
 
-    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.web.routes.monitoring.get_project_root")
     @patch("dango.analysis.metrics.run_analysis")
-    @patch("dango.web.routes.insights.log_auth_event")
+    @patch("dango.web.routes.monitoring.log_auth_event")
     def test_run_returns_fresh_results(
         self,
         mock_audit: MagicMock,
@@ -275,7 +275,7 @@ class TestRunInsights:
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """POST /api/insights/run executes and returns results."""
+        """POST /api/monitoring/run executes and returns results."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
         mock_run.return_value = [
@@ -283,16 +283,16 @@ class TestRunInsights:
         ]
 
         resp = client.post(
-            "/api/insights/run",
+            "/api/monitoring/run",
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
         assert resp.status_code == 200
         data = resp.json()
         assert data["flagged"] == 1
 
-    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.web.routes.monitoring.get_project_root")
     @patch("dango.analysis.metrics.run_analysis")
-    @patch("dango.web.routes.insights.log_auth_event")
+    @patch("dango.web.routes.monitoring.log_auth_event")
     def test_run_with_source_filter(
         self,
         mock_audit: MagicMock,
@@ -300,13 +300,13 @@ class TestRunInsights:
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """POST /api/insights/run?source=stripe passes source filter."""
+        """POST /api/monitoring/run?source=stripe passes source filter."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
         mock_run.return_value = []
 
         resp = client.post(
-            "/api/insights/run?source=stripe",
+            "/api/monitoring/run?source=stripe",
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
         assert resp.status_code == 200
@@ -316,17 +316,17 @@ class TestRunInsights:
 
 
 # ---------------------------------------------------------------------------
-# GET /api/insights/history
+# GET /api/monitoring/history
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestGetMetricHistory:
-    """Tests for GET /api/insights/history."""
+    """Tests for GET /api/monitoring/history."""
 
-    @patch("dango.web.routes.insights.get_project_root")
+    @patch("dango.web.routes.monitoring.get_project_root")
     @patch("dango.utils.dango_db.connect")
-    @patch("dango.web.routes.insights.log_auth_event")
+    @patch("dango.web.routes.monitoring.log_auth_event")
     def test_returns_history(
         self,
         mock_audit: MagicMock,
@@ -334,7 +334,7 @@ class TestGetMetricHistory:
         mock_root: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """GET /api/insights/history returns data points."""
+        """GET /api/monitoring/history returns data points."""
         client, project_root = _setup_client(tmp_path)
         mock_root.return_value = project_root
 
@@ -346,7 +346,7 @@ class TestGetMetricHistory:
             (95.0, "2026-03-09T12:00:00"),
         ]
 
-        resp = client.get("/api/insights/history?metric=test_metric&days=7")
+        resp = client.get("/api/monitoring/history?metric=test_metric&days=7")
         assert resp.status_code == 200
         data = resp.json()
         assert data["metric"] == "test_metric"


### PR DESCRIPTION
## Summary
- Rename "Insights" feature to "Monitoring" across UI, API, CLI, config, and models to prevent confusion with a potential future semantic layer (MetricFlow/dbt Metrics)
- Full backward compatibility: old field names (`warn_threshold`, `metrics:` key), file paths (`metrics.yml`), API routes (`/api/insights*` → 301/307 redirects), CLI command (`dango analyze` alias), and audit event (`INSIGHTS_VIEWED` alias) all continue to work
- 28 files changed across core models, web routes/templates, CLI commands, callers, tests, and CLAUDE.md docs

## Test plan
- [x] 3207 unit tests pass, 12 integration tests pass
- [x] ruff check + ruff format clean
- [x] mypy passes on all changed files
- [x] Backward compat: `MonitorConfig(warn_threshold=10.0)` → `alert_threshold == 10.0`
- [x] Backward compat: `MonitorsConfig(metrics=[...])` → `monitors` field populated
- [x] Backward compat: legacy `metrics.yml` loads via `load_monitors_config()`
- [x] New saves write `monitors.yml` with `monitors:` key
- [x] `/api/insights` → 301 redirect to `/api/monitoring`
- [x] `/insights` → 301 redirect to `/monitoring`
- [x] `dango monitor run` works; `dango analyze` still works as alias
- [x] Nav shows "Monitoring" (not "Insights")
- [ ] Manual: `dango start` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)