### PR TITLE
R10-F2: Source wizard lookback prompt, sync mode display, source edit command

### DIFF
--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -116,6 +116,49 @@ def source_add(ctx: click.Context) -> None:
         raise click.Abort()
 
 
+@source.command("edit")
+@click.pass_context
+def source_edit(ctx: click.Context) -> None:
+    """Open sources.yml in your default editor ($EDITOR)."""
+    from pathlib import Path
+
+    project_root = ctx.obj.get("project_root")
+    if not project_root:
+        console.print("[red]Not in a dango project directory[/red]")
+        return
+
+    sources_file = Path(project_root) / ".dango" / "sources.yml"
+    if not sources_file.exists():
+        console.print("[red]No sources.yml found[/red]")
+        console.print("[dim]Run 'dango source add' first[/dim]")
+        return
+
+    original = sources_file.read_text()
+    edited = click.edit(original, extension=".yml")
+
+    if edited is None:
+        console.print("[yellow]No editor or no changes.[/yellow]")
+        console.print(f"[dim]Edit manually: {sources_file}[/dim]")
+        return
+
+    if edited == original:
+        console.print("[dim]No changes detected.[/dim]")
+        return
+
+    # Validate YAML syntax
+    import yaml
+
+    try:
+        yaml.safe_load(edited)
+    except yaml.YAMLError as e:
+        console.print(f"[red]Invalid YAML:[/red] {e}")
+        console.print("[yellow]Changes NOT saved.[/yellow]")
+        return
+
+    sources_file.write_text(edited)
+    console.print("[green]sources.yml updated[/green]")
+
+
 @source.command("list")
 @click.option("--enabled-only", is_flag=True, help="Show only enabled sources")
 @click.pass_context

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -217,6 +217,31 @@ class SourceWizard:
             # Step 7: Create source config
             source_config = self._create_source_config(source_name, source_type, params, metadata)
 
+            # Step 7b: Prompt for lookback window if source has a registry default
+            default_lookback = (metadata.get("default_config") or {}).get("lookback_days")
+            if default_lookback is not None:
+                ad_sources = {"google_ads", "facebook_ads"}
+                console.print(f"\n[bold]Lookback window: {default_lookback} day(s)[/bold]")
+                console.print(
+                    "  [dim]Each incremental sync re-loads recent data to catch "
+                    "late-arriving records.[/dim]"
+                )
+                if source_type in ad_sources:
+                    console.print(
+                        "  [dim]Ad platform attribution can update for days after "
+                        "the initial report (e.g., Google Ads up to 30 days).[/dim]"
+                    )
+                keep = Confirm.ask(f"  Keep default of {default_lookback} days?", default=True)
+                if keep:
+                    source_config["lookback_days"] = default_lookback
+                else:
+                    from rich.prompt import IntPrompt
+
+                    custom = IntPrompt.ask("  Enter lookback days", default=default_lookback)
+                    if custom < 1:
+                        custom = 1
+                    source_config["lookback_days"] = custom
+
             # Step 8: If secrets required, validate credentials FIRST (before saving)
             if self.secret_params:
                 import os
@@ -331,14 +356,6 @@ class SourceWizard:
                 console.print(
                     "  [dim]You can press Ctrl+C during sync — progress is saved "
                     "and resumes on next run.[/dim]"
-                )
-
-            # Show lookback window setting if configured
-            lookback = (metadata.get("default_config") or {}).get("lookback_days")
-            if lookback:
-                console.print(
-                    f"\n  [dim]Lookback window: {lookback} day(s) — each incremental "
-                    f"sync re-loads recent data to catch late-arriving records.[/dim]"
                 )
 
             # Unified success message for all sources

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -810,6 +810,18 @@ async def get_source_status_data(source: dict) -> SourceStatus:
     supports_incremental = capabilities.get("incremental", True) if capabilities else True
     supports_date_range = capabilities.get("date_range", False) if capabilities else False
 
