### PR TITLE
R10-D1: Fix notebook DuckDB connection + add guidance cells

### DIFF
--- a/dango/notebooks/CLAUDE.md
+++ b/dango/notebooks/CLAUDE.md
@@ -14,9 +14,9 @@ Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking
 | `locking.py` | ~249 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
 | `proxy.py` | ~186 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |
 | `templates/__init__.py` | ~5 | Package marker | — |
-| `templates/explore.py` | ~30 | Data exploration starter template | `app` (marimo.App) |
-| `templates/quality.py` | ~40 | Data quality starter template | `app` (marimo.App) |
-| `templates/blank.py` | ~20 | Minimal blank starter template | `app` (marimo.App) |
+| `templates/explore.py` | ~57 | Data exploration starter template | `app` (marimo.App) |
+| `templates/quality.py` | ~67 | Data quality starter template | `app` (marimo.App) |
+| `templates/blank.py` | ~17 | Minimal blank starter template | `app` (marimo.App) |
 
 ## Architecture
 

--- a/dango/notebooks/templates/blank.py
+++ b/dango/notebooks/templates/blank.py
@@ -13,5 +13,5 @@ def setup():
     """Connect to the local DuckDB warehouse in read-only mode."""
     import duckdb
 
-    conn = duckdb.connect("data/warehouse.duckdb", read_only=True)
+    conn = duckdb.connect("data/warehouse.duckdb", config={"access_mode": "read_only"})
     return (conn,)

--- a/dango/notebooks/templates/explore.py
+++ b/dango/notebooks/templates/explore.py
@@ -9,11 +9,31 @@ app = marimo.App()
 
 
 @app.cell
+def guidance():
+    """Introductory guidance for the explore notebook."""
+    import marimo as mo
+
+    return (
+        mo.md(
+            """
+# Data Exploration
+
+This notebook is connected to your DuckDB warehouse in **read-only** mode.
+Each cell's output appears below it — edit the SQL in `sample_query` to explore
+your data.
+
+**Tip:** Use `mo.ui.table(df)` for interactive, sortable tables.
+"""
+        ),
+    )
+
+
+@app.cell
 def setup():
     """Connect to the local DuckDB warehouse in read-only mode."""
     import duckdb
 
-    conn = duckdb.connect("data/warehouse.duckdb", read_only=True)
+    conn = duckdb.connect("data/warehouse.duckdb", config={"access_mode": "read_only"})
     return (conn,)
 
 

--- a/dango/notebooks/templates/quality.py
+++ b/dango/notebooks/templates/quality.py
@@ -9,11 +9,31 @@ app = marimo.App()
 
 
 @app.cell
+def guidance():
+    """Introductory guidance for the quality notebook."""
+    import marimo as mo
+
+    return (
+        mo.md(
+            """
+# Data Quality
+
+This notebook shows **row counts** and **column metadata** for tables in your
+DuckDB warehouse (read-only). Each cell's output appears below it — edit the
+WHERE clause in `null_analysis` to inspect a specific table.
+
+**Tip:** Use `mo.ui.table(df)` for interactive, sortable tables.
+"""
+        ),
+    )
+
+
+@app.cell
 def setup():
     """Connect to the local DuckDB warehouse in read-only mode."""
     import duckdb
 
-    conn = duckdb.connect("data/warehouse.duckdb", read_only=True)
+    conn = duckdb.connect("data/warehouse.duckdb", config={"access_mode": "read_only"})
     return (conn,)
 
 


### PR DESCRIPTION
## Summary
- **BUG-178 (Critical):** Replace `read_only=True` with `config={"access_mode": "read_only"}` in all three notebook templates (`explore.py`, `quality.py`, `blank.py`) to prevent WAL write lock that blocks `dango sync`
- **BUG-184 (Low):** Add `mo.md()` guidance cells to `explore.py` and `quality.py` explaining what the notebook does and how to interact with it

## Test plan
- [x] `grep -n "read_only=True"` returns no matches in templates
- [x] `grep -n "access_mode"` confirms all 3 files use config dict
- [x] `ruff check` + `ruff format --check` pass
- [x] `mypy` passes (no issues in 4 source files)
- [x] `pytest tests/unit/test_notebook_cli.py tests/unit/test_web_notebooks.py` — 42 tests pass
- [x] All files under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)