### PR TITLE
R10-F3: Fix sync bugs (BUG-152, BUG-182)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ dango/                          # Python package source
 │   └── watcher_runner.py       # → local/watcher_runner.py
 │
 ├── ingestion/                  # Level 1 — Data loading
-│   ├── dlt_runner.py           # ⚠ 2415 lines — orchestrates full sync pipeline
+│   ├── dlt_runner.py           # ⚠ 2458 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # Multi-format file loading with dedup (922 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
@@ -332,7 +332,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `ingestion/dlt_runner.py` | 2415 | — (exempt, too risky) |
+| `ingestion/dlt_runner.py` | 2458 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2288 | — |
 | `visualization/metabase.py` | 1151 | — |
@@ -357,7 +357,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 600 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
-| `transformation/generator.py` | 548 | — |
+| `transformation/generator.py` | 575 | — |
 | `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 846 | — (provisioning orchestration + BYOS) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ dango/                          # Python package source
 │   └── watcher_runner.py       # → local/watcher_runner.py
 │
 ├── ingestion/                  # Level 1 — Data loading
-│   ├── dlt_runner.py           # ⚠ 2458 lines — orchestrates full sync pipeline
+│   ├── dlt_runner.py           # ⚠ 2460 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # Multi-format file loading with dedup (922 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
@@ -332,7 +332,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 
 | File | Lines | Refactoring Task |
 |------|-------|-----------------|
-| `ingestion/dlt_runner.py` | 2458 | — (exempt, too risky) |
+| `ingestion/dlt_runner.py` | 2460 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2288 | — |
 | `visualization/metabase.py` | 1151 | — |
@@ -357,7 +357,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/validate.py` | 651 | — |
 | `config/models.py` | 600 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
