### PR TITLE
R10-D2: Notebook lock reliability (heartbeat expiry + WS notify)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `platform/scheduling/jobs.py` | 895 | — (module-level job functions) |
 | `utils/post_sync.py` | 553 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 518 | — (schedule read-only, history, trigger, notifications) |
+| `web/routes/notebooks.py` | 506 | — (notebook management API + heartbeat lock expiry + WS notify) |
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |

--- a/dango/notebooks/CLAUDE.md
+++ b/dango/notebooks/CLAUDE.md
@@ -11,7 +11,7 @@ Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking
 | `__init__.py` | ~45 | Re-exports public symbols | All public API |
 | `manager.py` | ~262 | Marimo process lifecycle (PID file, start/stop/status) + idle auto-shutdown | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()`, `start_idle_checker()`, `stop_idle_checker()` |
 | `snapshot.py` | ~143 | DuckDB snapshot management | `create_snapshot()`, `list_snapshots()`, `cleanup_snapshots()` |
-| `locking.py` | ~249 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
+| `locking.py` | ~285 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `expire_stale_locks()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
 | `proxy.py` | ~186 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |
 | `templates/__init__.py` | ~5 | Package marker | — |
 | `templates/explore.py` | ~30 | Data exploration starter template | `app` (marimo.App) |
@@ -66,7 +66,7 @@ CLI (notebook new/open/list, snapshot)
 
 Located in `.dango/dango.db` (managed by `dango/utils/dango_db.py`):
 
-- **`notebook_locks`** — `notebook_id` (PK), `locked_by`, `locked_at`, `expires_at`
+- **`notebook_locks`** — `notebook_id` (PK), `locked_by`, `locked_at`, `expires_at`, `last_heartbeat_at` (added via `_ADDITIVE_DDL`)
 - **`notebook_metadata`** — `id` (PK), `name`, `description`, `created_by`, `created_at`, `updated_at`
 
 ## Testing

