### PR TITLE
R10-F1: Fix 6 sources with date_range/start_date mismatch

### DIFF
--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -427,7 +427,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "popularity": 9,
         "capabilities": {
             "performance_metrics": True,
-            "date_range": True,
+            "date_range": False,
             "incremental": True,
             "custom_queries": False,
         },
@@ -1103,7 +1103,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "popularity": 5,
         "capabilities": {
             "performance_metrics": True,
-            "date_range": True,
+            "date_range": False,
             "incremental": True,
             "custom_queries": True,
         },
@@ -1254,7 +1254,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "popularity": 7,
         "capabilities": {
             "performance_metrics": False,
-            "date_range": True,
+            "date_range": False,
             "incremental": True,
             "custom_queries": False,
         },
@@ -1745,7 +1745,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "popularity": 7,
         "capabilities": {
             "performance_metrics": False,
-            "date_range": True,
+            "date_range": False,
             "incremental": True,
             "custom_queries": False,
         },
@@ -1806,7 +1806,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "popularity": 6,
         "capabilities": {
             "performance_metrics": False,
-            "date_range": True,
+            "date_range": False,
             "incremental": True,
             "custom_queries": False,
         },
@@ -1837,7 +1837,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "popularity": 3,
         "capabilities": {
             "performance_metrics": False,
-            "date_range": True,
+            "date_range": False,
             "incremental": False,
             "custom_queries": False,
         },

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -76,6 +76,25 @@ class TestSourceSupportsDateRange:
     def test_unknown_source_not_supported(self) -> None:
         assert _source_supports_date_range("nonexistent_source_xyz") is False
 
+    def test_chess_no_date_range(self) -> None:
+        """Chess source has no date-related params at all."""
+        assert _source_supports_date_range("chess") is False
+
+    def test_date_range_capability_matches_start_date_param(self) -> None:
+        """date_range capability flag must be consistent with start_date param presence."""
+        from dango.ingestion.sources.registry import SOURCE_REGISTRY
+
+        for source_type, metadata in SOURCE_REGISTRY.items():
+            caps = metadata.get("capabilities", {})
+            has_flag = caps.get("date_range", False)
+            all_params = metadata.get("optional_params", []) + metadata.get("required_params", [])
+            has_param = any(p.get("name") == "start_date" for p in all_params)
+
+            assert has_flag == has_param, (
+                f"Source '{source_type}': date_range={has_flag} but "
+                f"{'has' if has_param else 'missing'} start_date param"
+            )
+
 
 def _make_mock_source(name: str = "test_src", source_type: str = "stripe"):
     """Create a mock DataSource with the given name and type."""


### PR DESCRIPTION
## Summary

- Set `date_range: False` for 6 sources that declared date range support but lacked a `start_date` parameter: `facebook_ads`, `matomo`, `pipedrive`, `kafka`, `kinesis`, `chess`
- Add regression test that asserts no source in the registry can have `date_range: True` without a corresponding `start_date` param
- Fixes BUG-151 and BUG-187: the web UI showed a "Custom Date Range" option (based on `capabilities["date_range"]`) that silently did nothing because the CLI's `_source_supports_date_range()` checks for a literal `start_date` param

## Audit results (all 33 sources)

**8 sources retain `date_range: True`** (all have `start_date` param): google_analytics, stripe, shopify, slack, zendesk, google_ads, mux, workable

**6 sources fixed to `date_range: False`:**
| Source | Reason |
|--------|--------|
| `facebook_ads` | Uses `initial_load_past_days` (relative window) |
| `matomo` | Date params hardcoded in `default_config.queries` |
| `chess` | No date-related params at all |
| `pipedrive` | `since_timestamp` is incremental cursor |
| `kafka` | `start_from` is consumer offset |
| `kinesis` | `initial_at_timestamp` is stream iterator position |

**Remaining 19 sources** already had `date_range: False` — no change needed.

## Test plan

- [x] `pytest tests/unit/test_cli_sync.py -x -v` — 30 tests pass
- [x] `ruff check` + `ruff format --check` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)