-| `transformation/generator.py` | 575 | — |
+| `transformation/generator.py` | 577 | — |
 | `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 846 | — (provisioning orchestration + BYOS) |

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -457,6 +457,7 @@ class DltPipelineRunner:
                 "status": result_status,
                 "duration_seconds": round(duration, 2),
                 "rows_processed": rows_loaded,
+                "total_row_count": result.get("total_row_count"),
                 "full_refresh": is_full_refresh,
                 "error_message": error_message,
                 "start_date": effective_start,
@@ -1060,7 +1061,12 @@ class DltPipelineRunner:
 
             # Check for row count anomalies
             if rows_loaded >= 0:
-                anomaly = self._check_row_count_anomaly(source_name, rows_loaded)
+                total_row_count = self._get_source_total_rows(source_name)
+                if total_row_count is not None:
+                    stats["total_row_count"] = total_row_count
+                anomaly = self._check_row_count_anomaly(
+                    source_name, rows_loaded, total_rows=total_row_count
+                )
                 if anomaly:
                     stats["anomaly"] = anomaly
 
@@ -1697,41 +1703,76 @@ class DltPipelineRunner:
         mins = minutes % 60
         return f"{hours}h {mins}m"
 
-    def _check_row_count_anomaly(
-        self, source_name: str, current_rows: int
-    ) -> dict[str, Any] | None:
-        """Check for row count anomalies compared to previous sync.
+    def _get_source_total_rows(self, source_name: str) -> int | None:
+        """Get total row count across all tables in a source's raw schema."""
+        import duckdb
 
+        schema = f"raw_{source_name}"
+        try:
+            conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
+            tables = conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = ? AND table_name NOT LIKE '\\_dlt\\_%' ESCAPE '\\'",
+                [schema],
+            ).fetchall()
+            total = 0
+            for (table_name,) in tables:
+                result = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table_name}"').fetchone()
+                if result:
+                    total += result[0]
+            conn.close()
+            return total
+        except Exception:
+            return None
+
+    def _check_row_count_anomaly(
+        self, source_name: str, current_rows: int, total_rows: int | None = None
+    ) -> dict[str, Any] | None:
+        """Check for row count anomalies by comparing total table row counts.
+
+        Queries DuckDB for total rows across all tables in raw_{source_name}
+        schema, then compares against previous sync's total.
         Returns an anomaly dict if detected, None otherwise.
         """
         from dango.utils.sync_history import load_sync_history
 
-        history = load_sync_history(self.project_root, source_name, limit=5)
-        # Find the most recent successful sync (skip current)
-        prev_rows = None
-        for entry in history:
-            if entry.get("status") == "success" and entry.get("rows_processed", 0) > 0:
-                prev_rows = entry["rows_processed"]
-                break
+        # Get total rows across ALL tables in the source schema
+        if total_rows is None:
+            total_rows = self._get_source_total_rows(source_name)
+        if total_rows is None:
+            return None  # Can't query DB — skip check
 
-        if prev_rows is None:
+        # Find previous total from history
+        history = load_sync_history(self.project_root, source_name, limit=5)
+        prev_total = None
+        for entry in history:
+            if entry.get("status") == "success":
+                # Prefer total_row_count (new field), fall back to rows_processed
+                if entry.get("total_row_count", 0) > 0:
+                    prev_total = entry["total_row_count"]
+                    break
+                elif entry.get("rows_processed", 0) > 0:
+                    prev_total = entry["rows_processed"]
+                    break
+
+        if prev_total is None:
             return None  # No baseline — first successful sync
 
-        if current_rows == 0 and prev_rows > 0:
-            msg = f"Zero rows loaded (previous sync: {prev_rows:,})"
+        if total_rows == 0 and prev_total > 0:
+            msg = f"Zero rows in database (previous total: {prev_total:,})"
             console.print(f"  [red]⚠ {msg}[/red]")
-            return {"level": "error", "message": msg}
+            return {"level": "error", "message": msg, "total_row_count": total_rows}
 
-        if prev_rows > 0:
-            ratio = current_rows / prev_rows
+        if prev_total > 0:
+            ratio = total_rows / prev_total
             if ratio < 0.5:
-                msg = f"Row count dropped >50%: {current_rows:,} vs previous {prev_rows:,}"
+                msg = f"Total row count dropped >50%: {total_rows:,} vs previous {prev_total:,}"
                 console.print(f"  [yellow]⚠ {msg}[/yellow]")
-                return {"level": "warning", "message": msg}
+                return {"level": "warning", "message": msg, "total_row_count": total_rows}
             if ratio > 3.0:
-                msg = f"Row count spiked >300%: {current_rows:,} vs previous {prev_rows:,}"
+                msg = f"Total row count spiked >300%: {total_rows:,} vs previous {prev_total:,}"
                 console.print(f"  [yellow]⚠ {msg}[/yellow]")
-                return {"level": "warning", "message": msg}
+                return {"level": "warning", "message": msg, "total_row_count": total_rows}
 
         return None
 

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -1064,9 +1064,7 @@ class DltPipelineRunner:
                 total_row_count = self._get_source_total_rows(source_name)
                 if total_row_count is not None:
                     stats["total_row_count"] = total_row_count
-                anomaly = self._check_row_count_anomaly(
-                    source_name, rows_loaded, total_rows=total_row_count
-                )
+                anomaly = self._check_row_count_anomaly(source_name, total_rows=total_row_count)
                 if anomaly:
                     stats["anomaly"] = anomaly
 
@@ -1710,23 +1708,27 @@ class DltPipelineRunner:
         schema = f"raw_{source_name}"
         try:
             conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
-            tables = conn.execute(
-                "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = ? AND table_name NOT LIKE '\\_dlt\\_%' ESCAPE '\\'",
-                [schema],
-            ).fetchall()
-            total = 0
-            for (table_name,) in tables:
-                result = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table_name}"').fetchone()
-                if result:
-                    total += result[0]
-            conn.close()
-            return total
+            try:
+                tables = conn.execute(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = ? AND table_name NOT LIKE '\\_dlt\\_%' ESCAPE '\\'",
+                    [schema],
+                ).fetchall()
+                total = 0
+                for (table_name,) in tables:
+                    result = conn.execute(
+                        f'SELECT COUNT(*) FROM "{schema}"."{table_name}"'
+                    ).fetchone()
+                    if result:
+                        total += result[0]
+                return total
+            finally:
+                conn.close()
         except Exception:
             return None
 
     def _check_row_count_anomaly(
-        self, source_name: str, current_rows: int, total_rows: int | None = None
+        self, source_name: str, total_rows: int | None = None
     ) -> dict[str, Any] | None:
         """Check for row count anomalies by comparing total table row counts.
 

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -138,12 +138,14 @@ class DbtModelGenerator:
             return None
         try:
             conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
-            result = conn.execute(
-                "SELECT table_name FROM information_schema.tables "
-                "WHERE table_schema = ? AND table_name LIKE '%\\_\\_%' ESCAPE '\\'",
-                [schema],
-            ).fetchall()
-            conn.close()
+            try:
+                result = conn.execute(
+                    "SELECT table_name FROM information_schema.tables "
+                    "WHERE table_schema = ? AND table_name LIKE '%\\_\\_%' ESCAPE '\\'",
+                    [schema],
+                ).fetchall()
+            finally:
+                conn.close()
             for (table_name,) in result:
                 collapsed = "_".join(filter(None, table_name.split("_")))
                 if collapsed == normalized_name:

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -132,6 +132,26 @@ class DbtModelGenerator:
             # Table might not exist yet - return empty
             return []
 
+    def _find_dlt_nested_table(self, normalized_name: str, schema: str) -> str | None:
+        """Find a dlt nested table whose name with __ collapsed matches normalized_name."""
+        if not self.duckdb_path.exists():
+            return None
+        try:
+            conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
+            result = conn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = ? AND table_name LIKE '%\\_\\_%' ESCAPE '\\'",
+                [schema],
+            ).fetchall()
+            conn.close()
+            for (table_name,) in result:
+                collapsed = "_".join(filter(None, table_name.split("_")))
+                if collapsed == normalized_name:
+                    return table_name
+            return None
+        except Exception:
+            return None
+
     def infer_dedup_strategy(
         self, source: DataSource, columns: list[dict[str, Any]]
     ) -> tuple[str | None, list[str] | None]:
@@ -412,6 +432,13 @@ class DbtModelGenerator:
 
                     # Get schema from DuckDB
                     columns = self.get_table_schema(table_name, schema=schema_name)
+
+                    if not columns:
+                        # Try dlt nested table naming (double underscore convention)
+                        actual_name = self._find_dlt_nested_table(table_name, schema_name)
+                        if actual_name:
+                            columns = self.get_table_schema(actual_name, schema=schema_name)
+                            table_name = actual_name
 
                     if not columns:
                         # Skip this endpoint if table doesn't exist yet

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -124,9 +124,9 @@ exemptions:
 
   # --- Exempt (stable, not modified in v1) ---
   - file: dango/ingestion/dlt_runner.py
-    lines: 2415
+    lines: 2458
     category: exempt
-    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000. P5c grew +480 lines (credential unification, resource selection, local_files routing). P8-001 added headers/data_selector/params passthrough (+8 lines). R9-I added skip_sync_notification param + sync_result passthrough to post_sync hooks."
+    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000. P5c grew +480 lines (credential unification, resource selection, local_files routing). P8-001 added headers/data_selector/params passthrough (+8 lines). R9-I added skip_sync_notification param + sync_result passthrough to post_sync hooks. R10-F3 added _get_source_total_rows + rewrote anomaly check to use DB totals (BUG-182)."
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
@@ -180,9 +180,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 548
+    lines: 575
     category: exempt
-    reason: "DbtModelGenerator — generates dbt models from source configs. Stable, rarely modified."
+    reason: "DbtModelGenerator — generates dbt models from source configs. R10-F3 added _find_dlt_nested_table for double-underscore table discovery (BUG-152)."
     review_by: "v1.1"
 
   - file: dango/platform/local/watcher.py

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -124,7 +124,7 @@ exemptions:
 
   # --- Exempt (stable, not modified in v1) ---
   - file: dango/ingestion/dlt_runner.py
-    lines: 2458
+    lines: 2460
     category: exempt
     reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000. P5c grew +480 lines (credential unification, resource selection, local_files routing). P8-001 added headers/data_selector/params passthrough (+8 lines). R9-I added skip_sync_notification param + sync_result passthrough to post_sync hooks. R10-F3 added _get_source_total_rows + rewrote anomaly check to use DB totals (BUG-182)."
     review_by: "v1.1"
@@ -180,7 +180,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 575
+    lines: 577
     category: exempt
     reason: "DbtModelGenerator — generates dbt models from source configs. R10-F3 added _find_dlt_nested_table for double-underscore table discovery (BUG-152)."
     review_by: "v1.1"

--- a/tests/unit/test_dbt_generator.py
+++ b/tests/unit/test_dbt_generator.py
@@ -1,0 +1,64 @@
+"""tests/unit/test_dbt_generator.py
+
+Tests for DbtModelGenerator nested table discovery (BUG-152).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+
+@pytest.mark.unit
+class TestFindDltNestedTable:
+    """Tests for DbtModelGenerator._find_dlt_nested_table."""
+
+    def _make_generator(self, tmp_path: Path) -> object:
+        from dango.transformation.generator import DbtModelGenerator
+
+        gen = DbtModelGenerator(tmp_path)
+        return gen
+
+    def _create_db_with_tables(self, db_path: Path, schema: str, tables: list[str]) -> None:
+        conn = duckdb.connect(str(db_path))
+        conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+        for table in tables:
+            conn.execute(f'CREATE TABLE "{schema}"."{table}" (id INTEGER)')
+        conn.close()
+
+    def test_find_dlt_nested_table_found(self, tmp_path: Path) -> None:
+        gen = self._make_generator(tmp_path)
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True)
+        self._create_db_with_tables(
+            db_path, "raw_chess", ["players_profiles__streaming_platforms", "games"]
+        )
+
+        result = gen._find_dlt_nested_table("players_profiles_streaming_platforms", "raw_chess")
+        assert result == "players_profiles__streaming_platforms"
+
+    def test_find_dlt_nested_table_not_found(self, tmp_path: Path) -> None:
+        gen = self._make_generator(tmp_path)
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True)
+        self._create_db_with_tables(db_path, "raw_chess", ["games", "players"])
+
+        result = gen._find_dlt_nested_table("nonexistent_table", "raw_chess")
+        assert result is None
+
+    def test_find_dlt_nested_table_no_db(self, tmp_path: Path) -> None:
+        gen = self._make_generator(tmp_path)
+        result = gen._find_dlt_nested_table("some_table", "raw_chess")
+        assert result is None
+
+    def test_find_dlt_nested_table_multiple_underscores(self, tmp_path: Path) -> None:
+        """Table with triple underscore should also be findable."""
+        gen = self._make_generator(tmp_path)
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True)
+        self._create_db_with_tables(db_path, "raw_src", ["parent__child__grandchild"])
+
+        result = gen._find_dlt_nested_table("parent_child_grandchild", "raw_src")
+        assert result == "parent__child__grandchild"

--- a/tests/unit/test_ingestion_ux.py
+++ b/tests/unit/test_ingestion_ux.py
@@ -123,20 +123,19 @@ class TestCheckRowCountAnomaly:
         """No DuckDB file → graceful degradation, returns None."""
         runner = self._make_runner(tmp_path)
         self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 500}])
-        assert runner._check_row_count_anomaly("src", 100) is None
+        assert runner._check_row_count_anomaly("src") is None
 
     def test_no_history_returns_none(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
         self._setup_db(tmp_path, "src", {"orders": 100})
-        assert runner._check_row_count_anomaly("src", 100) is None
+        assert runner._check_row_count_anomaly("src") is None
 
     def test_incremental_no_false_alarm(self, tmp_path: Path) -> None:
         """DB has 68K rows total, history shows 68K previous → no warning."""
         runner = self._make_runner(tmp_path)
         self._setup_db(tmp_path, "src", {"orders": 50000, "customers": 18000})
         self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 68000}])
-        # Incremental sync only loaded 200 rows, but DB total is 68K
-        result = runner._check_row_count_anomaly("src", 200)
+        result = runner._check_row_count_anomaly("src")
         assert result is None
 
     def test_actual_drop_triggers_warning(self, tmp_path: Path) -> None:
@@ -144,7 +143,7 @@ class TestCheckRowCountAnomaly:
         runner = self._make_runner(tmp_path)
         self._setup_db(tmp_path, "src", {"orders": 250, "customers": 150})
         self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 1000}])
-        result = runner._check_row_count_anomaly("src", 50)
+        result = runner._check_row_count_anomaly("src")
         assert result is not None
         assert result["level"] == "warning"
         assert "dropped" in result["message"]
@@ -154,7 +153,7 @@ class TestCheckRowCountAnomaly:
         runner = self._make_runner(tmp_path)
         self._setup_db(tmp_path, "src", {"orders": 0, "customers": 0})
         self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 500}])
-        result = runner._check_row_count_anomaly("src", 0)
+        result = runner._check_row_count_anomaly("src")
         assert result is not None
         assert result["level"] == "error"
         assert "Zero rows" in result["message"]
@@ -165,7 +164,7 @@ class TestCheckRowCountAnomaly:
         self._setup_db(tmp_path, "src", {"orders": 300})
         self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 1000}])
         # DB total is 300 vs prev 1000 → >50% drop
-        result = runner._check_row_count_anomaly("src", 50)
+        result = runner._check_row_count_anomaly("src")
         assert result is not None
         assert result["level"] == "warning"
         assert "dropped" in result["message"]
@@ -175,7 +174,7 @@ class TestCheckRowCountAnomaly:
         runner = self._make_runner(tmp_path)
         self._setup_db(tmp_path, "src", {"orders": 50004, "customers": 18000})
         self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 68000}])
-        result = runner._check_row_count_anomaly("src", 4)
+        result = runner._check_row_count_anomaly("src")
         assert result is None
 
     def test_large_spike_returns_warning(self, tmp_path: Path) -> None:
@@ -183,7 +182,7 @@ class TestCheckRowCountAnomaly:
         runner = self._make_runner(tmp_path)
         self._setup_db(tmp_path, "src", {"orders": 4000})
         self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 1000}])
-        result = runner._check_row_count_anomaly("src", 3000)
+        result = runner._check_row_count_anomaly("src")
         assert result is not None
         assert result["level"] == "warning"
         assert "spiked" in result["message"]
@@ -194,7 +193,7 @@ class TestCheckRowCountAnomaly:
         # No DB setup — would return None if it tried to query
         self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 1000}])
         # Pass total_rows=800 directly — within normal range
-        result = runner._check_row_count_anomaly("src", 50, total_rows=800)
+        result = runner._check_row_count_anomaly("src", total_rows=800)
         assert result is None
 
     def test_dlt_internal_tables_excluded(self, tmp_path: Path) -> None:

--- a/tests/unit/test_ingestion_ux.py
+++ b/tests/unit/test_ingestion_ux.py
@@ -81,7 +81,11 @@ class TestIdentifyFailingResource:
 
 @pytest.mark.unit
 class TestCheckRowCountAnomaly:
-    """Tests for DltPipelineRunner._check_row_count_anomaly."""
+    """Tests for DltPipelineRunner._check_row_count_anomaly.
+
+    After BUG-182 fix, anomaly detection compares total DB rows (across all
+    tables in raw_{source} schema) against previous sync's total_row_count.
+    """
 
     def _make_runner(self, tmp_path: Path) -> object:
         """Create a minimal DltPipelineRunner with a project_root."""
@@ -89,6 +93,7 @@ class TestCheckRowCountAnomaly:
 
         runner = DltPipelineRunner.__new__(DltPipelineRunner)
         runner.project_root = tmp_path
+        runner.duckdb_path = tmp_path / "data" / "warehouse.duckdb"
         return runner
 
     def _write_history(self, tmp_path: Path, source_name: str, entries: list[dict]) -> None:
@@ -97,49 +102,118 @@ class TestCheckRowCountAnomaly:
         with open(history_dir / f"{source_name}.json", "w") as f:
             json.dump(entries, f)
 
-    def test_no_history_returns_none(self, tmp_path: Path) -> None:
-        runner = self._make_runner(tmp_path)
-        assert runner._check_row_count_anomaly("test_source", 100) is None
+    def _setup_db(self, tmp_path: Path, source_name: str, table_rows: dict[str, int]) -> None:
+        """Create DuckDB with raw_{source_name} schema and tables with given row counts."""
+        import duckdb
 
-    def test_first_successful_sync_returns_none(self, tmp_path: Path) -> None:
-        # History has only failed entries — no baseline
-        self._write_history(tmp_path, "src", [{"status": "failed", "rows_processed": 0}])
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        schema = f"raw_{source_name}"
+        conn = duckdb.connect(str(db_path))
+        conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+        for table_name, count in table_rows.items():
+            conn.execute(f'CREATE TABLE "{schema}"."{table_name}" (id INTEGER)')
+            if count > 0:
+                conn.execute(
+                    f'INSERT INTO "{schema}"."{table_name}" SELECT unnest(range(1, {count + 1}))'
+                )
+        conn.close()
+
+    def test_no_db_returns_none(self, tmp_path: Path) -> None:
+        """No DuckDB file → graceful degradation, returns None."""
         runner = self._make_runner(tmp_path)
+        self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 500}])
         assert runner._check_row_count_anomaly("src", 100) is None
 
-    def test_zero_rows_after_nonzero_returns_error(self, tmp_path: Path) -> None:
-        self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 500}])
+    def test_no_history_returns_none(self, tmp_path: Path) -> None:
         runner = self._make_runner(tmp_path)
+        self._setup_db(tmp_path, "src", {"orders": 100})
+        assert runner._check_row_count_anomaly("src", 100) is None
+
+    def test_incremental_no_false_alarm(self, tmp_path: Path) -> None:
+        """DB has 68K rows total, history shows 68K previous → no warning."""
+        runner = self._make_runner(tmp_path)
+        self._setup_db(tmp_path, "src", {"orders": 50000, "customers": 18000})
+        self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 68000}])
+        # Incremental sync only loaded 200 rows, but DB total is 68K
+        result = runner._check_row_count_anomaly("src", 200)
+        assert result is None
+
+    def test_actual_drop_triggers_warning(self, tmp_path: Path) -> None:
+        """DB has 400 rows, history shows 1000 total → warning (ratio 0.4 < 0.5)."""
+        runner = self._make_runner(tmp_path)
+        self._setup_db(tmp_path, "src", {"orders": 250, "customers": 150})
+        self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 1000}])
+        result = runner._check_row_count_anomaly("src", 50)
+        assert result is not None
+        assert result["level"] == "warning"
+        assert "dropped" in result["message"]
+
+    def test_zero_rows_error(self, tmp_path: Path) -> None:
+        """DB has 0 rows, history shows 500 total → error."""
+        runner = self._make_runner(tmp_path)
+        self._setup_db(tmp_path, "src", {"orders": 0, "customers": 0})
+        self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 500}])
         result = runner._check_row_count_anomaly("src", 0)
         assert result is not None
         assert result["level"] == "error"
         assert "Zero rows" in result["message"]
 
-    def test_large_drop_returns_warning(self, tmp_path: Path) -> None:
-        self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 1000}])
+    def test_backward_compat_falls_back_to_rows_processed(self, tmp_path: Path) -> None:
+        """History lacks total_row_count → falls back to rows_processed."""
         runner = self._make_runner(tmp_path)
-        result = runner._check_row_count_anomaly("src", 400)
+        self._setup_db(tmp_path, "src", {"orders": 300})
+        self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 1000}])
+        # DB total is 300 vs prev 1000 → >50% drop
+        result = runner._check_row_count_anomaly("src", 50)
         assert result is not None
         assert result["level"] == "warning"
         assert "dropped" in result["message"]
 
-    def test_large_spike_returns_warning(self, tmp_path: Path) -> None:
-        self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 100}])
+    def test_normal_growth_no_alarm(self, tmp_path: Path) -> None:
+        """DB has 68004, history shows 68000 → no warning."""
         runner = self._make_runner(tmp_path)
-        result = runner._check_row_count_anomaly("src", 500)
+        self._setup_db(tmp_path, "src", {"orders": 50004, "customers": 18000})
+        self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 68000}])
+        result = runner._check_row_count_anomaly("src", 4)
+        assert result is None
+
+    def test_large_spike_returns_warning(self, tmp_path: Path) -> None:
+        """DB total spiked >300% from previous → warning."""
+        runner = self._make_runner(tmp_path)
+        self._setup_db(tmp_path, "src", {"orders": 4000})
+        self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 1000}])
+        result = runner._check_row_count_anomaly("src", 3000)
         assert result is not None
         assert result["level"] == "warning"
         assert "spiked" in result["message"]
 
-    def test_normal_change_returns_none(self, tmp_path: Path) -> None:
-        self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 1000}])
+    def test_total_rows_passed_in(self, tmp_path: Path) -> None:
+        """When total_rows is passed, it uses that instead of querying DB."""
         runner = self._make_runner(tmp_path)
-        assert runner._check_row_count_anomaly("src", 800) is None
+        # No DB setup — would return None if it tried to query
+        self._write_history(tmp_path, "src", [{"status": "success", "total_row_count": 1000}])
+        # Pass total_rows=800 directly — within normal range
+        result = runner._check_row_count_anomaly("src", 50, total_rows=800)
+        assert result is None
 
-    def test_normal_increase_returns_none(self, tmp_path: Path) -> None:
-        self._write_history(tmp_path, "src", [{"status": "success", "rows_processed": 1000}])
+    def test_dlt_internal_tables_excluded(self, tmp_path: Path) -> None:
+        """_dlt_ prefixed tables should not be counted in total."""
+        import duckdb
+
         runner = self._make_runner(tmp_path)
-        assert runner._check_row_count_anomaly("src", 2500) is None
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = duckdb.connect(str(db_path))
+        conn.execute('CREATE SCHEMA IF NOT EXISTS "raw_src"')
+        conn.execute('CREATE TABLE "raw_src"."orders" (id INTEGER)')
+        conn.execute('INSERT INTO "raw_src"."orders" SELECT unnest(range(1, 101))')
+        conn.execute('CREATE TABLE "raw_src"."_dlt_loads" (id INTEGER)')
+        conn.execute('INSERT INTO "raw_src"."_dlt_loads" SELECT unnest(range(1, 10001))')
+        conn.close()
+
+        total = runner._get_source_total_rows("src")
+        assert total == 100  # Only orders, not _dlt_loads
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **BUG-152:** dlt nested tables use `__` in DuckDB but staging model generator collapsed consecutive underscores → table not found. Added `_find_dlt_nested_table()` fallback that matches collapsed names to actual `__` table names.
- **BUG-182:** Row count anomaly check compared per-sync loaded rows (subset) against previous total, causing false ">50% drop" warnings on every incremental sync. Rewrote to compare total DB rows across all source tables, with `total_row_count` persisted in sync history.

## Changes
| File | Change |
|------|--------|
| `dango/transformation/generator.py` | Added `_find_dlt_nested_table()`, modified lookup to try `__` naming |
| `dango/ingestion/dlt_runner.py` | Added `_get_source_total_rows()`, rewrote `_check_row_count_anomaly()` to use DB totals, added `total_row_count` to history |
| `tests/unit/test_dbt_generator.py` | New — 4 tests for nested table discovery |
| `tests/unit/test_ingestion_ux.py` | Rewrote anomaly tests with DuckDB setup — 11 tests |
| `docs/file-exemptions.yml` | Updated line counts |
| `CLAUDE.md` | Updated line counts in monolithic files table |

## Test plan
- [x] `pytest tests/unit/test_dbt_generator.py` — 4/4 pass
- [x] `pytest tests/unit/test_ingestion_ux.py` — 46/46 pass
- [x] Full unit suite passes
- [x] ruff check + format clean
- [x] mypy clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)