### PR TITLE
R10-E3: Sources UX fixes (BUG-159, BUG-160)

### DIFF
--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -2655,6 +2655,7 @@ window.closeUploadModal = closeUploadModal;
 window.openSourceDetail = openSourceDetail;
 window.closeSourceDetail = closeSourceDetail;
 window.openSyncHistory = openSyncHistory;
+window.closeSyncHistory = closeSyncHistory;
 window.runDbtModel = runDbtModel;
 window.refreshDbtModels = refreshDbtModels;
 window.switchTab = switchTab;

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -2024,7 +2024,7 @@ ${details.config.description ? `<div><span class="font-semibold text-gray-700">N
         // Set catalog link
         const catalogLinkEl = document.getElementById('detail-catalog-link');
         if (catalogLinkEl) {
-            catalogLinkEl.innerHTML = `<a href="/catalog?model=${encodeURIComponent(sourceName)}" class="text-sm text-indigo-600 hover:text-indigo-800 hover:underline">View in Catalog &rarr;</a>`;
+            catalogLinkEl.innerHTML = `<a href="/catalog?source=${encodeURIComponent(sourceName)}" class="text-sm text-indigo-600 hover:text-indigo-800 hover:underline">View in Catalog &rarr;</a>`;
         }
 
         // Show content, hide loading
@@ -2043,11 +2043,73 @@ function closeSourceDetail() {
 }
 
 async function openSyncHistory(sourceName) {
-    await openSourceDetail(sourceName);
-    setTimeout(() => {
-        const el = document.getElementById('detail-history');
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }, 200);
+    const modal = document.getElementById('sync-history-modal');
+    if (!modal) {
+        // Fallback: open full detail modal scrolled to history
+        await openSourceDetail(sourceName);
+        setTimeout(() => {
+            const el = document.getElementById('detail-history');
+            if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 200);
+        return;
+    }
+
+    // Show compact sync history modal
+    modal.classList.remove('hidden');
+    const nameEl = document.getElementById('sync-history-source-name');
+    if (nameEl) nameEl.textContent = sourceName;
+
+    const tbody = document.getElementById('sync-history-body');
+    const noHistory = document.getElementById('sync-history-empty');
+    if (tbody) tbody.innerHTML = '<tr><td colspan="4" class="px-4 py-3 text-center text-gray-500 text-sm">Loading...</td></tr>';
+    if (noHistory) noHistory.classList.add('hidden');
+
+    try {
+        const response = await fetch(`/api/sources/${encodeURIComponent(sourceName)}/details`);
+        if (!response.ok) throw new Error('Failed to load');
+        const data = await response.json();
+        const history = (data.history || []).slice(0, 5);
+
+        if (!history.length) {
+            if (tbody) tbody.innerHTML = '';
+            if (noHistory) noHistory.classList.remove('hidden');
+            return;
+        }
+
+        if (tbody) {
+            tbody.innerHTML = history.map(entry => {
+                const statusClass = entry.status === 'success'
+                    ? 'bg-green-100 text-green-800'
+                    : 'bg-red-100 text-red-800';
+                const statusLabel = entry.status === 'success' ? 'OK' : 'Fail';
+                const duration = entry.duration != null ? entry.duration.toFixed(1) + 's' : '-';
+                const rows = entry.row_count != null ? entry.row_count.toLocaleString() : '-';
+                const time = formatRelativeTime(entry.timestamp);
+                return `<tr class="border-t border-gray-100">
+                    <td class="px-4 py-2 text-sm text-gray-600">${escapeHtml(time)}</td>
+                    <td class="px-4 py-2"><span class="px-2 py-0.5 text-xs font-medium rounded-full ${statusClass}">${statusLabel}</span></td>
+                    <td class="px-4 py-2 text-sm text-gray-600">${escapeHtml(duration)}</td>
+                    <td class="px-4 py-2 text-sm text-gray-600">${escapeHtml(rows)}</td>
+                </tr>`;
+            }).join('');
+        }
+    } catch (error) {
+        console.error('Error loading sync history:', error);
+        if (tbody) tbody.innerHTML = '<tr><td colspan="4" class="px-4 py-3 text-center text-red-500 text-sm">Failed to load history</td></tr>';
+    }
+
+    // Wire up "View full details" link
+    const fullDetailsBtn = document.getElementById('sync-history-full-details');
+    if (fullDetailsBtn) {
+        fullDetailsBtn.onclick = () => {
+            closeSyncHistory();
+            openSourceDetail(sourceName);
+        };
+    }
+}
+
+function closeSyncHistory() {
+    document.getElementById('sync-history-modal')?.classList.add('hidden');
 }
 
 function renderSourceHistory(history) {

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -140,6 +140,13 @@
             </template>
             <template x-if="searchResults === null">
                 <div>
+                    <template x-if="sourceFilter">
+                        <div class="mb-3 flex items-center gap-2 text-sm text-gray-600">
+                            Showing tables from source: <span class="font-medium" x-text="sourceFilter"></span>
+                            <button @click="sourceFilter = null; activeTab = 'all'; if (!_skipPush) updateUrl(false)"
+                                class="ml-2 text-indigo-600 hover:underline text-xs">Show all</button>
+                        </div>
+                    </template>
                     <template x-if="filteredItems.length === 0 && !loading">
                         <div class="bg-white shadow rounded-lg p-8 text-center text-gray-500">
                             <template x-if="allModels.length === 0 && allSources.length === 0">
@@ -495,6 +502,7 @@ function catalogPage() {
     return {
         view: 'list',
         activeTab: 'all',
+        sourceFilter: null,
         searchQuery: '',
         searchResults: null,
         allModels: [],
@@ -582,6 +590,8 @@ function catalogPage() {
                 params.set('view', 'lineage');
                 if (this.lineageFocusName) params.set('focus', this.lineageFocusName);
                 if (this.lineageFocusSourceName) params.set('focus_source', this.lineageFocusSourceName);
+            } else if (this.sourceFilter) {
+                params.set('source', this.sourceFilter);
             } else if (this.activeTab !== 'all') {
                 params.set('filter', this.activeTab);
             }
@@ -596,6 +606,7 @@ function catalogPage() {
         async restoreFromUrl() {
             const params = new URLSearchParams(window.location.search);
             const model = params.get('model');
+            const source = params.get('source');
             const view = params.get('view');
             const filter = params.get('filter');
             if (model) {
@@ -604,6 +615,9 @@ function catalogPage() {
                 if (tab && ['columns', 'code', 'info'].includes(tab)) {
                     this.detailTab = tab;
                 }
+            } else if (source) {
+                this.activeTab = 'source';
+                this.sourceFilter = source;
             } else if (view === 'lineage') {
                 const focus = params.get('focus');
                 const focusSource = params.get('focus_source');
@@ -623,6 +637,9 @@ function catalogPage() {
         },
 
         get filteredItems() {
+            if (this.sourceFilter) {
+                return this.allSources.filter(s => s.source_name === this.sourceFilter);
+            }
             const items = [...this.allSources, ...this.allModels];
             if (this.activeTab === 'all') return items;
             return items.filter(i => i.type === this.activeTab);
@@ -637,7 +654,7 @@ function catalogPage() {
         goToList() {
             if (this._lineage) { this._lineage.destroy(); this._lineage = null; }
             this.selectedNode = null; this.impactHighlighted = false; this.impactCount = 0;
-            this.lineageFocusName = null; this.lineageFocusSourceName = null;
+            this.lineageFocusName = null; this.lineageFocusSourceName = null; this.sourceFilter = null;
             this.view = 'list'; this.selectedModel = null; this.detailTab = 'columns';
             if (!this._skipPush) this.updateUrl(false);
         },

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -265,6 +265,49 @@
         </div>
     </div>
 
+    <!-- Compact Sync History Modal -->
+    <div id="sync-history-modal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+        <div class="relative top-20 mx-auto p-5 border w-full max-w-lg shadow-lg rounded-md bg-white">
+            <!-- Header -->
+            <div class="flex items-center justify-between pb-3 border-b">
+                <h3 class="text-lg font-semibold text-gray-900">
+                    Recent Syncs: <span id="sync-history-source-name" class="text-blue-600"></span>
+                </h3>
+                <button onclick="closeSyncHistory()" class="text-gray-400 hover:text-gray-600">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+
+            <!-- History Table -->
+            <div class="mt-3 overflow-x-auto">
+                <table class="min-w-full">
+                    <thead>
+                        <tr class="text-left text-xs font-medium text-gray-500 uppercase">
+                            <th class="px-4 py-2">When</th>
+                            <th class="px-4 py-2">Status</th>
+                            <th class="px-4 py-2">Duration</th>
+                            <th class="px-4 py-2">Rows</th>
+                        </tr>
+                    </thead>
+                    <tbody id="sync-history-body">
+                    </tbody>
+                </table>
+                <div id="sync-history-empty" class="hidden text-center py-6 text-gray-500 text-sm">
+                    No sync history available
+                </div>
+            </div>
+
+            <!-- Footer -->
+            <div class="mt-4 pt-3 border-t flex justify-end">
+                <button id="sync-history-full-details" class="text-sm text-indigo-600 hover:text-indigo-800 hover:underline">
+                    View full details &rarr;
+                </button>
+            </div>
+        </div>
+    </div>
+
     <!-- Toast Notification Container -->
     <div id="toast-container" class="fixed bottom-4 right-4 space-y-2 z-50">
         <!-- Toasts will be added here dynamically -->


### PR DESCRIPTION
## Summary
- **BUG-159:** "View in Catalog" link now uses `?source=` parameter instead of `?model=`. Catalog page handles the new param by filtering to tables belonging to that source, with a banner and "Show all" button to clear the filter.
- **BUG-160:** Status pill click now opens a compact sync history popup (last 5 syncs: relative time, status badge, duration, rows) instead of the full detail modal. "View full details" link bridges to the full modal.

## Test plan
- [ ] Sources page → click source name → full detail popup with config, history, stats
- [ ] Sources page → click status pill → compact popup with last 5 syncs only
- [ ] Compact popup → "View full details" → opens full detail popup
- [ ] Source detail popup → "View in Catalog" → catalog shows filtered list of that source's tables
- [ ] Catalog → `?source=chess` URL → shows only that source's tables, "Show all" clears filter
- [ ] No JS console errors on sources or catalog pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)