### PR TITLE
R10-I: Fix webhook defaults, sync progress, pill consistency, in-place updates

### DIFF
--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -625,7 +625,7 @@ def schedule_add(ctx: click.Context) -> None:
                     "notify_on",
                     message="Notify on (select events)",
                     choices=["failure", "success", "stale"],
-                    default=["failure"],
+                    default=["failure", "success", "stale"],
                 )
             ]
         )

--- a/dango/cli/commands/schedule_webhook.py
+++ b/dango/cli/commands/schedule_webhook.py
@@ -108,12 +108,33 @@ def webhook_add(ctx: click.Context) -> None:
     if answers is None:
         return
 
+    # Prompt for event toggles only when no notification settings exist yet
+    # (i.e., first webhook being added). Subsequent webhooks inherit existing settings.
+    has_event_settings = "on_success" in notifications or "on_failure" in notifications
+    if not has_event_settings:
+        event_answers = inquirer.prompt(
+            [
+                inquirer.Checkbox(
+                    "events",
+                    message="Notify on events (space to toggle)",
+                    choices=["success", "failure", "stale"],
+                    default=["success", "failure", "stale"],
+                ),
+            ]
+        )
+        if event_answers is None:
+            return
+        notifications["on_success"] = "success" in event_answers["events"]
+        notifications["on_failure"] = "failure" in event_answers["events"]
+        notifications["on_stale"] = "stale" in event_answers["events"]
+
     entry: dict[str, str] = {
         "name": answers["name"],
         "url": answers["url"],
         "format": answers["format"],
     }
     webhooks.append(entry)
+
     _save_schedules_yaml(project_root, data)
     console.print(f"[green]Webhook '{answers['name']}' added.[/green]")
 

--- a/dango/platform/notifications/webhook.py
+++ b/dango/platform/notifications/webhook.py
@@ -105,7 +105,7 @@ class NotificationConfig(BaseModel):
 
     webhooks: list[WebhookConfig] = []
     on_failure: bool = True
-    on_success: bool = False
+    on_success: bool = True
     on_stale: bool = True
     on_governance: bool = True
     on_analysis: bool = True

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -214,14 +214,45 @@ async def run_sync_task(
             }
         )
 
-        # Run sync with the complete flow (data load -> dbt -> docs -> metabase)
-        summary = run_sync(
-            project_root=get_project_root(),
-            sources=[source_config],
-            start_date=start_date_obj,
-            end_date=end_date_obj,
-            full_refresh=full_refresh,
-        )
+        # Run sync in executor so the event loop stays free for WebSocket broadcasts
+        _project_root = get_project_root()
+
+        async def _sync_heartbeat() -> None:
+            """Broadcast progress every 30s while sync runs."""
+            try:
+                while True:
+                    await asyncio.sleep(30)
+                    elapsed = int(time.time() - start_time)
+                    await ws_manager.broadcast(
+                        {
+                            "event": "sync_progress",
+                            "source": source_name,
+                            "message": f"Sync in progress ({elapsed}s elapsed)",
+                            "timestamp": datetime.now().isoformat(),
+                        }
+                    )
+            except asyncio.CancelledError:
+                pass
+
+        heartbeat = asyncio.create_task(_sync_heartbeat())
+        try:
+            loop = asyncio.get_running_loop()
+            summary = await loop.run_in_executor(
+                None,
+                lambda: run_sync(
+                    project_root=_project_root,
+                    sources=[source_config],
+                    start_date=start_date_obj,
+                    end_date=end_date_obj,
+                    full_refresh=full_refresh,
+                ),
+            )
+        finally:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except asyncio.CancelledError:
+                pass
 
         success = summary["failed_count"] == 0
         # Also check that we actually have successful sources (not just zero failures)
@@ -292,6 +323,15 @@ async def run_sync_task(
         # Get row count after sync (only if successful)
         if success:
             rows_processed = get_source_row_count(source_name) or 0
+            await ws_manager.broadcast(
+                {
+                    "event": "data_load_complete",
+                    "source": source_name,
+                    "message": f"Data loaded: {rows_processed:,} rows",
+                    "timestamp": datetime.now().isoformat(),
+                    "rows_loaded": rows_processed,
+                }
+            )
 
         # Calculate duration
         duration = time.time() - start_time
@@ -346,6 +386,8 @@ async def run_sync_task(
                 else (error_message or "Sync failed"),
                 "timestamp": datetime.now().isoformat(),
                 "error": error_message if not success else None,
+                "rows_loaded": rows_processed if success else 0,
+                "duration_seconds": round(duration, 2),
             }
         )
 

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -32,6 +32,7 @@ let loadSourcesRetryTimeout = null;
 let activeFileOperations = new Map();
 // Track elapsed time intervals for active syncs: Map<sourceName, intervalId>
 let syncTimers = new Map();
