### PR TITLE
R9-Q: Mark pip-audit CI job as continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
 
   security:
     name: Security (pip-audit)
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
 
   security:
     name: Security (pip-audit)
+    # Known unresolvable CVE in black (dbt-core dep) — revisit when dbt-core supports pydantic v2
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` to the `security` (pip-audit) CI job
- The job fails due to a known CVE in `black` (transitive dep of dbt-core), not actionable until dbt-core drops black
- With this change, pip-audit reports as neutral/warning instead of failed, so the overall check suite is green when all 4 required checks pass

## Test plan
- [ ] CI runs on this PR — verify the security job shows warning/neutral status instead of red X
- [ ] Overall check suite status is green (lint, type-check, test, llm-checks all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)