+    # Derive sync mode and lookback from capabilities + config
+    sync_mode = "incremental" if supports_incremental else "full_refresh"
+    write_disposition = "merge" if supports_incremental else "replace"
+
+    lookback_days = source.get("lookback_days")
+    if lookback_days is None:
+        from dango.ingestion.sources.registry import get_source_metadata
+
+        meta = get_source_metadata(source_type)
+        if meta:
+            lookback_days = (meta.get("default_config") or {}).get("lookback_days")
+
     return SourceStatus(
         name=source_name,
         type=source_type,
@@ -821,4 +833,7 @@ async def get_source_status_data(source: dict) -> SourceStatus:
         tables=tables,
         supports_incremental=supports_incremental,
         supports_date_range=supports_date_range,
+        sync_mode=sync_mode,
+        lookback_days=lookback_days,
+        write_disposition=write_disposition,
     )

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -32,6 +32,9 @@ class SourceStatus(BaseModel):
     schedule_display: str | None = None  # Human-readable schedule (e.g., "Every 6 hours")
     supports_incremental: bool = True  # Whether source supports incremental sync
     supports_date_range: bool = False  # Whether source supports custom date range sync
+    sync_mode: str | None = None  # "incremental" or "full_refresh"
+    lookback_days: int | None = None  # Lookback window in days (if applicable)
+    write_disposition: str | None = None  # "merge" or "replace"
     needs_attention: bool = False  # Whether source has unresolved breaking drift
     attention_reason: str | None = None  # Why source needs attention
 

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -150,6 +150,19 @@ async def get_source_details(source_name: str) -> dict[str, object]:
     if tables_info and tables_info.get("has_multiple_tables"):
         tables = [TableInfo(**t) for t in tables_info["tables"]]
 
+    # Derive sync mode and lookback
+    from dango.ingestion.sources.registry import get_source_capabilities, get_source_metadata
+
+    capabilities = get_source_capabilities(source_config.get("type", ""))
+    supports_incremental = capabilities.get("incremental", True) if capabilities else True
+    sync_mode = "incremental" if supports_incremental else "full_refresh"
+
+    lookback_days = source_config.get("lookback_days")
+    if lookback_days is None:
+        meta = get_source_metadata(source_config.get("type", ""))
+        if meta:
+            lookback_days = (meta.get("default_config") or {}).get("lookback_days")
+
     return {
         "name": source_name,
         "config": masked_config,
@@ -157,4 +170,6 @@ async def get_source_details(source_name: str) -> dict[str, object]:
         "row_count": row_count,
         "freshness": freshness,
         "tables": tables,
+        "sync_mode": sync_mode,
+        "lookback_days": lookback_days,
     }

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1208,6 +1208,7 @@ function renderSourcesTable() {
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
                     ${source.type}
                 </span>
+                <div class="text-xs text-gray-400 mt-0.5">${source.sync_mode === 'full_refresh' ? 'Full Refresh' : 'Incremental'}${source.lookback_days ? ` (${source.lookback_days}d)` : ''}</div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap cursor-pointer" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" title="Click to view sync history">
                 ${renderStatusPill(source, isSyncing, hasFileOps)}
@@ -1960,6 +1961,13 @@ async function openSourceDetail(sourceName) {
             }
 
             freshnessElement.innerHTML = freshnessHTML;
+        }
+
+        const syncModeEl = document.getElementById('detail-sync-mode');
+        if (syncModeEl) {
+            const mode = details.sync_mode === 'incremental' ? 'Incremental' : 'Full Refresh';
+            const lookback = details.lookback_days ? ` (${details.lookback_days}d lookback)` : '';
+            syncModeEl.textContent = mode + lookback;
         }
 
         const history = details.history || [];

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -187,7 +187,7 @@
                 <!-- Content -->
                 <div id="detail-content" class="hidden space-y-6">
                     <!-- Stats Overview -->
-                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                         <div class="bg-blue-50 p-4 rounded-lg">
                             <div class="text-sm text-gray-600">Total Rows</div>
                             <div id="detail-row-count" class="text-2xl font-bold text-gray-900">-</div>
@@ -195,6 +195,10 @@
                         <div class="bg-purple-50 p-4 rounded-lg">
                             <div class="text-sm text-gray-600">Sync Count</div>
                             <div id="detail-sync-count" class="text-2xl font-bold text-gray-900">0</div>
+                        </div>
+                        <div class="bg-indigo-50 p-4 rounded-lg">
+                            <div class="text-sm text-gray-600">Sync Mode</div>
+                            <div id="detail-sync-mode" class="text-lg font-bold text-gray-900">-</div>
                         </div>
                     </div>
 