+let syncResults = new Map();  // Stores sync_completed data for in-place updates
 
 /**
  * Format a file size in bytes to a human-readable string (B/KB/MB/GB).
@@ -415,13 +416,25 @@ async function handleWebSocketMessage(data) {
 
         case 'sync_progress':
             addLogEntry('info', message, source);
-            // Update progress if we add progress bars in the future
+            break;
+
+        case 'data_load_complete':
+            addLogEntry('success', message || 'Data load complete', source);
             break;
 
         case 'sync_completed':
             console.log('✅ [WS] sync_completed - Source:', source);
             stopSyncTimer(source);
             addLogEntry('success', message || `Sync completed`, source);
+
+            // Store sync result for in-place update after dbt completes
+            if (data.rows_loaded !== undefined) {
+                syncResults.set(source, {
+                    rows_loaded: data.rows_loaded,
+                    timestamp: data.timestamp,
+                    duration_seconds: data.duration_seconds,
+                });
+            }
 
             // Suppress success toast during batch operations (multi-file uploads)
             // The final toast will show when dbt completes
@@ -556,14 +569,18 @@ async function handleWebSocketMessage(data) {
                 if (triggeredSource) {
                     activeSyncs.delete(triggeredSource);
                     console.log('🟢 [WS] [DELAYED] Cleared activeSyncs for:', triggeredSource);
+                    const result = syncResults.get(triggeredSource);
+                    if (result) {
+                        updateSourceRowAfterSync(triggeredSource, result);
+                        syncResults.delete(triggeredSource);
+                    } else {
+                        // Fallback if sync_completed didn't include data
+                        if (!isLoadingSources) loadSources();
+                    }
+                } else {
+                    if (!isLoadingSources) loadSources();
                 }
                 updateSyncCounter();
-
-                // Refresh sources list
-                if (!isLoadingSources) {
-                    console.log('🟢 [WS] [DELAYED] Calling loadSources() after user saw syncing state');
-                    loadSources();
-                }
             }, 500);  // Wait 500ms so user sees the syncing badge
             break;
 
@@ -1210,13 +1227,13 @@ function renderSourcesTable() {
                 </span>
                 <div class="text-xs text-gray-400 mt-0.5">${source.sync_mode === 'full_refresh' ? 'Full Refresh' : 'Incremental'}${source.lookback_days ? ` (${source.lookback_days}d)` : ''}</div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap cursor-pointer" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" title="Click to view sync history">
+            <td class="px-6 py-4 whitespace-nowrap cursor-pointer" data-col="status" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" title="Click to view sync history">
                 ${renderStatusPill(source, isSyncing, hasFileOps)}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="rows">
                 ${renderRowCount(source)}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="last-sync">
                 ${formatRelativeTime(source.last_sync)}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
@@ -1233,8 +1250,8 @@ function renderSourcesTable() {
 function getStatusBadge(status) {
     const badges = {
         'synced': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Synced</span>',
-        'syncing': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 animate-pulse">Syncing...</span>',
-        'processing': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800 animate-pulse">Processing...</span>',
+        'syncing': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 animate-pulse">⏳ Syncing...</span>',
+        'processing': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800 animate-pulse">⚙️ Processing...</span>',
         'empty': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Empty</span>',
         'not_synced': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">Not Synced</span>',
         'failed': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Failed</span>',
@@ -1330,7 +1347,7 @@ function updateSourceStatus(sourceName, newStatus) {
     console.log(`🔄 [updateSourceStatus] Row element found:`, !!row);
 
     if (row) {
-        const statusCell = row.querySelector('td:nth-child(3)');
+        const statusCell = row.querySelector('td[data-col="status"]');
         if (statusCell) {
             statusCell.innerHTML = getStatusBadge(newStatus);
         }
@@ -1347,6 +1364,49 @@ function updateSourceStatus(sourceName, newStatus) {
         if (sources && sources.length > 0) {
             renderSourcesTable();
         }
+    }
+}
+
+function updateSourceRowAfterSync(sourceName, result) {
+    const row = document.getElementById(`source-${sourceName}`);
+    if (!row) {
+        loadSources();
+        return;
+    }
+
+    // Update status pill to Synced
+    const statusCell = row.querySelector('td[data-col="status"]');
+    if (statusCell) {
+        statusCell.innerHTML = '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">✓ Synced</span>';
+    }
+
+    // Update row count
+    if (result.rows_loaded !== undefined && result.rows_loaded !== null) {
+        const rowCountCell = row.querySelector('td[data-col="rows"]');
+        if (rowCountCell) {
+            rowCountCell.textContent = result.rows_loaded.toLocaleString();
+        }
+    }
+
+    // Update last sync time
+    const lastSyncCell = row.querySelector('td[data-col="last-sync"]');
+    if (lastSyncCell) {
+        lastSyncCell.textContent = 'Just now';
+    }
+
+    // Re-enable sync button
+    const syncBtn = document.getElementById(`sync-btn-${sourceName}`);
+    if (syncBtn) {
+        syncBtn.disabled = false;
+        syncBtn.innerHTML = 'Sync Now &#9662;';
+    }
+
+    // Update sources array for consistency with future renders
+    const sourceObj = sources.find(s => s.name === sourceName);
+    if (sourceObj) {
+        sourceObj.freshness = { status: 'synced', last_sync_time: result.timestamp };
+        sourceObj.last_sync = result.timestamp;
+        if (result.rows_loaded !== undefined) sourceObj.row_count = result.rows_loaded;
     }
 }
 

--- a/tests/unit/test_cli_schedule_webhook.py
+++ b/tests/unit/test_cli_schedule_webhook.py
@@ -92,11 +92,14 @@ class TestWebhookAdd:
         mock_root.return_value = project_root
         _write_schedules_yaml(project_root, {})
 
-        mock_prompt.return_value = {
-            "name": "my_hook",
-            "url": "https://example.com/hook",
-            "format": "generic",
-        }
+        mock_prompt.side_effect = [
+            {
+                "name": "my_hook",
+                "url": "https://example.com/hook",
+                "format": "generic",
+            },
+            {"events": ["success", "failure", "stale"]},
+        ]
 
         runner = CliRunner()
         result = runner.invoke(cli, ["schedule", "webhook", "add"])
@@ -107,6 +110,50 @@ class TestWebhookAdd:
         webhooks = data["notifications"]["webhooks"]
         assert len(webhooks) == 1
         assert webhooks[0]["name"] == "my_hook"
+        # Verify event settings were written
+        assert data["notifications"]["on_success"] is True
+
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_second_webhook_skips_event_prompt(
+        self, mock_root: MagicMock, mock_prompt: MagicMock, tmp_path: Path
+    ) -> None:
+        """Adding a second webhook does NOT prompt for events (settings already exist)."""
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        # Pre-existing webhook + event settings
+        _write_schedules_yaml(
+            project_root,
+            {
+                "notifications": {
+                    "webhooks": [{"name": "existing", "url": "https://example.com/a"}],
+                    "on_success": True,
+                    "on_failure": True,
+                    "on_stale": False,
+                }
+            },
+        )
+
+        # Only one prompt call needed (name/url/format) — no event prompt
+        mock_prompt.return_value = {
+            "name": "second_hook",
+            "url": "https://example.com/b",
+            "format": "slack",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "webhook", "add"])
+        plain = _strip_ansi(result.output)
+        assert "added" in plain
+
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        webhooks = data["notifications"]["webhooks"]
+        assert len(webhooks) == 2
+        assert webhooks[1]["name"] == "second_hook"
+        # Event settings unchanged
+        assert data["notifications"]["on_stale"] is False
+        # Only one prompt call (no event prompt)
+        assert mock_prompt.call_count == 1
 
 
 @pytest.mark.unit

--- a/tests/unit/test_web_schedule_page.py
+++ b/tests/unit/test_web_schedule_page.py
@@ -153,7 +153,7 @@ class TestNotificationConfigEndpoint:
         data = resp.json()
         assert data["webhooks"] == []
         assert data["on_failure"] is True
-        assert data["on_success"] is False
+        assert data["on_success"] is True
         assert data["on_stale"] is True
         assert data["stale_threshold_hours"] == 24
 

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -38,7 +38,7 @@ def _make_config(**overrides: Any) -> NotificationConfig:
             {"name": "test-hook", "url": "https://example.com/hook"},
         ],
         "on_failure": True,
-        "on_success": False,
+        "on_success": True,
         "on_stale": True,
     }
     defaults.update(overrides)
@@ -105,7 +105,12 @@ class TestShouldNotify:
         config = _make_config(on_failure=True)
         assert should_notify(EventType.SYNC_FAILED, config) is True
 
-    def test_default_success_disabled(self) -> None:
+    def test_default_success_enabled(self) -> None:
+        """NotificationConfig() now defaults to on_success=True."""
+        config = NotificationConfig()
+        assert config.on_success is True
+
+    def test_explicit_success_disabled(self) -> None:
         config = _make_config(on_success=False)
         assert should_notify(EventType.SYNC_COMPLETED, config) is False
 


### PR DESCRIPTION
## Summary

- **BUG-180:** Change `on_success` default to `True` so webhooks fire on sync success. Add event toggle prompts to `dango schedule webhook add`. Update `schedule add` defaults to `["failure", "success", "stale"]`.
- **BUG-188:** Run `run_sync()` via `run_in_executor()` with a 30s heartbeat broadcasting `sync_progress` events during long syncs. Add `data_load_complete` event after row count.
- **BUG-189:** Add emoji prefixes to `getStatusBadge()` syncing/processing pills to match `renderStatusPill()` (consistent across all code paths).
- **BUG-190:** Enrich `sync_completed` broadcast with `rows_loaded`/`duration_seconds`. Add `updateSourceRowAfterSync()` for in-place DOM updates instead of full-table refetch after dbt completes.

## Test plan

- [x] `pytest tests/unit/test_webhook.py` — 31 passed
- [x] `pytest tests/unit/test_cli_schedule_webhook.py` — 15 passed
- [x] `pytest tests/unit/test_cli_schedule*.py` — 41 passed
- [x] Full unit suite — 808 passed
- [x] mypy clean on all modified Python files
- [x] All pre-commit hooks pass
- [ ] Manual: trigger sync → observe 30s heartbeats in browser DevTools WS tab
- [ ] Manual: verify status pill shows ⏳ emoji consistently for all source types
- [ ] Manual: verify source row updates in-place after sync (no table flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)