--- a/dango/notebooks/__init__.py
+++ b/dango/notebooks/__init__.py
@@ -7,6 +7,7 @@ file locking, and proxy utilities.
 from dango.notebooks.locking import (
     acquire_lock,
     copy_locked_notebook,
+    expire_stale_locks,
     force_release_lock,
     get_lock_info,
     is_locked,
@@ -44,6 +45,7 @@ __all__ = [
     "release_lock",
     "refresh_lock",
     "force_release_lock",
+    "expire_stale_locks",
     "is_locked",
     "get_lock_info",
     "copy_locked_notebook",

--- a/dango/notebooks/locking.py
+++ b/dango/notebooks/locking.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import shutil
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from dango.utils.dango_db import connect
@@ -52,7 +52,8 @@ def acquire_lock(project_root: Path, notebook_id: str, user: str) -> bool:
                 # Refresh existing lock
                 conn.execute(
                     "UPDATE notebook_locks "
-                    "SET expires_at = datetime('now', '+15 minutes') "
+                    "SET expires_at = datetime('now', '+15 minutes'), "
+                    "last_heartbeat_at = datetime('now') "
                     "WHERE notebook_id = ?",
                     (notebook_id,),
                 )
@@ -61,8 +62,9 @@ def acquire_lock(project_root: Path, notebook_id: str, user: str) -> bool:
             return False
 
         conn.execute(
-            "INSERT INTO notebook_locks (notebook_id, locked_by, locked_at, expires_at) "
-            "VALUES (?, ?, datetime('now'), datetime('now', '+15 minutes'))",
+            "INSERT INTO notebook_locks "
+            "(notebook_id, locked_by, locked_at, expires_at, last_heartbeat_at) "
+            "VALUES (?, ?, datetime('now'), datetime('now', '+15 minutes'), datetime('now'))",
             (notebook_id, user),
         )
         conn.commit()
@@ -123,7 +125,8 @@ def refresh_lock(project_root: Path, notebook_id: str, user: str) -> bool:
 
         conn.execute(
             "UPDATE notebook_locks "
-            "SET expires_at = datetime('now', '+15 minutes') "
+            "SET expires_at = datetime('now', '+15 minutes'), "
+            "last_heartbeat_at = datetime('now') "
             "WHERE notebook_id = ?",
             (notebook_id,),
         )
@@ -157,6 +160,39 @@ def force_release_lock(project_root: Path, notebook_id: str) -> bool:
         conn.commit()
         logger.info("Force-released lock on %s (was held by %s)", notebook_id, row["locked_by"])
         return True
+
+
+def expire_stale_locks(project_root: Path, timeout_seconds: int = 120) -> int:
+    """Remove locks whose last heartbeat exceeds the timeout.
+
+    Locks with NULL ``last_heartbeat_at`` (pre-migration) are skipped —
+    they continue to use the existing ``expires_at`` mechanism.
+
+    Args:
+        project_root: Project root directory.
+        timeout_seconds: Seconds since last heartbeat before expiry.
+
+    Returns:
+        Number of locks expired.
+    """
+    threshold = (datetime.now(timezone.utc) - timedelta(seconds=timeout_seconds)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    with connect(project_root) as conn:
+        cursor = conn.execute(
+            "DELETE FROM notebook_locks "
+            "WHERE last_heartbeat_at IS NOT NULL AND last_heartbeat_at < ?",
+            (threshold,),
+        )
+        conn.commit()
+        expired = cursor.rowcount
+        if expired:
+            logger.info(
+                "Expired %d stale notebook lock(s) (no heartbeat for %ds)",
+                expired,
+                timeout_seconds,
+            )
+        return expired
 
 
 def is_locked(project_root: Path, notebook_id: str) -> bool:

--- a/dango/utils/dango_db.py
+++ b/dango/utils/dango_db.py
@@ -191,6 +191,7 @@ CREATE TABLE IF NOT EXISTS source_attention (
 # Additive migrations — each wrapped in try/except to ignore "duplicate column".
 _ADDITIVE_DDL = [
     "ALTER TABLE drift_events ADD COLUMN severity TEXT",
+    "ALTER TABLE notebook_locks ADD COLUMN last_heartbeat_at TEXT",
 ]
 
 

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -44,7 +44,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/secrets.py` | Secrets and OAuth credential management (admin-only, .env + .dlt/secrets.toml CRUD) | `router` |
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule list/get, trigger, reload, cancel, history, notification config/test, `/schedules` page (read-only, ~518 lines). Config mutations removed by R10-C (BUG-175) — use CLI instead. | `router` |
-| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~490 lines) | `router` |
+| `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~506 lines) | `router` |
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1286 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
 | `routes/monitoring.py` | Monitor results, run trigger, history + backward-compat redirects for old `/api/insights*` paths (~295 lines) | `router` |

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -24,6 +24,7 @@ from dango.logging import get_logger
 from dango.notebooks.locking import (
     acquire_lock,
     copy_locked_notebook,
+    expire_stale_locks,
     force_release_lock,
     get_lock_info,
     refresh_lock,
@@ -34,6 +35,7 @@ from dango.utils.dango_db import connect
 from dango.validation import validate_identifier
 from dango.web.helpers import get_project_root
 from dango.web.routes.ui import _render_template
+from dango.web.routes.websocket import ws_manager
 
 router = APIRouter(tags=["notebooks"])
 logger = get_logger(__name__)
@@ -399,6 +401,8 @@ async def heartbeat_notebook(
     """Refresh lock expiry for an active editing session."""
     project_root = get_project_root()
 
+    await asyncio.to_thread(expire_stale_locks, project_root)
+
     refreshed = await asyncio.to_thread(refresh_lock, project_root, name, user.email)
     if not refreshed:
         return JSONResponse(
@@ -458,6 +462,15 @@ async def force_release_notebook_lock(
         request,
         project_root,
         notebook_name=name,
+    )
+
+    await ws_manager.broadcast(
+        {
+            "event": "notebook_lock_revoked",
+            "notebook": name,
+            "message": f"Lock on notebook '{name}' was force-released by an administrator.",
+            "timestamp": datetime.now().isoformat(),
+        }
     )
 
     return JSONResponse(content={"force_released": True})

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -29,6 +29,13 @@
             <p class="text-sm text-red-700" x-text="error"></p>
         </div>
 
+        <!-- Lock revoked banner -->
+        <div x-show="lockRevoked" x-cloak class="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
+            <p class="text-sm text-yellow-800">
+                Your lock on "<span x-text="revokedNotebook"></span>" has been revoked by an administrator.
+            </p>
+        </div>
+
         <!-- Success banner -->
         <div x-show="success" x-cloak class="mb-4 p-3 bg-green-50 border border-green-200 rounded-md">
             <p class="text-sm text-green-700" x-text="success"></p>
@@ -191,8 +198,13 @@ function notebooksPage() {
         heartbeatInterval: null,
         _boundBeforeUnload: null,
 
+        // Lock revocation
+        lockRevoked: false,
+        revokedNotebook: '',
+
         async init() {
             await this.loadNotebooks();
+            this.connectWs();
         },
 
         async loadNotebooks() {
@@ -268,6 +280,24 @@ function notebooksPage() {
                 window.removeEventListener('beforeunload', this._boundBeforeUnload);
                 this._boundBeforeUnload = null;
             }
+        },
+
+        connectWs() {
+            const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+            this._ws = new WebSocket(`${protocol}//${window.location.host}/ws`);
+            this._ws.onmessage = (evt) => {
+                try {
+                    const data = JSON.parse(evt.data);
+                    if (data.event === 'notebook_lock_revoked' && data.notebook === this.activeNotebook) {
+                        this.stopHeartbeat();
+                        this.lockRevoked = true;
+                        this.revokedNotebook = data.notebook;
+                        this.activeNotebook = null;
+                        this.loadNotebooks();
+                    }
+                } catch (e) { /* ignore parse errors */ }
+            };
+            this._ws.onclose = () => { setTimeout(() => this.connectWs(), 5000); };
         },
 
         async copyNotebook(nb) {

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -346,10 +346,16 @@ exemptions:
     reason: "TASK-045a: 8 test classes covering schedule help, list, status, remove, enable, disable, add wizard (sync, dbt, custom cron, cancelled). Marginally over limit."
     review_by: "v1.1"
 
-  - file: tests/unit/test_web_notebooks.py
-    lines: 515
+  - file: dango/web/routes/notebooks.py
+    lines: 506
     category: exempt
-    reason: "TEST-030: 7 test classes covering page, list, create, delete, lock, heartbeat, release, force-release, copy. Marginally over limit after locked_at test addition."
+    reason: "R10-D2: Grew to 506 adding heartbeat-based stale lock expiry and WebSocket force-unlock notification. Single router file for notebook management."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_web_notebooks.py
+    lines: 535
+    category: exempt
+    reason: "TEST-030+R10-D2: 7 test classes covering page, list, create, delete, lock, heartbeat, release, force-release (incl. WebSocket broadcast), copy."
     review_by: "v1.1"
 
   - file: dango/governance/schema_drift.py

--- a/tests/unit/test_notebook_locking.py
+++ b/tests/unit/test_notebook_locking.py
@@ -180,3 +180,63 @@ class TestCopyLockedNotebook:
 
         with pytest.raises(FileNotFoundError):
             copy_locked_notebook(tmp_path, "nonexistent", "bob")
+
+
+@pytest.mark.unit
+class TestExpireStaleLocks:
+    def test_expires_stale_lock(self, tmp_path):
+        from dango.notebooks.locking import acquire_lock, expire_stale_locks, is_locked
+
+        acquire_lock(tmp_path, "nb1", "alice")
+
+        # Set heartbeat to 3 minutes ago
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "UPDATE notebook_locks SET last_heartbeat_at = datetime('now', '-3 minutes') "
+                "WHERE notebook_id = 'nb1'"
+            )
+            conn.commit()
+
+        expired = expire_stale_locks(tmp_path, timeout_seconds=120)
+        assert expired == 1
+        assert is_locked(tmp_path, "nb1") is False
+
+    def test_active_heartbeat_preserved(self, tmp_path):
+        from dango.notebooks.locking import acquire_lock, expire_stale_locks, is_locked
+
+        acquire_lock(tmp_path, "nb1", "alice")
+
+        expired = expire_stale_locks(tmp_path, timeout_seconds=120)
+        assert expired == 0
+        assert is_locked(tmp_path, "nb1") is True
+
+    def test_null_heartbeat_preserved(self, tmp_path):
+        from dango.notebooks.locking import expire_stale_locks, is_locked
+
+        # Insert a lock without last_heartbeat_at (simulates pre-migration lock)
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "INSERT INTO notebook_locks (notebook_id, locked_by, locked_at, expires_at) "
+                "VALUES ('nb1', 'alice', datetime('now'), datetime('now', '+15 minutes'))"
+            )
+            conn.commit()
+
+        expired = expire_stale_locks(tmp_path, timeout_seconds=1)
+        assert expired == 0
+        assert is_locked(tmp_path, "nb1") is True
+
+    def test_returns_count(self, tmp_path):
+        from dango.notebooks.locking import acquire_lock, expire_stale_locks
+
+        acquire_lock(tmp_path, "nb1", "alice")
+        acquire_lock(tmp_path, "nb2", "bob")
+
+        # Set both heartbeats to 3 minutes ago
+        with connect(tmp_path) as conn:
+            conn.execute(
+                "UPDATE notebook_locks SET last_heartbeat_at = datetime('now', '-3 minutes')"
+            )
+            conn.commit()
+
+        expired = expire_stale_locks(tmp_path, timeout_seconds=120)
+        assert expired == 2

--- a/tests/unit/test_web_notebooks.py
+++ b/tests/unit/test_web_notebooks.py
@@ -481,6 +481,26 @@ class TestForceReleaseLock:
             == 403
         )
 
+    @patch(f"{_P}.ws_manager")
+    @patch(f"{_P}._audit")
+    @patch(f"{_P}.get_project_root")
+    def test_broadcasts_websocket_on_force_release(
+        self, mock_root: MagicMock, mock_audit: MagicMock, mock_ws: MagicMock, tmp_path: Path
+    ) -> None:
+        """Force-release broadcasts notebook_lock_revoked via WebSocket."""
+        from unittest.mock import AsyncMock
+
+        mock_ws.broadcast = AsyncMock()
+        mock_root.return_value = tmp_path
+        _init_db(tmp_path)
+        _seed_lock(tmp_path, "locked_nb", locked_by="other@test.com")
+        resp = _client(tmp_path).delete("/api/notebooks/locked_nb/lock")
+        assert resp.status_code == 200
+        mock_ws.broadcast.assert_called_once()
+        msg = mock_ws.broadcast.call_args[0][0]
+        assert msg["event"] == "notebook_lock_revoked"
+        assert msg["notebook"] == "locked_nb"
+
 
 @pytest.mark.unit
 class TestCopyNotebook:


### PR DESCRIPTION
## Summary
- **BUG-179:** Adds `last_heartbeat_at` column to `notebook_locks` via additive migration. The heartbeat endpoint now calls `expire_stale_locks()` to remove locks with no heartbeat for >120s, preventing orphaned locks when `beforeunload` fails.
- **BUG-176:** Force-unlock now broadcasts `notebook_lock_revoked` via WebSocket. The notebooks page listens for this event and shows a yellow banner to the affected user, stopping their heartbeat.

## Test plan
- [x] `pytest tests/unit/test_notebook_locking.py` — 22 tests pass (4 new for `expire_stale_locks`)
- [x] `pytest tests/unit/test_web_notebooks.py` — 33 tests pass (1 new for WS broadcast)
- [x] `ruff check` + `ruff format` + `mypy` clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)