### PR TITLE
R10-J2: Platform UX (BUG-153, BUG-173, BUG-181)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,7 +338,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `visualization/metabase.py` | 1151 | — |
 | `cli/init.py` | 1324 | — |
 | `visualization/dashboard_manager.py` | 1112 | — |
-| `cli/commands/platform.py` | 1011 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 1034 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -14,7 +14,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
 | `commands/source.py` (785 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (1011 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/platform.py` (1034 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -383,6 +383,29 @@ def start(ctx: click.Context, yes: bool) -> None:
         # Check for duplicate port configuration
         _check_duplicate_ports(platform_config)
 
+        # Auto-clean orphaned Docker containers from previous Dango session
+        try:
+            result = subprocess.run(
+                ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                container_ids = [c for c in result.stdout.strip().split("\n") if c]
+                console.print(
+                    f"[yellow]⚠[/yellow]  Found {len(container_ids)} orphaned Docker "
+                    "container(s) from a previous session, cleaning up..."
+                )
+                from dango.platform import DockerManager
+
+                manager = DockerManager(project_root)
+                manager.stop_services()
+                manager.stop_all_dango_containers()
+                console.print()
+        except Exception:
+            pass  # Best-effort — _check_docker_ports will catch remaining issues
+
         # Check Docker service ports (Metabase and dbt-docs)
         _check_docker_ports(platform_config)
 

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -197,6 +197,12 @@ async def insights_redirect() -> RedirectResponse:
     return RedirectResponse(url="/monitoring", status_code=301)
 
 
+@router.get("/query")
+async def query_redirect() -> RedirectResponse:
+    """Redirect /query to Metabase query builder."""
+    return RedirectResponse(url="/metabase/question/new", status_code=301)
+
+
 @router.get("/api")
 async def api_info() -> dict[str, str]:
     """API information endpoint."""

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -110,7 +110,14 @@
                     </template>
                 </tbody>
                 <tbody x-show="notebooks.length === 0" x-cloak>
-                    <tr><td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">No notebooks yet. Create one to get started.</td></tr>
+                    <tr><td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">
+                        <template x-if="canExecute">
+                            <span>No notebooks yet. Create one to get started.</span>
+                        </template>
+                        <template x-if="!canExecute">
+                            <span>No notebooks available.</span>
+                        </template>
+                    </td></tr>
                 </tbody>
             </table>
         </div>

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -81,7 +81,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 1011
+    lines: 1034
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary
- **BUG-153:** Role-aware notebooks empty state — Viewers see "No notebooks available" instead of misleading "Create one to get started"
- **BUG-173:** Add `/query` → `/metabase/question/new` permanent redirect so nav link works before Metabase proxy is active
- **BUG-181:** Auto-detect and clean orphaned Docker containers before port check, preventing unnecessary abort on restart

## Test plan
- [x] ruff check + format pass
- [x] mypy passes on changed files
- [x] 280 unit tests pass (`pytest tests/unit/ -x -k "notebook or ui or platform"`)
- [x] `platform.py` line count (1034) updated in `docs/file-exemptions.yml`, repo `CLAUDE.md`, and `dango/cli/CLAUDE.md`
- [ ] Manual: verify notebooks page shows correct empty state for Viewer vs Editor roles
- [ ] Manual: verify `/query` redirects to Metabase question builder
- [ ] Manual: verify `dango start` auto-cleans orphaned containers without aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)