### PR TITLE
R10-G1: Generalize monitor auto-generation for all source types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ dango/                          # Python package source
 │   ├── data_validation.py      # Data validation utilities
 │   ├── env_file.py             # .env file parsing and serialization
 │   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
-│   ├── post_sync.py            # Post-sync hook dispatcher (~553 lines)
+│   ├── post_sync.py            # Post-sync hook dispatcher (~554 lines)
 │   └── git_info.py             # Git repository info + deployment guardrails
 │
 ├── migrations/                 # Level 0 — Database migration framework
@@ -344,7 +344,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 895 | — (module-level job functions) |
-| `utils/post_sync.py` | 553 | — (post-sync hooks + sync notification) |
+| `utils/post_sync.py` | 554 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 518 | — (schedule read-only, history, trigger, notifications) |
 | `web/routes/notebooks.py` | 506 | — (notebook management API + heartbeat lock expiry + WS notify) |
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |

--- a/dango/analysis/templates.py
+++ b/dango/analysis/templates.py
@@ -43,7 +43,9 @@ def generate_metrics_for_source(
     }
     generator = generators.get(source_type)
     if generator is not None:
-        return generator(source_name)
+        result = generator(source_name)
+        if result:
+            return result
     # Fallback: auto-discover tables and generate generic metrics
     return _generic_metrics(source_name, project_root)
 

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -20,7 +20,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~553 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_ga4_metrics()`, `_send_sync_notification()` |
+| `post_sync.py` (~554 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -385,12 +385,12 @@ def _run_pii_scan(project_root: Path, sources: list[str]) -> None:
 def _run_analysis(project_root: Path, sources: list[str]) -> None:
     """Run automated analysis on freshly synced sources.
 
-    Also auto-generates GA4 metric templates after first sync (column names
+    Also auto-generates metric templates after first sync (column names
     are only known once DuckDB has data).
     """
     try:
-        # Auto-generate GA4 metric templates now that columns exist in DuckDB
-        _ensure_ga4_metrics(project_root, sources)
+        # Auto-generate metric templates now that columns exist in DuckDB
+        _ensure_default_metrics(project_root, sources)
 
         from dango.analysis.metrics import run_analysis
 
@@ -402,8 +402,8 @@ def _run_analysis(project_root: Path, sources: list[str]) -> None:
         logger.warning("analysis_hook_error", sources=sources, exc_info=True)
 
 
-def _ensure_ga4_metrics(project_root: Path, sources: list[str]) -> None:
-    """Generate GA4 metric templates if not already present.  Never raises."""
+def _ensure_default_metrics(project_root: Path, sources: list[str]) -> None:
+    """Generate metric templates for synced sources if not already present.  Never raises."""
     try:
         from dango.analysis.config import add_monitors_to_config, load_monitors_config
         from dango.analysis.templates import generate_metrics_for_source
@@ -412,20 +412,21 @@ def _ensure_ga4_metrics(project_root: Path, sources: list[str]) -> None:
         config = get_config(project_root)
         existing_names = {m.name for m in load_monitors_config(project_root).monitors}
         for source in config.sources.sources:
-            if source.type.value != "google_analytics" or source.name not in sources:
+            if source.name not in sources:
                 continue
             new = [
                 m
                 for m in generate_metrics_for_source(
-                    "google_analytics", source.name, project_root=project_root
+                    source.type.value, source.name, project_root=project_root
                 )
                 if m.name not in existing_names
             ]
             if new:
                 add_monitors_to_config(project_root, new)
-                logger.info("ga4_metrics_auto_generated", source=source.name, count=len(new))
+                existing_names.update(m.name for m in new)
+                logger.info("metrics_auto_generated", source=source.name, count=len(new))
     except Exception:
-        logger.debug("ga4_metrics_auto_generate_skipped", exc_info=True)
+        logger.debug("metrics_auto_generate_skipped", exc_info=True)
 
 
 def _deliver_to_webhooks(

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -311,7 +311,7 @@ exemptions:
   # --- Phase 4 scheduling ---
 
   - file: dango/utils/post_sync.py
-    lines: 553
+    lines: 554
     category: exempt
     reason: "R9-I: Added _deliver_to_webhooks shared helper and _send_sync_notification for CLI sync webhook delivery. Marginally over limit."
     review_by: "v1.1"

--- a/tests/unit/test_analysis_templates.py
+++ b/tests/unit/test_analysis_templates.py
@@ -129,10 +129,19 @@ class TestGenerateMetricsForSource:
         sessions_metric = next(m for m in metrics if "sessions" in m.name)
         assert "engaged" not in sessions_metric.value_expression
 
-    def test_csv_generates_no_metrics(self) -> None:
-        """CSV template returns empty (table name unknown at add time)."""
+    def test_csv_generates_no_metrics_without_warehouse(self) -> None:
+        """CSV without project_root returns empty (table name unknown at add time)."""
         metrics = generate_metrics_for_source("csv", "uploads")
         assert len(metrics) == 0
+
+    def test_csv_falls_through_to_generic_after_sync(self, tmp_path: Path) -> None:
+        """CSV with warehouse falls through to generic metrics (BUG-174)."""
+        _create_generic_warehouse(tmp_path, "uploads", {"sales_2024": ["id", "amount"]})
+
+        metrics = generate_metrics_for_source("csv", "uploads", project_root=tmp_path)
+
+        assert len(metrics) >= 1
+        assert any("sales_2024" in m.source_table for m in metrics)
 
     def test_unknown_source_returns_empty(self) -> None:
         """Unknown source type returns an empty list."""

--- a/tests/unit/test_analysis_templates.py
+++ b/tests/unit/test_analysis_templates.py
@@ -182,13 +182,15 @@ class TestGA4DynamicMetrics:
         assert len(metrics) == 1
         assert metrics[0].name == "ga_daily_sessions"
 
-    def test_no_matching_columns_returns_empty(self, tmp_path: Path) -> None:
-        """No matching columns → no metrics."""
+    def test_no_matching_columns_falls_through_to_generic(self, tmp_path: Path) -> None:
+        """No matching GA4 columns → falls through to generic row_count metrics."""
         _create_ga4_warehouse(tmp_path, ["other_column", "another_column"])
 
         metrics = generate_metrics_for_source("google_analytics", "ga", project_root=tmp_path)
 
-        assert len(metrics) == 0
+        # Generic fallback discovers the traffic table and generates row_count
+        assert len(metrics) >= 1
+        assert any("row_count" in m.name for m in metrics)
 
     def test_duckdb_error_returns_empty(self, tmp_path: Path) -> None:
         """DuckDB errors are swallowed gracefully."""

--- a/tests/unit/test_post_sync.py
+++ b/tests/unit/test_post_sync.py
@@ -6,7 +6,7 @@ Tests for the post-sync dispatcher (dango/utils/post_sync.py).
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -140,3 +140,189 @@ class TestDispatchPostSyncHooks:
         import dango.utils.post_sync as ps
 
         assert not hasattr(ps, "_run_drift_detection")
+
+
+_CFG = "dango.config"
+_ANALYSIS_CFG = "dango.analysis.config"
+_ANALYSIS_TPL = "dango.analysis.templates"
+
+
+def _make_source(name: str, source_type: str) -> MagicMock:
+    """Create a mock DataSource with name and type."""
+    src = MagicMock()
+    src.name = name
+    src.type.value = source_type
+    return src
+
+
+@pytest.mark.unit
+class TestEnsureDefaultMetrics:
+    """Unit tests for _ensure_default_metrics (BUG-174)."""
+
+    def test_non_ga4_source_triggers_generate(self, tmp_path: Path) -> None:
+        """Non-GA4 source (hubspot) triggers generate_metrics_for_source with correct type."""
+        from dango.utils.post_sync import _ensure_default_metrics
+
+        mock_config = MagicMock()
+        mock_config.sources.sources = [_make_source("hs", "hubspot")]
+        mock_monitors_config = MagicMock()
+        mock_monitors_config.monitors = []
+
+        with (
+            patch(f"{_CFG}.get_config", return_value=mock_config),
+            patch(f"{_ANALYSIS_CFG}.load_monitors_config", return_value=mock_monitors_config),
+            patch(f"{_ANALYSIS_TPL}.generate_metrics_for_source", return_value=[]) as mock_gen,
+            patch(f"{_ANALYSIS_CFG}.add_monitors_to_config"),
+        ):
+            _ensure_default_metrics(tmp_path, ["hs"])
+
+        mock_gen.assert_called_once_with("hubspot", "hs", project_root=tmp_path)
+
+    def test_ga4_source_still_passes_google_analytics(self, tmp_path: Path) -> None:
+        """GA4 source passes 'google_analytics' type (no regression)."""
+        from dango.utils.post_sync import _ensure_default_metrics
+
+        mock_config = MagicMock()
+        mock_config.sources.sources = [_make_source("ga", "google_analytics")]
+        mock_monitors_config = MagicMock()
+        mock_monitors_config.monitors = []
+
+        with (
+            patch(f"{_CFG}.get_config", return_value=mock_config),
+            patch(f"{_ANALYSIS_CFG}.load_monitors_config", return_value=mock_monitors_config),
+            patch(f"{_ANALYSIS_TPL}.generate_metrics_for_source", return_value=[]) as mock_gen,
+            patch(f"{_ANALYSIS_CFG}.add_monitors_to_config"),
+        ):
+            _ensure_default_metrics(tmp_path, ["ga"])
+
+        mock_gen.assert_called_once_with("google_analytics", "ga", project_root=tmp_path)
+
+    def test_multiple_sources_each_processed(self, tmp_path: Path) -> None:
+        """Multiple sources in single sync each get processed."""
+        from dango.utils.post_sync import _ensure_default_metrics
+
+        mock_config = MagicMock()
+        mock_config.sources.sources = [
+            _make_source("hs", "hubspot"),
+            _make_source("stripe1", "stripe"),
+        ]
+        mock_monitors_config = MagicMock()
+        mock_monitors_config.monitors = []
+
+        with (
+            patch(f"{_CFG}.get_config", return_value=mock_config),
+            patch(f"{_ANALYSIS_CFG}.load_monitors_config", return_value=mock_monitors_config),
+            patch(f"{_ANALYSIS_TPL}.generate_metrics_for_source", return_value=[]) as mock_gen,
+            patch(f"{_ANALYSIS_CFG}.add_monitors_to_config"),
+        ):
+            _ensure_default_metrics(tmp_path, ["hs", "stripe1"])
+
+        assert mock_gen.call_count == 2
+
+    def test_dedup_against_existing_monitors(self, tmp_path: Path) -> None:
+        """Monitors already in config are not re-added."""
+        from dango.analysis.models import MonitorConfig
+        from dango.utils.post_sync import _ensure_default_metrics
+
+        existing_monitor = MagicMock()
+        existing_monitor.name = "hs_contacts_row_count"
+
+        mock_config = MagicMock()
+        mock_config.sources.sources = [_make_source("hs", "hubspot")]
+        mock_monitors_config = MagicMock()
+        mock_monitors_config.monitors = [existing_monitor]
+
+        new_metric = MonitorConfig(
+            name="hs_deals_row_count",
+            source_table="raw_hs.deals",
+            value_expression="COUNT(*)",
+        )
+        dup_metric = MonitorConfig(
+            name="hs_contacts_row_count",
+            source_table="raw_hs.contacts",
+            value_expression="COUNT(*)",
+        )
+
+        with (
+            patch(f"{_CFG}.get_config", return_value=mock_config),
+            patch(f"{_ANALYSIS_CFG}.load_monitors_config", return_value=mock_monitors_config),
+            patch(
+                f"{_ANALYSIS_TPL}.generate_metrics_for_source",
+                return_value=[new_metric, dup_metric],
+            ),
+            patch(f"{_ANALYSIS_CFG}.add_monitors_to_config") as mock_add,
+        ):
+            _ensure_default_metrics(tmp_path, ["hs"])
+
+        # Only the non-duplicate metric should be added
+        mock_add.assert_called_once()
+        added = mock_add.call_args[0][1]
+        assert len(added) == 1
+        assert added[0].name == "hs_deals_row_count"
+
+    def test_never_raises(self, tmp_path: Path) -> None:
+        """Function never raises — catches exceptions."""
+        from dango.utils.post_sync import _ensure_default_metrics
+
+        with patch(f"{_CFG}.get_config", side_effect=RuntimeError("boom")):
+            # Should not raise
+            _ensure_default_metrics(tmp_path, ["hs"])
+
+    def test_non_synced_sources_skipped(self, tmp_path: Path) -> None:
+        """Only synced sources are processed (non-synced sources skipped)."""
+        from dango.utils.post_sync import _ensure_default_metrics
+
+        mock_config = MagicMock()
+        mock_config.sources.sources = [
+            _make_source("hs", "hubspot"),
+            _make_source("other", "stripe"),
+        ]
+        mock_monitors_config = MagicMock()
+        mock_monitors_config.monitors = []
+
+        with (
+            patch(f"{_CFG}.get_config", return_value=mock_config),
+            patch(f"{_ANALYSIS_CFG}.load_monitors_config", return_value=mock_monitors_config),
+            patch(f"{_ANALYSIS_TPL}.generate_metrics_for_source", return_value=[]) as mock_gen,
+            patch(f"{_ANALYSIS_CFG}.add_monitors_to_config"),
+        ):
+            # Only "hs" was synced, not "other"
+            _ensure_default_metrics(tmp_path, ["hs"])
+
+        mock_gen.assert_called_once_with("hubspot", "hs", project_root=tmp_path)
+
+    def test_cross_source_dedup(self, tmp_path: Path) -> None:
+        """Monitors added by source A are not duplicated by source B."""
+        from dango.analysis.models import MonitorConfig
+        from dango.utils.post_sync import _ensure_default_metrics
+
+        mock_config = MagicMock()
+        mock_config.sources.sources = [
+            _make_source("src_a", "hubspot"),
+            _make_source("src_b", "stripe"),
+        ]
+        mock_monitors_config = MagicMock()
+        mock_monitors_config.monitors = []
+
+        shared_metric = MonitorConfig(
+            name="shared_metric",
+            source_table="raw_src_a.table",
+            value_expression="COUNT(*)",
+        )
+
+        with (
+            patch(f"{_CFG}.get_config", return_value=mock_config),
+            patch(f"{_ANALYSIS_CFG}.load_monitors_config", return_value=mock_monitors_config),
+            patch(
+                f"{_ANALYSIS_TPL}.generate_metrics_for_source",
+                return_value=[shared_metric],
+            ),
+            patch(f"{_ANALYSIS_CFG}.add_monitors_to_config") as mock_add,
+        ):
+            _ensure_default_metrics(tmp_path, ["src_a", "src_b"])
+
+        # First source adds it, second source should skip it (dedup)
+        assert mock_add.call_count == 1
+        added = mock_add.call_args[0][1]
+        assert len(added) == 1
+        assert added[0].name == "shared_metric"

--- a/tests/unit/test_post_sync.py
+++ b/tests/unit/test_post_sync.py
@@ -142,6 +142,8 @@ class TestDispatchPostSyncHooks:
         assert not hasattr(ps, "_run_drift_detection")
 
 
+# Patch at source modules because _ensure_default_metrics uses lazy imports
+# inside the function body (fresh `from X import Y` each call).
 _CFG = "dango.config"
 _ANALYSIS_CFG = "dango.analysis.config"
 _ANALYSIS_TPL = "dango.analysis.templates"
@@ -256,6 +258,7 @@ class TestEnsureDefaultMetrics:
 
         # Only the non-duplicate metric should be added
         mock_add.assert_called_once()
+        assert mock_add.call_args[0][0] == tmp_path  # project_root passed correctly
         added = mock_add.call_args[0][1]
         assert len(added) == 1
         assert added[0].name == "hs_deals_row_count"


### PR DESCRIPTION
## Summary
- Remove GA4-only filter in `_ensure_default_metrics()` so all source types (hubspot, chess, CSV, etc.) get metric templates auto-generated after first sync (BUG-174)
- Add fallthrough in `templates.py`: registered generators returning `[]` now fall back to generic table-discovery metrics (fixes CSV after sync)
- Add cross-source dedup to prevent duplicate monitors when multiple sources sync together

## Test plan
- [x] 7 new unit tests in `TestEnsureDefaultMetrics` — non-GA4 trigger, GA4 regression, multi-source, dedup, never-raises, non-synced skip, cross-source dedup
- [x] Updated existing `test_no_matching_columns` to reflect fallthrough behavior
- [x] All 46 unit tests pass (`test_post_sync.py` + `test_analysis_templates.py`)
- [x] Integration test passes (`test_analysis_integration.py`)
- [x] ruff check + format + mypy clean
- [x] `post_sync.py` line count updated in exemptions (553 → 554)

🤖 Generated with [Claude Code](https://claude.com/claude-code)