### PR TITLE
R10-N2: Bulk DuckDB read_only cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ dango/                          # Python package source
 │   │   ├── model.py            # model group (add/remove)
 │   │   ├── platform.py         # start/stop/status + port helpers (1011 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (785 lines)
+│   │   ├── source.py           # source group (add/list/remove) + sync (828 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
@@ -160,7 +160,7 @@ dango/                          # Python package source
 ├── web/                        # Level 2 — FastAPI web server
 │   ├── app.py                  # Entry point (~370 lines) — routers, middleware, admin bootstrap
 │   ├── models.py               # Pydantic request/response DTOs (incl. auth DTOs)
-│   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (810 lines)
+│   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (840 lines)
 │   ├── middleware/             # Request middleware
 │   │   ├── auth.py             # Session/API key auth + CSRF check (~325 lines)
 │   │   └── rate_limit.py       # Rate limiting (~212 lines)
@@ -257,7 +257,7 @@ dango/                          # Python package source
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
 │   ├── __init__.py             # run_dbt_models(), generate_dbt_docs()
-│   └── generator.py            # DbtModelGenerator (610 lines)
+│   └── generator.py            # DbtModelGenerator (613 lines)
 │
 ├── oauth/                      # Level 1 — OAuth flows
 │   ├── __init__.py             # OAuthManager
@@ -341,7 +341,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/platform.py` | 1034 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
-| `web/helpers.py` | 819 | — (extracted from app.py by TASK-085) |
+| `web/helpers.py` | 840 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 895 | — (module-level job functions) |
 | `utils/post_sync.py` | 632 | — (post-sync hooks + sync notification) |
@@ -350,14 +350,14 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 785 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 828 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 595 | — (push deploy workflow + deploy lock + journal) |
-| `cli/validate.py` | 651 | — |
+| `cli/validate.py` | 652 | — |
 | `config/models.py` | 600 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
-| `transformation/generator.py` | 610 | — |
+| `transformation/generator.py` | 613 | — |
 | `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 846 | — (provisioning orchestration + BYOS) |

