### PR TITLE
R10-E2: Fix catalog back-button and lineage source disambiguation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `config/models.py` | 600 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 548 | — |
-| `web/routes/catalog.py` | 1331 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
+| `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 846 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -45,7 +45,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule list/get, trigger, reload, cancel, history, notification config/test, `/schedules` page (read-only, ~518 lines). Config mutations removed by R10-C (BUG-175) — use CLI instead. | `router` |
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~506 lines) | `router` |
-| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1331 lines) | `router` |
+| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1336 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
 | `routes/monitoring.py` | Monitor results, run trigger, history + backward-compat redirects for old `/api/insights*` paths (~295 lines) | `router` |
 | `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~496 lines) | `router` |

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -1156,6 +1156,7 @@ def _build_lineage_dag() -> dict[str, Any] | None:
                 "id": uid,
                 "name": src.get("name", ""),
                 "type": "source",
+                "source_name": src.get("source_name", ""),
                 "schema": src.get("schema", ""),
                 "materialization": None,
                 "description": src.get("description", ""),

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -394,7 +394,7 @@
                         </div>
                     </div>
                     <div x-show="hasLineage">
-                        <button @click="viewInLineage(selectedModel.name)"
+                        <button @click="viewInLineage(selectedModel.name, selectedModel.source_name)"
                                 class="px-3 py-1.5 text-sm font-medium bg-indigo-100 text-indigo-700 rounded-md hover:bg-indigo-200 transition-colors">
                             View in Lineage
                         </button>
@@ -421,7 +421,7 @@
                     <option value="3">3 hops</option>
                     <option value="5">5 hops</option>
                 </select>
-                <button @click="lineageFocusName = null; renderLineage()" class="text-indigo-600 hover:underline">Show Full DAG</button>
+                <button @click="lineageFocusName = null; lineageFocusSourceName = null; renderLineage()" class="text-indigo-600 hover:underline">Show Full DAG</button>
             </div>
             <template x-if="lineageNodes.length === 0">
                 <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
