### PR TITLE
R10-R: Fix doc drift, dashboard defaults, pip-audit CVE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
   security:
     name: Security (pip-audit)
-    # Known unresolvable CVE in black (dbt-core dep) — revisit when dbt-core supports pydantic v2
+    # Known CVE-2026-32274 in black (dbt-core dep) — revisit when dbt-core supports pydantic v2
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +65,7 @@ jobs:
           cache: pip
       - run: pip install -c constraints.txt -e ".[dev]"
       - name: pip-audit
-        run: pip-audit
+        run: pip-audit --ignore-vuln CVE-2026-32274
 
   llm-checks:
     name: LLM checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,16 +82,16 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (1011 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (1034 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove) + sync (828 lines)
+│   │   ├── source.py           # source group (add/list/remove/edit) + sync (829 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
-│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (808 lines)
-│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (813 lines)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (813 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (846 lines)
 │   │   ├── dev.py              # dev group (default run + clean) — branch-based dbt dev
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
@@ -123,7 +123,7 @@ dango/                          # Python package source
 │   ├── __init__.py             # Re-exports 96 public symbols
 │   ├── models.py               # Role, User, Session, APIKey Pydantic models
 │   ├── database.py             # SQLite CRUD (WAL mode, 529 lines)
-│   ├── security.py             # Bcrypt hashing, token generation (375 lines)
+│   ├── security.py             # Bcrypt hashing, token generation (386 lines)
 │   ├── sessions.py             # Session + API key lifecycle (289 lines)
 │   ├── permissions.py          # 29 permissions, 3 role mappings
 │   ├── lockout.py              # Brute-force protection (5 attempts / 15-min)
@@ -131,7 +131,7 @@ dango/                          # Python package source
 │   ├── admin.py                # Bootstrap admin, config path helpers
 │   ├── totp.py                 # TOTP 2FA + recovery codes
 │   ├── oauth_login.py          # OAuth provider ABC + Google/GitHub
-│   ├── metabase_sync.py        # Sync users/roles to Metabase (498 lines)
+│   ├── metabase_sync.py        # Sync users/roles to Metabase (552 lines)
 │   └── metabase_bridge.py      # Async SSO session bridging
 │
 ├── governance/                 # Level 1 — Data governance (schema drift + PII scanning)
@@ -143,8 +143,8 @@ dango/                          # Python package source
 │
 ├── notebooks/                  # Level 1 — Marimo notebook management
 │   ├── __init__.py             # Re-exports public symbols
-│   ├── manager.py              # Marimo process lifecycle (197 lines)
-│   ├── locking.py              # File-level notebook locking (249 lines)
+│   ├── manager.py              # Marimo process lifecycle (262 lines)
+│   ├── locking.py              # File-level notebook locking (285 lines)
 │   ├── snapshot.py             # DuckDB snapshot management
 │   ├── proxy.py                # HTTP + WebSocket reverse proxy (186 lines)
 │   └── templates/              # Marimo starter templates (explore, quality, blank)
@@ -160,30 +160,30 @@ dango/                          # Python package source
 │   └── formatter.py            # Result categorization + display formatting
 │
 ├── web/                        # Level 2 — FastAPI web server
-│   ├── app.py                  # Entry point (~370 lines) — routers, middleware, admin bootstrap
+│   ├── app.py                  # Entry point (~449 lines) — routers, middleware, admin bootstrap
 │   ├── models.py               # Pydantic request/response DTOs (incl. auth DTOs)
 │   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (851 lines)
 │   ├── middleware/             # Request middleware
-│   │   ├── auth.py             # Session/API key auth + CSRF check (~325 lines)
-│   │   └── rate_limit.py       # Rate limiting (~212 lines)
+│   │   ├── auth.py             # Session/API key auth + CSRF check (~324 lines)
+│   │   └── rate_limit.py       # Rate limiting (~235 lines)
 │   ├── routes/                 # Route modules
 │   │   ├── __init__.py         # Package marker
-│   │   ├── auth.py             # Login/logout, OAuth, invite, API keys (~854 lines)
-│   │   ├── auth_2fa.py         # TOTP 2FA endpoints (~328 lines)
-│   │   ├── users.py            # Admin user CRUD (525 lines)
+│   │   ├── auth.py             # Login/logout, OAuth, invite, API keys (~852 lines)
+│   │   ├── auth_2fa.py         # TOTP 2FA endpoints (~340 lines)
+│   │   ├── users.py            # Admin user CRUD (527 lines)
 │   │   ├── health.py           # /api/status, /api/watcher/status, /api/health/platform
 │   │   ├── config.py           # /api/config, /api/metabase-config
 │   │   ├── sources.py          # /api/sources, /api/sources/{name}/details
 │   │   ├── sync.py             # /api/sources/{name}/sync + run_sync_task()
 │   │   ├── logs.py             # /api/logs, /api/sources/{name}/logs
 │   │   ├── dbt.py              # /api/dbt/models, /api/dbt/models/{name}/run + dbt docs proxy
-│   │   ├── upload.py           # CSV upload/list/delete (699 lines)
+│   │   ├── upload.py           # CSV upload/list/delete (705 lines)
 │   │   ├── websocket.py        # ConnectionManager, ws_manager, /ws
 │   │   ├── ui.py               # /, /health, /logs, /login, /account, /admin/users
 │   │   ├── metabase_proxy.py   # Metabase reverse proxy + SSO session
 │   │   ├── secrets.py          # Secrets + OAuth credential management (admin-only)
 │   │   ├── oauth_connect.py    # Web-based OAuth connect/callback
-│   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact, models, search (1157 lines)
+│   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact, models, search (1336 lines)
 │   │   ├── governance.py       # Schema drift + PII results API
 │   │   ├── monitoring.py       # Monitor results, run trigger, history
 │   │   ├── notebooks.py        # Notebook management API + page route
@@ -202,7 +202,7 @@ dango/                          # Python package source
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
-│   ├── metabase.py             # Metabase API (1152 lines)
+│   ├── metabase.py             # Metabase API (1151 lines)
 │   └── dashboard_manager.py    # Dashboard export/import (1112 lines)
 │
 ├── platform/                   # Level 2 — Docker, network, file watcher, scheduling
@@ -220,14 +220,14 @@ dango/                          # Python package source
 │   │   ├── scheduler.py        # SchedulerService (lifecycle, events, cancellation)
 │   │   ├── resilience.py       # Retry, timeout, cancellation
 │   │   ├── history.py          # Execution history tracking
-│   │   ├── jobs.py             # Module-level job functions (894 lines)
+│   │   ├── jobs.py             # Module-level job functions (895 lines)
 │   │   └── sync_trigger.py     # Server-side manual sync runner
 │   ├── notifications/          # Webhook notifications (TASK-043+)
 │   │   ├── webhook.py          # Event types, config, async sender
 │   │   └── slack.py            # Slack Block Kit formatter
 │   ├── cloud/                  # Cloud components (TASK-022+)
 │   │   ├── __init__.py         # Re-exports 69 symbols
-│   │   ├── digitalocean.py     # DO REST API v2 client (542 lines)
+│   │   ├── digitalocean.py     # DO REST API v2 client (547 lines)
 │   │   ├── provisioning.py     # Size tiers, regions, provision_droplet()
 │   │   ├── firewall.py         # Firewall lifecycle, IP allowlisting
 │   │   ├── spaces.py           # DO Spaces (S3-compatible via boto3)
@@ -338,10 +338,10 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
 | `cli/source_wizard.py` | 2306 | — |
 | `visualization/metabase.py` | 1151 | — |
-| `cli/init.py` | 1324 | — |
+| `cli/init.py` | 1334 | — |
 | `visualization/dashboard_manager.py` | 1112 | — |
 | `cli/commands/platform.py` | 1034 | — (extracted from main.py by TASK-005) |
-| `web/routes/auth.py` | 854 | — (split evaluated in DOC-025: exempt, security-critical) |
+| `web/routes/auth.py` | 852 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 851 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
@@ -349,10 +349,10 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `utils/post_sync.py` | 632 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 518 | — (schedule read-only, history, trigger, notifications) |
 | `web/routes/notebooks.py` | 506 | — (notebook management API + heartbeat lock expiry + WS notify) |
-| `web/routes/upload.py` | 701 | — (extracted from app.py by TASK-085) |
+| `web/routes/upload.py` | 705 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 828 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 829 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 698 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 595 | — (push deploy workflow + deploy lock + journal) |
@@ -361,11 +361,11 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 613 | — |
 | `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
-| `web/routes/sync.py` | 558 | — (sync endpoints + background task) |
+| `web/routes/sync.py` | 602 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 846 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |
 | `platform/cloud/server_setup.py` | 666 | — (server setup + install source detection) |
-| `cli/commands/auth.py` | 660 | — (13 auth subcommands) |
+| `cli/commands/auth.py` | 661 | — (13 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 527 | — (admin user CRUD + invite) |
 | `platform/local/watcher.py` | 518 | — |
@@ -442,7 +442,10 @@ git rebase v1
 git push -u origin feat/<task-name>
 gh pr create --base v1 --title "TASK-XXX: Description" --body "..."
 
-# Merge via API (avoids local checkout conflicts)
+# Merge — Option A (preferred when merge queue is enabled):
+gh pr merge NUMBER --merge-queue
+
+# Merge — Option B (direct merge via API):
 gh api repos/getdango/dango/pulls/NUMBER/merge -X PUT -f merge_method=merge
 
 # If merge blocked by strict branch protection:

--- a/dango/auth/CLAUDE.md
+++ b/dango/auth/CLAUDE.md
@@ -11,7 +11,7 @@ User authentication and access control for Dango. Handles password-based login w
 | `__init__.py` | 238 | Re-exports 95 public symbols | All public API |
 | `models.py` | 172 | Pydantic models | `Role`, `User`, `UserCreate`, `UserUpdate`, `UserResponse`, `Session`, `APIKey` |
 | `database.py` | 529 | SQLite CRUD (WAL mode, FK enforcement) | `create_user()`, `get_user_by_*()`, `list_users()`, `update_user()`, `create_session()`, `get_session_by_token()`, `create_api_key()` |
-| `security.py` | 375 | Pure crypto utilities | `hash_password()`, `verify_password()`, `check_password_strength()`, `generate_session_token()`, `generate_api_key()`, `generate_invite_token()`, `generate_recovery_codes()` |
+| `security.py` | 386 | Pure crypto utilities | `hash_password()`, `verify_password()`, `check_password_strength()`, `generate_session_token()`, `generate_api_key()`, `generate_invite_token()`, `generate_recovery_codes()` |
 | `sessions.py` | 289 | High-level session + API key lifecycle | `create_session()`, `validate_session()`, `validate_partial_session()`, `create_api_key()`, `validate_api_key()` |
 | `permissions.py` | 195 | 29 permissions, 3 role mappings | `PERMISSIONS`, `ROLE_PERMISSIONS`, `has_permission()`, `require_permission()` |
 | `lockout.py` | 181 | Brute-force protection (5 attempts / 15-min) | `record_failed_login()`, `check_account_locked()`, `unlock_account()` |
@@ -19,7 +19,7 @@ User authentication and access control for Dango. Handles password-based login w
 | `admin.py` | 124 | Bootstrap + path helpers | `ensure_admin()`, `is_auth_enabled()`, `get_auth_db_path()` |
 | `totp.py` | 220 | TOTP 2FA: setup/verify/enable/disable, recovery codes | `generate_totp_secret()`, `verify_totp_code()`, `setup_totp()`, `enable_totp()`, `consume_recovery_code()` |
 | `oauth_login.py` | 307 | OAuth provider ABC + Google/GitHub implementations | `OAuthLoginProvider`, `GoogleOAuthProvider`, `GitHubOAuthProvider`, `get_provider()` |
-| `metabase_sync.py` | 498 | Sync users/roles to Metabase (encrypted passwords) | `sync_user_to_metabase()`, `sync_all_users_to_metabase()`, `sync_user_role()`, `decrypt_metabase_password()` |
+| `metabase_sync.py` | 552 | Sync users/roles to Metabase (encrypted passwords) | `sync_user_to_metabase()`, `sync_all_users_to_metabase()`, `sync_user_role()`, `decrypt_metabase_password()` |
 | `metabase_bridge.py` | 152 | Async SSO session bridging on login/logout | `bridge_metabase_login()`, `bridge_metabase_logout()`, `ensure_metabase_synced()` |
 
 ## Architecture
@@ -233,14 +233,14 @@ Session bridging syncs Dango auth state to Metabase so users get single sign-on.
 **External packages:** `pwdlib[bcrypt]`, `pyotp`, `httpx`, `requests`, `pydantic`, `rich`
 
 **Used by:**
-- `web/middleware/auth.py` (325 lines) — session/API key validation on every request
-- `web/routes/auth.py` (~854 lines) — login, password change, OAuth, invite accept. Defines `_bridge_metabase_session()` helper (shared with auth_2fa.py).
-- `web/routes/auth_2fa.py` (~328 lines) — TOTP setup/verify/disable. Imports `_bridge_metabase_session` from auth.py.
-- `web/routes/users.py` (525 lines) — user CRUD, invite creation, reinvite
-- `web/routes/ui.py` (183 lines) — login/account/invite page rendering
-- `web/routes/metabase_proxy.py` (268 lines) — SSO re-bridging on 401
-- `web/app.py` (~370 lines) — first-run admin bootstrap in `lifespan()`
-- `cli/commands/auth.py` (660 lines) — 13 auth subcommands (add-user, list-users, change-role, unlock, etc.)
+- `web/middleware/auth.py` (324 lines) — session/API key validation on every request
+- `web/routes/auth.py` (~852 lines) — login, password change, OAuth, invite accept. Defines `_bridge_metabase_session()` helper (shared with auth_2fa.py).
+- `web/routes/auth_2fa.py` (~340 lines) — TOTP setup/verify/disable. Imports `_bridge_metabase_session` from auth.py.
+- `web/routes/users.py` (527 lines) — user CRUD, invite creation, reinvite
+- `web/routes/ui.py` (324 lines) — login/account/invite page rendering
+- `web/routes/metabase_proxy.py` (321 lines) — SSO re-bridging on 401
+- `web/app.py` (~449 lines) — first-run admin bootstrap in `lifespan()`
+- `cli/commands/auth.py` (661 lines) — 13 auth subcommands (add-user, list-users, change-role, unlock, etc.)
 
 ## Testing
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -12,51 +12,51 @@ Click-based command-line interface for all Dango operations — project init, so
 | `__init__.py` (12 lines) | Shared `console` (Rich Console) instance | `console` |
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
-| `commands/project.py` (292 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (828 lines) | `source` group (`add`, `list`, `remove`) + `sync` | `source`, `sync()` |
+| `commands/project.py` (307 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
+| `commands/source.py` (829 lines) | `source` group (`add`, `list`, `remove`, `edit`) + `sync` | `source`, `sync()` |
 | `commands/platform.py` (1034 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
-| `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
-| `commands/cleanup.py` (322 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
+| `commands/auth.py` (661 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
+| `commands/cleanup.py` (388 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
-| `commands/transform.py` (326 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
+| `commands/transform.py` (343 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
 | `commands/upgrade.py` (236 lines) | `upgrade` command — local Dango upgrade via pip + migrations | `upgrade()`, `get_latest_version_cached()` |
-| `commands/data.py` (360 lines) | `db` group (`status`, `clean`) + `validate` | `db`, `validate()` |
-| `commands/config_cmd.py` (179 lines) | `config` group (`validate`, `show`) | `config` |
+| `commands/data.py` (388 lines) | `db` group (`status`, `clean`) + `validate` | `db`, `validate()` |
+| `commands/config_cmd.py` (240 lines) | `config` group (`validate`, `show`) | `config` |
 | `commands/metabase_cmd.py` (412 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
-| `commands/model.py` (212 lines) | `model` group (`add`, `remove`) | `model` |
-| `commands/dashboard.py` (125 lines) | `dashboard` group (`provision`) | `dashboard` |
+| `commands/model.py` (258 lines) | `model` group (`add`, `remove`) | `model` |
+| `commands/dashboard.py` (153 lines) | `dashboard` group (`provision`) | `dashboard` |
 | `commands/remote.py` (698 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
-| `commands/serve.py` (~203 lines) | `serve` production foreground server with `--workers` option. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
+| `commands/serve.py` (~205 lines) | `serve` production foreground server with `--workers` option. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
 | `commands/deploy.py` (705 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (808 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
-| `commands/deploy_provision.py` (813 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
+| `commands/deploy_wizard.py` (813 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
+| `commands/deploy_provision.py` (846 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query` | `remote_status()`, `remote_logs()` |
 | `commands/schedule.py` (743 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
-| `commands/governance.py` (208 lines) | `governance` group (drift-report, pii-report, pii-set, pii-list) | `governance`, `drift_report()`, `pii_report()`, `pii_set()`, `pii_list()` |
-| `commands/notebook.py` | `notebook` group (new, open) | `notebook`, `notebook_new()`, `notebook_open()` |
-| `commands/snapshot.py` | `snapshot` group (add, list, run, db) | `snapshot`, `snapshot_add()`, `snapshot_list()`, `snapshot_run()`, `snapshot_db()` |
-| `commands/analyze.py` (~95 lines) | `monitor` group + `analyze` alias | `monitor` (group), `monitor_run()`, `analyze()` |
-| `commands/dev.py` (~310 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
-| `commands/web.py` (66 lines) | `web` dev server command | `web()` |
+| `commands/governance.py` (220 lines) | `governance` group (drift-report, pii-report, pii-set, pii-list) | `governance`, `drift_report()`, `pii_report()`, `pii_set()`, `pii_list()` |
+| `commands/notebook.py` (157 lines) | `notebook` group (new, open) | `notebook`, `notebook_new()`, `notebook_open()` |
+| `commands/snapshot.py` (383 lines) | `snapshot` group (add, list, run, db) | `snapshot`, `snapshot_add()`, `snapshot_list()`, `snapshot_run()`, `snapshot_db()` |
+| `commands/analyze.py` (~97 lines) | `monitor` group + `analyze` alias | `monitor` (group), `monitor_run()`, `analyze()` |
+| `commands/dev.py` (~429 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
+| `commands/web.py` (69 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1324 lines) | Project initialization wizard | `ProjectInitializer` |
-| `wizard.py` (296 lines) | Interactive setup wizards | `ProjectWizard` |
+| `init.py` (1334 lines) | Project initialization wizard | `ProjectInitializer` |
+| `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2306 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |
-| `utils.py` (129 lines) | Display helpers + project context | `require_project_context()` |
+| `utils.py` (164 lines) | Display helpers + project context | `require_project_context()` |
 | `validate.py` (652 lines) | Project validation logic | `validate_project()` |
-| `db_helpers.py` (129 lines) | Schema/table matching for db commands | `build_schema_table_mapping()`, `is_table_configured()` |
+| `db_helpers.py` (140 lines) | Schema/table matching for db commands | `build_schema_table_mapping()`, `is_table_configured()` |
 | `env_helpers.py` (319 lines) | `.env` file management | `create_env_template()`, `validate_env_file()`, `guide_env_setup()` |
-| `oauth.py` (428 lines) | OAuth CLI flows | `authenticate_facebook()`, `authenticate_google()`, `check_token_expiry()` |
-| `schema_manager.py` (335 lines) | dbt `schema.yml` auto-generation | `update_model_schemas()` |
+| `oauth.py` (439 lines) | OAuth CLI flows | `authenticate_facebook()`, `authenticate_google()`, `check_token_expiry()` |
+| `schema_manager.py` (338 lines) | dbt `schema.yml` auto-generation | `update_model_schemas()` |
 | `helpers/__init__.py` (6 lines) | Package marker | — |
-| `helpers/port_manager.py` (48 lines) | Port checking | `check_port_in_use()` |
-| `helpers/process_manager.py` (336 lines) | FastAPI server process management | `start_fastapi_server()` |
+| `helpers/port_manager.py` (49 lines) | Port checking | `check_port_in_use()` |
+| `helpers/process_manager.py` (345 lines) | FastAPI server process management | `start_fastapi_server()` |
 
 ## Architecture
 
@@ -74,7 +74,7 @@ dango (top-level group)
 ├── validate                    ← commands/data.py
 ├── web                         ← commands/web.py
 ├── source (group)              ← commands/source.py
-│   ├── add, list, remove
+│   ├── add, list, remove, edit
 ├── config (group)              ← commands/config_cmd.py
 │   ├── validate, show
 ├── db (group)                  ← commands/data.py

--- a/dango/cli/commands/dashboard.py
+++ b/dango/cli/commands/dashboard.py
@@ -21,11 +21,13 @@ def dashboard(ctx: click.Context) -> None:
 
 
 @dashboard.command("provision")
-@click.option("--url", default="http://localhost:3001", help="Metabase URL")
-@click.option("--username", default="admin@example.com", help="Metabase admin username")
+@click.option("--url", default="http://localhost:3000", help="Metabase URL")
+@click.option(
+    "--username", default=None, help="Metabase admin username (auto-detected from auth DB)"
+)
 @click.option("--password", prompt=True, hide_input=True, help="Metabase admin password")
 @click.pass_context
-def dashboard_provision(ctx: click.Context, url: str, username: str, password: str) -> None:
+def dashboard_provision(ctx: click.Context, url: str, username: str | None, password: str) -> None:
     """
     Provision Data Pipeline Health dashboard in Metabase.
 
@@ -39,13 +41,36 @@ def dashboard_provision(ctx: click.Context, url: str, username: str, password: s
     The dashboard provides instant visibility into your data pipeline.
 
     Examples:
-      dango dashboard provision                  # Use defaults (localhost:3001)
+      dango dashboard provision                  # Use defaults (localhost:3000)
       dango dashboard provision --url http://metabase.local
     """
     from rich.panel import Panel
     from rich.table import Table
 
     from dango.visualization import provision_dashboard
+
+    # Resolve admin email: env var → auth DB → fallback
+    if username is None:
+        import os
+
+        username = os.environ.get("DANGO_ADMIN_EMAIL", "")
+        if not username:
+            try:
+                from dango.auth.admin import get_auth_db_path
+                from dango.auth.database import list_users
+                from dango.auth.models import Role
+
+                project_root = ctx.obj["project_root"]
+                db_path = get_auth_db_path(project_root)
+                if db_path.exists():
+                    users = list_users(db_path, active_only=True)
+                    admins = [u for u in users if u.role == Role.ADMIN]
+                    if admins and admins[0].email != "admin@localhost":
+                        username = admins[0].email
+            except Exception:
+                pass
+        if not username:
+            username = "admin@example.com"
 
     console.print("\n🍡 [bold]Provisioning Metabase Dashboard[/bold]\n")
 

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -75,6 +75,7 @@ def source() -> None:
       dango source add      Add a new data source
       dango source list     List all sources
       dango source remove   Remove a source
+      dango source edit     Open sources.yml in $EDITOR
     """
     pass
 

--- a/dango/governance/CLAUDE.md
+++ b/dango/governance/CLAUDE.md
@@ -12,7 +12,7 @@ Data governance module: schema drift detection and PII scanning. Monitors DuckDB
 | `models.py` (~107 lines) | Pydantic V2 response models | `DriftEvent`, `DriftResponse`, `SourceAttention`, `AcceptDriftResponse`, `PiiFinding`, `PiiResponse`, `PiiOverride`, `PiiOverridesResponse` |
 | `schema_drift.py` (~654 lines) | Schema drift detection + breaking drift protection | `detect_drift_for_sources()`, `detect_table_drift()`, `get_drift_history()`, `accept_drift()`, `get_sources_needing_attention()`, `_send_drift_webhook()` |
 | `pii_detector.py` (~614 lines) | PII scanning engine (Presidio + spaCy) | `scan_sources_for_pii()`, `scan_table_for_pii()`, `get_pii_findings()`, `_send_pii_webhook()`, `_register_intl_phone_recognizer()` |
-| `pii_overrides.py` (~250 lines) | PII override CRUD (YAML-based, `.dango/pii-overrides.yml`) | `get_overrides_for_table()`, `get_pii_overrides()`, `set_pii_override()`, `delete_pii_override()` |
+| `pii_overrides.py` (~296 lines) | PII override CRUD (YAML-based, `.dango/pii-overrides.yml`) | `get_overrides_for_table()`, `get_pii_overrides()`, `set_pii_override()`, `delete_pii_override()` |
 
 ## Common Tasks
 

--- a/dango/platform/notifications/CLAUDE.md
+++ b/dango/platform/notifications/CLAUDE.md
@@ -9,8 +9,8 @@ Webhook notification infrastructure for sync event notifications. Sends configur
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` (28 lines) | Re-exports public API from `webhook.py` | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload`, `load_notification_config`, `should_notify` |
-| `webhook.py` (365 lines) | Event types, config models, event filtering, async sender with retry | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload`, `EVENT_TO_CATEGORY`, `load_notification_config`, `should_notify` |
-| `slack.py` (124 lines) | Slack Block Kit formatter for webhook payloads | `format_slack_message` |
+| `webhook.py` (377 lines) | Event types, config models, event filtering, async sender with retry | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload`, `EVENT_TO_CATEGORY`, `load_notification_config`, `should_notify` |
+| `slack.py` (145 lines) | Slack Block Kit formatter for webhook payloads | `format_slack_message` |
 
 ## Key Conventions
 

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -9,8 +9,8 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` (64 lines) | Re-exports public API | `SchedulerService`, `ResilienceConfig`, `run_with_resilience`, history functions, job functions |
-| `scheduler.py` (430 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
-| `resilience.py` (211 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
+| `scheduler.py` (448 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
+| `resilience.py` (245 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
 | `jobs.py` (895 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `sync_trigger.py` (147 lines) | Server-side manual sync runner invoked via SSH from `dango remote sync` | `main()`, `_run_sync()` |

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -19,7 +19,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `dbt_status.py` | Persistent dbt model status from run_results.json | `update_model_status()`, `get_model_statuses()` |
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
-| `dango_db.py` (~179 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
+| `dango_db.py` (~210 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
 | `post_sync.py` (~632 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -12,8 +12,8 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `models.py` | Pydantic request/response DTOs | `TableInfo`, `SourceStatus`, `ServiceHealth`, `SyncRequest`, `SyncResponse`, `LogEntry`, `WatcherStatus`, `LoginRequest`, `AcceptInviteRequest`, `TwoFAVerifyRequest` |
 | `helpers.py` | Shared helpers: DuckDB queries, config loading, service health, logging (851 lines) | `get_project_root()`, `load_sources_config()`, `get_duckdb_path()`, `get_dbt_models()`, `mask_sensitive_config()`, `get_source_freshness()`, `append_log_entry()`, `load_all_logs()`, `check_service_status_async()`, `get_platform_health_data()`, `get_source_status_data()` |
 | `__init__.py` | Public exports | `app` module |
-| `middleware/auth.py` | Session/API key auth + CSRF check on every request (~325 lines) | `AuthMiddleware`, `is_secure_request()`, `COOKIE_NAME` |
-| `middleware/rate_limit.py` | Rate limiting (login 10/min, API 200/min, localhost exempt, ~212 lines) | `RateLimitMiddleware` |
+| `middleware/auth.py` | Session/API key auth + CSRF check on every request (~324 lines) | `AuthMiddleware`, `is_secure_request()`, `COOKIE_NAME` |
+| `middleware/rate_limit.py` | Rate limiting (login 10/min, API 200/min, localhost exempt, ~235 lines) | `RateLimitMiddleware` |
 | `templates/base.html` | Shared Jinja2 layout: head (compiled Tailwind CSS), header, nav bar (9-item flat: Overview/Sources/Models/Schedules/Catalog/Query/Dashboards/Notebooks/Monitoring + gear dropdown), responsive hamburger menu, footer, script blocks | Blocks: `title`, `subtitle_attrs`, `header_right`, `nav`, `content`, `footer`, `scripts` |
 | `templates/error.html` | HTML error page (extends `base.html`) — status code, title, message, back/home links | Rendered by `dango_error_handler()` for browser 401/403 requests |
 | `templates/dashboard.html` | Overview page (extends `base.html`) — health widget, service cards, activity log | Loads `app.js` |
@@ -28,13 +28,13 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `templates/invite.html` | Invite acceptance page — set password for invited users | — |
 | `templates/secrets.html` | Secrets management page (env vars + OAuth credentials) | — |
 | `routes/__init__.py` | Package marker | — |
-| `routes/auth.py` | Login/logout, password change, OAuth flows, invite accept, API key CRUD (~854 lines) | `_bridge_metabase_session()`, `_set_session_cookie()` |
-| `routes/auth_2fa.py` | TOTP 2FA setup/verify/disable/recovery (~328 lines) | — |
-| `routes/users.py` | Admin user CRUD: create, edit, deactivate, delete, unlock, invite (525 lines) | — |
+| `routes/auth.py` | Login/logout, password change, OAuth flows, invite accept, API key CRUD (~852 lines) | `_bridge_metabase_session()`, `_set_session_cookie()` |
+| `routes/auth_2fa.py` | TOTP 2FA setup/verify/disable/recovery (~340 lines) | — |
+| `routes/users.py` | Admin user CRUD: create, edit, deactivate, delete, unlock, invite (527 lines) | — |
 | `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` (incl. DuckDB capacity gauge, OAuth token health, component disk breakdown, cloud resource metrics, backup staleness, deployment info), `/api/deployments/history` (admin-only) | — |
 | `routes/config.py` | `/api/config`, `/api/metabase-config` | — |
 | `routes/sources.py` | `/api/sources`, `/api/sources/{name}/details` | — |
-| `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + background `run_sync_task()` (~558 lines) | `run_sync_task()` |
+| `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + background `run_sync_task()` (~602 lines) | `run_sync_task()` |
 | `routes/logs.py` | `/api/logs`, `/api/sources/{name}/logs` | — |
 | `routes/dbt.py` | `/api/dbt/models`, `/api/dbt/models/{name}/run` + dbt docs proxy (`/manifest.json`, `/catalog.json`, `/dbt-docs/*`) | `run_dbt_model_task()` |
 | `routes/upload.py` | CSV upload/list/delete + background `run_dbt_after_delete()` | `run_dbt_after_delete()` |
@@ -46,7 +46,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/schedules.py` | Schedule list/get, trigger, reload, cancel, history, notification config/test, `/schedules` page (read-only, ~518 lines). Config mutations removed by R10-C (BUG-175) — use CLI instead. | `router` |
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~506 lines) | `router` |
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1336 lines) | `router` |
-| `routes/governance.py` | Schema drift + PII results API (~120 lines) | `router` |
+| `routes/governance.py` | Schema drift + PII results API (~203 lines) | `router` |
 | `routes/monitoring.py` | Monitor results, run trigger, history, dbt test results + backward-compat redirects for old `/api/insights*` paths (~398 lines) | `router` |
 | `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~496 lines) | `router` |
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -18,14 +18,14 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/upload.py
-    lines: 701
+    lines: 705
     category: exempt
     reason: "CSV upload/list/delete endpoints. Extracted from web/app.py by TASK-085. DELETE endpoint alone has ~300 lines of DuckDB cleanup logic."
     review_by: "v1.1"
 
   # --- Phase 2 auth additions ---
   - file: dango/web/routes/auth.py
-    lines: 854
+    lines: 852
     category: exempt
     reason: "Login/logout, OAuth flows, invite accept, API key CRUD. DOC-025 evaluated split (auth_api.py + auth_oauth.py) — rejected: breaks all test patches, scatters security-critical code. Bridge helper extracted to reduce duplication."
     review_by: "v1.1"
@@ -37,7 +37,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/auth/metabase_sync.py
-    lines: 521
+    lines: 552
     category: exempt
     reason: "BUG-011 added find_metabase_user_by_email() and email-exists fallback in sync_user_to_metabase() (+23 lines). Planned split in TASK-075b."
     review_by: "v1.1"
@@ -49,7 +49,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/auth.py
-    lines: 660
+    lines: 661
     category: exempt
     reason: "R7-E added change-role command and audit logging to all user management commands (+122 lines)."
     review_by: "v1.1"
@@ -93,7 +93,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 828
+    lines: 829
     category: exempt
     reason: "Source management commands (add/list/remove) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation."
     review_by: "v1.1"
@@ -154,7 +154,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1324
+    lines: 1334
     category: exempt
     reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen."
     review_by: "v1.1"
@@ -207,7 +207,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_catalog_lineage.py
-    lines: 599
+    lines: 631
     category: exempt
     reason: "P7-002: 16 tests covering lineage DAG (7) + impact analysis (9). Separate file from test_catalog_api.py per STANDARDS.md §7 split-at-creation rule."
     review_by: "v1.1"
@@ -219,7 +219,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_digitalocean_client.py
-    lines: 628
+    lines: 629
     category: exempt
     reason: "TASK-022+023+025: 36 tests covering DigitalOceanClient init, retry/backoff logic (9 cases), Droplet/SSH Key/Firewall CRUD (incl. get_firewall, update_firewall), and error handling. Retry tests require per-test mock setup for call sequencing — each is self-contained for readability."
     review_by: "v1.1"
@@ -323,7 +323,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/web/routes/sync.py
-    lines: 558
+    lines: 602
     category: exempt
     reason: "TASK-040c: Added remote sync trigger API (POST /api/sync/trigger, GET /api/sync/status/{id}) with background task + execution history. Extends existing per-source sync endpoint."
     review_by: "v1.1"
@@ -377,7 +377,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_pii_detection.py
-    lines: 632
+    lines: 717
     category: exempt
     reason: "BUG-027/BUG-133/BUG-139: added tests for PERSON threshold, intl phone, and override application. Test coverage for complex detection logic."
     review_by: "v1.1"
@@ -389,7 +389,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_platform_startup.py
-    lines: 601
+    lines: 623
     category: exempt
     reason: "R9-B: BUG-115/118 tests added metabase.yml write-back assertions and refresh_metabase_connection container-name tests. Each test class requires independent auth DB setup and multi-layer mocking."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary

- **Fix #18:** `dango dashboard provision` default port changed from 3001 to 3000 (standard Metabase port)
- **Fix #19:** `dango dashboard provision --username` now auto-detects admin email from auth DB (env var → auth DB → fallback), matching the pattern in `platform/common/startup.py`
- Add `source edit` to source group docstring (was missing from R10-F2)
- Update 12 stale line counts in `file-exemptions.yml` to match `wc -l`
- Update all line counts in root `CLAUDE.md` (repo structure annotations + monolithic files table)
- Update line counts in 7 module `CLAUDE.md` files (cli, auth, web, utils, governance, scheduling, notifications)
- Add `--ignore-vuln CVE-2026-32274` to pip-audit CI step (known black CVE from dbt-core dep)
- Document merge queue (`gh pr merge N --merge-queue`) as preferred merge method alongside existing API method

## Test plan

- [x] `ruff check` + `ruff format --check` pass on changed files
- [x] `mypy dango/cli/commands/dashboard.py` passes
- [x] `pre-commit run claude-md-staleness --all-files` passes
- [x] `pre-commit run file-size-check --all-files` passes
- [x] `dango dashboard provision --help` shows `localhost:3000` + "auto-detected from auth DB"
- [x] `pytest tests/unit/test_cli_commands.py tests/unit/test_cli_auth.py tests/unit/test_web_imports.py` — all pass
- [ ] Full `pytest tests/unit/ -x` (running, ~25% through, all passing)

Fixes #18, Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)