### PR TITLE
R10-A: Set misfire_grace_time=None for local-first recovery (BUG-167)

### DIFF
--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -33,7 +33,7 @@ from dango.logging import get_logger
 logger = get_logger(__name__)
 
 _DEFAULT_THREAD_POOL_SIZE = 20
-_DEFAULT_MISFIRE_GRACE_TIME = 3600  # 1 hour
+_DEFAULT_MISFIRE_GRACE_TIME = None  # Unlimited — missed jobs always run once on startup
 
 
 class SchedulerService:
@@ -112,6 +112,9 @@ class SchedulerService:
         self._scheduler.add_listener(self._on_job_executed, EVENT_JOB_EXECUTED)
         self._scheduler.add_listener(self._on_job_error, EVENT_JOB_ERROR)
         self._scheduler.add_listener(self._on_job_missed, EVENT_JOB_MISSED)
+
+        # Log missed jobs that will be recovered on start
+        self._log_missed_recovery()
 
         self._scheduler.start()
         self._started = True
@@ -388,6 +391,21 @@ class SchedulerService:
             )
         except Exception:  # noqa: BLE001
             logger.debug("history_cleanup_setup_failed", exc_info=True)
+
+    def _log_missed_recovery(self) -> None:
+        """Log count of missed jobs that will be recovered on startup."""
+        from datetime import datetime, timezone
+
+        jobs = self._scheduler.get_jobs()
+        now = datetime.now(timezone.utc)
+        missed = [j for j in jobs if j.next_run_time is not None and j.next_run_time < now]
+        if missed:
+            logger.info(
+                "scheduler_recovering_missed_jobs",
+                count=len(missed),
+                job_ids=[j.id for j in missed],
+                message=f"Recovering {len(missed)} missed job(s) (coalesced to single execution)",
+            )
 
     def _log_startup_summary(self) -> None:
         """Log the number of loaded jobs and next run times."""

--- a/docs/decisions/ADR-002-apscheduler-over-celery.md
+++ b/docs/decisions/ADR-002-apscheduler-over-celery.md
@@ -9,14 +9,14 @@ Dango needs a job scheduler to orchestrate periodic data pipeline tasks: dlt syn
 The scheduler runs inside the Dango web server (FastAPI with asyncio) and must not block HTTP request handling.
 
 ## Decision
-Use APScheduler 3.x (`AsyncIOScheduler`) with a SQLite job store, `ThreadPoolExecutor(20)`, and default job settings of `coalesce=True`, `max_instances=1`, `misfire_grace_time=3600`.
+Use APScheduler 3.x (`AsyncIOScheduler`) with a SQLite job store, `ThreadPoolExecutor(20)`, and default job settings of `coalesce=True`, `max_instances=1`, `misfire_grace_time=None`.
 
 ## Rationale
 VAL-005 validated APScheduler 3.11.2 with 16/16 tests passing:
 
 - **Non-blocking:** `AsyncIOScheduler` integrates with FastAPI's asyncio loop. HTTP requests remain responsive while background jobs execute in the thread pool.
 - **Persistence:** SQLAlchemy job store backed by SQLite survives process restarts. Jobs are recovered automatically on startup.