@@ -506,7 +506,7 @@ function catalogPage() {
         overview: null,
         // Lineage state
         lineageNodes: [], lineageEdges: [],
-        lineageFocusName: null, lineageDepth: 2,
+        lineageFocusName: null, lineageFocusSourceName: null, lineageDepth: 2,
         selectedNode: null, impactHighlighted: false, impactCount: 0, _lineage: null,
         // Governance state
         piiFindings: [], driftEvents: [], piiOverrides: [],
@@ -561,9 +561,9 @@ function catalogPage() {
             this._skipPush = true;
             await this.restoreFromUrl();
             this._skipPush = false;
-            window.addEventListener('popstate', () => {
+            window.addEventListener('popstate', async () => {
                 this._skipPush = true;
-                this.restoreFromUrl();
+                await this.restoreFromUrl();
                 this._skipPush = false;
             });
         },
@@ -581,6 +581,7 @@ function catalogPage() {
             } else if (this.view === 'lineage') {
                 params.set('view', 'lineage');
                 if (this.lineageFocusName) params.set('focus', this.lineageFocusName);
+                if (this.lineageFocusSourceName) params.set('focus_source', this.lineageFocusSourceName);
             } else if (this.activeTab !== 'all') {
                 params.set('filter', this.activeTab);
             }
@@ -605,13 +606,17 @@ function catalogPage() {
                 }
             } else if (view === 'lineage') {
                 const focus = params.get('focus');
+                const focusSource = params.get('focus_source');
                 if (focus) {
                     this.lineageFocusName = focus;
+                    this.lineageFocusSourceName = focusSource || null;
                     this.lineageDepth = 2;
                 }
                 this.view = 'lineage';
-                this.selectedNode = focus ? (this.lineageNodes.find(n => n.name === focus) || null) : null;
-                this.$nextTick(() => this.renderLineage());
+                this.selectedNode = focus ? (this.lineageNodes.find(n =>
+                    n.name === focus && (!focusSource || n.source_name === focusSource)
+                ) || null) : null;
+                this.$nextTick(() => { this.$nextTick(() => this.renderLineage()); });
             } else if (filter && ['source', 'staging', 'intermediate', 'marts'].includes(filter)) {
                 this.activeTab = filter;
             }
@@ -632,7 +637,7 @@ function catalogPage() {
         goToList() {
             if (this._lineage) { this._lineage.destroy(); this._lineage = null; }
             this.selectedNode = null; this.impactHighlighted = false; this.impactCount = 0;
-            this.lineageFocusName = null;
+            this.lineageFocusName = null; this.lineageFocusSourceName = null;
             this.view = 'list'; this.selectedModel = null; this.detailTab = 'columns';
             if (!this._skipPush) this.updateUrl(false);
         },
@@ -763,14 +768,16 @@ function catalogPage() {
             finally { this.profilingLoading = false; }
         },
 
-        viewInLineage(name) {
+        viewInLineage(name, sourceName) {
             this.view = 'lineage'; this.impactHighlighted = false; this.impactCount = 0;
-            this.lineageFocusName = name; this.lineageDepth = 2;
-            // Pre-select the node so detail panel opens
-            const node = this.lineageNodes.find(n => n.name === name);
+            this.lineageFocusName = name; this.lineageFocusSourceName = sourceName || null;
+            this.lineageDepth = 2;
+            const node = this.lineageNodes.find(n =>
+                n.name === name && (!sourceName || n.source_name === sourceName)
+            );
             this.selectedNode = node || null;
             if (!this._skipPush) this.updateUrl(false);
-            this.$nextTick(() => this.renderLineage());
+            this.$nextTick(() => { this.$nextTick(() => this.renderLineage()); });
         },
 
         timeAgo(dateStr) {
@@ -787,7 +794,7 @@ function catalogPage() {
                 this.goToList();
             } else {
                 this.view = 'lineage'; this.selectedNode = null;
-                this.lineageFocusName = null;
+                this.lineageFocusName = null; this.lineageFocusSourceName = null;
                 this.impactHighlighted = false; this.impactCount = 0;
                 if (!this._skipPush) this.updateUrl(false);
                 this.$nextTick(() => this.renderLineage());
@@ -807,7 +814,9 @@ function catalogPage() {
                 parents[e.target].push(e.source);
             }
             // Find focus node ID
-            const focusNode = this.lineageNodes.find(n => n.name === focusName);
+            const focusNode = this.lineageNodes.find(n =>
+                n.name === focusName && (!this.lineageFocusSourceName || n.source_name === this.lineageFocusSourceName)
+            );
             if (!focusNode) return { nodes: this.lineageNodes, edges: this.lineageEdges };
             const focusId = focusNode.id;
             const reachable = new Set([focusId]);

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -797,7 +797,7 @@ function catalogPage() {
                 this.lineageFocusName = null; this.lineageFocusSourceName = null;
                 this.impactHighlighted = false; this.impactCount = 0;
                 if (!this._skipPush) this.updateUrl(false);
-                this.$nextTick(() => this.renderLineage());
+                this.$nextTick(() => { this.$nextTick(() => this.renderLineage()); });
             }
         },
         filterLineage(focusName, depth) {

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -329,9 +329,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/catalog.py
-    lines: 1331
+    lines: 1336
     category: exempt
-    reason: "P7-001+P7-002+BUG-016+R9-G+R10-E1: Column schema, profiling, lineage DAG, impact analysis, model list/detail/search, raw table discovery, overview summary, per-source stats. Single router file — manifest parsing helpers are private to the same module."
+    reason: "P7-001+P7-002+BUG-016+R9-G+R10-E1+R10-E2: Column schema, profiling, lineage DAG, impact analysis, model list/detail/search, raw table discovery, overview summary, per-source stats. Single router file — manifest parsing helpers are private to the same module."
     review_by: "v1.1"
 
   - file: tests/unit/test_catalog_models.py

--- a/tests/unit/test_catalog_lineage.py
+++ b/tests/unit/test_catalog_lineage.py
@@ -126,8 +126,10 @@ def _make_manifest(
     src: dict[str, Any] = {}
     if sources:
         for uid, s in sources.items():
+            parts = uid.split(".")
             src[uid] = {
-                "name": s.get("name", uid.split(".")[-1]),
+                "name": s.get("name", parts[-1] if parts else ""),
+                "source_name": s.get("source_name", parts[2] if len(parts) > 2 else ""),
                 "schema": s.get("schema", "raw_shop"),
                 "description": s.get("description", ""),
                 "columns": s.get("columns", {}),
@@ -351,6 +353,36 @@ class TestGetLineage:
         assert len(source_nodes) == 1
         assert source_nodes[0]["name"] == "orders"
         assert source_nodes[0]["materialization"] is None
+
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_source_nodes_include_source_name(
+        self,
+        mock_manifest: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Source nodes in lineage include source_name for disambiguation."""
+        client, _ = _setup_client(tmp_path)
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shopify.orders": {
+                    "name": "orders",
+                    "source_name": "shopify",
+                },
+                "source.proj.stripe.orders": {
+                    "name": "orders",
+                    "source_name": "stripe",
+                },
+            },
+        )
+
+        resp = client.get("/api/catalog/lineage")
+        data = resp.json()
+
+        source_nodes = [n for n in data["nodes"] if n["type"] == "source"]
+        assert len(source_nodes) == 2
+        source_names = {n["source_name"] for n in source_nodes}
+        assert source_names == {"shopify", "stripe"}
+        assert all(n["name"] == "orders" for n in source_nodes)
 
     def test_requires_permission(self, tmp_path: Path) -> None:
         """Endpoint requires governance.view permission (viewer has it)."""


### PR DESCRIPTION
## Summary
- **BUG-156:** Browser back button now properly re-renders catalog page content (async popstate handler + double `$nextTick`)
- **BUG-158:** Lineage view disambiguates same-named source tables (e.g., `shopify.orders` vs `stripe.orders`) using `source_name` field

## Changes
- Backend: Added `source_name` field to source nodes in `_build_lineage_dag()`
- Frontend: Track `lineageFocusSourceName` state, pass `focus_source` URL param, disambiguate in `viewInLineage()`/`filterLineage()`/`restoreFromUrl()`
- Tests: Added `test_source_nodes_include_source_name` + updated `_make_manifest()` helper

## Test plan
- [x] `pytest tests/unit/test_catalog_lineage.py` — 17 passed
- [x] `pytest tests/unit/test_catalog_models.py` — 24 passed
- [x] `ruff check` + `ruff format --check` + `mypy` — all clean
- [x] Pre-commit hooks pass
- [ ] Manual: navigate catalog → click model → back button → page re-renders
- [ ] Manual: view source table → "View in Lineage" → shows filtered graph for that source only

🤖 Generated with [Claude Code](https://claude.com/claude-code)