--- a/dango/analysis/drilldown.py
+++ b/dango/analysis/drilldown.py
@@ -103,7 +103,7 @@ def _query_dimension_breakdown(
     sql += f" GROUP BY {dimension} ORDER BY ABS({metric.value_expression}) DESC LIMIT {MAX_GROUPS}"
 
     try:
-        conn = duckdb.connect(str(duckdb_path), read_only=True)
+        conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
         try:
             rows = conn.execute(sql).fetchall()
         finally:

--- a/dango/analysis/metrics.py
+++ b/dango/analysis/metrics.py
@@ -125,7 +125,7 @@ def _execute_metric(duckdb_path: Path, metric: MonitorConfig) -> MetricValue:
     sql = _build_metric_sql(metric)
 
     try:
-        conn = duckdb.connect(str(duckdb_path), read_only=True)
+        conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
         try:
             row = conn.execute(sql).fetchone()
         finally:

--- a/dango/analysis/templates.py
+++ b/dango/analysis/templates.py
@@ -173,7 +173,7 @@ def _generic_metrics(name: str, project_root: Path | None) -> list[MonitorConfig
     try:
         import duckdb
 
-        conn = duckdb.connect(str(db_path), read_only=True)
+        conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
         try:
             tables = conn.execute(
                 "SELECT table_name FROM information_schema.tables "
@@ -251,7 +251,7 @@ def _get_table_columns(schema: str, table: str, project_root: Path | None) -> li
     try:
         import duckdb
 
-        conn = duckdb.connect(str(db_path), read_only=True)
+        conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
         try:
             rows = conn.execute(
                 """

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,7 +13,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (785 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/source.py` (828 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
 | `commands/platform.py` (1034 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
@@ -47,7 +47,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |
 | `utils.py` (129 lines) | Display helpers + project context | `require_project_context()` |
-| `validate.py` (651 lines) | Project validation logic | `validate_project()` |
+| `validate.py` (652 lines) | Project validation logic | `validate_project()` |
 | `db_helpers.py` (129 lines) | Schema/table matching for db commands | `build_schema_table_mapping()`, `is_table_configured()` |
 | `env_helpers.py` (319 lines) | `.env` file management | `create_env_template()`, `validate_env_file()`, `guide_env_setup()` |
 | `oauth.py` (428 lines) | OAuth CLI flows | `authenticate_facebook()`, `authenticate_google()`, `check_token_expiry()` |

--- a/dango/cli/commands/data.py
+++ b/dango/cli/commands/data.py
@@ -50,27 +50,29 @@ def db_status(ctx: click.Context) -> None:
             return
 
         # Connect to database
-        conn = duckdb.connect(str(duckdb_path), read_only=True)
+        conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
+        try:
+            # Get all tables from relevant schemas (without row counts first)
+            # Include: raw, raw_*, staging, intermediate, marts
+            tables = conn.execute("""
+                SELECT table_schema, table_name
+                FROM information_schema.tables
+                WHERE table_schema IN ('raw', 'staging', 'intermediate', 'marts')
+                   OR table_schema LIKE 'raw_%'
+                ORDER BY table_schema, table_name
+            """).fetchall()
 
-        # Get all tables from relevant schemas (without row counts first)
-        # Include: raw, raw_*, staging, intermediate, marts
-        tables = conn.execute("""
-            SELECT table_schema, table_name
-            FROM information_schema.tables
-            WHERE table_schema IN ('raw', 'staging', 'intermediate', 'marts')
-               OR table_schema LIKE 'raw_%'
-            ORDER BY table_schema, table_name
-        """).fetchall()
-
-        # Get row counts for each table individually
-        result = []
-        for schema, table in tables:
-            try:
-                row = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
-                count = row[0] if row else 0
-                result.append((schema, table, f"{count:,} rows"))
-            except Exception:
-                result.append((schema, table, "Error"))
+            # Get row counts for each table individually
+            result = []
+            for schema, table in tables:
+                try:
+                    row = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
+                    count = row[0] if row else 0
+                    result.append((schema, table, f"{count:,} rows"))
+                except Exception:
+                    result.append((schema, table, "Error"))
+        finally:
+            conn.close()
 
         # Build schema-to-table mapping from source configurations
         from ..db_helpers import build_schema_table_mapping, is_table_configured
@@ -97,8 +99,6 @@ def db_status(ctx: click.Context) -> None:
                     configured_tables.append((schema, table, size, "✅"))
             else:
                 orphaned_tables.append((schema, table, size))
-
-        conn.close()
 
         # Display configured tables
         if configured_tables:

--- a/dango/cli/commands/remote_mgmt.py
+++ b/dango/cli/commands/remote_mgmt.py
@@ -478,12 +478,12 @@ def remote_query(ctx: click.Context, sql: str, timeout: int) -> None:
     # server. shlex.quote handles local quoting; SSH passes through one
     # additional shell layer, but since the quoted argument contains no
     # unquoted metacharacters this is safe for standard SQL input.
-    # DuckDB's read_only=True provides defense-in-depth against writes.
+    # DuckDB's access_mode=read_only provides defense-in-depth against writes.
     escaped_sql = shlex.quote(sql)
     cmd = (
         f"{_VENV_PYTHON} -c "
         f"'import duckdb,sys; "
-        f'db=duckdb.connect("{_DUCKDB_PATH}",read_only=True); '
+        f'db=duckdb.connect("{_DUCKDB_PATH}",config={{"access_mode":"read_only"}}); '
         f"r=db.sql(sys.argv[1]); "
         f'r.show() if r.description else print("OK")\' '
         f"{escaped_sql}"

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -215,77 +215,77 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
         duckdb_path = project_root / "data" / "warehouse.duckdb"
         if duckdb_path.exists():
             try:
-                conn = duckdb.connect(str(duckdb_path), read_only=True)
+                conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
+                try:
+                    # Method 1: Check _dlt_loads tables for dlt-based sources
+                    # Each source has raw_{source_name}._dlt_loads with inserted_at timestamp
+                    for src in sources:
+                        raw_schema = f"raw_{src.name}"
+                        try:
+                            # Check if _dlt_loads table exists for this source
+                            result = conn.execute(f"""
+                                SELECT MAX(inserted_at) as last_sync
+                                FROM "{raw_schema}"._dlt_loads
+                                WHERE status = 0
+                            """).fetchone()
+                            if result and result[0]:
+                                # Convert to naive datetime if timezone-aware
+                                last_sync_dt = result[0]
+                                if hasattr(last_sync_dt, "replace") and last_sync_dt.tzinfo:
+                                    last_sync_dt = last_sync_dt.replace(tzinfo=None)
+                                last_sync_times[src.name] = last_sync_dt
+                        except Exception:
+                            # Table doesn't exist for this source, continue
+                            pass
 
-                # Method 1: Check _dlt_loads tables for dlt-based sources
-                # Each source has raw_{source_name}._dlt_loads with inserted_at timestamp
-                for src in sources:
-                    raw_schema = f"raw_{src.name}"
-                    try:
-                        # Check if _dlt_loads table exists for this source
-                        result = conn.execute(f"""
-                            SELECT MAX(inserted_at) as last_sync
-                            FROM "{raw_schema}"._dlt_loads
-                            WHERE status = 0
-                        """).fetchone()
-                        if result and result[0]:
-                            # Convert to naive datetime if timezone-aware
-                            last_sync_dt = result[0]
-                            if hasattr(last_sync_dt, "replace") and last_sync_dt.tzinfo:
-                                last_sync_dt = last_sync_dt.replace(tzinfo=None)
-                            last_sync_times[src.name] = last_sync_dt
-                    except Exception:
-                        # Table doesn't exist for this source, continue
-                        pass
-
-                # Method 2: Check CSV metadata table (may override with more recent time)
-                tables = conn.execute("""
-                    SELECT table_name FROM information_schema.tables
-                    WHERE table_schema = 'main' AND table_name = '_dango_file_metadata'
-                """).fetchall()
-
-                if tables:
-                    result = conn.execute("""
-                        SELECT source_name, MAX(loaded_at) as last_sync
-                        FROM _dango_file_metadata
-                        WHERE status = 'loaded'
-                        GROUP BY source_name
+                    # Method 2: Check CSV metadata table (may override with more recent time)
+                    tables = conn.execute("""
+                        SELECT table_name FROM information_schema.tables
+                        WHERE table_schema = 'main' AND table_name = '_dango_file_metadata'
                     """).fetchall()
 
-                    for source_name, last_sync in result:
-                        # Only update if more recent than dlt load time
-                        if (
-                            source_name not in last_sync_times
-                            or last_sync > last_sync_times[source_name]
-                        ):
-                            last_sync_times[source_name] = last_sync
+                    if tables:
+                        result = conn.execute("""
+                            SELECT source_name, MAX(loaded_at) as last_sync
+                            FROM _dango_file_metadata
+                            WHERE status = 'loaded'
+                            GROUP BY source_name
+                        """).fetchall()
 
-                # Get row counts per source
-                for src in sources:
-                    raw_schema = f"raw_{src.name}"
-                    try:
-                        schema_tables = conn.execute(
-                            """
-                            SELECT table_name FROM information_schema.tables
-                            WHERE table_schema = ?
-                              AND table_name NOT LIKE '\\_dlt\\_%' ESCAPE '\\'
-                              AND table_name NOT LIKE '\\_dango\\_%' ESCAPE '\\'
-                            """,
-                            [raw_schema],
-                        ).fetchall()
-                        total = 0
-                        for (tbl,) in schema_tables:
-                            cnt = conn.execute(
-                                f'SELECT COUNT(*) FROM "{raw_schema}"."{tbl}"'
-                            ).fetchone()
-                            if cnt:
-                                total += cnt[0]
-                        if total > 0:
-                            row_counts[src.name] = total
-                    except Exception:
-                        pass
+                        for source_name, last_sync in result:
+                            # Only update if more recent than dlt load time
+                            if (
+                                source_name not in last_sync_times
+                                or last_sync > last_sync_times[source_name]
+                            ):
+                                last_sync_times[source_name] = last_sync
 
-                conn.close()
+                    # Get row counts per source
+                    for src in sources:
+                        raw_schema = f"raw_{src.name}"
+                        try:
+                            schema_tables = conn.execute(
+                                """
+                                SELECT table_name FROM information_schema.tables
+                                WHERE table_schema = ?
+                                  AND table_name NOT LIKE '\\_dlt\\_%' ESCAPE '\\'
+                                  AND table_name NOT LIKE '\\_dango\\_%' ESCAPE '\\'
+                                """,
+                                [raw_schema],
+                            ).fetchall()
+                            total = 0
+                            for (tbl,) in schema_tables:
+                                cnt = conn.execute(
+                                    f'SELECT COUNT(*) FROM "{raw_schema}"."{tbl}"'
+                                ).fetchone()
+                                if cnt:
+                                    total += cnt[0]
+                            if total > 0:
+                                row_counts[src.name] = total
+                        except Exception:
+                            pass
+                finally:
+                    conn.close()
             except Exception:
                 # If we can't read metadata, just skip - last_sync will show "never"
                 pass

--- a/dango/cli/schema_manager.py
+++ b/dango/cli/schema_manager.py
@@ -117,21 +117,21 @@ class SchemaManager:
             List of dicts with 'name' and 'type' keys
         """
         try:
-            conn = duckdb.connect(str(self.duckdb_path), read_only=True)
+            conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
+            try:
+                # Query information schema for columns
+                query = f"""
+                    SELECT column_name, data_type
+                    FROM information_schema.columns
+                    WHERE table_schema = '{layer}'
+                      AND table_name = '{model_name}'
+                    ORDER BY ordinal_position
+                """
 
-            # Query information schema for columns
-            query = f"""
-                SELECT column_name, data_type
-                FROM information_schema.columns
-                WHERE table_schema = '{layer}'
-                  AND table_name = '{model_name}'
-                ORDER BY ordinal_position
-            """
-
-            result = conn.execute(query).fetchall()
-            conn.close()
-
-            return [{"name": col_name, "type": col_type} for col_name, col_type in result]
+                result = conn.execute(query).fetchall()
+                return [{"name": col_name, "type": col_type} for col_name, col_type in result]
+            finally:
+                conn.close()
 
         except Exception:
             # Model might not exist yet

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -437,19 +437,20 @@ class ProjectValidator:
             try:
                 import duckdb
 
-                con = duckdb.connect(str(db_path), read_only=True)
-
-                # Check if database has tables across ALL schemas (not just main)
-                # Query information_schema to get all user tables
-                result = con.execute("""
-                    SELECT table_schema, COUNT(*) as table_count
-                    FROM information_schema.tables
-                    WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
-                      AND table_type = 'BASE TABLE'
-                      AND table_name NOT LIKE '_dlt_%'
-                    GROUP BY table_schema
-                """).fetchall()
-                con.close()
+                con = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
+                try:
+                    # Check if database has tables across ALL schemas (not just main)
+                    # Query information_schema to get all user tables
+                    result = con.execute("""
+                        SELECT table_schema, COUNT(*) as table_count
+                        FROM information_schema.tables
+                        WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
+                          AND table_type = 'BASE TABLE'
+                          AND table_name NOT LIKE '_dlt_%'
+                        GROUP BY table_schema
+                    """).fetchall()
+                finally:
+                    con.close()
 
                 # Count total tables and format schema summary
                 total_tables = sum(row[1] for row in result)

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -206,7 +206,7 @@ def scan_sources_for_pii(
             existing_keys = _get_existing_keys(project_root, source)
 
             schema = f"raw_{source}"
-            conn = duckdb.connect(str(db_path), read_only=True)
+            conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
             try:
                 tables = conn.execute(
                     "SELECT table_name FROM information_schema.tables "
@@ -276,7 +276,7 @@ def scan_table_for_pii(
     db_path = project_root / "data" / "warehouse.duckdb"
     schema = f"raw_{source}"
 
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         columns = conn.execute(
             "SELECT column_name, data_type "
@@ -298,7 +298,7 @@ def scan_table_for_pii(
         try:
             col_name = validate_identifier(col_name)
 
-            conn = duckdb.connect(str(db_path), read_only=True)
+            conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
             try:
                 values = conn.execute(
                     f'SELECT DISTINCT "{col_name}"::VARCHAR '

--- a/dango/governance/schema_drift.py
+++ b/dango/governance/schema_drift.py
@@ -60,7 +60,7 @@ def detect_drift_for_sources(
             logger.debug("drift_source_start", source=source)
             schema = f"raw_{source}"
 
-            conn = duckdb.connect(str(db_path), read_only=True)
+            conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
             try:
                 tables = conn.execute(
                     "SELECT table_name FROM information_schema.tables "
@@ -304,7 +304,7 @@ def _get_current_schema(
     db_path = project_root / "data" / "warehouse.duckdb"
     schema = f"raw_{source}"
 
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         columns = conn.execute(
             "SELECT column_name, data_type "

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -88,46 +88,47 @@ class DbtModelGenerator:
             return []
 
         try:
-            conn = duckdb.connect(str(self.duckdb_path), read_only=True)
+            conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
+            try:
+                # Query table schema
+                result = conn.execute(f"""
+                    SELECT
+                        column_name,
+                        data_type,
+                        is_nullable
+                    FROM information_schema.columns
+                    WHERE table_schema = '{schema}'
+                      AND table_name = '{table_name}'
+                    ORDER BY ordinal_position
+                """).fetchall()
 
-            # Query table schema
-            result = conn.execute(f"""
-                SELECT
-                    column_name,
-                    data_type,
-                    is_nullable
-                FROM information_schema.columns
-                WHERE table_schema = '{schema}'
-                  AND table_name = '{table_name}'
-                ORDER BY ordinal_position
-            """).fetchall()
+                columns = []
+                for row in result:
+                    column_name, data_type, is_nullable = row
 
-            columns = []
-            for row in result:
-                column_name, data_type, is_nullable = row
+                    # Generate tests based on column properties
+                    tests = []
+                    if is_nullable == "NO":
+                        tests.append("not_null")
 
-                # Generate tests based on column properties
-                tests = []
-                if is_nullable == "NO":
-                    tests.append("not_null")
+                    # Common patterns for unique columns (exact primary key names only;
+                    # _id suffix columns are typically foreign keys and NOT unique)
+                    if column_name.lower() in ["id", "uuid", "key"]:
+                        tests.append("unique")
 
-                # Common patterns for unique columns (exact primary key names only;
-                # _id suffix columns are typically foreign keys and NOT unique)
-                if column_name.lower() in ["id", "uuid", "key"]:
-                    tests.append("unique")
+                    columns.append(
+                        {
+                            "name": column_name,
+                            "type": data_type,
+                            "nullable": is_nullable == "YES",
+                            "tests": tests,
+                            "description": f"{column_name} column",
+                        }
+                    )
 
-                columns.append(
-                    {
-                        "name": column_name,
-                        "type": data_type,
-                        "nullable": is_nullable == "YES",
-                        "tests": tests,
-                        "description": f"{column_name} column",
-                    }
-                )
-
-            conn.close()
-            return columns
+                return columns
+            finally:
+                conn.close()
 
         except Exception:
             # Table might not exist yet - return empty
@@ -234,17 +235,19 @@ class DbtModelGenerator:
             List of user data table names
         """
         try:
-            conn = duckdb.connect(str(self.duckdb_path), read_only=True)
-            result = conn.execute(
-                """
-                SELECT table_name
-                FROM information_schema.tables
-                WHERE table_schema = ?
-                ORDER BY table_name
-            """,
-                [schema_name],
-            ).fetchall()
-            conn.close()
+            conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
+            try:
+                result = conn.execute(
+                    """
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = ?
+                    ORDER BY table_name
+                """,
+                    [schema_name],
+                ).fetchall()
+            finally:
+                conn.close()
 
             # Filter out dlt internal tables and metadata tables
             skip_prefixes = ("_dlt_", "dimensions", "metrics")

--- a/dango/utils/data_validation.py
+++ b/dango/utils/data_validation.py
@@ -44,87 +44,84 @@ def validate_cursor_field(
     }
 
     try:
-        conn = duckdb.connect(str(duckdb_path), read_only=True)
+        conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
+        try:
+            # Check if table exists
+            table_exists_row = conn.execute(f"""
+                SELECT COUNT(*)
+                FROM information_schema.tables
+                WHERE table_schema='{schema}' AND table_name='{source_name}'
+            """).fetchone()
 
-        # Check if table exists
-        table_exists_row = conn.execute(f"""
-            SELECT COUNT(*)
-            FROM information_schema.tables
-            WHERE table_schema='{schema}' AND table_name='{source_name}'
-        """).fetchone()
+            if table_exists_row is None:
+                issues.append(f"Failed to check if table {schema}.{source_name} exists")
+                return result
 
-        if table_exists_row is None:
-            issues.append(f"Failed to check if table {schema}.{source_name} exists")
-            conn.close()
+            table_exists = table_exists_row[0]
+
+            if not table_exists:
+                issues.append(f"Table {schema}.{source_name} does not exist")
+                return result
+
+            # Check if cursor field exists
+            column_info = conn.execute(f"""
+                SELECT column_name, data_type
+                FROM information_schema.columns
+                WHERE table_schema='{schema}'
+                  AND table_name='{source_name}'
+                  AND column_name='{cursor_field}'
+            """).fetchone()
+
+            if not column_info:
+                issues.append(f"Cursor field '{cursor_field}' not found in table")
+                result["exists"] = False
+                return result
+
+            result["exists"] = True
+            result["data_type"] = column_info[1]
+
+            # Get sample values to verify format
+            sample_query = f"""
+                SELECT "{cursor_field}"
+                FROM "{schema}"."{source_name}"
+                WHERE "{cursor_field}" IS NOT NULL
+                ORDER BY "{cursor_field}" DESC
+                LIMIT 5
+            """
+            samples = conn.execute(sample_query).fetchall()
+            result["sample_values"] = [str(row[0]) for row in samples]
+
+            # Validate data type is appropriate for cursor
+            valid_types = ["TIMESTAMP", "DATE", "INTEGER", "BIGINT", "VARCHAR"]
+            data_type = result["data_type"]
+            if isinstance(data_type, str) and not any(
+                vtype in data_type.upper() for vtype in valid_types
+            ):
+                issues.append(
+                    f"Cursor field has unexpected type '{data_type}'. "
+                    f"Expected: {', '.join(valid_types)}"
+                )
+
+            # Check if cursor field has NULL values
+            null_count_row = conn.execute(f"""
+                SELECT COUNT(*)
+                FROM "{schema}"."{source_name}"
+                WHERE "{cursor_field}" IS NULL
+            """).fetchone()
+
+            if null_count_row is None:
+                issues.append("Failed to check for NULL values in cursor field")
+            else:
+                null_count = null_count_row[0]
+                if null_count > 0:
+                    issues.append(f"{null_count} NULL values found in cursor field")
+
+            # Overall validation
+            result["valid"] = result["exists"] and len(issues) == 0
+
             return result
-
-        table_exists = table_exists_row[0]
-
-        if not table_exists:
-            issues.append(f"Table {schema}.{source_name} does not exist")
+        finally:
             conn.close()
-            return result
-
-        # Check if cursor field exists
-        column_info = conn.execute(f"""
-            SELECT column_name, data_type
-            FROM information_schema.columns
-            WHERE table_schema='{schema}'
-              AND table_name='{source_name}'
-              AND column_name='{cursor_field}'
-        """).fetchone()
-
-        if not column_info:
-            issues.append(f"Cursor field '{cursor_field}' not found in table")
-            result["exists"] = False
-            conn.close()
-            return result
-
-        result["exists"] = True
-        result["data_type"] = column_info[1]
-
-        # Get sample values to verify format
-        sample_query = f"""
-            SELECT "{cursor_field}"
-            FROM "{schema}"."{source_name}"
-            WHERE "{cursor_field}" IS NOT NULL
-            ORDER BY "{cursor_field}" DESC
-            LIMIT 5
-        """
-        samples = conn.execute(sample_query).fetchall()
-        result["sample_values"] = [str(row[0]) for row in samples]
-
-        # Validate data type is appropriate for cursor
-        valid_types = ["TIMESTAMP", "DATE", "INTEGER", "BIGINT", "VARCHAR"]
-        data_type = result["data_type"]
-        if isinstance(data_type, str) and not any(
-            vtype in data_type.upper() for vtype in valid_types
-        ):
-            issues.append(
-                f"Cursor field has unexpected type '{data_type}'. "
-                f"Expected: {', '.join(valid_types)}"
-            )
-
-        # Check if cursor field has NULL values
-        null_count_row = conn.execute(f"""
-            SELECT COUNT(*)
-            FROM "{schema}"."{source_name}"
-            WHERE "{cursor_field}" IS NULL
-        """).fetchone()
-
-        if null_count_row is None:
-            issues.append("Failed to check for NULL values in cursor field")
-        else:
-            null_count = null_count_row[0]
-            if null_count > 0:
-                issues.append(f"{null_count} NULL values found in cursor field")
-
-        conn.close()
-
-        # Overall validation
-        result["valid"] = result["exists"] and len(issues) == 0
-
-        return result
 
     except Exception as e:
         issues.append(f"Validation error: {e}")
@@ -166,32 +163,33 @@ def detect_schema_changes(
     }
 
     try:
-        conn = duckdb.connect(str(duckdb_path), read_only=True)
+        conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
+        try:
+            # Get current schema
+            columns = conn.execute(f"""
+                SELECT column_name, data_type
+                FROM information_schema.columns
+                WHERE table_schema='{schema}' AND table_name='{source_name}'
+                ORDER BY ordinal_position
+            """).fetchall()
 
-        # Get current schema
-        columns = conn.execute(f"""
-            SELECT column_name, data_type
-            FROM information_schema.columns
-            WHERE table_schema='{schema}' AND table_name='{source_name}'
-            ORDER BY ordinal_position
-        """).fetchall()
+            current_columns.extend(col[0] for col in columns)
+            result["column_types"] = {col[0]: col[1] for col in columns}
 
-        current_columns.extend(col[0] for col in columns)
-        result["column_types"] = {col[0]: col[1] for col in columns}
+            # Compare with expected schema if provided
+            if expected_schema:
+                current_set = set(current_columns)
+                expected_set = set(expected_schema)
 
-        # Compare with expected schema if provided
-        if expected_schema:
-            current_set = set(current_columns)
-            expected_set = set(expected_schema)
+                added_columns = list(current_set - expected_set)
+                removed_columns = list(expected_set - current_set)
+                result["added_columns"] = added_columns
+                result["removed_columns"] = removed_columns
+                result["changed"] = len(added_columns) > 0 or len(removed_columns) > 0
 
-            added_columns = list(current_set - expected_set)
-            removed_columns = list(expected_set - current_set)
-            result["added_columns"] = added_columns
-            result["removed_columns"] = removed_columns
-            result["changed"] = len(added_columns) > 0 or len(removed_columns) > 0
-
-        conn.close()
-        return result
+            return result
+        finally:
+            conn.close()
 
     except Exception as e:
         console.print(f"[yellow]⚠️  Schema detection error: {e}[/yellow]")
@@ -221,50 +219,50 @@ def validate_data_completeness(
     result = {"row_count": 0, "has_data": False, "last_loaded": None, "health_score": "unknown"}
 
     try:
-        conn = duckdb.connect(str(duckdb_path), read_only=True)
-
-        # Get row count
-        count_row = conn.execute(f"""
-            SELECT COUNT(*)
-            FROM "{schema}"."{source_name}"
-        """).fetchone()
-
-        if count_row is None:
-            result["row_count"] = 0
-            result["has_data"] = False
-            conn.close()
-            return result
-
-        count = count_row[0]
-        result["row_count"] = count
-        result["has_data"] = count > 0
-
-        # Try to get last load time from dlt metadata
+        conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
         try:
-            last_load = conn.execute(f"""
-                SELECT MAX(_dango_loaded_at)
+            # Get row count
+            count_row = conn.execute(f"""
+                SELECT COUNT(*)
                 FROM "{schema}"."{source_name}"
             """).fetchone()
 
-            if last_load and last_load[0]:
-                result["last_loaded"] = str(last_load[0])
-        except Exception:
-            pass
+            if count_row is None:
+                result["row_count"] = 0
+                result["has_data"] = False
+                return result
 
-        # Determine health score
-        if count == 0:
-            result["health_score"] = "empty"
-        elif count < 10:
-            result["health_score"] = "very_low"
-        elif count < 100:
-            result["health_score"] = "low"
-        elif count < 10000:
-            result["health_score"] = "good"
-        else:
-            result["health_score"] = "excellent"
+            count = count_row[0]
+            result["row_count"] = count
+            result["has_data"] = count > 0
 
-        conn.close()
-        return result
+            # Try to get last load time from dlt metadata
+            try:
+                last_load = conn.execute(f"""
+                    SELECT MAX(_dango_loaded_at)
+                    FROM "{schema}"."{source_name}"
+                """).fetchone()
+
+                if last_load and last_load[0]:
+                    result["last_loaded"] = str(last_load[0])
+            except Exception:
+                pass
+
+            # Determine health score
+            if count == 0:
+                result["health_score"] = "empty"
+            elif count < 10:
+                result["health_score"] = "very_low"
+            elif count < 100:
+                result["health_score"] = "low"
+            elif count < 10000:
+                result["health_score"] = "good"
+            else:
+                result["health_score"] = "excellent"
+
+            return result
+        finally:
+            conn.close()
 
     except Exception as e:
         console.print(f"[yellow]⚠️  Completeness check error: {e}[/yellow]")

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -108,7 +108,7 @@ def check_duckdb_health(duckdb_path: Path) -> dict[str, Any]:
 
         for attempt in range(max_retries):
             try:
-                conn = duckdb.connect(str(duckdb_path), read_only=True)
+                conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
                 break
             except Exception as e:
                 last_error = e
@@ -302,7 +302,7 @@ def get_component_disk_usage(project_root: Path) -> dict[str, Any]:
             duckdb_info["file_size_mb"] = round(duckdb_path.stat().st_size / (1024**2), 2)
             # Per-schema estimated sizes (read-only connection)
             try:
-                conn = duckdb.connect(str(duckdb_path), read_only=True)
+                conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
                 try:
                     rows = conn.execute(
                         "SELECT schema_name, COALESCE(SUM(estimated_size), 0) "

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -111,7 +111,7 @@ def profile_table(
     db_path = project_root / "data" / "warehouse.duckdb"
     schema = f"raw_{source}"
 
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         # Discover columns
         columns = conn.execute(
@@ -417,7 +417,7 @@ def _run_profiling(project_root: Path, sources: list[str]) -> None:
             logger.debug("profiling_source_start", source=source)
             schema = f"raw_{source}"
 
-            conn = duckdb.connect(str(db_path), read_only=True)
+            conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
             try:
                 tables = conn.execute(
                     "SELECT table_name FROM information_schema.tables "

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -79,25 +79,25 @@ def get_dbt_model_row_count(schema: str, model_name: str) -> int | None:
         return None
 
     try:
-        conn = duckdb.connect(str(db_path), read_only=True)
+        conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
+        try:
+            # Check if table exists
+            result = conn.execute(f"""
+                SELECT COUNT(*)
+                FROM information_schema.tables
+                WHERE table_schema = '{schema}' AND table_name = '{model_name}'
+            """).fetchone()
 
-        # Check if table exists
-        result = conn.execute(f"""
-            SELECT COUNT(*)
-            FROM information_schema.tables
-            WHERE table_schema = '{schema}' AND table_name = '{model_name}'
-        """).fetchone()
+            if result and result[0] > 0:
+                # Table exists, get row count
+                count_result = conn.execute(
+                    f'SELECT COUNT(*) FROM "{schema}"."{model_name}"'
+                ).fetchone()
+                return count_result[0] if count_result else 0
 
-        if result and result[0] > 0:
-            # Table exists, get row count
-            count_result = conn.execute(
-                f'SELECT COUNT(*) FROM "{schema}"."{model_name}"'
-            ).fetchone()
+            return None
+        finally:
             conn.close()
-            return count_result[0] if count_result else 0
-
-        conn.close()
-        return None
 
     except Exception as e:
         logger.error(f"Error getting row count for {schema}.{model_name}: {e}")
@@ -223,69 +223,67 @@ def get_source_row_count(source_name: str) -> int | None:
 
     try:
         with timeout_context(2):  # 2 second timeout
-            conn = duckdb.connect(str(db_path), read_only=True)
-
-            # Check for multi-resource schema first (raw_{source_name})
-            multi_schema = f"raw_{source_name}"
-            result = conn.execute(f"""
-                SELECT COUNT(*)
-                FROM information_schema.tables
-                WHERE table_schema = '{multi_schema}'
-                  AND table_name NOT LIKE '_dlt_%'
-                  AND table_name NOT IN ('spreadsheet', 'spreadsheet_info')
-            """).fetchone()
-
-            if result and result[0] > 0:
-                # Multi-resource source: sum rows across all tables in schema
-                tables = conn.execute(f"""
-                    SELECT table_name
+            conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
+            try:
+                # Check for multi-resource schema first (raw_{source_name})
+                multi_schema = f"raw_{source_name}"
+                result = conn.execute(f"""
+                    SELECT COUNT(*)
                     FROM information_schema.tables
                     WHERE table_schema = '{multi_schema}'
                       AND table_name NOT LIKE '_dlt_%'
                       AND table_name NOT IN ('spreadsheet', 'spreadsheet_info')
-                """).fetchall()
+                """).fetchone()
 
-                total_rows = 0
-                for (table_name,) in tables:
+                if result and result[0] > 0:
+                    # Multi-resource source: sum rows across all tables in schema
+                    tables = conn.execute(f"""
+                        SELECT table_name
+                        FROM information_schema.tables
+                        WHERE table_schema = '{multi_schema}'
+                          AND table_name NOT LIKE '_dlt_%'
+                          AND table_name NOT IN ('spreadsheet', 'spreadsheet_info')
+                    """).fetchall()
+
+                    total_rows = 0
+                    for (table_name,) in tables:
+                        count_result = conn.execute(
+                            f'SELECT COUNT(*) FROM "{multi_schema}"."{table_name}"'
+                        ).fetchone()
+                        if count_result:
+                            total_rows += count_result[0]
+
+                    return total_rows
+
+                # Single-resource source: check raw.{source_name} table
+                result = conn.execute(f"""
+                    SELECT COUNT(*)
+                    FROM information_schema.tables
+                    WHERE table_schema = 'raw' AND table_name = '{source_name}'
+                """).fetchone()
+
+                if result and result[0] > 0:
                     count_result = conn.execute(
-                        f'SELECT COUNT(*) FROM "{multi_schema}"."{table_name}"'
+                        f'SELECT COUNT(*) FROM "raw"."{source_name}"'
                     ).fetchone()
-                    if count_result:
-                        total_rows += count_result[0]
+                    return count_result[0] if count_result else 0
 
+                # Fall back to staging table
+                result = conn.execute(f"""
+                    SELECT COUNT(*)
+                    FROM information_schema.tables
+                    WHERE table_schema = 'staging' AND table_name = 'stg_{source_name}'
+                """).fetchone()
+
+                if result and result[0] > 0:
+                    count_result = conn.execute(
+                        f'SELECT COUNT(*) FROM "staging"."stg_{source_name}"'
+                    ).fetchone()
+                    return count_result[0] if count_result else 0
+
+                return None
+            finally:
                 conn.close()
-                return total_rows
-
-            # Single-resource source: check raw.{source_name} table
-            result = conn.execute(f"""
-                SELECT COUNT(*)
-                FROM information_schema.tables
-                WHERE table_schema = 'raw' AND table_name = '{source_name}'
-            """).fetchone()
-
-            if result and result[0] > 0:
-                count_result = conn.execute(
-                    f'SELECT COUNT(*) FROM "raw"."{source_name}"'
-                ).fetchone()
-                conn.close()
-                return count_result[0] if count_result else 0
-
-            # Fall back to staging table
-            result = conn.execute(f"""
-                SELECT COUNT(*)
-                FROM information_schema.tables
-                WHERE table_schema = 'staging' AND table_name = 'stg_{source_name}'
-            """).fetchone()
-
-            if result and result[0] > 0:
-                count_result = conn.execute(
-                    f'SELECT COUNT(*) FROM "staging"."stg_{source_name}"'
-                ).fetchone()
-                conn.close()
-                return count_result[0] if count_result else 0
-
-            conn.close()
-            return None
 
     except TimeoutError:
         logger.warning(
@@ -316,72 +314,75 @@ def get_source_tables_info(source_name: str) -> dict[str, Any] | None:
         return None
 
     try:
-        conn = duckdb.connect(str(db_path), read_only=True)
-
-        # All sources use raw_{source_name} schema
-        schema_name = f"raw_{source_name}"
-        result = conn.execute(f"""
-            SELECT COUNT(*)
-            FROM information_schema.tables
-            WHERE table_schema = '{schema_name}'
-              AND table_name NOT LIKE '_dlt_%'
-              AND table_name NOT IN ('spreadsheet', 'spreadsheet_info')
-        """).fetchone()
-
-        if result and result[0] > 0:
-            # Get per-table breakdown
-            tables_result = conn.execute(f"""
-                SELECT table_name
+        conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
+        try:
+            # All sources use raw_{source_name} schema
+            schema_name = f"raw_{source_name}"
+            result = conn.execute(f"""
+                SELECT COUNT(*)
                 FROM information_schema.tables
                 WHERE table_schema = '{schema_name}'
                   AND table_name NOT LIKE '_dlt_%'
                   AND table_name NOT IN ('spreadsheet', 'spreadsheet_info')
-                ORDER BY table_name
-            """).fetchall()
+            """).fetchone()
 
-            tables = []
-            total_rows = 0
-            for (table_name,) in tables_result:
+            if result and result[0] > 0:
+                # Get per-table breakdown
+                tables_result = conn.execute(f"""
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = '{schema_name}'
+                      AND table_name NOT LIKE '_dlt_%'
+                      AND table_name NOT IN ('spreadsheet', 'spreadsheet_info')
+                    ORDER BY table_name
+                """).fetchall()
+
+                tables = []
+                total_rows = 0
+                for (table_name,) in tables_result:
+                    count_result = conn.execute(
+                        f'SELECT COUNT(*) FROM "{schema_name}"."{table_name}"'
+                    ).fetchone()
+                    if count_result:
+                        row_count = count_result[0]
+                        total_rows += row_count
+                        tables.append(
+                            {"name": table_name, "row_count": row_count, "schema": schema_name}
+                        )
+
+                return {
+                    "total_rows": total_rows,
+                    "tables": tables,
+                    "has_multiple_tables": len(tables) > 1,
+                }
+
+            # Fall back to staging table (for backward compatibility)
+            result = conn.execute(f"""
+                SELECT COUNT(*)
+                FROM information_schema.tables
+                WHERE table_schema = 'staging' AND table_name = 'stg_{source_name}'
+            """).fetchone()
+
+            if result and result[0] > 0:
                 count_result = conn.execute(
-                    f'SELECT COUNT(*) FROM "{schema_name}"."{table_name}"'
+                    f'SELECT COUNT(*) FROM "staging"."stg_{source_name}"'
                 ).fetchone()
-                if count_result:
-                    row_count = count_result[0]
-                    total_rows += row_count
-                    tables.append(
-                        {"name": table_name, "row_count": row_count, "schema": schema_name}
-                    )
+                row_count = count_result[0] if count_result else 0
+                return {
+                    "total_rows": row_count,
+                    "tables": [
+                        {
+                            "name": f"stg_{source_name}",
+                            "row_count": row_count,
+                            "schema": "staging",
+                        }
+                    ],
+                    "has_multiple_tables": False,
+                }
 
+            return None
+        finally:
             conn.close()
-            return {
-                "total_rows": total_rows,
-                "tables": tables,
-                "has_multiple_tables": len(tables) > 1,
-            }
-
-        # Fall back to staging table (for backward compatibility)
-        result = conn.execute(f"""
-            SELECT COUNT(*)
-            FROM information_schema.tables
-            WHERE table_schema = 'staging' AND table_name = 'stg_{source_name}'
-        """).fetchone()
-
-        if result and result[0] > 0:
-            count_result = conn.execute(
-                f'SELECT COUNT(*) FROM "staging"."stg_{source_name}"'
-            ).fetchone()
-            row_count = count_result[0] if count_result else 0
-            conn.close()
-            return {
-                "total_rows": row_count,
-                "tables": [
-                    {"name": f"stg_{source_name}", "row_count": row_count, "schema": "staging"}
-                ],
-                "has_multiple_tables": False,
-            }
-
-        conn.close()
-        return None
 
     except Exception as e:
         logger.error(f"Error getting table info for {source_name}: {e}")

--- a/dango/web/routes/ai.py
+++ b/dango/web/routes/ai.py
@@ -146,7 +146,7 @@ def _get_column_schema(db_path: str, source: str, table: str) -> list[dict[str, 
     try:
         schema = f"raw_{validate_source_name(source)}"
         safe_table = validate_identifier(table)
-        conn = duckdb.connect(db_path, read_only=True)
+        conn = duckdb.connect(db_path, config={"access_mode": "read_only"})
         try:
             rows = conn.execute(
                 "SELECT column_name, data_type, is_nullable "

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -48,7 +48,7 @@ def _get_column_schema(
         List of ``{"name": ..., "type": ..., "nullable": bool}``.
     """
     schema = f"raw_{source}"
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         rows = conn.execute(
             "SELECT column_name, data_type, is_nullable "
@@ -130,7 +130,7 @@ def _get_row_count(db_path: Path, source: str, table: str) -> int:
         Number of rows.
     """
     schema = f"raw_{source}"
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         result = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
     finally:
@@ -149,7 +149,7 @@ def _source_schema_exists(db_path: Path, source: str) -> bool:
         ``True`` if the schema exists.
     """
     schema = f"raw_{source}"
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         result = conn.execute(
             f"SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = '{schema}'"
@@ -171,7 +171,7 @@ def _table_exists(db_path: Path, source: str, table: str) -> bool:
         ``True`` if the table exists.
     """
     schema = f"raw_{source}"
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         result = conn.execute(
             "SELECT COUNT(*) FROM information_schema.tables "
@@ -192,7 +192,7 @@ def _get_raw_tables_from_duckdb(db_path: Path) -> list[dict[str, str]]:
     Returns:
         List of ``{"schema": ..., "table": ..., "source_name": ...}``.
     """
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         rows = conn.execute(
             "SELECT table_schema, table_name FROM information_schema.tables "
@@ -341,7 +341,7 @@ def _get_model_column_schema(
         List of ``{"name": ..., "type": ..., "nullable": bool}``,
         or empty list if the table does not exist.
     """
-    conn = duckdb.connect(str(db_path), read_only=True)
+    conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         rows = conn.execute(
             "SELECT column_name, data_type, is_nullable "
@@ -1039,7 +1039,7 @@ async def get_catalog_model(
 
         def _count_rows() -> int | None:
             try:
-                conn = duckdb.connect(str(db_path), read_only=True)
+                conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
                 try:
                     row = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{table}"').fetchone()
                     return row[0] if row else 0

--- a/dango/web/routes/query.py
+++ b/dango/web/routes/query.py
@@ -6,7 +6,7 @@ Security layers (defense-in-depth):
 1. RBAC: ``require_permission("query.execute")`` — Editor + Admin only
 2. Length limit: 100 KB max SQL
 3. sqlglot whitelist: only ``exp.Select`` allowed
-4. DuckDB ``read_only=True``: rejects writes even if validation bypassed
+4. DuckDB ``config={"access_mode": "read_only"}``: rejects writes even if validation bypassed
 5. Timeout: 30 s via ``asyncio.wait_for``
 6. Row limit: 10 000 rows max
 7. Audit logging: every query execution logged
@@ -70,7 +70,7 @@ def _looks_like_select(sql: str) -> bool:
     """Return True if *sql* starts with SELECT or WITH (case-insensitive).
 
     Used as a basic keyword guard when sqlglot is unavailable or fails to
-    parse.  ``read_only=True`` prevents database writes but does NOT prevent
+    parse.  Read-only access mode prevents database writes but does NOT prevent
     file-system writes (``COPY TO``, ``EXPORT DATABASE``), so we need this
     check as an additional layer.
     """
@@ -100,7 +100,7 @@ def _validate_sql(sql: str) -> None:
         statements = sqlglot.parse(sql, dialect="duckdb")
     except sqlglot.errors.SqlglotError as exc:
         # sqlglot could not parse — fall back to keyword check.
-        # read_only=True is defense-in-depth for DB writes, but does not
+        # Read-only access mode is defense-in-depth for DB writes, but does not
         # prevent file-system writes (COPY TO, EXPORT), so we reject
         # anything that doesn't look like a SELECT.
         logger.warning("sqlglot_parse_failed", sql_length=len(sql))
@@ -141,7 +141,7 @@ def _execute_query(
     This is a blocking function intended to be called via
     ``asyncio.to_thread``.
     """
-    conn = duckdb.connect(db_path, read_only=True)
+    conn = duckdb.connect(db_path, config={"access_mode": "read_only"})
     try:
         result = conn.execute(sql)
         columns = [desc[0] for desc in result.description]

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -12,7 +12,7 @@ limit: 500  # Informational — scripts/check_file_sizes.py owns the enforced th
 exemptions:
   # --- Post-TASK-085 split results (from web/app.py 3032 → web/routes/) ---
   - file: dango/web/helpers.py
-    lines: 819
+    lines: 840
     category: exempt
     reason: "Shared helper functions for web routes. Consolidates DuckDB queries, config loading, service health checks, and log management. Extracted from web/app.py by TASK-085. Mirrors cli/utils.py pattern."
     review_by: "v1.1"
@@ -93,7 +93,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 785
+    lines: 828
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"
@@ -174,13 +174,13 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/validate.py
-    lines: 651
+    lines: 652
     category: exempt
     reason: "Validation commands (config, sources, connections). Each validator is independent."
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 610
+    lines: 613
     category: exempt
     reason: "DbtModelGenerator — generates dbt models from source configs. R10-G2 added _enrich_columns_from_profiling for dbt test enrichment."
     review_by: "v1.1"

--- a/tests/integration/test_remote.py
+++ b/tests/integration/test_remote.py
@@ -89,7 +89,7 @@ class TestRemoteQuery:
         result = ssh.exec_command(
             '/srv/dango/venv/bin/python -c "'
             "import duckdb; "
-            "conn = duckdb.connect('/srv/dango/project/data/warehouse.duckdb', read_only=True); "
+            "conn = duckdb.connect('/srv/dango/project/data/warehouse.duckdb', config={'access_mode': 'read_only'}); "
             "print(conn.execute('SELECT 1 AS val').fetchone()[0]); "
             'conn.close()"',
             timeout=30,

--- a/tests/unit/test_profiling.py
+++ b/tests/unit/test_profiling.py
@@ -314,7 +314,7 @@ class TestRunProfiling:
         _make_warehouse(tmp_path)
         call_idx = 0
 
-        def connect_se(path, read_only=False):
+        def connect_se(path, **kwargs):
             nonlocal call_idx
             call_idx += 1
             if call_idx == 1:

--- a/tests/unit/test_remote_management_cli.py
+++ b/tests/unit/test_remote_management_cli.py
@@ -405,7 +405,7 @@ class TestRemoteQueryCommand:
         assert "42" in result.output
 
     def test_query_uses_readonly(self, tmp_path):
-        """query command passes read_only=True to DuckDB."""
+        """query command passes access_mode=read_only to DuckDB."""
         mock_loader = _make_loader()
         mock_ssh_instance = MagicMock()
         mock_ssh_instance.exec_command.return_value = _make_command_result(stdout="OK")
@@ -418,7 +418,7 @@ class TestRemoteQueryCommand:
             _run(["query", "SELECT 1"], tmp_path)
 
         cmd = mock_ssh_instance.exec_command.call_args[0][0]
-        assert "read_only=True" in cmd
+        assert '"access_mode":"read_only"' in cmd
 
     def test_query_failure_shows_error(self, tmp_path):
         """query command prints stderr on failure."""


### PR DESCRIPTION
## Summary
- Replace all 37 `duckdb.connect(..., read_only=True)` call sites with `config={"access_mode": "read_only"}` across 17 source files — the `read_only=True` parameter can still create WAL write locks, while the config approach prevents this entirely
- Add try/finally to ~13 sites that had bare `conn.close()` without exception safety
- Fix remote SSH command string in `cli/commands/remote_mgmt.py` with proper f-string brace escaping
- Update comments/docstrings in `web/routes/query.py` referencing the old parameter
- Update 3 test files to match the new calling convention
- Update file-exemptions.yml and CLAUDE.md line counts for files that grew

## Test plan
- [x] `grep -rn "read_only=True" dango/` → 0 matches in source
- [x] `ruff check dango/` → clean
- [x] `ruff format --check dango/` → clean
- [x] `mypy` on all 18 changed source files → clean
- [x] `pytest tests/unit/ -x` → 3307 passed, 0 failed
- [x] Pre-commit hooks pass (including file-size-check, CLAUDE.md staleness)
- [x] `wc -l` verified for all exempted files, file-exemptions.yml updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)