-- **Missed schedule handling:** `coalesce=True` merges multiple missed runs into one execution (prevents flood on restart). `misfire_grace_time=3600` (Dango-configured; APScheduler's default is undefined) allows jobs up to 1 hour late to still run.
+- **Missed schedule handling:** `coalesce=True` merges multiple missed runs into one execution (prevents flood on restart). `misfire_grace_time=None` (unlimited; Dango-configured) ensures missed jobs always recover on startup regardless of how long the scheduler was offline — appropriate for local-first deployments where Dango may be stopped for days.
 - **Overlap prevention:** `max_instances=1` ensures the same job never runs concurrently. This directly enforces DuckDB's single-writer constraint — a sync job that takes longer than its interval simply skips the next trigger.
 - **Dynamic management:** Jobs can be added, listed, and removed at runtime via API, enabling user-configurable schedules.
 - **Event system:** `EVENT_JOB_EXECUTED` and `EVENT_JOB_ERROR` listeners provide execution history tracking.
@@ -31,3 +31,9 @@ VAL-005 validated APScheduler 3.11.2 with 16/16 tests passing:
 - Jobs execute in threads (`ThreadPoolExecutor`), not async coroutines. This is appropriate for Dango's I/O-bound sync jobs (API calls, database writes) but means CPU-bound work would block a thread.
 - Thread pool size of 20 is sufficient for Dango's workload. Most jobs are I/O-bound and complete quickly. If a deployment has more than 20 concurrent jobs, the pool size can be increased.
 - Tied to APScheduler 3.x API. If a future version needs features only in 4.x, migration would require rewriting scheduler integration code.
+
+## Revision History
+
+| Date | Change |
+|------|--------|
+| 2026-05-05 | Changed `misfire_grace_time` from `3600` to `None` (BUG-167). Local-first deployments may be offline for days; unlimited grace time ensures missed jobs always recover on startup. |

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -303,9 +303,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_scheduler.py
-    lines: 596
+    lines: 658
     category: exempt
-    reason: "TASK-036+039: 10 test classes covering SchedulerService init, lifecycle, jobs, status, event listeners, history integration, coroutine bridge, cloud warning, startup summary, health endpoint, and job stubs. Each class requires isolated mock setup with APScheduler dual-patch pattern."
+    reason: "TASK-036+039+BUG-167: 11 test classes covering SchedulerService init, lifecycle, jobs, status, event listeners, history integration, coroutine bridge, cloud warning, startup summary, missed recovery, health endpoint, and job stubs. Each class requires isolated mock setup with APScheduler dual-patch pattern."
     review_by: "v1.1"
 
   # --- Phase 4 scheduling ---

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -516,6 +516,68 @@ class TestJobFunctions:
         assert callable(configure_jobs)
 
 
+@pytest.mark.unit
+class TestSchedulerMissedRecovery:
+    """Test missed job recovery logging on startup."""
+
+    def test_missed_jobs_logged_on_startup(self, tmp_path):
+        """Jobs with next_run_time in the past should be logged as recovering."""
+        from datetime import datetime, timezone
+
+        svc = _make_service(tmp_path)
+        past_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        job = MagicMock()
+        job.id = "sync-google-sheets"
+        job.next_run_time = past_time
+        svc._scheduler.get_jobs.return_value = [job]
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._log_missed_recovery()
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "scheduler_recovering_missed_jobs"
+        assert call_args[1]["count"] == 1
+
+    def test_no_log_when_no_missed_jobs(self, tmp_path):
+        """No log when all jobs have future next_run_time."""
+        from datetime import datetime, timezone
+
+        svc = _make_service(tmp_path)
+        future_time = datetime(2099, 1, 1, tzinfo=timezone.utc)
+
+        job = MagicMock()
+        job.id = "sync-google-sheets"
+        job.next_run_time = future_time
+        svc._scheduler.get_jobs.return_value = [job]
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._log_missed_recovery()
+
+        mock_logger.info.assert_not_called()
+
+    def test_no_log_when_next_run_time_is_none(self, tmp_path):
+        """Jobs with next_run_time=None (paused) should not count as missed."""
+        svc = _make_service(tmp_path)
+
+        job = MagicMock()
+        job.id = "paused-job"
+        job.next_run_time = None
+        svc._scheduler.get_jobs.return_value = [job]
+
+        with patch(f"{_SCHEDULER_MOD}.logger") as mock_logger:
+            svc._log_missed_recovery()
+
+        mock_logger.info.assert_not_called()
+
+    def test_misfire_grace_time_is_none(self):
+        """Verify _DEFAULT_MISFIRE_GRACE_TIME is None (unlimited)."""
+        from dango.platform.scheduling.scheduler import _DEFAULT_MISFIRE_GRACE_TIME
+
+        assert _DEFAULT_MISFIRE_GRACE_TIME is None
+
+
 _HEALTH_MOD = "dango.web.routes.health"
 
 


### PR DESCRIPTION
## Summary
- Changed `_DEFAULT_MISFIRE_GRACE_TIME` from `3600` to `None` (unlimited) so missed jobs always recover on startup regardless of offline duration
- Added `_log_missed_recovery()` method that logs which jobs will be recovered before scheduler starts
- Updated ADR-002 decision/rationale and added revision history

## Test plan
- [x] `pytest tests/unit/test_scheduler.py` — 41 passed
- [x] `pytest tests/unit/test_scheduler_resilience.py tests/unit/test_sync_jobs.py` — 63 passed
- [x] mypy clean, ruff clean, all pre-commit hooks pass
- [ ] Smoke test: stop Dango for >1 hour, restart, verify missed sync executes once

🤖 Generated with [Claude Code](https://claude.com/claude-code)