### PR TITLE
R10-B: CSV schema evolution NULL padding + zero-load error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ dango/                          # Python package source
 │
 ├── ingestion/                  # Level 1 — Data loading
 │   ├── dlt_runner.py           # ⚠ 2415 lines — orchestrates full sync pipeline
-│   ├── csv_loader.py           # Multi-format file loading with dedup (867 lines)
+│   ├── csv_loader.py           # Multi-format file loading with dedup (922 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
 │   └── dlt_sources/            # ⚠ DO NOT MODIFY — vendored connectors (127 files)
@@ -342,7 +342,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
-| `ingestion/csv_loader.py` | 867 | — |
+| `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 895 | — (module-level job functions) |
 | `utils/post_sync.py` | 553 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 859 | — (schedule CRUD, history, notifications, webhook CRUD) |

--- a/dango/ingestion/csv_loader.py
+++ b/dango/ingestion/csv_loader.py
@@ -238,6 +238,21 @@ class CSVLoader:
 
             conn.close()
 
+            # BUG-169: If files were classified for loading but none loaded, report error
+            files_attempted = len(classified["new"]) + len(classified["updated"])
+            files_loaded = stats["new"] + stats["updated"]
+            if files_attempted > 0 and files_loaded == 0 and stats["deleted"] == 0:
+                error_msg = (
+                    f"No data loaded from {files_attempted} file(s)"
+                    " — all files failed or had 0 rows"
+                )
+                console.print(f"  [red]✗ {error_msg}[/red]")
+                return {
+                    "status": "error",
+                    "error": error_msg,
+                    **stats,
+                }
+
             console.print(
                 f"  ✓ Loaded: {stats['new']} new, {stats['updated']} updated, "
                 f"{stats['deleted']} deleted | Total rows: {stats['total_rows']}"
@@ -437,6 +452,35 @@ class CSVLoader:
         """
         for col_name, col_type in new_columns.items():
             conn.execute(f'ALTER TABLE {target_table} ADD COLUMN "{col_name}" {col_type}')
+
+    def _build_insert_select(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        temp_table: str,
+        target_table: str,
+    ) -> tuple[str, list[str]]:
+        """Build INSERT SELECT with NULL padding for missing columns.
+
+        Returns:
+            Tuple of (sql_statement, missing_data_columns). missing_data_columns lists
+            non-metadata columns present in target but absent from temp (will be NULL).
+        """
+        target_cols = [row[0] for row in conn.execute(f"DESCRIBE {target_table}").fetchall()]
+        temp_cols = {row[0] for row in conn.execute(f"DESCRIBE {temp_table}").fetchall()}
+
+        select_parts = []
+        missing_data_cols = []
+        for col in target_cols:
+            if col in temp_cols:
+                select_parts.append(f'"{col}"')
+            else:
+                select_parts.append(f'NULL AS "{col}"')
+                if not col.startswith("_dango_"):
+                    missing_data_cols.append(col)
+
+        select_clause = ", ".join(select_parts)
+        sql = f"INSERT INTO {target_table} SELECT {select_clause} FROM {temp_table}"
+        return sql, missing_data_cols
 
     def _validate_all_files_schema_match(
         self,
@@ -727,8 +771,13 @@ class CSVLoader:
                 conn.execute(f"DROP TABLE {temp_table}")
                 return False
 
-            # Insert into target
-            conn.execute(f"INSERT INTO {target_table} SELECT * FROM {temp_table}")
+            # Insert into target (with NULL padding for missing columns)
+            insert_sql, missing_cols = self._build_insert_select(conn, temp_table, target_table)
+            if missing_cols:
+                console.print(
+                    f"    [dim]Note: {filename} missing columns {missing_cols} → loading as NULL[/dim]"
+                )
+            conn.execute(insert_sql)
 
             # Update metadata
             conn.execute(
@@ -805,8 +854,14 @@ class CSVLoader:
                 # Delete old data
                 conn.execute(f"DELETE FROM {target_table} WHERE _dango_filename = ?", [filename])
 
-                # Insert new data
-                conn.execute(f"INSERT INTO {target_table} SELECT * FROM {temp_table}")
+                # Insert new data (with NULL padding for missing columns)
+                insert_sql, missing_cols = self._build_insert_select(conn, temp_table, target_table)
+                if missing_cols:
+                    console.print(
+                        f"    [dim]Note: {filename} missing columns"
+                        f" {missing_cols} → loading as NULL[/dim]"
+                    )
+                conn.execute(insert_sql)
 
                 # Update metadata
                 conn.execute(

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -168,7 +168,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/ingestion/csv_loader.py
-    lines: 867
+    lines: 922
     category: exempt
     reason: "Multi-format file loading (CSV, JSON, JSONL, Parquet) with deduplication and schema evolution. Single-purpose module."
     review_by: "v1.1"

--- a/tests/unit/test_csv_schema_evolution.py
+++ b/tests/unit/test_csv_schema_evolution.py
@@ -130,3 +130,95 @@ class TestAllowSchemaChangesMissingColumns:
         # Load with schema evolution — missing column should be tolerated
         result = loader.load("test_src", config, "raw_test_src", allow_schema_changes=True)
         assert result["status"] == "success"
+
+        # BUG-168: Verify data was actually loaded with NULLs (not just no error)
+        assert result["total_rows"] == 3  # 2 from file1 + 1 from file2
+
+        conn = duckdb.connect(str(db_path), read_only=True)
+        rows = conn.execute(
+            "SELECT id, name, email FROM raw_test_src.test_src ORDER BY id"
+        ).fetchall()
+        conn.close()
+
+        # file2's row (id=3) should have email=NULL
+        assert rows[2][0] == 3  # id
+        assert rows[2][1] == "Charlie"  # name
+        assert rows[2][2] is None  # email is NULL
+
+
+@pytest.mark.unit
+class TestZeroLoadedRowsReturnsError:
+    """BUG-169: sync returns error when all file loads produce 0 rows."""
+
+    def test_empty_file_only_returns_error(self, csv_env: Any) -> None:
+        """CSV with header-only (0 rows) returns status error."""
+        loader, db_path, data_dir, config = csv_env
+
+        # First load: establish table with real data
+        _make_csv(data_dir, "file1.csv", "id,name", ["1,Alice"])
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "success"
+
+        # Add a header-only file (0 rows) — file1 stays unchanged
+        _make_csv(data_dir, "file2.csv", "id,name", [])
+
+        # Second load: file2 has 0 rows (skipped), file1 unchanged → no new loads
+        # But file1 is "unchanged" so files_attempted = 1 (just file2)
+        # and files_loaded = 0 → error
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "error"
+        assert "No data loaded" in result["error"]
+
+    def test_deletion_only_is_success(self, csv_env: Any) -> None:
+        """File deleted from disk → sync detects deletion → status success."""
+        loader, db_path, data_dir, config = csv_env
+
+        # Load a file to establish table
+        _make_csv(data_dir, "file1.csv", "id,name", ["1,Alice"])
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "success"
+
+        # Delete the file from disk
+        (data_dir / "file1.csv").unlink()
+
+        # Sync should succeed (deletion detected)
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "success"
+        assert result["deleted"] == 1
+
+
+@pytest.mark.unit
+class TestSchemaEvolutionTriggersDrift:
+    """BUG-170: drift detection fires after CSV schema evolution."""
+
+    def test_column_added_detected_after_schema_evolution(self, csv_env: Any) -> None:
+        """After schema evolution adds a column, drift detection finds column_added."""
+        from dango.governance.schema_drift import detect_table_drift
+
+        loader, db_path, data_dir, config = csv_env
+        project_root = loader.project_root
+
+        # Step 1: Load CSV with columns id, name → establish table
+        _make_csv(data_dir, "file1.csv", "id,name", ["1,Alice", "2,Bob"])
+        result = loader.load("test_src", config, "raw_test_src")
+        assert result["status"] == "success"
+
+        # Step 2: First drift call establishes baseline (returns [])
+        # detect_table_drift uses project_root / "data" / "warehouse.duckdb"
+        # and project_root / ".dango" / "dango.db" — both exist via csv_env fixture
+        events = detect_table_drift(project_root, "test_src", "test_src")
+        assert events == []
+
+        # Step 3: Load CSV with id, name, email using allow_schema_changes
+        _make_csv(data_dir, "file2.csv", "id,name,email", ["3,Charlie,c@x.com"])
+        result = loader.load("test_src", config, "raw_test_src", allow_schema_changes=True)
+        assert result["status"] == "success"
+
+        # Step 4: Drift detection should find column_added for "email"
+        events = detect_table_drift(project_root, "test_src", "test_src")
+
+        assert len(events) >= 1
+        added_events = [e for e in events if e["event_type"] == "column_added"]
+        assert len(added_events) == 1
+        assert added_events[0]["column_name"] == "email"
+        assert added_events[0]["severity"] == "additive"


### PR DESCRIPTION
## Summary

- **BUG-168 (Critical):** Replace `INSERT INTO target SELECT * FROM temp` with `_build_insert_select()` that explicitly lists columns with NULL padding for missing ones. Fixes Binder Error when CSV has fewer columns than target table.
- **BUG-169 (Medium):** Return `status: "error"` when all attempted file loads produce 0 rows (previously returned misleading "success"). Only fires when no deletions occurred.
- **BUG-170 (Medium):** Integration test proving `detect_table_drift()` correctly finds `column_added` after CSV schema evolution.

## Test plan

- [x] `pytest tests/unit/test_csv_schema_evolution.py -x` — 6 tests pass
- [x] `pytest tests/unit/test_csv_loader.py -x` — 22 tests pass
- [x] `pytest tests/unit/test_drift_detection.py -x` — 32 tests pass
- [x] `mypy dango/ingestion/csv_loader.py` — no issues
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `wc -l dango/ingestion/csv_loader.py` — 922 lines (exemption updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)