### PR TITLE
R10-E1: Catalog per-source breakdown + Tailwind safelist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `config/models.py` | 600 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 548 | — |
-| `web/routes/catalog.py` | 1286 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery) |
+| `web/routes/catalog.py` | 1331 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 846 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -45,7 +45,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule list/get, trigger, reload, cancel, history, notification config/test, `/schedules` page (read-only, ~518 lines). Config mutations removed by R10-C (BUG-175) — use CLI instead. | `router` |
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~506 lines) | `router` |
-| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1286 lines) | `router` |
+| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1331 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
 | `routes/monitoring.py` | Monitor results, run trigger, history + backward-compat redirects for old `/api/insights*` paths (~295 lines) | `router` |
 | `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~496 lines) | `router` |

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -210,21 +210,25 @@ def _get_source_summary_stats(db_path: Path) -> dict[str, dict[str, int]]:
         db_path: Path to DuckDB warehouse file.
 
     Returns:
-        ``{source_name: {"table_count": int, "row_count_total": int}}``.
+        ``{source_name: {"table_count": int, "estimated_row_total": int}}``.
     """
-    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
-        rows = conn.execute(
-            "SELECT schema_name, COUNT(*) AS table_count, "
-            "COALESCE(SUM(estimated_size), 0) AS row_count_total "
-            "FROM duckdb_tables() "
-            "WHERE schema_name LIKE 'raw_%' "
-            "AND table_name NOT LIKE '_dlt_%' "
-            "GROUP BY schema_name"
-        ).fetchall()
-    finally:
-        conn.close()
-    return {r[0][4:]: {"table_count": r[1], "row_count_total": r[2]} for r in rows}
+        conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
+        try:
+            rows = conn.execute(
+                "SELECT schema_name, COUNT(*) AS table_count, "
+                "COALESCE(SUM(estimated_size), 0) AS estimated_row_total "
+                "FROM duckdb_tables() "
+                "WHERE schema_name LIKE 'raw_%' "
+                "AND table_name NOT LIKE '_dlt_%' "
+                "GROUP BY schema_name"
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        logger.warning("source_summary_stats_failed", db_path=str(db_path))
+        return {}
+    return {r[0][4:]: {"table_count": r[1], "estimated_row_total": r[2]} for r in rows}
 
 
 # ---------------------------------------------------------------------------
@@ -906,12 +910,12 @@ async def list_catalog_models(
     sources_detail: list[dict[str, Any]] = []
     for src_cfg in sources_config:
         src_name = src_cfg.get("name", "")
-        stats = source_stats.get(src_name, {"table_count": 0, "row_count_total": 0})
+        stats = source_stats.get(src_name, {"table_count": 0, "estimated_row_total": 0})
         sources_detail.append(
             {
                 "name": src_name,
                 "table_count": stats["table_count"],
-                "row_count_total": stats["row_count_total"],
+                "estimated_row_total": stats["estimated_row_total"],
                 "freshness_status": freshness_by_source.get(src_name),
             }
         )

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -203,6 +203,30 @@ def _get_raw_tables_from_duckdb(db_path: Path) -> list[dict[str, str]]:
     return [{"schema": r[0], "table": r[1], "source_name": r[0][4:]} for r in rows]
 
 
+def _get_source_summary_stats(db_path: Path) -> dict[str, dict[str, int]]:
+    """Query per-source table counts and estimated row counts.
+
+    Args:
+        db_path: Path to DuckDB warehouse file.
+
+    Returns:
+        ``{source_name: {"table_count": int, "row_count_total": int}}``.
+    """
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
+    try:
+        rows = conn.execute(
+            "SELECT schema_name, COUNT(*) AS table_count, "
+            "COALESCE(SUM(estimated_size), 0) AS row_count_total "
+            "FROM duckdb_tables() "
+            "WHERE schema_name LIKE 'raw_%' "
+            "AND table_name NOT LIKE '_dlt_%' "
+            "GROUP BY schema_name"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0][4:]: {"table_count": r[1], "row_count_total": r[2]} for r in rows}
+
+
 # ---------------------------------------------------------------------------
 # Manifest / model helpers (called via asyncio.to_thread)
 # ---------------------------------------------------------------------------
@@ -827,9 +851,13 @@ async def list_catalog_models(
     # BUG-132: Discover raw tables without dbt staging models
     project_root = get_project_root()
     db_path = project_root / "data" / "warehouse.duckdb"
+    source_stats: dict[str, dict[str, int]] = {}
     if db_path.exists():
+        raw_tables, source_stats = await asyncio.gather(
+            asyncio.to_thread(_get_raw_tables_from_duckdb, db_path),
+            asyncio.to_thread(_get_source_summary_stats, db_path),
+        )
         known_names = {s["name"] for s in result["sources"]}
-        raw_tables = await asyncio.to_thread(_get_raw_tables_from_duckdb, db_path)
         for rt in raw_tables:
             if rt["table"] not in known_names:
                 result["sources"].append(
@@ -872,11 +900,28 @@ async def list_catalog_models(
                     "hours_since_sync": f.get("hours_since_sync"),
                 }
             )
+
+    # BUG-155: Per-source breakdown with table count, row count, freshness
+    freshness_by_source = {item["source"]: item["status"] for item in freshness_items}
+    sources_detail: list[dict[str, Any]] = []
+    for src_cfg in sources_config:
+        src_name = src_cfg.get("name", "")
+        stats = source_stats.get(src_name, {"table_count": 0, "row_count_total": 0})
+        sources_detail.append(
+            {
+                "name": src_name,
+                "table_count": stats["table_count"],
+                "row_count_total": stats["row_count_total"],
+                "freshness_status": freshness_by_source.get(src_name),
+            }
+        )
+
     result["overview"] = {
         "source_count": len(sources_config),
         "table_count": len(result["sources"]),
         "model_count": len(result["models"]),
         "freshness": freshness_items,
+        "sources_detail": sources_detail,
     }
 
     return result

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -65,6 +65,26 @@
                     </div>
                 </div>
             </template>
+            <!-- BUG-155: Per-source breakdown cards -->
+            <template x-if="overview && overview.sources_detail && overview.sources_detail.length > 0">
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 mb-4">
+                    <template x-for="sd in overview.sources_detail" :key="sd.name">
+                        <div class="bg-white shadow rounded-lg p-3 flex items-center justify-between">
+                            <div>
+                                <div class="font-medium text-gray-900 text-sm" x-text="sd.name"></div>
+                                <div class="text-xs text-gray-500">
+                                    <span x-text="sd.table_count"></span> table<span x-show="sd.table_count !== 1">s</span>
+                                    &middot;
+                                    <span x-text="sd.row_count_total.toLocaleString()"></span> rows
+                                </div>
+                            </div>
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                                  :class="sd.freshness_status === 'fresh' ? 'bg-green-100 text-green-800' : sd.freshness_status === 'stale' ? 'bg-amber-100 text-amber-800' : 'bg-gray-100 text-gray-600'"
+                                  x-text="sd.freshness_status || 'unknown'"></span>
+                        </div>
+                    </template>
+                </div>
+            </template>
             <!-- Type filter tabs -->
             <div class="catalog-tabs">
                 <template x-for="tab in tabs" :key="tab.key">

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -75,7 +75,7 @@
                                 <div class="text-xs text-gray-500">
                                     <span x-text="sd.table_count"></span> table<span x-show="sd.table_count !== 1">s</span>
                                     &middot;
-                                    <span x-text="sd.row_count_total.toLocaleString()"></span> rows
+                                    <span x-text="sd.estimated_row_total.toLocaleString()"></span> rows
                                 </div>
                             </div>
                             <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -329,15 +329,15 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/catalog.py
-    lines: 1286
+    lines: 1331
     category: exempt
-    reason: "P7-001+P7-002+BUG-016+R9-G: Column schema, profiling, lineage DAG, impact analysis, model list/detail/search, raw table discovery, overview summary. Single router file — manifest parsing helpers are private to the same module."
+    reason: "P7-001+P7-002+BUG-016+R9-G+R10-E1: Column schema, profiling, lineage DAG, impact analysis, model list/detail/search, raw table discovery, overview summary, per-source stats. Single router file — manifest parsing helpers are private to the same module."
     review_by: "v1.1"
 
   - file: tests/unit/test_catalog_models.py
-    lines: 923
+    lines: 1039
     category: exempt
-    reason: "BUG-016+R9-G: 22 tests covering catalog model list (8) + model detail (11) + raw table discovery (3). Test infrastructure shared with test_catalog_lineage.py."
+    reason: "BUG-016+R9-G+R10-E1: 24 tests covering catalog model list (8) + model detail (11) + raw table discovery (3) + sources_detail (2). Test infrastructure shared with test_catalog_lineage.py."
     review_by: "v1.1"
 
   - file: tests/unit/test_cli_schedule.py

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     "./dango/web/templates/**/*.html",
     "./dango/web/static/js/**/*.js",
   ],
+  safelist: ['xl:table-cell'],
   theme: {
     extend: {
       colors: {

--- a/tests/unit/test_catalog_models.py
+++ b/tests/unit/test_catalog_models.py
@@ -816,6 +816,7 @@ class TestGetCatalogModel:
 class TestRawTableDiscovery:
     """Tests for _get_raw_tables_from_duckdb and list endpoint integration."""
 
+    @patch("dango.web.routes.catalog._get_source_summary_stats")
     @patch("dango.web.routes.catalog.get_project_root")
     @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
     @patch("dango.web.routes.catalog._get_run_results")
@@ -826,6 +827,7 @@ class TestRawTableDiscovery:
         mock_run_results: MagicMock,
         mock_raw_tables: MagicMock,
         mock_root: MagicMock,
+        mock_source_stats: MagicMock,
         tmp_path: Path,
     ) -> None:
         """Unmodeled raw tables appear in sources list (BUG-132)."""
@@ -834,6 +836,7 @@ class TestRawTableDiscovery:
         db_dir.mkdir()
         (db_dir / "warehouse.duckdb").touch()
         mock_root.return_value = project_root
+        mock_source_stats.return_value = {}
 
         mock_manifest.return_value = _make_manifest(
             sources={
@@ -857,6 +860,7 @@ class TestRawTableDiscovery:
         assert "order_items" in source_names  # from raw tables
         assert source_names.count("orders") == 1  # no duplicate
 
+    @patch("dango.web.routes.catalog._get_source_summary_stats")
     @patch("dango.web.routes.catalog.get_project_root")
     @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
     @patch("dango.web.routes.catalog._get_run_results")
@@ -867,6 +871,7 @@ class TestRawTableDiscovery:
         mock_run_results: MagicMock,
         mock_raw_tables: MagicMock,
         mock_root: MagicMock,
+        mock_source_stats: MagicMock,
         tmp_path: Path,
     ) -> None:
         """Response includes overview with source/table/model counts (BUG-128)."""
@@ -875,6 +880,7 @@ class TestRawTableDiscovery:
         db_dir.mkdir()
         (db_dir / "warehouse.duckdb").touch()
         mock_root.return_value = project_root
+        mock_source_stats.return_value = {}
 
         mock_manifest.return_value = _make_manifest(
             sources={
@@ -921,3 +927,113 @@ class TestRawTableDiscovery:
         assert "overview" in data
         assert data["overview"]["model_count"] == 0
         assert data["overview"]["table_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# BUG-155: Per-source breakdown in overview
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSourcesDetail:
+    """Tests for sources_detail in catalog overview (BUG-155)."""
+
+    @patch("dango.web.helpers.get_project_root")
+    @patch("dango.web.routes.catalog._get_source_summary_stats")
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_sources_detail_in_overview(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_raw_tables: MagicMock,
+        mock_root: MagicMock,
+        mock_source_stats: MagicMock,
+        mock_helpers_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """sources_detail contains per-source table count and row count."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+        mock_root.return_value = project_root
+        mock_helpers_root.return_value = project_root
+
+        # Create sources config
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "sources.yml").write_text(
+            "sources:\n  - name: shop\n    type: postgres\n  - name: crm\n    type: hubspot\n"
+        )
+
+        mock_manifest.return_value = _make_manifest()
+        mock_run_results.return_value = None
+        mock_raw_tables.return_value = []
+        mock_source_stats.return_value = {
+            "shop": {"table_count": 5, "row_count_total": 12000},
+            "crm": {"table_count": 3, "row_count_total": 800},
+        }
+
+        resp = client.get("/api/catalog/models")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        overview = data["overview"]
+        assert "sources_detail" in overview
+        assert len(overview["sources_detail"]) == 2
+
+        detail_map = {sd["name"]: sd for sd in overview["sources_detail"]}
+        assert detail_map["shop"]["table_count"] == 5
+        assert detail_map["shop"]["row_count_total"] == 12000
+        assert detail_map["crm"]["table_count"] == 3
+        assert detail_map["crm"]["row_count_total"] == 800
+
+    @patch("dango.web.helpers.get_project_root")
+    @patch("dango.web.routes.catalog._get_source_summary_stats")
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_sources_detail_missing_source_in_duckdb(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_raw_tables: MagicMock,
+        mock_root: MagicMock,
+        mock_source_stats: MagicMock,
+        mock_helpers_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Source in config but not in DuckDB gets zero counts."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+        mock_root.return_value = project_root
+        mock_helpers_root.return_value = project_root
+
+        # Source in config but not in DuckDB stats
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "sources.yml").write_text(
+            "sources:\n  - name: shop\n    type: postgres\n  - name: new_source\n    type: stripe\n"
+        )
+
+        mock_manifest.return_value = _make_manifest()
+        mock_run_results.return_value = None
+        mock_raw_tables.return_value = []
+        mock_source_stats.return_value = {
+            "shop": {"table_count": 3, "row_count_total": 500},
+            # new_source is NOT in DuckDB yet
+        }
+
+        resp = client.get("/api/catalog/models")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        detail_map = {sd["name"]: sd for sd in data["overview"]["sources_detail"]}
+        assert detail_map["new_source"]["table_count"] == 0
+        assert detail_map["new_source"]["row_count_total"] == 0

--- a/tests/unit/test_catalog_models.py
+++ b/tests/unit/test_catalog_models.py
@@ -973,8 +973,8 @@ class TestSourcesDetail:
         mock_run_results.return_value = None
         mock_raw_tables.return_value = []
         mock_source_stats.return_value = {
-            "shop": {"table_count": 5, "row_count_total": 12000},
-            "crm": {"table_count": 3, "row_count_total": 800},
+            "shop": {"table_count": 5, "estimated_row_total": 12000},
+            "crm": {"table_count": 3, "estimated_row_total": 800},
         }
 
         resp = client.get("/api/catalog/models")
@@ -987,9 +987,9 @@ class TestSourcesDetail:
 
         detail_map = {sd["name"]: sd for sd in overview["sources_detail"]}
         assert detail_map["shop"]["table_count"] == 5
-        assert detail_map["shop"]["row_count_total"] == 12000
+        assert detail_map["shop"]["estimated_row_total"] == 12000
         assert detail_map["crm"]["table_count"] == 3
-        assert detail_map["crm"]["row_count_total"] == 800
+        assert detail_map["crm"]["estimated_row_total"] == 800
 
     @patch("dango.web.helpers.get_project_root")
     @patch("dango.web.routes.catalog._get_source_summary_stats")
@@ -1026,7 +1026,7 @@ class TestSourcesDetail:
         mock_run_results.return_value = None
         mock_raw_tables.return_value = []
         mock_source_stats.return_value = {
-            "shop": {"table_count": 3, "row_count_total": 500},
+            "shop": {"table_count": 3, "estimated_row_total": 500},
             # new_source is NOT in DuckDB yet
         }
 
@@ -1036,4 +1036,4 @@ class TestSourcesDetail:
         data = resp.json()
         detail_map = {sd["name"]: sd for sd in data["overview"]["sources_detail"]}
         assert detail_map["new_source"]["table_count"] == 0
-        assert detail_map["new_source"]["row_count_total"] == 0
+        assert detail_map["new_source"]["estimated_row_total"] == 0


### PR DESCRIPTION
## Summary
- **BUG-155**: Add `sources_detail` to catalog overview response with per-source `table_count`, `row_count_total`, and `freshness_status`. New `_get_source_summary_stats()` helper queries `duckdb_tables()` with read-only access mode. Template renders responsive cards grid.
- **BUG-157**: Add `xl:table-cell` to Tailwind safelist in `tailwind.config.js` so profiling stat columns will be included in compiled CSS (actual rebuild in R10-O).

## Test plan
- [x] `pytest tests/unit/test_catalog_models.py -x` — 24 tests pass
- [x] `ruff check` + `mypy` clean on catalog.py
- [x] Pre-commit hooks pass
- [ ] Manual: verify `sources_detail` in `/api/catalog/models` response with real data
- [ ] Manual: verify source cards render in catalog page

🤖 Generated with [Claude Code](https://claude.com/claude-code)