--- a/tests/unit/test_source_edit.py
+++ b/tests/unit/test_source_edit.py
@@ -1,0 +1,125 @@
+"""tests/unit/test_source_edit.py
+
+Tests for dango source edit command and SourceStatus sync mode fields.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.source import source_edit
+from dango.web.models import SourceStatus
+
+
+class TestSourceStatusSyncFields:
+    """Test SourceStatus model accepts sync mode fields."""
+
+    def test_sync_mode_defaults_none(self) -> None:
+        status = SourceStatus(name="test", type="csv", enabled=True)
+        assert status.sync_mode is None
+        assert status.lookback_days is None
+        assert status.write_disposition is None
+
+    def test_sync_mode_incremental(self) -> None:
+        status = SourceStatus(
+            name="test",
+            type="google_analytics",
+            enabled=True,
+            sync_mode="incremental",
+            lookback_days=2,
+            write_disposition="merge",
+        )
+        assert status.sync_mode == "incremental"
+        assert status.lookback_days == 2
+        assert status.write_disposition == "merge"
+
+    def test_sync_mode_full_refresh(self) -> None:
+        status = SourceStatus(
+            name="test",
+            type="csv",
+            enabled=True,
+            sync_mode="full_refresh",
+            write_disposition="replace",
+        )
+        assert status.sync_mode == "full_refresh"
+        assert status.lookback_days is None
+        assert status.write_disposition == "replace"
+
+
+class TestSourceEdit:
+    """Test dango source edit command."""
+
+    def test_no_project_root(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(source_edit, obj={"project_root": None})
+        assert result.exit_code == 0
+        assert "Not in a dango project" in result.output
+
+    def test_no_sources_file(self, tmp_path: pytest.TempPathFactory) -> None:
+        runner = CliRunner()
+        result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
+        assert result.exit_code == 0
+        assert "No sources.yml found" in result.output
+
+    def test_editor_returns_none(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Editor returns None when user doesn't save."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        sources_file = dango_dir / "sources.yml"
+        sources_file.write_text("sources:\n  - name: test\n")
+
+        runner = CliRunner()
+        with patch("click.edit", return_value=None):
+            result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
+        assert result.exit_code == 0
+        assert "No editor or no changes" in result.output
+        assert "sources.yml" in result.output
+
+    def test_no_changes(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Editor returns same content."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        sources_file = dango_dir / "sources.yml"
+        original = "sources:\n  - name: test\n"
+        sources_file.write_text(original)
+
+        runner = CliRunner()
+        with patch("click.edit", return_value=original):
+            result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
+        assert result.exit_code == 0
+        assert "No changes detected" in result.output
+
+    def test_valid_edit_saves(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Valid YAML edit is saved."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        sources_file = dango_dir / "sources.yml"
+        original = "sources:\n  - name: test\n"
+        edited = "sources:\n  - name: test\n    enabled: false\n"
+        sources_file.write_text(original)
+
+        runner = CliRunner()
+        with patch("click.edit", return_value=edited):
+            result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
+        assert result.exit_code == 0
+        assert "sources.yml updated" in result.output
+        assert sources_file.read_text() == edited
+
+    def test_invalid_yaml_rejected(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Invalid YAML is rejected and file unchanged."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        sources_file = dango_dir / "sources.yml"
+        original = "sources:\n  - name: test\n"
+        invalid = "sources:\n  - name: test\n  bad: [unclosed\n"
+        sources_file.write_text(original)
+
+        runner = CliRunner()
+        with patch("click.edit", return_value=invalid):
+            result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
+        assert result.exit_code == 0
+        assert "Invalid YAML" in result.output
+        assert "Changes NOT saved" in result.output
+        # File should be unchanged
+        assert sources_file.read_text() == original


### PR DESCRIPTION
## Summary

- **BUG-163/166:** Add interactive lookback_days prompt in source wizard (between config creation and save) with attribution explanation for ad platforms. Remove old read-only display.
- **BUG-164:** Show sync mode (Incremental/Full Refresh) and lookback days in web UI — source detail modal stat box + sub-badge in source table. New `sync_mode`, `lookback_days`, `write_disposition` fields on `SourceStatus` model.
- **BUG-165:** Add `dango source edit` command that opens sources.yml in `$EDITOR` with YAML validation before saving.

## Test plan

- [x] 9 new unit tests passing (`tests/unit/test_source_edit.py`)
- [x] Existing tests pass (`test_cli_sync.py`, `test_source_registry.py`)
- [x] mypy clean on all modified files
- [x] ruff lint + format clean
- [x] All pre-commit hooks pass
- [ ] Manual: `dango source add` with google_analytics → lookback prompt appears
- [ ] Manual: `dango source edit` → opens editor or prints path
- [ ] Manual: Sources page detail modal → shows "Sync Mode: Incremental (2d lookback)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)