### PR TITLE
R10-N: Process separation for syncs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 851 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
-| `platform/scheduling/jobs.py` | 895 | — (module-level job functions) |
+| `platform/scheduling/jobs.py` | 849 | — (module-level job functions) |
 | `utils/post_sync.py` | 632 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 518 | — (schedule read-only, history, trigger, notifications) |
 | `web/routes/notebooks.py` | 506 | — (notebook management API + heartbeat lock expiry + WS notify) |
@@ -361,7 +361,6 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 613 | — |
 | `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
-| `web/routes/sync.py` | 602 | — (sync endpoints + background task) |
 | `cli/commands/deploy_provision.py` | 846 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |
 | `platform/cloud/server_setup.py` | 666 | — (server setup + install source detection) |

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -26,6 +26,7 @@ platform/
 │   ├── watcher_lifecycle.py  # start/stop/status for watcher subprocess
 │   └── watcher_runner.py    # Background watcher process entry point
 │
+├── sync_process.py      # Subprocess launch + polling for process-isolated syncs (R10-N)
 ├── scheduling/          # APScheduler-based job scheduling (TASK-036+)
 │   ├── __init__.py      # Re-exports SchedulerService, ResilienceConfig, run_with_resilience, history functions
 │   ├── CLAUDE.md        # Scheduling module navigation doc
@@ -33,7 +34,7 @@ platform/
 │   ├── resilience.py    # Resilience: retry, timeout, cancellation (extracted from scheduler.py)
 │   ├── history.py       # Execution history tracking (TASK-039)
 │   ├── jobs.py          # Module-level job functions (pickle-safe)
-│   └── sync_trigger.py  # Server-side manual sync runner (dango remote sync)
+│   └── sync_trigger.py  # Subprocess entrypoint for manual + UI + scheduler syncs
 │
 ├── notifications/       # Webhook notification infrastructure (TASK-043+)
 │   ├── __init__.py      # Re-exports WebhookSender, EventType, etc.
@@ -82,7 +83,8 @@ platform/
 | `scheduling/resilience.py` | Resilience: retry with backoff, timeout via thread kill, cancellation | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `scheduling/history.py` | Execution history tracking for scheduled jobs | `record_start`, `record_completion`, `record_failure`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
 | `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
-| `scheduling/sync_trigger.py` | Server-side manual sync runner (invoked via SSH) | `main()`, `_run_sync()` |
+| `scheduling/sync_trigger.py` | Subprocess entrypoint for sync operations (progress writing, lock, OAuth) | `run_manual_sync()`, `_write_status()` |
+| `sync_process.py` | Subprocess launch + polling for process-isolated syncs | `launch_sync_subprocess`, `poll_sync_status`, `poll_sync_status_blocking`, `read_sync_status`, `cleanup_sync_status` |
 | `notifications/webhook.py` | Event types, config models, event filtering, async sender with retry | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload` |
 | `notifications/slack.py` | Slack Block Kit formatter for webhook payloads | `format_slack_message` |
 | `cloud/digitalocean.py` | DigitalOcean REST API v2 client | `DigitalOceanClient` |
@@ -169,6 +171,11 @@ from dango.platform.cloud import migrate_server, MigrateResult
 # Upgrade (TASK-106)
 from dango.platform.cloud import upgrade_dango, UpgradeResult, validate_version_string
 from dango.platform.cloud.upgrade import check_versions
+```
+
+# Sync subprocess (R10-N)
+from dango.platform.sync_process import launch_sync_subprocess, poll_sync_status
+from dango.platform.sync_process import poll_sync_status_blocking, cleanup_sync_status
 ```
 
 ### Also valid (backwards-compatible shims):

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,8 +12,8 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (448 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (245 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (895 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
-| `sync_trigger.py` (147 lines) | Server-side manual sync runner invoked via SSH from `dango remote sync` | `main()`, `_run_sync()` |
+| `jobs.py` (849 lines) | Module-level job functions (pickle-safe for APScheduler) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `sync_trigger.py` (306 lines) | Subprocess entrypoint for sync operations — progress writing, lock acquisition, OAuth validation | `run_manual_sync()`, `_write_status()` |
 
 ## Key Conventions
 

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -438,6 +438,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         from dango.utils.sync_history import save_sync_history_entry
 
         job_id = f"schedule:{schedule_name}"
+        total_rows = 0
 
         # Sync each source in a subprocess with skip_dbt=True
         # (dbt coalesced after all sources)
@@ -447,7 +448,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
 
             src_t0 = time.monotonic()
 
-            process = launch_sync_subprocess(
+            process, sync_id = launch_sync_subprocess(
                 project_root,
                 sources=[src.name],
                 full_refresh=full_refresh,
@@ -459,6 +460,8 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             success, _result = poll_sync_status_blocking(
                 project_root,
                 process,
+                source_name=src.name,
+                sync_id=sync_id,
                 broadcast_fn=_broadcast,
             )
 
@@ -467,6 +470,10 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                     _result.get("error", "Unknown error") if _result else "Subprocess failed"
                 )
                 raise RuntimeError(f"Sync failed for {src.name}: {error_msg}")
+
+            # Accumulate rows_loaded from subprocess result
+            if _result and isinstance(_result, dict):
+                total_rows += _result.get("rows_loaded", 0)
 
             save_sync_history_entry(
                 project_root,
@@ -480,7 +487,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 },
             )
             _add_pending_dbt_source(project_root, src.name)
-            cleanup_sync_status(project_root)
+            cleanup_sync_status(project_root, sync_id=sync_id)
 
         # Run coalesced dbt (waits for coalesce window, merges pending sources)
         dbt_ok = _run_coalesced_dbt(project_root)
@@ -524,6 +531,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             schedule_name=schedule_name,
             sources=source_names,
             duration_seconds=round(elapsed, 2),
+            rows_loaded=total_rows,
             dashboard_url=dashboard_url,
         )
         _check_freshness(project_root, schedule_name, source_names, sender)

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -377,11 +377,12 @@ def _run_coalesced_dbt(project_root: Path) -> bool:
 def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) -> None:
     """Run a scheduled data sync for the given sources.
 
-    Called by APScheduler from a thread-pool executor.  Wraps ``run_sync()``
-    with DbtLock serialization, WebSocket broadcasting, webhook notifications,
-    and execution history recording.
+    Called by APScheduler from a thread-pool executor.  Launches each source
+    sync in a subprocess (via ``sync_process.launch_sync_subprocess``),
+    keeping the DbtLock out of the web server process.
 
     Sources are synced individually with cancellation checks between each source.
+    dbt is coalesced after all sources complete.
 
     Args:
         schedule_name: Human-readable schedule identifier.
@@ -392,80 +393,24 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
     full_refresh = bool(kwargs.get("full_refresh", False))
     t0 = time.monotonic()
 
-    from dango.exceptions import DbtLockError, JobCancelledError, JobTimeoutError
+    from dango.exceptions import JobCancelledError, JobTimeoutError
     from dango.platform.notifications.webhook import (
         EventType,
         WebhookSender,
         load_notification_config,
     )
-    from dango.utils.dbt_lock import DbtLock
+    from dango.platform.sync_process import (
+        cleanup_sync_status,
+        launch_sync_subprocess,
+        poll_sync_status_blocking,
+    )
 
     sender = WebhookSender(load_notification_config(project_root))
     source_names = list(sources)
-    lock = DbtLock(project_root, source="scheduler", operation=f"sync:{schedule_name}")
 
     record_id: int | None = None
 
     try:
-        # Acquire lock with retry (wait up to 5 minutes, retry every 5 seconds)
-        max_wait = 300
-        retry_interval = 5
-        acquired = False
-        wait_start = time.monotonic()
-        queued_broadcast = False
-
-        while not acquired:
-            try:
-                lock.acquire()
-                acquired = True
-            except DbtLockError:
-                elapsed_wait = time.monotonic() - wait_start
-                if elapsed_wait >= max_wait:
-                    elapsed = time.monotonic() - t0
-                    logger.warning(
-                        "scheduler_lock_timeout",
-                        schedule=schedule_name,
-                        sources=source_names,
-                    )
-                    _broadcast(
-                        {
-                            "event": "sync_failed",
-                            "schedule": schedule_name,
-                            "sources": source_names,
-                            "error": "Could not acquire lock after 5 minutes",
-                            "timestamp": _ts(),
-                        }
-                    )
-                    _notify(
-                        sender,
-                        event_type=EventType.SYNC_FAILED,
-                        schedule_name=schedule_name,
-                        sources=source_names,
-                        error="Could not acquire lock after 5 minutes",
-                        duration_seconds=elapsed,
-                    )
-                    _log_execution_event(
-                        schedule_name=schedule_name,
-                        job_type="sync",
-                        status="lock_failed",
-                        duration_seconds=elapsed,
-                        error="Lock timeout after 5 minutes",
-                        sources=source_names,
-                    )
-                    return
-                if not queued_broadcast:
-                    _broadcast(
-                        {
-                            "event": "job_queued",
-                            "schedule": schedule_name,
-                            "sources": source_names,
-                            "message": "Waiting for lock...",
-                            "timestamp": _ts(),
-                        }
-                    )
-                    queued_broadcast = True
-                time.sleep(retry_interval)
-
         resolved = _resolve_sources(project_root, source_names)
         if not resolved:
             elapsed = time.monotonic() - t0
@@ -490,28 +435,39 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             }
         )
 
-        from dango.ingestion.dlt_runner import run_sync
         from dango.utils.sync_history import save_sync_history_entry
 
         job_id = f"schedule:{schedule_name}"
-        total_rows = 0
-        # Sync each source with skip_dbt=True (dbt coalesced after all sources)
+
+        # Sync each source in a subprocess with skip_dbt=True
+        # (dbt coalesced after all sources)
         for src in resolved:
             if _scheduler_service is not None and _scheduler_service.is_cancelled(job_id):
                 raise JobCancelledError(f"Sync cancelled between sources for {schedule_name}")
+
             src_t0 = time.monotonic()
-            sync_result = run_sync(
+
+            process = launch_sync_subprocess(
                 project_root,
-                [src],
+                sources=[src.name],
                 full_refresh=full_refresh,
                 skip_dbt=True,
-                skip_sync_notification=True,
+                source_label="scheduler",
+                max_lock_wait=300,
             )
-            total_rows += sum(
-                r.get("rows_loaded", 0)
-                for r in sync_result.get("results", [])
-                if isinstance(r, dict)
+
+            success, _result = poll_sync_status_blocking(
+                project_root,
+                process,
+                broadcast_fn=_broadcast,
             )
+
+            if not success:
+                error_msg = (
+                    _result.get("error", "Unknown error") if _result else "Subprocess failed"
+                )
+                raise RuntimeError(f"Sync failed for {src.name}: {error_msg}")
+
             save_sync_history_entry(
                 project_root,
                 src.name,
@@ -524,6 +480,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 },
             )
             _add_pending_dbt_source(project_root, src.name)
+            cleanup_sync_status(project_root)
 
         # Run coalesced dbt (waits for coalesce window, merges pending sources)
         dbt_ok = _run_coalesced_dbt(project_root)
@@ -567,7 +524,6 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             schedule_name=schedule_name,
             sources=source_names,
             duration_seconds=round(elapsed, 2),
-            rows_loaded=total_rows,
             dashboard_url=dashboard_url,
         )
         _check_freshness(project_root, schedule_name, source_names, sender)
@@ -668,8 +624,6 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             error=error_msg,
             duration_seconds=elapsed,
         )
-    finally:
-        lock.release()
 
 
 def run_scheduled_dbt(

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -1,11 +1,18 @@
 """dango/platform/scheduling/sync_trigger.py
 
-Server-side manual sync runner invoked via SSH from ``dango remote sync``.
+Server-side manual sync runner invoked via SSH from ``dango remote sync``,
+and subprocess entrypoint for process-isolated syncs from the web UI and
+scheduler.
 
 Usage (on the remote server)::
 
     /srv/dango/venv/bin/python -m dango.platform.scheduling.sync_trigger \
         '{"sources":["x"],"full_refresh":false}'
+
+Usage (subprocess from web UI / scheduler)::
+
+    python -m dango.platform.scheduling.sync_trigger \
+        '{"sources":["x"],"full_refresh":false,"write_progress":true,"source_label":"ui"}'
 
 Prints a JSON result line to stdout on completion::
 
@@ -15,7 +22,9 @@ Prints a JSON result line to stdout on completion::
 from __future__ import annotations
 
 import json
+import os
 import sys
+import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -32,11 +41,63 @@ from dango.platform.scheduling.history import (
 logger = get_logger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Progress file helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_status(state_dir: Path, **fields: Any) -> None:
+    """Atomically write sync status to state_dir/sync_status.json.
+
+    Uses write-to-temp + os.replace() for crash-safe atomic updates.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    status_path = state_dir / "sync_status.json"
+
+    data = {
+        "pid": os.getpid(),
+        "updated_at": datetime.now(tz=timezone.utc).isoformat(),
+        **fields,
+    }
+
+    # Write to temp file in same directory, then atomic rename
+    fd = tempfile.NamedTemporaryFile(
+        mode="w",
+        dir=state_dir,
+        prefix=".sync_status_",
+        suffix=".tmp",
+        delete=False,
+    )
+    try:
+        json.dump(data, fd)
+        fd.close()
+        os.replace(fd.name, status_path)
+    except Exception:
+        # Clean up temp file on failure
+        fd.close()
+        try:
+            os.unlink(fd.name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Main sync function
+# ---------------------------------------------------------------------------
+
+
 def run_manual_sync(
     project_root: Path,
     sources: list[str],
     full_refresh: bool = False,
     backfill_days: int | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    write_progress: bool = False,
+    source_label: str = "manual",
+    skip_dbt: bool = False,
+    max_lock_wait: int = 0,
 ) -> dict[str, Any]:
     """Execute a manual sync with execution history tracking.
 
@@ -45,6 +106,12 @@ def run_manual_sync(
         sources: List of source names to sync.
         full_refresh: Whether to do a full refresh sync.
         backfill_days: Number of days to backfill, or ``None``.
+        start_date: ISO date string for start_date filter.
+        end_date: ISO date string for end_date filter.
+        write_progress: If True, write progress to .dango/state/sync_status.json.
+        source_label: Label for the sync trigger (e.g., "ui", "scheduler", "manual").
+        skip_dbt: If True, skip dbt run after data load.
+        max_lock_wait: Max seconds to wait for lock (0 = fail immediately).
 
     Returns:
         Dict with ``record_id``, ``status``, and ``duration_seconds``.
@@ -53,29 +120,95 @@ def run_manual_sync(
     from dango.ingestion import run_sync
     from dango.utils import DbtLock, DbtLockError
 
+    state_dir = project_root / ".dango" / "state"
     db_path = get_scheduler_db_path(project_root)
-    record_id = record_start(db_path, "manual", sources=sources)
+    record_id = record_start(db_path, source_label, sources=sources)
     start_time = time.time()
 
-    lock = None
+    def _progress(phase: str, message: str, **extra: Any) -> None:
+        if write_progress:
+            _write_status(
+                state_dir,
+                phase=phase,
+                message=message,
+                sources=sources,
+                source_label=source_label,
+                started_at=datetime.fromtimestamp(start_time, tz=timezone.utc).isoformat(),
+                elapsed_seconds=round(time.time() - start_time, 1),
+                **extra,
+            )
+
+    _progress("starting", "Initializing sync")
+
+    # --- OAuth validation (before lock) ---
     try:
-        lock = DbtLock(
-            project_root=project_root,
-            source="manual",
-            operation=f"sync:{','.join(sources)}",
-        )
-        lock.acquire()
-    except DbtLockError as exc:
-        record_failure(db_path, record_id, f"Lock unavailable: {exc}")
+        from dango.exceptions import OAuthTokenExpiredError, OAuthTokenRevokedError
+        from dango.oauth.validation import validate_before_sync
+
+        config = load_config(project_root)
+        for name in sources:
+            src = config.sources.get_source(name)
+            if src is not None:
+                validate_before_sync(src.type.value, project_root)
+    except (OAuthTokenExpiredError, OAuthTokenRevokedError) as oauth_err:
+        error_msg = f"OAuth validation failed: {oauth_err.user_message}"
+        record_failure(db_path, record_id, error_msg)
         duration = round(time.time() - start_time, 1)
+        _progress("failed", error_msg, error=error_msg)
         return {
             "record_id": record_id,
             "status": "failed",
             "duration_seconds": duration,
-            "error": f"Lock unavailable: {exc}",
+            "error": error_msg,
+        }
+    except Exception:
+        # Non-OAuth errors during validation: continue (benefit of the doubt)
+        pass
+
+    # --- Lock acquisition with retry ---
+    _progress("lock_waiting", "Waiting for lock")
+    lock = None
+    try:
+        lock = DbtLock(
+            project_root=project_root,
+            source=source_label,
+            operation=f"sync:{','.join(sources)}",
+        )
+
+        acquired = False
+        wait_start = time.time()
+        while not acquired:
+            try:
+                lock.acquire()
+                acquired = True
+            except DbtLockError as exc:
+                elapsed_wait = time.time() - wait_start
+                if elapsed_wait >= max_lock_wait:
+                    error_msg = f"Lock unavailable: {exc}"
+                    record_failure(db_path, record_id, error_msg)
+                    duration = round(time.time() - start_time, 1)
+                    _progress("failed", error_msg, error=error_msg)
+                    return {
+                        "record_id": record_id,
+                        "status": "failed",
+                        "duration_seconds": duration,
+                        "error": error_msg,
+                    }
+                time.sleep(5)
+    except DbtLockError as exc:
+        error_msg = f"Lock unavailable: {exc}"
+        record_failure(db_path, record_id, error_msg)
+        duration = round(time.time() - start_time, 1)
+        _progress("failed", error_msg, error=error_msg)
+        return {
+            "record_id": record_id,
+            "status": "failed",
+            "duration_seconds": duration,
+            "error": error_msg,
         }
 
     try:
+        # Reload config (may have been loaded above for OAuth, but safe to reload)
         config = load_config(project_root)
         resolved = []
         for name in sources:
@@ -88,6 +221,7 @@ def run_manual_sync(
             logger.warning("manual_sync_no_sources", source_names=sources)
             record_failure(db_path, record_id, msg)
             duration = round(time.time() - start_time, 1)
+            _progress("failed", msg, error=msg)
             return {
                 "record_id": record_id,
                 "status": "failed",
@@ -95,19 +229,33 @@ def run_manual_sync(
                 "error": msg,
             }
 
-        start_date = None
+        # Parse date params
+        start_date_obj = None
         if backfill_days is not None:
-            start_date = datetime.now(tz=timezone.utc) - timedelta(days=backfill_days)
+            start_date_obj = datetime.now(tz=timezone.utc) - timedelta(days=backfill_days)
+        elif start_date is not None:
+            start_date_obj = datetime.fromisoformat(start_date).replace(tzinfo=timezone.utc)
+
+        end_date_obj = None
+        if end_date is not None:
+            end_date_obj = datetime.fromisoformat(end_date).replace(tzinfo=timezone.utc)
+
+        _progress("data_load", "Loading data from source")
 
         run_sync(
             project_root=project_root,
             sources=resolved,
             full_refresh=full_refresh,
-            start_date=start_date,
+            start_date=start_date_obj,
+            end_date=end_date_obj,
+            skip_dbt=skip_dbt,
         )
+
+        _progress("data_load_complete", "Data load completed")
 
         record_completion(db_path, record_id)
         duration = round(time.time() - start_time, 1)
+        _progress("completed", "Sync completed successfully")
         return {
             "record_id": record_id,
             "status": "success",
@@ -115,13 +263,15 @@ def run_manual_sync(
         }
     except Exception as exc:
         logger.warning("manual_sync_failed", error=str(exc), exc_info=True)
-        record_failure(db_path, record_id, str(exc))
+        error_msg = str(exc)
+        record_failure(db_path, record_id, error_msg)
         duration = round(time.time() - start_time, 1)
+        _progress("failed", f"Sync failed: {error_msg}", error=error_msg)
         return {
             "record_id": record_id,
             "status": "failed",
             "duration_seconds": duration,
-            "error": str(exc),
+            "error": error_msg,
         }
     finally:
         if lock is not None:
@@ -133,7 +283,10 @@ def run_manual_sync(
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python -m dango.platform.scheduling.sync_trigger '<json>'", file=sys.stderr)
+        print(
+            "Usage: python -m dango.platform.scheduling.sync_trigger '<json>'",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     args: dict[str, Any] = json.loads(sys.argv[1])
@@ -143,5 +296,11 @@ if __name__ == "__main__":
         sources=args["sources"],
         full_refresh=args.get("full_refresh", False),
         backfill_days=args.get("backfill_days"),
+        start_date=args.get("start_date"),
+        end_date=args.get("end_date"),
+        write_progress=args.get("write_progress", False),
+        source_label=args.get("source_label", "manual"),
+        skip_dbt=args.get("skip_dbt", False),
+        max_lock_wait=args.get("max_lock_wait", 0),
     )
     print(json.dumps(result))

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -46,13 +46,14 @@ logger = get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _write_status(state_dir: Path, **fields: Any) -> None:
-    """Atomically write sync status to state_dir/sync_status.json.
+def _write_status(state_dir: Path, sync_id: str | None = None, **fields: Any) -> None:
+    """Atomically write sync status to state_dir/sync_status_{sync_id}.json.
 
-    Uses write-to-temp + os.replace() for crash-safe atomic updates.
+    Uses write-to-temp + fsync + os.replace() for crash-safe atomic updates.
     """
     state_dir.mkdir(parents=True, exist_ok=True)
-    status_path = state_dir / "sync_status.json"
+    filename = f"sync_status_{sync_id}.json" if sync_id else "sync_status.json"
+    status_path = state_dir / filename
 
     data = {
         "pid": os.getpid(),
@@ -61,7 +62,7 @@ def _write_status(state_dir: Path, **fields: Any) -> None:
     }
 
     # Write to temp file in same directory, then atomic rename
-    fd = tempfile.NamedTemporaryFile(
+    tmp_f = tempfile.NamedTemporaryFile(
         mode="w",
         dir=state_dir,
         prefix=".sync_status_",
@@ -69,14 +70,16 @@ def _write_status(state_dir: Path, **fields: Any) -> None:
         delete=False,
     )
     try:
-        json.dump(data, fd)
-        fd.close()
-        os.replace(fd.name, status_path)
+        json.dump(data, tmp_f)
+        tmp_f.flush()
+        os.fsync(tmp_f.fileno())
+        tmp_f.close()
+        os.replace(tmp_f.name, status_path)
     except Exception:
         # Clean up temp file on failure
-        fd.close()
+        tmp_f.close()
         try:
-            os.unlink(fd.name)
+            os.unlink(tmp_f.name)
         except OSError:
             pass
         raise
@@ -98,6 +101,8 @@ def run_manual_sync(
     source_label: str = "manual",
     skip_dbt: bool = False,
     max_lock_wait: int = 0,
+    sync_id: str | None = None,
+    record_id: int | None = None,
 ) -> dict[str, Any]:
     """Execute a manual sync with execution history tracking.
 
@@ -112,9 +117,12 @@ def run_manual_sync(
         source_label: Label for the sync trigger (e.g., "ui", "scheduler", "manual").
         skip_dbt: If True, skip dbt run after data load.
         max_lock_wait: Max seconds to wait for lock (0 = fail immediately).
+        sync_id: Unique identifier for the status file (avoids concurrent clobber).
+        record_id: Existing execution history record ID to reuse (avoids double records).
 
     Returns:
-        Dict with ``record_id``, ``status``, and ``duration_seconds``.
+        Dict with ``record_id``, ``status``, ``duration_seconds``, and optionally
+        ``rows_loaded``.
     """
     from dango.config.helpers import load_config
     from dango.ingestion import run_sync
@@ -122,13 +130,15 @@ def run_manual_sync(
 
     state_dir = project_root / ".dango" / "state"
     db_path = get_scheduler_db_path(project_root)
-    record_id = record_start(db_path, source_label, sources=sources)
+    if record_id is None:
+        record_id = record_start(db_path, source_label, sources=sources)
     start_time = time.time()
 
     def _progress(phase: str, message: str, **extra: Any) -> None:
         if write_progress:
             _write_status(
                 state_dir,
+                sync_id=sync_id,
                 phase=phase,
                 message=message,
                 sources=sources,
@@ -242,7 +252,7 @@ def run_manual_sync(
 
         _progress("data_load", "Loading data from source")
 
-        run_sync(
+        sync_result = run_sync(
             project_root=project_root,
             sources=resolved,
             full_refresh=full_refresh,
@@ -251,15 +261,25 @@ def run_manual_sync(
             skip_dbt=skip_dbt,
         )
 
-        _progress("data_load_complete", "Data load completed")
+        # Extract rows loaded from sync result
+        rows_loaded = 0
+        if isinstance(sync_result, dict):
+            rows_loaded = sum(
+                r.get("rows_loaded", 0)
+                for r in sync_result.get("results", [])
+                if isinstance(r, dict)
+            )
+
+        _progress("data_load_complete", "Data load completed", rows_loaded=rows_loaded)
 
         record_completion(db_path, record_id)
         duration = round(time.time() - start_time, 1)
-        _progress("completed", "Sync completed successfully")
+        _progress("completed", "Sync completed successfully", rows_loaded=rows_loaded)
         return {
             "record_id": record_id,
             "status": "success",
             "duration_seconds": duration,
+            "rows_loaded": rows_loaded,
         }
     except Exception as exc:
         logger.warning("manual_sync_failed", error=str(exc), exc_info=True)
@@ -302,5 +322,7 @@ if __name__ == "__main__":
         source_label=args.get("source_label", "manual"),
         skip_dbt=args.get("skip_dbt", False),
         max_lock_wait=args.get("max_lock_wait", 0),
+        sync_id=args.get("sync_id"),
+        record_id=args.get("record_id"),
     )
     print(json.dumps(result))

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -7,12 +7,12 @@ in a subprocess, keeping the DuckDB write lock out of the web server process.
 This allows notebooks and the web UI to coexist without lock conflicts.
 
 Public API:
-    get_sync_status_path(project_root) -- path to sync status file
-    read_sync_status(project_root)     -- read current status (or None)
-    cleanup_sync_status(project_root)  -- remove stale status file
-    launch_sync_subprocess(...)        -- spawn sync subprocess
-    poll_sync_status(...)              -- async poll with WS broadcasts
-    poll_sync_status_blocking(...)     -- sync poll for scheduler threads
+    get_sync_status_path(project_root, sync_id) -- path to sync status file
+    read_sync_status(project_root, sync_id)     -- read current status (or None)
+    cleanup_sync_status(project_root, sync_id)  -- remove stale status file
+    launch_sync_subprocess(...)                  -- spawn sync subprocess
+    poll_sync_status(...)                        -- async poll with WS broadcasts
+    poll_sync_status_blocking(...)               -- sync poll for scheduler threads
 """
 
 from __future__ import annotations
@@ -26,20 +26,22 @@ import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-def get_sync_status_path(project_root: Path) -> Path:
-    """Return .dango/state/sync_status.json path."""
-    return project_root / ".dango" / "state" / "sync_status.json"
+def get_sync_status_path(project_root: Path, sync_id: str | None = None) -> Path:
+    """Return .dango/state/sync_status_{sync_id}.json path."""
+    filename = f"sync_status_{sync_id}.json" if sync_id else "sync_status.json"
+    return project_root / ".dango" / "state" / filename
 
 
-def read_sync_status(project_root: Path) -> dict[str, Any] | None:
+def read_sync_status(project_root: Path, sync_id: str | None = None) -> dict[str, Any] | None:
     """Read current sync status file. Returns None if missing or unparseable."""
-    path = get_sync_status_path(project_root)
+    path = get_sync_status_path(project_root, sync_id)
     try:
         if not path.exists():
             return None
@@ -59,13 +61,13 @@ def _is_pid_alive(pid: int) -> bool:
         return False
 
 
-def cleanup_sync_status(project_root: Path) -> None:
+def cleanup_sync_status(project_root: Path, sync_id: str | None = None) -> None:
     """Remove stale status file (dead PID or completed).
 
     Safe to call any time — only removes the file if the referenced
     process is no longer running or the sync has a terminal phase.
     """
-    status = read_sync_status(project_root)
+    status = read_sync_status(project_root, sync_id)
     if status is None:
         return
 
@@ -74,7 +76,7 @@ def cleanup_sync_status(project_root: Path) -> None:
     terminal_phases = {"completed", "failed"}
 
     if phase in terminal_phases or (pid is not None and not _is_pid_alive(pid)):
-        path = get_sync_status_path(project_root)
+        path = get_sync_status_path(project_root, sync_id)
         try:
             path.unlink(missing_ok=True)
         except OSError:
@@ -91,13 +93,19 @@ def launch_sync_subprocess(
     skip_dbt: bool = False,
     source_label: str = "ui",
     max_lock_wait: int = 0,
-) -> subprocess.Popen:
-    """Spawn sync subprocess via sys.executable. Returns Popen handle.
+    record_id: int | None = None,
+) -> tuple[subprocess.Popen, str]:
+    """Spawn sync subprocess via sys.executable.
+
+    Returns (Popen handle, sync_id). The sync_id uniquely identifies the
+    status file so concurrent syncs don't clobber each other.
 
     The subprocess runs ``python -m dango.platform.scheduling.sync_trigger``
-    with write_progress=True, so it writes status to .dango/state/sync_status.json.
+    with write_progress=True.
     """
-    # Clean up any stale status file before launching
+    sync_id = uuid4().hex[:12]
+
+    # Clean up any stale status file for the default path (legacy)
     cleanup_sync_status(project_root)
 
     args_dict: dict[str, Any] = {
@@ -108,6 +116,7 @@ def launch_sync_subprocess(
         "source_label": source_label,
         "skip_dbt": skip_dbt,
         "max_lock_wait": max_lock_wait,
+        "sync_id": sync_id,
     }
     if start_date is not None:
         args_dict["start_date"] = start_date
@@ -115,14 +124,16 @@ def launch_sync_subprocess(
         args_dict["end_date"] = end_date
     if backfill_days is not None:
         args_dict["backfill_days"] = backfill_days
+    if record_id is not None:
+        args_dict["record_id"] = record_id
 
     json_args = json.dumps(args_dict)
 
     process = subprocess.Popen(
         [sys.executable, "-m", "dango.platform.scheduling.sync_trigger", json_args],
         cwd=str(project_root),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
     logger.info(
@@ -130,37 +141,55 @@ def launch_sync_subprocess(
         pid=process.pid,
         sources=sources,
         source_label=source_label,
+        sync_id=sync_id,
     )
-    return process
+    return process, sync_id
 
 
 async def poll_sync_status(
     project_root: Path,
     process: subprocess.Popen,
     source_name: str,
+    sync_id: str | None = None,
     poll_interval: float = 2.0,
     heartbeat_interval: float = 30.0,
+    max_poll_time: float = 3600.0,
 ) -> tuple[bool, dict[str, Any] | None]:
     """Async poll — reads status file, broadcasts WS events on transitions.
 
     Emits heartbeat every ``heartbeat_interval`` seconds. Detects subprocess
-    crash via ``process.poll()``. Returns (success, result_dict).
+    crash via ``process.poll()``. Times out after ``max_poll_time`` seconds.
+    Returns (success, result_dict).
     """
     from dango.web.routes.websocket import ws_manager
 
     last_phase: str | None = None
     last_heartbeat = time.time()
     start_time = time.time()
-    final_status: dict[str, Any] | None = None
 
     while True:
         await asyncio.sleep(poll_interval)
+
+        # Check timeout
+        elapsed = time.time() - start_time
+        if elapsed >= max_poll_time:
+            process.terminate()
+            error_msg = f"Sync timed out after {int(elapsed)}s"
+            await ws_manager.broadcast(
+                {
+                    "event": "sync_failed",
+                    "source": source_name,
+                    "message": error_msg,
+                    "timestamp": _ts(),
+                }
+            )
+            return False, {"error": error_msg, "phase": "failed"}
 
         # Check if subprocess has exited
         exit_code = process.poll()
 
         # Read current status
-        status = read_sync_status(project_root)
+        status = read_sync_status(project_root, sync_id)
 
         if status is not None:
             current_phase = status.get("phase", "")
@@ -172,19 +201,17 @@ async def poll_sync_status(
 
             # Detect terminal state
             if current_phase in ("completed", "failed"):
-                final_status = status
-                success = current_phase == "completed"
-                return success, final_status
+                return current_phase == "completed", status
 
         # Heartbeat
         now = time.time()
         if now - last_heartbeat >= heartbeat_interval:
-            elapsed = int(now - start_time)
+            elapsed_int = int(now - start_time)
             await ws_manager.broadcast(
                 {
                     "event": "sync_progress",
                     "source": source_name,
-                    "message": f"Sync in progress ({elapsed}s elapsed)",
+                    "message": f"Sync in progress ({elapsed_int}s elapsed)",
                     "timestamp": _ts(),
                 }
             )
@@ -209,20 +236,40 @@ async def poll_sync_status(
 def poll_sync_status_blocking(
     project_root: Path,
     process: subprocess.Popen,
+    source_name: str = "",
+    sync_id: str | None = None,
     broadcast_fn: Callable[[dict[str, Any]], None] | None = None,
     poll_interval: float = 2.0,
+    max_poll_time: float = 3600.0,
 ) -> tuple[bool, dict[str, Any] | None]:
     """Synchronous version for APScheduler thread pool. Returns (success, result_dict).
 
     Uses time.sleep() for polling. Calls optional broadcast_fn on phase transitions.
     """
     last_phase: str | None = None
+    start_time = time.time()
 
     while True:
         time.sleep(poll_interval)
 
+        # Check timeout
+        elapsed = time.time() - start_time
+        if elapsed >= max_poll_time:
+            process.terminate()
+            error_msg = f"Sync timed out after {int(elapsed)}s"
+            if broadcast_fn is not None:
+                broadcast_fn(
+                    {
+                        "event": "sync_failed",
+                        "source": source_name,
+                        "message": error_msg,
+                        "timestamp": _ts(),
+                    }
+                )
+            return False, {"error": error_msg, "phase": "failed"}
+
         exit_code = process.poll()
-        status = read_sync_status(project_root)
+        status = read_sync_status(project_root, sync_id)
 
         if status is not None:
             current_phase = status.get("phase", "")
@@ -232,6 +279,7 @@ def poll_sync_status_blocking(
                 broadcast_fn(
                     {
                         "event": _phase_to_event(current_phase),
+                        "source": source_name,
                         "phase": current_phase,
                         "message": status.get("message", ""),
                         "timestamp": _ts(),
@@ -253,6 +301,7 @@ def poll_sync_status_blocking(
                 broadcast_fn(
                     {
                         "event": "sync_failed",
+                        "source": source_name,
                         "message": error_msg,
                         "timestamp": _ts(),
                     }

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -1,0 +1,318 @@
+"""dango/platform/sync_process.py
+
+Subprocess launch and polling utilities for process-isolated syncs.
+
+The web server and scheduler use these functions to run sync operations
+in a subprocess, keeping the DuckDB write lock out of the web server process.
+This allows notebooks and the web UI to coexist without lock conflicts.
+
+Public API:
+    get_sync_status_path(project_root) -- path to sync status file
+    read_sync_status(project_root)     -- read current status (or None)
+    cleanup_sync_status(project_root)  -- remove stale status file
+    launch_sync_subprocess(...)        -- spawn sync subprocess
+    poll_sync_status(...)              -- async poll with WS broadcasts
+    poll_sync_status_blocking(...)     -- sync poll for scheduler threads
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from dango.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def get_sync_status_path(project_root: Path) -> Path:
+    """Return .dango/state/sync_status.json path."""
+    return project_root / ".dango" / "state" / "sync_status.json"
+
+
+def read_sync_status(project_root: Path) -> dict[str, Any] | None:
+    """Read current sync status file. Returns None if missing or unparseable."""
+    path = get_sync_status_path(project_root)
+    try:
+        if not path.exists():
+            return None
+        with open(path) as f:
+            result: dict[str, Any] = json.load(f)
+            return result
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _is_pid_alive(pid: int) -> bool:
+    """Check if a PID is alive (cross-platform)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def cleanup_sync_status(project_root: Path) -> None:
+    """Remove stale status file (dead PID or completed).
+
+    Safe to call any time — only removes the file if the referenced
+    process is no longer running or the sync has a terminal phase.
+    """
+    status = read_sync_status(project_root)
+    if status is None:
+        return
+
+    pid = status.get("pid")
+    phase = status.get("phase", "")
+    terminal_phases = {"completed", "failed"}
+
+    if phase in terminal_phases or (pid is not None and not _is_pid_alive(pid)):
+        path = get_sync_status_path(project_root)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def launch_sync_subprocess(
+    project_root: Path,
+    sources: list[str],
+    full_refresh: bool = False,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    backfill_days: int | None = None,
+    skip_dbt: bool = False,
+    source_label: str = "ui",
+    max_lock_wait: int = 0,
+) -> subprocess.Popen:
+    """Spawn sync subprocess via sys.executable. Returns Popen handle.
+
+    The subprocess runs ``python -m dango.platform.scheduling.sync_trigger``
+    with write_progress=True, so it writes status to .dango/state/sync_status.json.
+    """
+    # Clean up any stale status file before launching
+    cleanup_sync_status(project_root)
+
+    args_dict: dict[str, Any] = {
+        "project_root": str(project_root),
+        "sources": sources,
+        "full_refresh": full_refresh,
+        "write_progress": True,
+        "source_label": source_label,
+        "skip_dbt": skip_dbt,
+        "max_lock_wait": max_lock_wait,
+    }
+    if start_date is not None:
+        args_dict["start_date"] = start_date
+    if end_date is not None:
+        args_dict["end_date"] = end_date
+    if backfill_days is not None:
+        args_dict["backfill_days"] = backfill_days
+
+    json_args = json.dumps(args_dict)
+
+    process = subprocess.Popen(
+        [sys.executable, "-m", "dango.platform.scheduling.sync_trigger", json_args],
+        cwd=str(project_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    logger.info(
+        "sync_subprocess_launched",
+        pid=process.pid,
+        sources=sources,
+        source_label=source_label,
+    )
+    return process
+
+
+async def poll_sync_status(
+    project_root: Path,
+    process: subprocess.Popen,
+    source_name: str,
+    poll_interval: float = 2.0,
+    heartbeat_interval: float = 30.0,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Async poll — reads status file, broadcasts WS events on transitions.
+
+    Emits heartbeat every ``heartbeat_interval`` seconds. Detects subprocess
+    crash via ``process.poll()``. Returns (success, result_dict).
+    """
+    from dango.web.routes.websocket import ws_manager
+
+    last_phase: str | None = None
+    last_heartbeat = time.time()
+    start_time = time.time()
+    final_status: dict[str, Any] | None = None
+
+    while True:
+        await asyncio.sleep(poll_interval)
+
+        # Check if subprocess has exited
+        exit_code = process.poll()
+
+        # Read current status
+        status = read_sync_status(project_root)
+
+        if status is not None:
+            current_phase = status.get("phase", "")
+
+            # Broadcast on phase transitions
+            if current_phase != last_phase:
+                await _broadcast_phase_transition(ws_manager, source_name, current_phase, status)
+                last_phase = current_phase
+
+            # Detect terminal state
+            if current_phase in ("completed", "failed"):
+                final_status = status
+                success = current_phase == "completed"
+                return success, final_status
+
+        # Heartbeat
+        now = time.time()
+        if now - last_heartbeat >= heartbeat_interval:
+            elapsed = int(now - start_time)
+            await ws_manager.broadcast(
+                {
+                    "event": "sync_progress",
+                    "source": source_name,
+                    "message": f"Sync in progress ({elapsed}s elapsed)",
+                    "timestamp": _ts(),
+                }
+            )
+            last_heartbeat = now
+
+        # Process crashed without writing final status
+        if exit_code is not None and (
+            status is None or status.get("phase") not in ("completed", "failed")
+        ):
+            error_msg = f"Sync process terminated unexpectedly (exit code {exit_code})"
+            await ws_manager.broadcast(
+                {
+                    "event": "sync_failed",
+                    "source": source_name,
+                    "message": error_msg,
+                    "timestamp": _ts(),
+                }
+            )
+            return False, {"error": error_msg, "phase": "failed"}
+
+
+def poll_sync_status_blocking(
+    project_root: Path,
+    process: subprocess.Popen,
+    broadcast_fn: Callable[[dict[str, Any]], None] | None = None,
+    poll_interval: float = 2.0,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Synchronous version for APScheduler thread pool. Returns (success, result_dict).
+
+    Uses time.sleep() for polling. Calls optional broadcast_fn on phase transitions.
+    """
+    last_phase: str | None = None
+
+    while True:
+        time.sleep(poll_interval)
+
+        exit_code = process.poll()
+        status = read_sync_status(project_root)
+
+        if status is not None:
+            current_phase = status.get("phase", "")
+
+            # Broadcast on phase transitions
+            if current_phase != last_phase and broadcast_fn is not None:
+                broadcast_fn(
+                    {
+                        "event": _phase_to_event(current_phase),
+                        "phase": current_phase,
+                        "message": status.get("message", ""),
+                        "timestamp": _ts(),
+                    }
+                )
+                last_phase = current_phase
+
+            # Detect terminal state
+            if current_phase in ("completed", "failed"):
+                success = current_phase == "completed"
+                return success, status
+
+        # Process crashed without writing final status
+        if exit_code is not None and (
+            status is None or status.get("phase") not in ("completed", "failed")
+        ):
+            error_msg = f"Sync process terminated unexpectedly (exit code {exit_code})"
+            if broadcast_fn is not None:
+                broadcast_fn(
+                    {
+                        "event": "sync_failed",
+                        "message": error_msg,
+                        "timestamp": _ts(),
+                    }
+                )
+            return False, {"error": error_msg, "phase": "failed"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ts() -> str:
+    """UTC ISO timestamp."""
+    from datetime import datetime, timezone
+
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _phase_to_event(phase: str) -> str:
+    """Map status file phase to a WebSocket event name."""
+    mapping = {
+        "starting": "sync_started",
+        "lock_waiting": "sync_progress",
+        "data_load": "sync_progress",
+        "data_load_complete": "data_load_complete",
+        "dbt_started": "dbt_run_all_started",
+        "dbt_complete": "dbt_run_all_completed",
+        "completed": "sync_completed",
+        "failed": "sync_failed",
+    }
+    return mapping.get(phase, "sync_progress")
+
+
+async def _broadcast_phase_transition(
+    ws_manager: Any,
+    source_name: str,
+    phase: str,
+    status: dict[str, Any],
+) -> None:
+    """Broadcast a WebSocket event for a phase transition."""
+    event = _phase_to_event(phase)
+    message: dict[str, Any] = {
+        "event": event,
+        "source": source_name,
+        "message": status.get("message", ""),
+        "timestamp": _ts(),
+    }
+
+    # Add extra fields based on phase
+    if phase == "data_load_complete":
+        message["rows_loaded"] = status.get("rows_loaded", 0)
+    elif phase == "dbt_started":
+        message["source"] = f"dbt (triggered by {source_name})"
+    elif phase == "dbt_complete":
+        message["source"] = f"dbt (triggered by {source_name})"
+    elif phase == "completed":
+        message["rows_loaded"] = status.get("rows_loaded", 0)
+        message["duration_seconds"] = status.get("elapsed_seconds", 0)
+    elif phase == "failed":
+        message["error"] = status.get("error")
+
+    await ws_manager.broadcast(message)

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -34,7 +34,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` (incl. DuckDB capacity gauge, OAuth token health, component disk breakdown, cloud resource metrics, backup staleness, deployment info), `/api/deployments/history` (admin-only) | — |
 | `routes/config.py` | `/api/config`, `/api/metabase-config` | — |
 | `routes/sources.py` | `/api/sources`, `/api/sources/{name}/details` | — |
-| `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + background `run_sync_task()` (~602 lines) | `run_sync_task()` |
+| `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + subprocess-based `run_sync_task()` (~370 lines) | `run_sync_task()` |
 | `routes/logs.py` | `/api/logs`, `/api/sources/{name}/logs` | — |
 | `routes/dbt.py` | `/api/dbt/models`, `/api/dbt/models/{name}/run` + dbt docs proxy (`/manifest.json`, `/catalog.json`, `/dbt-docs/*`) | `run_dbt_model_task()` |
 | `routes/upload.py` | CSV upload/list/delete + background `run_dbt_after_delete()` | `run_dbt_after_delete()` |
@@ -98,7 +98,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 - **Rename-via-PUT guard:** Any CRUD API where the resource name is in both URL path and request body must check `body.name != url_name → 400`. Without this, renames silently orphan related records (e.g., execution history keyed by schedule name).
 - **`load_sources_config()` patching:** `load_sources_config()` in `helpers.py` internally calls `get_project_root()`. Patching `get_project_root` at the route module level doesn't reach the call inside `load_sources_config()`. Patch `load_sources_config` directly at the route module level instead.
 - **Alpine.js object reactivity:** Proxy doesn't track `delete obj[key]` or direct property mutation. Must use object spread reassignment (`this.obj = {...updated}`) for reactive updates. Arrays with `.push()`/`.splice()` work fine; objects do not.
-- **Dual logger debt in `routes/sync.py`:** Uses both stdlib `logging` and structlog `get_logger`. Known debt — consolidate when touching the file.
+- **`routes/sync.py` uses subprocess model (R10-N):** Syncs run in a subprocess via `sync_process.py` — the web server process never holds the DuckDB write lock. `run_sync_task()` launches subprocess + polls status file.
 
 ## Adding a New Page
 

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -103,6 +103,10 @@ async def run_sync_task(
     sync_timestamp = datetime.now().isoformat()
     project_root = get_project_root()
 
+    # Create execution history record (passed to subprocess to avoid double records)
+    db_path = get_scheduler_db_path(project_root)
+    record_id = record_start(db_path, "ui", sources=[source_name])
+
     # Immediate UI feedback
     await ws_manager.broadcast(
         {
@@ -131,6 +135,7 @@ async def run_sync_task(
             start_date=start_date,
             end_date=end_date,
             source_label="ui",
+            record_id=record_id,
         )
 
         # Poll until completion (broadcasts WS events + heartbeat internally)
@@ -195,6 +200,9 @@ async def run_sync_task(
                 "message": f"Sync failed: {error_message}",
             }
         )
+
+        # Record execution history failure (subprocess may not have had the chance)
+        record_failure(db_path, record_id, error_message)
 
         history_entry = {
             "timestamp": sync_timestamp,
@@ -339,14 +347,12 @@ async def _run_manual_sync(
             project_root, process, display_name, sync_id=sync_id
         )
 
-        # Subprocess already records completion/failure via record_id.
-        # Only record here if the subprocess crashed without doing so.
-        if (
-            _result
-            and _result.get("phase") == "failed"
-            and "unexpectedly" in _result.get("error", "")
-        ):
-            record_failure(db_path, record_id, _result["error"])
+        # Subprocess records its own completion/failure via record_id for normal
+        # exits. Record failure here for cases where the subprocess didn't get
+        # the chance (crash, timeout, poller-detected failure).
+        if not success:
+            error = _result.get("error", "Unknown error") if _result else "Unknown error"
+            record_failure(db_path, record_id, error)
 
         cleanup_sync_status(project_root, sync_id=sync_id)
     except Exception as exc:

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -23,7 +23,6 @@ from dango.logging import get_logger
 from dango.platform.scheduling.history import (
     get_execution_record,
     get_scheduler_db_path,
-    record_completion,
     record_failure,
     record_start,
 )
@@ -82,11 +81,6 @@ async def trigger_sync(source_name: str, sync_request: SyncRequest) -> SyncRespo
         )
     )
 
-    # Broadcast sync started event via WebSocket
-    await ws_manager.broadcast(
-        {"event": "sync_started", "source": source_name, "timestamp": datetime.now().isoformat()}
-    )
-
     return SyncResponse(
         success=True,
         message=f"Sync started for {source_name}",
@@ -127,9 +121,10 @@ async def run_sync_task(
         }
     )
 
+    sync_id: str | None = None
     try:
         # Launch subprocess (DbtLock acquired inside subprocess)
-        process = launch_sync_subprocess(
+        process, sync_id = launch_sync_subprocess(
             project_root=project_root,
             sources=[source_name],
             full_refresh=full_refresh,
@@ -139,7 +134,9 @@ async def run_sync_task(
         )
 
         # Poll until completion (broadcasts WS events + heartbeat internally)
-        success, result = await poll_sync_status(project_root, process, source_name)
+        success, result = await poll_sync_status(
+            project_root, process, source_name, sync_id=sync_id
+        )
 
         # Calculate duration
         duration = time.time() - start_time
@@ -183,7 +180,7 @@ async def run_sync_task(
             )
 
         # Cleanup status file
-        cleanup_sync_status(project_root)
+        cleanup_sync_status(project_root, sync_id=sync_id)
 
     except Exception as e:
         _logger.warning("sync_task_error", source=source_name, error=str(e), exc_info=True)
@@ -218,6 +215,10 @@ async def run_sync_task(
             }
         )
 
+        # Cleanup status file even on exception
+        if sync_id is not None:
+            cleanup_sync_status(project_root, sync_id=sync_id)
+
 
 # ---------------------------------------------------------------------------
 # Remote sync trigger API (TASK-040c)
@@ -236,10 +237,12 @@ async def trigger_manual_sync(
     """
     project_root = get_project_root()
 
-    # Validate sources exist
+    # Validate sources exist (sanitize names like trigger_sync does)
     sources_config = load_sources_config()
     known_names = {s.get("name") for s in sources_config}
+    validated_sources = []
     for src in body.sources:
+        src = validate_source_name(src)
         if src not in known_names:
             return JSONResponse(
                 status_code=404,
@@ -248,6 +251,7 @@ async def trigger_manual_sync(
                     "message": f"Source {src!r} not found.",
                 },
             )
+        validated_sources.append(src)
 
     # Parse backfill duration
     backfill_days: int | None = None
@@ -263,15 +267,15 @@ async def trigger_manual_sync(
                 },
             )
 
-    # Create execution history record
+    # Create execution history record (passed to subprocess to avoid double records)
     db_path = get_scheduler_db_path(project_root)
-    job_id = record_start(db_path, "manual", sources=body.sources)
+    job_id = record_start(db_path, "manual", sources=validated_sources)
 
     # Launch background sync via subprocess
     asyncio.create_task(
         _run_manual_sync(
             project_root,
-            body.sources,
+            validated_sources,
             body.full_refresh,
             backfill_days,
             job_id,
@@ -286,7 +290,7 @@ async def trigger_manual_sync(
         email=user.email,
         ip=request.client.host if request.client else None,
         details={
-            "sources": body.sources,
+            "sources": validated_sources,
             "full_refresh": body.full_refresh,
             "backfill": body.backfill,
             "job_id": job_id,
@@ -296,7 +300,7 @@ async def trigger_manual_sync(
     return JSONResponse(
         content={
             "job_id": job_id,
-            "sources": body.sources,
+            "sources": validated_sources,
             "status": "started",
         },
     )
@@ -317,29 +321,39 @@ async def _run_manual_sync(
         poll_sync_status,
     )
 
+    sync_id: str | None = None
     try:
-        process = launch_sync_subprocess(
+        # Pass record_id so subprocess reuses it (avoids double history records)
+        process, sync_id = launch_sync_subprocess(
             project_root=project_root,
             sources=source_names,
             full_refresh=full_refresh,
             backfill_days=backfill_days,
             source_label="manual",
+            record_id=record_id,
         )
 
         # Use first source name for WS events (manual sync may have multiple)
         display_name = source_names[0] if source_names else "manual"
-        success, _result = await poll_sync_status(project_root, process, display_name)
+        success, _result = await poll_sync_status(
+            project_root, process, display_name, sync_id=sync_id
+        )
 
-        if success:
-            record_completion(db_path, record_id)
-        else:
-            error = _result.get("error", "Unknown error") if _result else "Unknown error"
-            record_failure(db_path, record_id, error)
+        # Subprocess already records completion/failure via record_id.
+        # Only record here if the subprocess crashed without doing so.
+        if (
+            _result
+            and _result.get("phase") == "failed"
+            and "unexpectedly" in _result.get("error", "")
+        ):
+            record_failure(db_path, record_id, _result["error"])
 
-        cleanup_sync_status(project_root)
+        cleanup_sync_status(project_root, sync_id=sync_id)
     except Exception as exc:
         _logger.warning("manual_sync_failed", error=str(exc), exc_info=True)
         record_failure(db_path, record_id, str(exc))
+        if sync_id is not None:
+            cleanup_sync_status(project_root, sync_id=sync_id)
 
 
 @router.get("/api/sync/status/{record_id}")

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -1,14 +1,16 @@
 """dango/web/routes/sync.py
 
 Source sync trigger endpoint, background sync task, and remote sync trigger API.
+
+Syncs run in a subprocess via sync_process.py — the web server process never
+holds the DuckDB write lock, so notebooks and the UI remain responsive.
 """
 
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -40,7 +42,6 @@ from dango.web.helpers import (
 from dango.web.models import SyncRequest, SyncResponse, SyncTriggerRequest
 from dango.web.routes.websocket import ws_manager
 
-logger = logging.getLogger(__name__)
 _logger = get_logger(__name__)
 
 router = APIRouter(tags=["sync"])
@@ -97,244 +98,57 @@ async def trigger_sync(source_name: str, sync_request: SyncRequest) -> SyncRespo
 async def run_sync_task(
     source_name: str, full_refresh: bool, start_date: str | None, end_date: str | None
 ) -> None:
-    """Run sync task in background.
-
-    This function imports and runs the dlt sync process, broadcasting updates via WebSocket
-    """
-    from dango.utils import DbtLock, DbtLockError
+    """Run sync task in a subprocess, polling for status and broadcasting updates."""
+    from dango.platform.sync_process import (
+        cleanup_sync_status,
+        launch_sync_subprocess,
+        poll_sync_status,
+    )
 
     start_time = time.time()
     sync_timestamp = datetime.now().isoformat()
-    success = False
-    error_message = None
-    rows_processed = 0
     project_root = get_project_root()
 
-    # Try to acquire lock before running sync (which includes dbt)
-    lock = None
+    # Immediate UI feedback
+    await ws_manager.broadcast(
+        {
+            "event": "sync_started",
+            "source": source_name,
+            "message": f"Starting sync for {source_name}",
+            "timestamp": sync_timestamp,
+        }
+    )
+    append_log_entry(
+        {
+            "timestamp": sync_timestamp,
+            "level": "info",
+            "source": source_name,
+            "message": f"Starting sync for {source_name}",
+        }
+    )
+
     try:
-        lock = DbtLock(
+        # Launch subprocess (DbtLock acquired inside subprocess)
+        process = launch_sync_subprocess(
             project_root=project_root,
-            source="ui",
-            operation=f"sync {source_name} (includes dbt run)",
-        )
-        lock.acquire()
-    except DbtLockError as e:
-        # Lock is held by another process - broadcast error and return
-        error_msg = str(e).split("\n")[0]
-        await ws_manager.broadcast(
-            {
-                "event": "sync_failed",
-                "source": source_name,
-                "message": error_msg,
-                "timestamp": datetime.now().isoformat(),
-            }
-        )
-        append_log_entry(
-            {
-                "timestamp": datetime.now().isoformat(),
-                "level": "error",
-                "source": source_name,
-                "message": f"Sync blocked: {error_msg}",
-            }
-        )
-        logger.warning(f"Could not acquire dbt lock for sync {source_name}: {e}")
-        return
-
-    try:
-        from dango.config.helpers import load_config
-
-        # Log sync start
-        append_log_entry(
-            {
-                "timestamp": sync_timestamp,
-                "level": "info",
-                "source": source_name,
-                "message": f"Starting sync for {source_name}",
-            }
+            sources=[source_name],
+            full_refresh=full_refresh,
+            start_date=start_date,
+            end_date=end_date,
+            source_label="ui",
         )
 
-        # Broadcast sync started
-        await ws_manager.broadcast(
-            {
-                "event": "sync_started",
-                "source": source_name,
-                "message": f"Starting sync for {source_name}",
-                "timestamp": sync_timestamp,
-            }
-        )
-
-        # Load config and get source
-        config = load_config(get_project_root())
-        source_config = config.sources.get_source(source_name)
-
-        if not source_config:
-            raise ValueError(f"Source '{source_name}' not found in configuration")
-
-        # Pre-sync OAuth token validation
-        from dango.exceptions import OAuthTokenExpiredError, OAuthTokenRevokedError
-        from dango.oauth.validation import validate_before_sync
-
-        try:
-            validate_before_sync(source_config.type.value, project_root)
-        except (OAuthTokenRevokedError, OAuthTokenExpiredError) as oauth_err:
-            await ws_manager.broadcast(
-                {
-                    "event": "sync_failed",
-                    "source": source_name,
-                    "message": oauth_err.user_message,
-                    "timestamp": datetime.now().isoformat(),
-                }
-            )
-            append_log_entry(
-                {
-                    "timestamp": datetime.now().isoformat(),
-                    "level": "error",
-                    "source": source_name,
-                    "message": f"OAuth validation failed: {oauth_err.user_message}",
-                }
-            )
-            return
-
-        # Use the same run_sync function as CLI for consistent behavior
-        # This ensures: data load -> dbt run -> docs generation -> Metabase sync
-        from dango.ingestion import run_sync
-
-        # Parse dates if provided (validate_date_string raises InvalidDateFormatError)
-        start_date_obj = validate_date_string(start_date) if start_date else None
-        end_date_obj = validate_date_string(end_date) if end_date else None
-
-        # Log before running sync
-        append_log_entry(
-            {
-                "timestamp": datetime.now().isoformat(),
-                "level": "info",
-                "source": source_name,
-                "message": "Loading data from source",
-            }
-        )
-
-        # Run sync in executor so the event loop stays free for WebSocket broadcasts
-        _project_root = get_project_root()
-
-        async def _sync_heartbeat() -> None:
-            """Broadcast progress every 30s while sync runs."""
-            try:
-                while True:
-                    await asyncio.sleep(30)
-                    elapsed = int(time.time() - start_time)
-                    await ws_manager.broadcast(
-                        {
-                            "event": "sync_progress",
-                            "source": source_name,
-                            "message": f"Sync in progress ({elapsed}s elapsed)",
-                            "timestamp": datetime.now().isoformat(),
-                        }
-                    )
-            except asyncio.CancelledError:
-                pass
-
-        heartbeat = asyncio.create_task(_sync_heartbeat())
-        try:
-            loop = asyncio.get_running_loop()
-            summary = await loop.run_in_executor(
-                None,
-                lambda: run_sync(
-                    project_root=_project_root,
-                    sources=[source_config],
-                    start_date=start_date_obj,
-                    end_date=end_date_obj,
-                    full_refresh=full_refresh,
-                ),
-            )
-        finally:
-            heartbeat.cancel()
-            try:
-                await heartbeat
-            except asyncio.CancelledError:
-                pass
-
-        success = summary["failed_count"] == 0
-        # Also check that we actually have successful sources (not just zero failures)
-        has_successful_sources = len(summary.get("success_sources", [])) > 0
-
-        # Extract error message if sync failed
-        if not success and summary.get("failed_sources"):
-            # Get error from first failed source (there should only be one when syncing single source)
-            error_message = summary["failed_sources"][0].get("error", "Unknown error")
-        else:
-            error_message = None
-
-        # Log after data load
-        append_log_entry(
-            {
-                "timestamp": datetime.now().isoformat(),
-                "level": "success" if success else "error",
-                "source": source_name,
-                "message": f"Data load {'completed' if success else 'failed'}"
-                + (f": {error_message}" if error_message else ""),
-            }
-        )
-
-        # Broadcast and log dbt run (which happens inside run_sync AFTER data load)
-        # ONLY broadcast dbt messages if sync actually succeeded AND we have successful sources
-        if success and has_successful_sources:
-            # Build helpful message about what dbt will run
-            dbt_message = f"Running dbt models for source: {source_name}"
-            dbt_detail = f"Processing staging.{source_name} and downstream models"
-
-            # Broadcast dbt started (happens after data load, before dbt actually runs in run_sync)
-            await ws_manager.broadcast(
-                {
-                    "event": "dbt_run_all_started",
-                    "source": f"dbt (triggered by {source_name})",
-                    "message": dbt_message,
-                    "timestamp": datetime.now().isoformat(),
-                }
-            )
-            append_log_entry(
-                {
-                    "timestamp": datetime.now().isoformat(),
-                    "level": "info",
-                    "source": f"dbt (triggered by {source_name})",
-                    "message": dbt_detail,
-                }
-            )
-
-            append_log_entry(
-                {
-                    "timestamp": datetime.now().isoformat(),
-                    "level": "success",
-                    "source": f"dbt (triggered by {source_name})",
-                    "message": f"dbt models completed: staging.{source_name} and downstream",
-                }
-            )
-
-            # Broadcast dbt run completed
-            await ws_manager.broadcast(
-                {
-                    "event": "dbt_run_all_completed",
-                    "source": f"dbt (triggered by {source_name})",
-                    "message": f"dbt models completed for {source_name}",
-                    "timestamp": datetime.now().isoformat(),
-                }
-            )
-
-        # Get row count after sync (only if successful)
-        if success:
-            rows_processed = get_source_row_count(source_name) or 0
-            await ws_manager.broadcast(
-                {
-                    "event": "data_load_complete",
-                    "source": source_name,
-                    "message": f"Data loaded: {rows_processed:,} rows",
-                    "timestamp": datetime.now().isoformat(),
-                    "rows_loaded": rows_processed,
-                }
-            )
+        # Poll until completion (broadcasts WS events + heartbeat internally)
+        success, result = await poll_sync_status(project_root, process, source_name)
 
         # Calculate duration
         duration = time.time() - start_time
+        error_message = result.get("error") if result else None
+
+        # Get row count after sync (only if successful)
+        rows_processed = 0
+        if success:
+            rows_processed = get_source_row_count(source_name) or 0
 
         # Save sync history
         history_entry = {
@@ -347,7 +161,7 @@ async def run_sync_task(
         }
         save_sync_history_entry(source_name, history_entry)
 
-        # Log completion (conditional based on success/failure)
+        # Log completion
         if success:
             append_log_entry(
                 {
@@ -357,15 +171,7 @@ async def run_sync_task(
                     "message": f"Sync completed in {round(duration, 1)}s - {rows_processed:,} rows",
                 }
             )
-
-            # Trigger Metabase schema sync to ensure new tables are discoverable
-            # This matches CLI behavior (main.py:1265-1275) which calls sync_metabase_schema
-            # after run_sync() as a backup in case the internal call was skipped
-            from dango.visualization.metabase import sync_metabase_schema
-
-            sync_metabase_schema(project_root)
         else:
-            # For failures, log with error details
             append_log_entry(
                 {
                     "timestamp": datetime.now().isoformat(),
@@ -376,26 +182,14 @@ async def run_sync_task(
                 }
             )
 
-        # Broadcast completion with detailed error message if failed
-        await ws_manager.broadcast(
-            {
-                "event": "sync_completed" if success else "sync_failed",
-                "source": source_name,
-                "message": "Sync completed successfully"
-                if success
-                else (error_message or "Sync failed"),
-                "timestamp": datetime.now().isoformat(),
-                "error": error_message if not success else None,
-                "rows_loaded": rows_processed if success else 0,
-                "duration_seconds": round(duration, 2),
-            }
-        )
+        # Cleanup status file
+        cleanup_sync_status(project_root)
 
     except Exception as e:
-        logger.error(f"Error running sync for {source_name}: {e}")
+        _logger.warning("sync_task_error", source=source_name, error=str(e), exc_info=True)
         error_message = str(e)
 
-        # Log error
+        duration = time.time() - start_time
         append_log_entry(
             {
                 "timestamp": datetime.now().isoformat(),
@@ -405,10 +199,6 @@ async def run_sync_task(
             }
         )
 
-        # Calculate duration
-        duration = time.time() - start_time
-
-        # Save failed sync history
         history_entry = {
             "timestamp": sync_timestamp,
             "status": "failed",
@@ -419,7 +209,6 @@ async def run_sync_task(
         }
         save_sync_history_entry(source_name, history_entry)
 
-        # Broadcast error
         await ws_manager.broadcast(
             {
                 "event": "sync_failed",
@@ -428,12 +217,6 @@ async def run_sync_task(
                 "timestamp": datetime.now().isoformat(),
             }
         )
-    finally:
-        if lock is not None:
-            try:
-                lock.release()
-            except Exception:
-                pass
 
 
 # ---------------------------------------------------------------------------
@@ -484,8 +267,7 @@ async def trigger_manual_sync(
     db_path = get_scheduler_db_path(project_root)
     job_id = record_start(db_path, "manual", sources=body.sources)
 
-    # Launch background sync — use asyncio.create_task so the async
-    # coroutine runs on the event loop (WebSocket broadcasts work correctly).
+    # Launch background sync via subprocess
     asyncio.create_task(
         _run_manual_sync(
             project_root,
@@ -528,58 +310,36 @@ async def _run_manual_sync(
     record_id: int,
     db_path: Any,
 ) -> None:
-    """Background task that executes a manual sync and records the result."""
-    from dango.config.helpers import load_config
-    from dango.ingestion import run_sync
-    from dango.utils import DbtLock, DbtLockError
-
-    lock = None
-    try:
-        lock = DbtLock(
-            project_root=project_root,
-            source="manual",
-            operation=f"sync:{','.join(source_names)}",
-        )
-        lock.acquire()
-    except DbtLockError as exc:
-        record_failure(db_path, record_id, f"Lock unavailable: {exc}")
-        return
+    """Background task that executes a manual sync in a subprocess and records the result."""
+    from dango.platform.sync_process import (
+        cleanup_sync_status,
+        launch_sync_subprocess,
+        poll_sync_status,
+    )
 
     try:
-        config = load_config(project_root)
-        resolved = []
-        for name in source_names:
-            src = config.sources.get_source(name)
-            if src is not None:
-                resolved.append(src)
-
-        if not resolved:
-            msg = f"No valid sources found for: {', '.join(source_names)}"
-            _logger.warning("manual_sync_no_sources", source_names=source_names)
-            record_failure(db_path, record_id, msg)
-            return
-
-        start_date = None
-        if backfill_days is not None:
-            start_date = datetime.now(tz=timezone.utc) - timedelta(days=backfill_days)
-
-        run_sync(
+        process = launch_sync_subprocess(
             project_root=project_root,
-            sources=resolved,
+            sources=source_names,
             full_refresh=full_refresh,
-            start_date=start_date,
+            backfill_days=backfill_days,
+            source_label="manual",
         )
 
-        record_completion(db_path, record_id)
+        # Use first source name for WS events (manual sync may have multiple)
+        display_name = source_names[0] if source_names else "manual"
+        success, _result = await poll_sync_status(project_root, process, display_name)
+
+        if success:
+            record_completion(db_path, record_id)
+        else:
+            error = _result.get("error", "Unknown error") if _result else "Unknown error"
+            record_failure(db_path, record_id, error)
+
+        cleanup_sync_status(project_root)
     except Exception as exc:
         _logger.warning("manual_sync_failed", error=str(exc), exc_info=True)
         record_failure(db_path, record_id, str(exc))
-    finally:
-        if lock is not None:
-            try:
-                lock.release()
-            except Exception:
-                pass
 
 
 @router.get("/api/sync/status/{record_id}")

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -243,9 +243,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py
-    lines: 895
+    lines: 849
     category: exempt
-    reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with DbtLock, WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. R9-I added rows_loaded/dashboard_url to _notify + sync result accumulation. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
+    reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. R10-N moved sync to subprocess (removed DbtLock + run_sync, added launch_sync_subprocess + poll). Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/digitalocean.py
@@ -297,9 +297,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_sync_jobs.py
-    lines: 685
+    lines: 658
     category: exempt
-    reason: "TASK-041+R9-I: 30 tests across 8 classes covering configure_jobs, _broadcast, _notify (incl. rows_loaded/dashboard_url), _build_dashboard_url (domain/localhost/error), run_scheduled_sync, run_scheduled_dbt, and _check_freshness. Each test requires isolated mock setup for lazy-import patching."
+    reason: "TASK-041+R10-N: 26 tests across 8 classes covering configure_jobs, _broadcast, _notify (incl. rows_loaded/dashboard_url), _build_dashboard_url (domain/localhost/error), run_scheduled_sync (subprocess-based), run_scheduled_dbt, and _check_freshness. Each test requires isolated mock setup for lazy-import patching."
     review_by: "v1.1"
 
   - file: tests/unit/test_scheduler.py
@@ -322,11 +322,7 @@ exemptions:
     reason: "TASK-037+038+045b: 11 read-only endpoints (history×2, list/get, trigger, reload, cancel, unscheduled, page route, notification config/test). R10-C removed 5 config-mutating endpoints (BUG-175). Marginally over limit."
     review_by: "v1.1"
 
-  - file: dango/web/routes/sync.py
-    lines: 602
-    category: exempt
-    reason: "TASK-040c: Added remote sync trigger API (POST /api/sync/trigger, GET /api/sync/status/{id}) with background task + execution history. Extends existing per-source sync endpoint."
-    review_by: "v1.1"
+  # Removed: dango/web/routes/sync.py — now ~370 lines after R10-N (sync moved to subprocess)
 
   - file: dango/web/routes/catalog.py
     lines: 1336

--- a/tests/integration/test_sync_notification.py
+++ b/tests/integration/test_sync_notification.py
@@ -21,7 +21,7 @@ _dbt_lock_module = sys.modules["dango.utils.dbt_lock"]
 
 _JOBS_MOD = "dango.platform.scheduling.jobs"
 _CFG_MOD = "dango.config.helpers"
-_SYNC_MOD = "dango.ingestion.dlt_runner"
+_SYNC_PROC_MOD = "dango.platform.sync_process"
 _HTTPX_CLIENT = "dango.platform.notifications.webhook.httpx.AsyncClient"
 _ASYNC_SLEEP = "dango.platform.notifications.webhook.asyncio.sleep"
 
@@ -48,8 +48,7 @@ class TestSyncFailureNotification:
         }
         (dango_dir / "schedules.yml").write_text(yaml.safe_dump(schedules_data))
 
-        # 2. Mock infrastructure: lock, config, run_sync (raises)
-        mock_lock = MagicMock()
+        # 2. Mock infrastructure: config, subprocess (fails)
         src = MagicMock()
         src.name = "src1"
         config = MagicMock()
@@ -85,9 +84,15 @@ class TestSyncFailureNotification:
             jobs_mod._event_loop = MagicMock(spec=asyncio.AbstractEventLoop)
 
             with (
-                patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
                 patch(f"{_CFG_MOD}.load_config", return_value=config),
-                patch(f"{_SYNC_MOD}.run_sync", side_effect=RuntimeError("Connection refused")),
+                patch(
+                    f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                    return_value=(MagicMock(), "test_id"),
+                ),
+                patch(
+                    f"{_SYNC_PROC_MOD}.poll_sync_status_blocking",
+                    return_value=(False, {"error": "Connection refused", "phase": "failed"}),
+                ),
                 patch(f"{_JOBS_MOD}._broadcast"),
                 patch(f"{_JOBS_MOD}.asyncio") as mock_asyncio_mod,
                 patch(_HTTPX_CLIENT, return_value=mock_client),

--- a/tests/unit/test_scheduler_gaps.py
+++ b/tests/unit/test_scheduler_gaps.py
@@ -23,7 +23,7 @@ _dbt_lock_module = sys.modules["dango.utils.dbt_lock"]
 _SCHEDULER_MOD = "dango.platform.scheduling.scheduler"
 _JOBS_MOD = "dango.platform.scheduling.jobs"
 _NOTIF_MOD = "dango.platform.notifications.webhook"
-_SYNC_MOD = "dango.ingestion.dlt_runner"
+_SYNC_PROC_MOD = "dango.platform.sync_process"
 _CFG_MOD = "dango.config.helpers"
 _HIST_MOD = "dango.utils.sync_history"
 
@@ -214,16 +214,21 @@ class TestMultiSourceDbtLock:
     """Second schedule gets lock contention on shared sources."""
 
     def test_lock_contention_reported(self, tmp_path):
-        """When DbtLock.acquire raises, the job broadcasts lock_failed."""
-        from dango.exceptions import DbtLockError
-
-        mock_lock = MagicMock()
-        mock_lock.acquire.side_effect = DbtLockError("held by another schedule")
+        """When subprocess fails due to lock, the job broadcasts sync_failed."""
+        config = _make_config_with_sources("src1")
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id"),
+            ),
+            patch(
+                f"{_SYNC_PROC_MOD}.poll_sync_status_blocking",
+                return_value=(False, {"error": "Lock unavailable", "phase": "failed"}),
+            ),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify"),
             patch(f"{_JOBS_MOD}._log_execution_event") as mock_log,
@@ -233,8 +238,8 @@ class TestMultiSourceDbtLock:
             run_scheduled_sync("hourly", ["src1"], project_root=str(tmp_path))
 
         events = [c.args[0]["event"] for c in mock_bc.call_args_list]
-        assert "job_queued" in events
-        assert mock_log.call_args[1]["status"] == "lock_failed"
+        assert "sync_failed" in events
+        assert mock_log.call_args[1]["status"] == "failed"
 
 
 # ---------------------------------------------------------------------------
@@ -251,8 +256,7 @@ class TestCancellationBetweenSources:
         import dango.platform.scheduling.jobs as jobs_mod
 
         config = _make_config_with_sources("src1", "src2", "src3")
-        mock_lock = MagicMock()
-        synced_sources: list[str] = []
+        launched_sources: list[str] = []
 
         mock_svc = MagicMock()
         cancel_count = 0
@@ -267,25 +271,29 @@ class TestCancellationBetweenSources:
         mock_svc._running_records = {}
         mock_svc.register_execution = MagicMock()
 
-        def mock_run_sync(root, sources, **kw):
-            synced_sources.append(sources[0].name)
+        def mock_launch(project_root, sources, **kw):
+            launched_sources.append(sources[0])
+            return MagicMock(), "test_id"
 
         old_svc = jobs_mod._scheduler_service
         try:
             jobs_mod._scheduler_service = mock_svc
 
             with (
-                patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
                 patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
                 patch(f"{_NOTIF_MOD}.WebhookSender"),
                 patch(f"{_CFG_MOD}.load_config", return_value=config),
-                patch(f"{_SYNC_MOD}.run_sync", side_effect=mock_run_sync),
+                patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", side_effect=mock_launch),
+                patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
+                patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
                 patch(f"{_HIST_MOD}.save_sync_history_entry"),
                 patch(f"{_JOBS_MOD}._broadcast"),
                 patch(f"{_JOBS_MOD}._notify"),
                 patch(f"{_JOBS_MOD}._log_execution_event"),
                 patch(f"{_JOBS_MOD}._try_record_start", return_value=None),
                 patch(f"{_JOBS_MOD}._try_finish_record"),
+                patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
+                patch(f"{_JOBS_MOD}._run_coalesced_dbt"),
             ):
                 from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -293,8 +301,8 @@ class TestCancellationBetweenSources:
         finally:
             jobs_mod._scheduler_service = old_svc
 
-        # src1 synced, then cancelled before src2
-        assert synced_sources == ["src1"]
+        # src1 launched, then cancelled before src2
+        assert launched_sources == ["src1"]
 
 
 # ---------------------------------------------------------------------------
@@ -353,18 +361,23 @@ class TestRecordStartWiring:
     def test_record_start_called_on_sync(self, tmp_path):
         """run_scheduled_sync should call _try_record_start when scheduler is available."""
         config = _make_config_with_sources("src1")
-        mock_lock = MagicMock()
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync"),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id"),
+            ),
+            patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
+            patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry"),
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify"),
             patch(f"{_JOBS_MOD}._check_freshness"),
+            patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
+            patch(f"{_JOBS_MOD}._run_coalesced_dbt"),
             patch(f"{_JOBS_MOD}._try_record_start", return_value=42) as mock_start,
             patch(f"{_JOBS_MOD}._try_finish_record") as mock_finish,
         ):
@@ -411,14 +424,15 @@ class TestTimeoutDistinctStatus:
     def test_timeout_records_timeout_status(self, tmp_path):
         """When JobTimeoutError is raised, execution log should show 'timeout'."""
         config = _make_config_with_sources("src1")
-        mock_lock = MagicMock()
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync", side_effect=JobTimeoutError("timed out")),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                side_effect=JobTimeoutError("timed out"),
+            ),
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify"),
             patch(f"{_JOBS_MOD}._log_execution_event") as mock_log,
@@ -434,14 +448,15 @@ class TestTimeoutDistinctStatus:
     def test_cancellation_records_cancelled_status(self, tmp_path):
         """When JobCancelledError is raised, execution log should show 'cancelled'."""
         config = _make_config_with_sources("src1")
-        mock_lock = MagicMock()
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync", side_effect=JobCancelledError("cancelled")),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                side_effect=JobCancelledError("cancelled"),
+            ),
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._log_execution_event") as mock_log,
             patch(f"{_JOBS_MOD}._try_record_start", return_value=None),

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -153,7 +153,8 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
-                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=mock_process
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(mock_process, "test_id"),
             ) as mock_launch,
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
@@ -182,7 +183,9 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+            ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry"),
@@ -207,7 +210,9 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+            ),
             patch(
                 f"{_SYNC_PROC_MOD}.poll_sync_status_blocking",
                 return_value=(False, {"error": "boom"}),
@@ -229,7 +234,9 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+            ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry") as mock_hist,
@@ -253,7 +260,9 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+            ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry"),

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -23,7 +23,7 @@ _JOBS_MOD = "dango.platform.scheduling.jobs"
 
 # Lazy imports in job functions → patch at origin
 _NOTIF_MOD = "dango.platform.notifications.webhook"
-_SYNC_MOD = "dango.ingestion.dlt_runner"
+_SYNC_PROC_MOD = "dango.platform.sync_process"
 _DBT_MOD = "dango.transformation"
 _HIST_MOD = "dango.utils.sync_history"
 _CFG_MOD = "dango.config.helpers"
@@ -141,18 +141,22 @@ class TestBroadcastHelper:
 
 @pytest.mark.unit
 class TestRunScheduledSync:
-    """Test run_scheduled_sync() job function."""
+    """Test run_scheduled_sync() job function (subprocess-based)."""
 
-    def test_acquires_and_releases_lock(self, tmp_path):
-        mock_lock = MagicMock()
+    def test_launches_subprocess_per_source(self, tmp_path):
         config = _make_config_with_sources("src1")
 
+        mock_process = MagicMock()
+
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=mock_process
+            ) as mock_launch,
+            patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
+            patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry"),
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify"),
@@ -164,52 +168,23 @@ class TestRunScheduledSync:
 
             run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
 
-        mock_lock.acquire.assert_called_once()
-        mock_lock.release.assert_called_once()
-
-    def test_lock_failure_broadcasts_and_notifies(self, tmp_path):
-        from dango.exceptions import DbtLockError
-
-        mock_lock = MagicMock()
-        mock_lock.acquire.side_effect = DbtLockError("busy")
-
-        # Simulate time passing beyond max_wait to exit the retry loop quickly
-        elapsed = [0.0]
-
-        def fake_monotonic():
-            elapsed[0] += 301  # Jump past 300s max_wait
-            return elapsed[0]
-
-        with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
-            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
-            patch(f"{_NOTIF_MOD}.WebhookSender"),
-            patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
-            patch(f"{_JOBS_MOD}._notify") as mock_notify,
-            patch(f"{_JOBS_MOD}._log_execution_event") as mock_record,
-            patch(f"{_JOBS_MOD}.time.sleep"),
-            patch(f"{_JOBS_MOD}.time.monotonic", side_effect=fake_monotonic),
-        ):
-            from dango.platform.scheduling.jobs import run_scheduled_sync
-
-            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path))
-
-        events = [c.args[0]["event"] for c in mock_bc.call_args_list]
-        assert "sync_failed" in events
-        mock_notify.assert_called_once()
-        mock_record.assert_called_once()
-        assert mock_record.call_args[1]["status"] == "lock_failed"
+        mock_launch.assert_called_once()
+        call_kwargs = mock_launch.call_args[1]
+        assert call_kwargs["sources"] == ["src1"]
+        assert call_kwargs["skip_dbt"] is True
+        assert call_kwargs["source_label"] == "scheduler"
+        assert call_kwargs["max_lock_wait"] == 300
 
     def test_broadcasts_sync_started_and_completed(self, tmp_path):
-        mock_lock = MagicMock()
         config = _make_config_with_sources("src1")
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
+            patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry"),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify"),
@@ -225,19 +200,20 @@ class TestRunScheduledSync:
         assert "sync_started" in events
         assert "sync_completed" in events
 
-    def test_exception_broadcasts_sync_failed(self, tmp_path):
-        mock_lock = MagicMock()
+    def test_subprocess_failure_broadcasts_sync_failed(self, tmp_path):
         config = _make_config_with_sources("src1")
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync", side_effect=RuntimeError("boom")),
+            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(
+                f"{_SYNC_PROC_MOD}.poll_sync_status_blocking",
+                return_value=(False, {"error": "boom"}),
+            ),
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._notify"),
-            patch(f"{_JOBS_MOD}._add_pending_dbt_source"),
         ):
             from dango.platform.scheduling.jobs import run_scheduled_sync
 
@@ -245,18 +221,17 @@ class TestRunScheduledSync:
 
         events = [c.args[0]["event"] for c in mock_bc.call_args_list]
         assert "sync_failed" in events
-        mock_lock.release.assert_called_once()
 
     def test_records_history_per_source(self, tmp_path):
-        mock_lock = MagicMock()
         config = _make_config_with_sources("src1", "src2")
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
+            patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry") as mock_hist,
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify"),
@@ -272,15 +247,15 @@ class TestRunScheduledSync:
 
     def test_notifies_on_success(self, tmp_path):
         """Notification should be dispatched on successful sync."""
-        mock_lock = MagicMock()
         config = _make_config_with_sources("src1")
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync", return_value={}),
+            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=MagicMock()),
+            patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
+            patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
             patch(f"{_HIST_MOD}.save_sync_history_entry"),
             patch(f"{_JOBS_MOD}._broadcast"),
             patch(f"{_JOBS_MOD}._notify") as mock_notify,
@@ -296,16 +271,14 @@ class TestRunScheduledSync:
 
     def test_no_sources_resolved_records_and_returns(self, tmp_path):
         """When all source names are unknown, record no_sources and return early."""
-        mock_lock = MagicMock()
         config = MagicMock()
         config.sources.get_source.return_value = None  # all unknown
 
         with (
-            patch.object(_dbt_lock_module, "DbtLock", return_value=mock_lock),
             patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
-            patch(f"{_SYNC_MOD}.run_sync") as mock_run,
+            patch(f"{_SYNC_PROC_MOD}.launch_sync_subprocess") as mock_launch,
             patch(f"{_JOBS_MOD}._broadcast") as mock_bc,
             patch(f"{_JOBS_MOD}._log_execution_event") as mock_record,
         ):
@@ -313,7 +286,7 @@ class TestRunScheduledSync:
 
             run_scheduled_sync("daily", ["bogus"], project_root=str(tmp_path))
 
-        mock_run.assert_not_called()
+        mock_launch.assert_not_called()
         mock_bc.assert_not_called()
         mock_record.assert_called_once()
         assert mock_record.call_args[1]["status"] == "no_sources"

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -1,0 +1,355 @@
+"""tests/unit/test_sync_process.py
+
+Tests for dango.platform.sync_process — subprocess launch and polling utilities.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_MOD = "dango.platform.sync_process"
+_WS_MOD = "dango.web.routes.websocket"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_status_file(tmp_path, phase="starting", **extra):
+    """Write a sync status file for testing."""
+    state_dir = tmp_path / ".dango" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    status = {
+        "pid": os.getpid(),
+        "phase": phase,
+        "message": f"Test phase: {phase}",
+        "sources": ["test_source"],
+        **extra,
+    }
+    with open(state_dir / "sync_status.json", "w") as f:
+        json.dump(status, f)
+    return status
+
+
+# ---------------------------------------------------------------------------
+# get_sync_status_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetSyncStatusPath:
+    def test_returns_expected_path(self, tmp_path):
+        from dango.platform.sync_process import get_sync_status_path
+
+        path = get_sync_status_path(tmp_path)
+        assert path == tmp_path / ".dango" / "state" / "sync_status.json"
+
+
+# ---------------------------------------------------------------------------
+# read_sync_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReadSyncStatus:
+    def test_returns_none_when_missing(self, tmp_path):
+        from dango.platform.sync_process import read_sync_status
+
+        assert read_sync_status(tmp_path) is None
+
+    def test_reads_valid_file(self, tmp_path):
+        from dango.platform.sync_process import read_sync_status
+
+        _write_status_file(tmp_path, phase="data_load")
+        status = read_sync_status(tmp_path)
+        assert status is not None
+        assert status["phase"] == "data_load"
+
+    def test_returns_none_on_invalid_json(self, tmp_path):
+        from dango.platform.sync_process import read_sync_status
+
+        state_dir = tmp_path / ".dango" / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "sync_status.json").write_text("not json{{{")
+        assert read_sync_status(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# cleanup_sync_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCleanupSyncStatus:
+    def test_removes_completed_status(self, tmp_path):
+        from dango.platform.sync_process import cleanup_sync_status, get_sync_status_path
+
+        _write_status_file(tmp_path, phase="completed")
+        cleanup_sync_status(tmp_path)
+        assert not get_sync_status_path(tmp_path).exists()
+
+    def test_removes_failed_status(self, tmp_path):
+        from dango.platform.sync_process import cleanup_sync_status, get_sync_status_path
+
+        _write_status_file(tmp_path, phase="failed")
+        cleanup_sync_status(tmp_path)
+        assert not get_sync_status_path(tmp_path).exists()
+
+    def test_removes_dead_pid(self, tmp_path):
+        from dango.platform.sync_process import cleanup_sync_status, get_sync_status_path
+
+        _write_status_file(tmp_path, phase="data_load", pid=999999)
+        with patch(f"{_MOD}._is_pid_alive", return_value=False):
+            cleanup_sync_status(tmp_path)
+        assert not get_sync_status_path(tmp_path).exists()
+
+    def test_noop_when_no_file(self, tmp_path):
+        from dango.platform.sync_process import cleanup_sync_status
+
+        cleanup_sync_status(tmp_path)  # should not raise
+
+    def test_keeps_active_status(self, tmp_path):
+        from dango.platform.sync_process import cleanup_sync_status, get_sync_status_path
+
+        _write_status_file(tmp_path, phase="data_load", pid=os.getpid())
+        cleanup_sync_status(tmp_path)
+        assert get_sync_status_path(tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# launch_sync_subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLaunchSyncSubprocess:
+    @patch("subprocess.Popen")
+    def test_builds_correct_command(self, mock_popen, tmp_path):
+        from dango.platform.sync_process import launch_sync_subprocess
+
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_popen.return_value = mock_process
+
+        process = launch_sync_subprocess(
+            project_root=tmp_path,
+            sources=["hubspot"],
+            full_refresh=True,
+            source_label="ui",
+        )
+
+        assert process is mock_process
+        call_args = mock_popen.call_args
+        cmd = call_args[0][0]
+        assert cmd[0] == sys.executable
+        assert cmd[1] == "-m"
+        assert cmd[2] == "dango.platform.scheduling.sync_trigger"
+
+        # Verify JSON args
+        json_str = cmd[3]
+        args = json.loads(json_str)
+        assert args["sources"] == ["hubspot"]
+        assert args["full_refresh"] is True
+        assert args["write_progress"] is True
+        assert args["source_label"] == "ui"
+
+    @patch("subprocess.Popen")
+    def test_includes_optional_params(self, mock_popen, tmp_path):
+        from dango.platform.sync_process import launch_sync_subprocess
+
+        mock_popen.return_value = MagicMock(pid=1)
+
+        launch_sync_subprocess(
+            project_root=tmp_path,
+            sources=["src"],
+            start_date="2026-01-01",
+            end_date="2026-01-31",
+            backfill_days=7,
+            skip_dbt=True,
+            max_lock_wait=300,
+        )
+
+        json_str = mock_popen.call_args[0][0][3]
+        args = json.loads(json_str)
+        assert args["start_date"] == "2026-01-01"
+        assert args["end_date"] == "2026-01-31"
+        assert args["backfill_days"] == 7
+        assert args["skip_dbt"] is True
+        assert args["max_lock_wait"] == 300
+
+    @patch("subprocess.Popen")
+    def test_cleans_stale_status_before_launch(self, mock_popen, tmp_path):
+        from dango.platform.sync_process import get_sync_status_path, launch_sync_subprocess
+
+        _write_status_file(tmp_path, phase="completed")
+        mock_popen.return_value = MagicMock(pid=1)
+
+        launch_sync_subprocess(project_root=tmp_path, sources=["src"])
+
+        assert not get_sync_status_path(tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# poll_sync_status (async)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPollSyncStatus:
+    @pytest.mark.anyio
+    async def test_detects_completed_phase(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status
+
+        _write_status_file(tmp_path, phase="completed")
+        process = MagicMock()
+        process.poll.return_value = 0
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        with patch(f"{_WS_MOD}.ws_manager", mock_ws):
+            success, result = await poll_sync_status(
+                tmp_path, process, "test_source", poll_interval=0.01
+            )
+
+        assert success is True
+        assert result["phase"] == "completed"
+
+    @pytest.mark.anyio
+    async def test_detects_failed_phase(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status
+
+        _write_status_file(tmp_path, phase="failed", error="boom")
+        process = MagicMock()
+        process.poll.return_value = 1
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        with patch(f"{_WS_MOD}.ws_manager", mock_ws):
+            success, result = await poll_sync_status(
+                tmp_path, process, "test_source", poll_interval=0.01
+            )
+
+        assert success is False
+
+    @pytest.mark.anyio
+    async def test_crash_detection(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status
+
+        # No status file, but process exits with error
+        process = MagicMock()
+        process.poll.return_value = 1
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        with patch(f"{_WS_MOD}.ws_manager", mock_ws):
+            success, result = await poll_sync_status(
+                tmp_path, process, "test_source", poll_interval=0.01
+            )
+
+        assert success is False
+        assert "unexpectedly" in result["error"]
+        # Verify sync_failed was broadcast
+        broadcast_calls = mock_ws.broadcast.call_args_list
+        events = [c.args[0]["event"] for c in broadcast_calls]
+        assert "sync_failed" in events
+
+    @pytest.mark.anyio
+    async def test_broadcasts_phase_transitions(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status
+
+        # Start with data_load phase, then transition to completed
+        call_count = [0]
+
+        def _mock_read(proj_root):
+            call_count[0] += 1
+            if call_count[0] <= 1:
+                return {"pid": 1, "phase": "data_load", "message": "Loading"}
+            return {"pid": 1, "phase": "completed", "message": "Done"}
+
+        process = MagicMock()
+        process.poll.return_value = None
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        with (
+            patch(f"{_MOD}.read_sync_status", side_effect=_mock_read),
+            patch(f"{_WS_MOD}.ws_manager", mock_ws),
+        ):
+            success, result = await poll_sync_status(
+                tmp_path, process, "test_source", poll_interval=0.01
+            )
+
+        assert success is True
+        # Should have broadcast for data_load and completed transitions
+        assert mock_ws.broadcast.call_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# poll_sync_status_blocking (sync)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPollSyncStatusBlocking:
+    def test_detects_completed(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(tmp_path, phase="completed")
+        process = MagicMock()
+        process.poll.return_value = 0
+
+        with patch(f"{_MOD}.time.sleep"):
+            success, result = poll_sync_status_blocking(tmp_path, process, poll_interval=0.01)
+
+        assert success is True
+
+    def test_detects_failed(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(tmp_path, phase="failed", error="oops")
+        process = MagicMock()
+        process.poll.return_value = 1
+
+        with patch(f"{_MOD}.time.sleep"):
+            success, result = poll_sync_status_blocking(tmp_path, process, poll_interval=0.01)
+
+        assert success is False
+
+    def test_crash_detection(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        process = MagicMock()
+        process.poll.return_value = 137
+
+        with patch(f"{_MOD}.time.sleep"):
+            success, result = poll_sync_status_blocking(tmp_path, process, poll_interval=0.01)
+
+        assert success is False
+        assert "unexpectedly" in result["error"]
+
+    def test_calls_broadcast_fn_on_transitions(self, tmp_path):
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(tmp_path, phase="completed")
+        process = MagicMock()
+        process.poll.return_value = 0
+        broadcast_fn = MagicMock()
+
+        with patch(f"{_MOD}.time.sleep"):
+            poll_sync_status_blocking(
+                tmp_path, process, broadcast_fn=broadcast_fn, poll_interval=0.01
+            )
+
+        broadcast_fn.assert_called_once()
+        call_msg = broadcast_fn.call_args[0][0]
+        assert call_msg["event"] == "sync_completed"

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -1,6 +1,6 @@
 """tests/unit/test_sync_process.py
 
-Tests for dango.platform.sync_process — subprocess launch and polling utilities.
+Tests for dango.platform.sync_process — subprocess launch and polling.
 """
 
 from __future__ import annotations
@@ -16,15 +16,11 @@ _MOD = "dango.platform.sync_process"
 _WS_MOD = "dango.web.routes.websocket"
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _write_status_file(tmp_path, phase="starting", **extra):
+def _write_status_file(tmp_path, phase="starting", sync_id=None, **extra):
     """Write a sync status file for testing."""
     state_dir = tmp_path / ".dango" / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"sync_status_{sync_id}.json" if sync_id else "sync_status.json"
     status = {
         "pid": os.getpid(),
         "phase": phase,
@@ -32,28 +28,24 @@ def _write_status_file(tmp_path, phase="starting", **extra):
         "sources": ["test_source"],
         **extra,
     }
-    with open(state_dir / "sync_status.json", "w") as f:
+    with open(state_dir / filename, "w") as f:
         json.dump(status, f)
     return status
 
 
-# ---------------------------------------------------------------------------
-# get_sync_status_path
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 class TestGetSyncStatusPath:
-    def test_returns_expected_path(self, tmp_path):
+    def test_returns_expected_path_without_sync_id(self, tmp_path):
         from dango.platform.sync_process import get_sync_status_path
 
         path = get_sync_status_path(tmp_path)
         assert path == tmp_path / ".dango" / "state" / "sync_status.json"
 
+    def test_returns_expected_path_with_sync_id(self, tmp_path):
+        from dango.platform.sync_process import get_sync_status_path
 
-# ---------------------------------------------------------------------------
-# read_sync_status
-# ---------------------------------------------------------------------------
+        path = get_sync_status_path(tmp_path, sync_id="abc123")
+        assert path == tmp_path / ".dango" / "state" / "sync_status_abc123.json"
 
 
 @pytest.mark.unit
@@ -71,6 +63,14 @@ class TestReadSyncStatus:
         assert status is not None
         assert status["phase"] == "data_load"
 
+    def test_reads_file_with_sync_id(self, tmp_path):
+        from dango.platform.sync_process import read_sync_status
+
+        _write_status_file(tmp_path, phase="completed", sync_id="xyz789")
+        status = read_sync_status(tmp_path, sync_id="xyz789")
+        assert status is not None
+        assert status["phase"] == "completed"
+
     def test_returns_none_on_invalid_json(self, tmp_path):
         from dango.platform.sync_process import read_sync_status
 
@@ -78,11 +78,6 @@ class TestReadSyncStatus:
         state_dir.mkdir(parents=True, exist_ok=True)
         (state_dir / "sync_status.json").write_text("not json{{{")
         assert read_sync_status(tmp_path) is None
-
-
-# ---------------------------------------------------------------------------
-# cleanup_sync_status
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -121,10 +116,12 @@ class TestCleanupSyncStatus:
         cleanup_sync_status(tmp_path)
         assert get_sync_status_path(tmp_path).exists()
 
+    def test_cleanup_with_sync_id(self, tmp_path):
+        from dango.platform.sync_process import cleanup_sync_status, get_sync_status_path
 
-# ---------------------------------------------------------------------------
-# launch_sync_subprocess
-# ---------------------------------------------------------------------------
+        _write_status_file(tmp_path, phase="completed", sync_id="test123")
+        cleanup_sync_status(tmp_path, sync_id="test123")
+        assert not get_sync_status_path(tmp_path, sync_id="test123").exists()
 
 
 @pytest.mark.unit
@@ -137,7 +134,7 @@ class TestLaunchSyncSubprocess:
         mock_process.pid = 12345
         mock_popen.return_value = mock_process
 
-        process = launch_sync_subprocess(
+        process, sync_id = launch_sync_subprocess(
             project_root=tmp_path,
             sources=["hubspot"],
             full_refresh=True,
@@ -145,6 +142,7 @@ class TestLaunchSyncSubprocess:
         )
 
         assert process is mock_process
+        assert len(sync_id) == 12  # uuid hex[:12]
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
         assert cmd[0] == sys.executable
@@ -158,6 +156,23 @@ class TestLaunchSyncSubprocess:
         assert args["full_refresh"] is True
         assert args["write_progress"] is True
         assert args["source_label"] == "ui"
+        assert args["sync_id"] == sync_id
+
+    @patch("subprocess.Popen")
+    def test_uses_devnull_not_pipe(self, mock_popen, tmp_path):
+        """Stdout/stderr must use DEVNULL to prevent pipe deadlock."""
+        import subprocess
+
+        mock_popen.return_value = MagicMock(pid=1)
+        launch = __import__(
+            "dango.platform.sync_process", fromlist=["launch_sync_subprocess"]
+        ).launch_sync_subprocess
+
+        launch(project_root=tmp_path, sources=["src"])
+
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs["stdout"] == subprocess.DEVNULL
+        assert call_kwargs["stderr"] == subprocess.DEVNULL
 
     @patch("subprocess.Popen")
     def test_includes_optional_params(self, mock_popen, tmp_path):
@@ -165,7 +180,7 @@ class TestLaunchSyncSubprocess:
 
         mock_popen.return_value = MagicMock(pid=1)
 
-        launch_sync_subprocess(
+        _process, _sync_id = launch_sync_subprocess(
             project_root=tmp_path,
             sources=["src"],
             start_date="2026-01-01",
@@ -173,6 +188,7 @@ class TestLaunchSyncSubprocess:
             backfill_days=7,
             skip_dbt=True,
             max_lock_wait=300,
+            record_id=42,
         )
 
         json_str = mock_popen.call_args[0][0][3]
@@ -182,22 +198,17 @@ class TestLaunchSyncSubprocess:
         assert args["backfill_days"] == 7
         assert args["skip_dbt"] is True
         assert args["max_lock_wait"] == 300
+        assert args["record_id"] == 42
 
     @patch("subprocess.Popen")
-    def test_cleans_stale_status_before_launch(self, mock_popen, tmp_path):
-        from dango.platform.sync_process import get_sync_status_path, launch_sync_subprocess
+    def test_returns_unique_sync_ids(self, mock_popen, tmp_path):
+        from dango.platform.sync_process import launch_sync_subprocess
 
-        _write_status_file(tmp_path, phase="completed")
         mock_popen.return_value = MagicMock(pid=1)
 
-        launch_sync_subprocess(project_root=tmp_path, sources=["src"])
-
-        assert not get_sync_status_path(tmp_path).exists()
-
-
-# ---------------------------------------------------------------------------
-# poll_sync_status (async)
-# ---------------------------------------------------------------------------
+        _, id1 = launch_sync_subprocess(project_root=tmp_path, sources=["src"])
+        _, id2 = launch_sync_subprocess(project_root=tmp_path, sources=["src"])
+        assert id1 != id2
 
 
 @pytest.mark.unit
@@ -206,7 +217,8 @@ class TestPollSyncStatus:
     async def test_detects_completed_phase(self, tmp_path):
         from dango.platform.sync_process import poll_sync_status
 
-        _write_status_file(tmp_path, phase="completed")
+        sid = "test1"
+        _write_status_file(tmp_path, phase="completed", sync_id=sid)
         process = MagicMock()
         process.poll.return_value = 0
 
@@ -215,7 +227,7 @@ class TestPollSyncStatus:
 
         with patch(f"{_WS_MOD}.ws_manager", mock_ws):
             success, result = await poll_sync_status(
-                tmp_path, process, "test_source", poll_interval=0.01
+                tmp_path, process, "test_source", sync_id=sid, poll_interval=0.01
             )
 
         assert success is True
@@ -225,7 +237,8 @@ class TestPollSyncStatus:
     async def test_detects_failed_phase(self, tmp_path):
         from dango.platform.sync_process import poll_sync_status
 
-        _write_status_file(tmp_path, phase="failed", error="boom")
+        sid = "test2"
+        _write_status_file(tmp_path, phase="failed", error="boom", sync_id=sid)
         process = MagicMock()
         process.poll.return_value = 1
 
@@ -234,7 +247,7 @@ class TestPollSyncStatus:
 
         with patch(f"{_WS_MOD}.ws_manager", mock_ws):
             success, result = await poll_sync_status(
-                tmp_path, process, "test_source", poll_interval=0.01
+                tmp_path, process, "test_source", sync_id=sid, poll_interval=0.01
             )
 
         assert success is False
@@ -252,12 +265,11 @@ class TestPollSyncStatus:
 
         with patch(f"{_WS_MOD}.ws_manager", mock_ws):
             success, result = await poll_sync_status(
-                tmp_path, process, "test_source", poll_interval=0.01
+                tmp_path, process, "test_source", sync_id="nosuch", poll_interval=0.01
             )
 
         assert success is False
         assert "unexpectedly" in result["error"]
-        # Verify sync_failed was broadcast
         broadcast_calls = mock_ws.broadcast.call_args_list
         events = [c.args[0]["event"] for c in broadcast_calls]
         assert "sync_failed" in events
@@ -266,10 +278,9 @@ class TestPollSyncStatus:
     async def test_broadcasts_phase_transitions(self, tmp_path):
         from dango.platform.sync_process import poll_sync_status
 
-        # Start with data_load phase, then transition to completed
         call_count = [0]
 
-        def _mock_read(proj_root):
+        def _mock_read(proj_root, sync_id=None):
             call_count[0] += 1
             if call_count[0] <= 1:
                 return {"pid": 1, "phase": "data_load", "message": "Loading"}
@@ -290,13 +301,72 @@ class TestPollSyncStatus:
             )
 
         assert success is True
-        # Should have broadcast for data_load and completed transitions
         assert mock_ws.broadcast.call_count >= 2
 
+    @pytest.mark.anyio
+    async def test_timeout_terminates_process(self, tmp_path):
+        """Polling should terminate subprocess and return failure after max_poll_time."""
+        from dango.platform.sync_process import poll_sync_status
 
-# ---------------------------------------------------------------------------
-# poll_sync_status_blocking (sync)
-# ---------------------------------------------------------------------------
+        process = MagicMock()
+        process.poll.return_value = None  # never exits
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        # Use very short max_poll_time
+        with (
+            patch(f"{_MOD}.read_sync_status", return_value=None),
+            patch(f"{_WS_MOD}.ws_manager", mock_ws),
+        ):
+            success, result = await poll_sync_status(
+                tmp_path,
+                process,
+                "test_source",
+                poll_interval=0.01,
+                max_poll_time=0.02,
+            )
+
+        assert success is False
+        assert "timed out" in result["error"]
+        process.terminate.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_heartbeat_emitted(self, tmp_path):
+        """Heartbeat should be broadcast every heartbeat_interval seconds."""
+        from dango.platform.sync_process import poll_sync_status
+
+        call_count = [0]
+
+        def _mock_read(proj_root, sync_id=None):
+            call_count[0] += 1
+            # Return completed on 4th read to allow some heartbeats
+            if call_count[0] >= 4:
+                return {"pid": 1, "phase": "completed", "message": "Done"}
+            return None  # no status yet
+
+        process = MagicMock()
+        process.poll.return_value = None
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        with (
+            patch(f"{_MOD}.read_sync_status", side_effect=_mock_read),
+            patch(f"{_WS_MOD}.ws_manager", mock_ws),
+        ):
+            success, _ = await poll_sync_status(
+                tmp_path,
+                process,
+                "test_source",
+                poll_interval=0.01,
+                heartbeat_interval=0.02,
+            )
+
+        assert success is True
+        # Check that at least one heartbeat was emitted
+        events = [c.args[0]["event"] for c in mock_ws.broadcast.call_args_list]
+        assert "sync_progress" in events
 
 
 @pytest.mark.unit
@@ -353,3 +423,53 @@ class TestPollSyncStatusBlocking:
         broadcast_fn.assert_called_once()
         call_msg = broadcast_fn.call_args[0][0]
         assert call_msg["event"] == "sync_completed"
+
+    def test_broadcast_includes_source_name(self, tmp_path):
+        """Blocking poller should include source in broadcast messages."""
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(tmp_path, phase="completed")
+        process = MagicMock()
+        process.poll.return_value = 0
+        broadcast_fn = MagicMock()
+
+        with patch(f"{_MOD}.time.sleep"):
+            poll_sync_status_blocking(
+                tmp_path,
+                process,
+                source_name="hubspot",
+                broadcast_fn=broadcast_fn,
+                poll_interval=0.01,
+            )
+
+        call_msg = broadcast_fn.call_args[0][0]
+        assert call_msg["source"] == "hubspot"
+
+    def test_timeout_terminates_process(self, tmp_path):
+        """Blocking poller should terminate process after max_poll_time."""
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        process = MagicMock()
+        process.poll.return_value = None  # never exits
+
+        # Use time mock so sleep doesn't actually sleep but time advances
+        elapsed = [0.0]
+
+        def fake_sleep(n):
+            elapsed[0] += n
+
+        def fake_time():
+            return elapsed[0]
+
+        with (
+            patch(f"{_MOD}.time.sleep", side_effect=fake_sleep),
+            patch(f"{_MOD}.time.time", side_effect=fake_time),
+            patch(f"{_MOD}.read_sync_status", return_value=None),
+        ):
+            success, result = poll_sync_status_blocking(
+                tmp_path, process, max_poll_time=5.0, poll_interval=2.0
+            )
+
+        assert success is False
+        assert "timed out" in result["error"]
+        process.terminate.assert_called_once()

--- a/tests/unit/test_sync_trigger.py
+++ b/tests/unit/test_sync_trigger.py
@@ -1,10 +1,11 @@
 """tests/unit/test_sync_trigger.py
 
-Tests for the server-side manual sync runner (TASK-040c).
+Tests for the server-side manual sync runner (TASK-040c + R10-N subprocess).
 """
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +15,7 @@ _PATCH_UTILS = "dango.utils"
 _PATCH_CONFIG = "dango.config.helpers"
 _PATCH_INGESTION = "dango.ingestion"
 _PATCH_HISTORY = "dango.platform.scheduling.sync_trigger"
+_PATCH_OAUTH = "dango.oauth.validation"
 
 
 # ---------------------------------------------------------------------------
@@ -23,7 +25,12 @@ _PATCH_HISTORY = "dango.platform.scheduling.sync_trigger"
 
 def _make_config(source_names):
     config = MagicMock()
-    sources_by_name = {n: MagicMock(name=n) for n in source_names}
+    sources_by_name = {}
+    for n in source_names:
+        src = MagicMock()
+        src.name = n
+        src.type.value = "hubspot"
+        sources_by_name[n] = src
     config.sources.get_source.side_effect = lambda n: sources_by_name.get(n)
     return config
 
@@ -43,8 +50,10 @@ class TestRunManualSync:
     @patch(f"{_PATCH_HISTORY}.record_completion")
     @patch(f"{_PATCH_HISTORY}.record_start", return_value=1)
     @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
     def test_success(
         self,
+        mock_oauth,
         mock_db_path,
         mock_start,
         mock_complete,
@@ -73,8 +82,10 @@ class TestRunManualSync:
     @patch(f"{_PATCH_HISTORY}.record_completion")
     @patch(f"{_PATCH_HISTORY}.record_start", return_value=2)
     @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
     def test_backfill_passes_start_date(
         self,
+        mock_oauth,
         mock_db_path,
         mock_start,
         mock_complete,
@@ -97,10 +108,22 @@ class TestRunManualSync:
     @patch(f"{_PATCH_HISTORY}.record_failure")
     @patch(f"{_PATCH_HISTORY}.record_start", return_value=3)
     @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
-    def test_lock_failure(self, mock_db_path, mock_start, mock_failure, mock_lock_cls, tmp_path):
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_lock_failure(
+        self,
+        mock_oauth,
+        mock_config,
+        mock_db_path,
+        mock_start,
+        mock_failure,
+        mock_lock_cls,
+        tmp_path,
+    ):
         from dango.exceptions import DbtLockError
         from dango.platform.scheduling.sync_trigger import run_manual_sync
 
+        mock_config.return_value = _make_config(["src1"])
         mock_lock_cls.return_value.acquire.side_effect = DbtLockError("lock held")
 
         result = run_manual_sync(tmp_path, sources=["src1"])
@@ -115,8 +138,10 @@ class TestRunManualSync:
     @patch(f"{_PATCH_HISTORY}.record_failure")
     @patch(f"{_PATCH_HISTORY}.record_start", return_value=4)
     @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
     def test_no_valid_sources(
         self,
+        mock_oauth,
         mock_db_path,
         mock_start,
         mock_failure,
@@ -142,8 +167,10 @@ class TestRunManualSync:
     @patch(f"{_PATCH_HISTORY}.record_failure")
     @patch(f"{_PATCH_HISTORY}.record_start", return_value=5)
     @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
     def test_sync_exception_records_failure(
         self,
+        mock_oauth,
         mock_db_path,
         mock_start,
         mock_failure,
@@ -162,3 +189,139 @@ class TestRunManualSync:
         assert "DuckDB crash" in result["error"]
         mock_failure.assert_called_once()
         mock_lock_cls.return_value.release.assert_called_once()
+
+    @patch(f"{_PATCH_INGESTION}.run_sync")
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=6)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_skip_dbt_param(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_lock_cls,
+        mock_config,
+        mock_sync,
+        tmp_path,
+    ):
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        result = run_manual_sync(tmp_path, sources=["src1"], skip_dbt=True)
+
+        assert result["status"] == "success"
+        call_kwargs = mock_sync.call_args[1]
+        assert call_kwargs["skip_dbt"] is True
+
+    @patch(f"{_PATCH_INGESTION}.run_sync")
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=7)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_start_end_date_params(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_lock_cls,
+        mock_config,
+        mock_sync,
+        tmp_path,
+    ):
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        result = run_manual_sync(
+            tmp_path, sources=["src1"], start_date="2026-01-01", end_date="2026-01-31"
+        )
+
+        assert result["status"] == "success"
+        call_kwargs = mock_sync.call_args[1]
+        assert call_kwargs["start_date"] is not None
+        assert call_kwargs["end_date"] is not None
+
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_HISTORY}.record_failure")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=8)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    def test_oauth_failure(self, mock_db_path, mock_start, mock_failure, mock_config, tmp_path):
+        from dango.exceptions import OAuthTokenRevokedError
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["google_sheets"])
+
+        with patch(
+            f"{_PATCH_OAUTH}.validate_before_sync",
+            side_effect=OAuthTokenRevokedError(
+                "Token revoked",
+                user_message="Token revoked",
+            ),
+        ):
+            result = run_manual_sync(tmp_path, sources=["google_sheets"])
+
+        assert result["status"] == "failed"
+        assert "OAuth" in result["error"]
+        mock_failure.assert_called_once()
+
+
+@pytest.mark.unit
+class TestWriteStatus:
+    """Tests for _write_status() atomic file writing."""
+
+    def test_creates_status_file(self, tmp_path):
+        from dango.platform.scheduling.sync_trigger import _write_status
+
+        state_dir = tmp_path / ".dango" / "state"
+        _write_status(state_dir, phase="starting", message="test")
+
+        status_file = state_dir / "sync_status.json"
+        assert status_file.exists()
+
+        data = json.loads(status_file.read_text())
+        assert data["phase"] == "starting"
+        assert data["message"] == "test"
+        assert "pid" in data
+        assert "updated_at" in data
+
+    def test_overwrites_existing(self, tmp_path):
+        from dango.platform.scheduling.sync_trigger import _write_status
+
+        state_dir = tmp_path / ".dango" / "state"
+        _write_status(state_dir, phase="starting", message="first")
+        _write_status(state_dir, phase="completed", message="second")
+
+        data = json.loads((state_dir / "sync_status.json").read_text())
+        assert data["phase"] == "completed"
+
+    def test_write_progress_integration(self, tmp_path):
+        """run_manual_sync with write_progress=True creates status file."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        config = _make_config(["src1"])
+
+        with (
+            patch(f"{_PATCH_INGESTION}.run_sync"),
+            patch(f"{_PATCH_CONFIG}.load_config", return_value=config),
+            patch(f"{_PATCH_UTILS}.DbtLock"),
+            patch(f"{_PATCH_HISTORY}.record_completion"),
+            patch(f"{_PATCH_HISTORY}.record_start", return_value=1),
+            patch(f"{_PATCH_HISTORY}.get_scheduler_db_path"),
+            patch(f"{_PATCH_OAUTH}.validate_before_sync"),
+        ):
+            result = run_manual_sync(tmp_path, sources=["src1"], write_progress=True)
+
+        assert result["status"] == "success"
+        # Status file should exist with final phase
+        status_file = tmp_path / ".dango" / "state" / "sync_status.json"
+        assert status_file.exists()
+        data = json.loads(status_file.read_text())
+        assert data["phase"] == "completed"

--- a/tests/unit/test_sync_trigger.py
+++ b/tests/unit/test_sync_trigger.py
@@ -44,7 +44,7 @@ def _make_config(source_names):
 class TestRunManualSync:
     """Tests for run_manual_sync()."""
 
-    @patch(f"{_PATCH_INGESTION}.run_sync")
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
     @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_UTILS}.DbtLock")
     @patch(f"{_PATCH_HISTORY}.record_completion")
@@ -76,7 +76,7 @@ class TestRunManualSync:
         mock_sync.assert_called_once()
         mock_complete.assert_called_once()
 
-    @patch(f"{_PATCH_INGESTION}.run_sync")
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
     @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_UTILS}.DbtLock")
     @patch(f"{_PATCH_HISTORY}.record_completion")
@@ -132,7 +132,7 @@ class TestRunManualSync:
         assert "Lock unavailable" in result["error"]
         mock_failure.assert_called_once()
 
-    @patch(f"{_PATCH_INGESTION}.run_sync")
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
     @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_UTILS}.DbtLock")
     @patch(f"{_PATCH_HISTORY}.record_failure")
@@ -190,7 +190,7 @@ class TestRunManualSync:
         mock_failure.assert_called_once()
         mock_lock_cls.return_value.release.assert_called_once()
 
-    @patch(f"{_PATCH_INGESTION}.run_sync")
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
     @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_UTILS}.DbtLock")
     @patch(f"{_PATCH_HISTORY}.record_completion")
@@ -218,7 +218,7 @@ class TestRunManualSync:
         call_kwargs = mock_sync.call_args[1]
         assert call_kwargs["skip_dbt"] is True
 
-    @patch(f"{_PATCH_INGESTION}.run_sync")
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
     @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_UTILS}.DbtLock")
     @patch(f"{_PATCH_HISTORY}.record_completion")
@@ -272,6 +272,110 @@ class TestRunManualSync:
         assert "OAuth" in result["error"]
         mock_failure.assert_called_once()
 
+    @patch(
+        f"{_PATCH_INGESTION}.run_sync",
+        return_value={"results": [{"rows_loaded": 100}], "failed_count": 0},
+    )
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_reuses_existing_record_id(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_complete,
+        mock_lock_cls,
+        mock_config,
+        mock_sync,
+        tmp_path,
+    ):
+        """When record_id is provided, should NOT call record_start."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        with patch(f"{_PATCH_HISTORY}.record_start") as mock_start:
+            result = run_manual_sync(tmp_path, sources=["src1"], record_id=42)
+
+        assert result["status"] == "success"
+        assert result["record_id"] == 42
+        mock_start.assert_not_called()
+
+    @patch(
+        f"{_PATCH_INGESTION}.run_sync",
+        return_value={"results": [{"rows_loaded": 150}], "failed_count": 0},
+    )
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=9)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_returns_rows_loaded(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_lock_cls,
+        mock_config,
+        mock_sync,
+        tmp_path,
+    ):
+        """Successful sync should include rows_loaded in result."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        result = run_manual_sync(tmp_path, sources=["src1"])
+
+        assert result["status"] == "success"
+        assert result["rows_loaded"] == 150
+
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_failure")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=10)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_lock_retry_loop(
+        self,
+        mock_oauth,
+        mock_config,
+        mock_db_path,
+        mock_start,
+        mock_failure,
+        mock_lock_cls,
+        tmp_path,
+    ):
+        """With max_lock_wait > 0, should retry before failing."""
+        from dango.exceptions import DbtLockError
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        # Fail first 2 attempts, succeed on third
+        attempts = [0]
+
+        def _side_effect():
+            attempts[0] += 1
+            if attempts[0] < 3:
+                raise DbtLockError("lock held")
+
+        mock_lock_cls.return_value.acquire.side_effect = _side_effect
+
+        with (
+            patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0}),
+            patch(f"{_PATCH_HISTORY}.record_completion"),
+            patch(f"{_PATCH_HISTORY}.time.sleep"),
+        ):
+            result = run_manual_sync(tmp_path, sources=["src1"], max_lock_wait=30)
+
+        assert result["status"] == "success"
+        assert attempts[0] == 3
+
 
 @pytest.mark.unit
 class TestWriteStatus:
@@ -302,6 +406,15 @@ class TestWriteStatus:
         data = json.loads((state_dir / "sync_status.json").read_text())
         assert data["phase"] == "completed"
 
+    def test_uses_sync_id_in_filename(self, tmp_path):
+        from dango.platform.scheduling.sync_trigger import _write_status
+
+        state_dir = tmp_path / ".dango" / "state"
+        _write_status(state_dir, sync_id="abc123", phase="starting", message="test")
+
+        assert (state_dir / "sync_status_abc123.json").exists()
+        assert not (state_dir / "sync_status.json").exists()
+
     def test_write_progress_integration(self, tmp_path):
         """run_manual_sync with write_progress=True creates status file."""
         from dango.platform.scheduling.sync_trigger import run_manual_sync
@@ -309,7 +422,10 @@ class TestWriteStatus:
         config = _make_config(["src1"])
 
         with (
-            patch(f"{_PATCH_INGESTION}.run_sync"),
+            patch(
+                f"{_PATCH_INGESTION}.run_sync",
+                return_value={"results": [{"rows_loaded": 42}], "failed_count": 0},
+            ),
             patch(f"{_PATCH_CONFIG}.load_config", return_value=config),
             patch(f"{_PATCH_UTILS}.DbtLock"),
             patch(f"{_PATCH_HISTORY}.record_completion"),
@@ -317,11 +433,58 @@ class TestWriteStatus:
             patch(f"{_PATCH_HISTORY}.get_scheduler_db_path"),
             patch(f"{_PATCH_OAUTH}.validate_before_sync"),
         ):
-            result = run_manual_sync(tmp_path, sources=["src1"], write_progress=True)
+            result = run_manual_sync(
+                tmp_path, sources=["src1"], write_progress=True, sync_id="prog1"
+            )
 
         assert result["status"] == "success"
-        # Status file should exist with final phase
-        status_file = tmp_path / ".dango" / "state" / "sync_status.json"
+        status_file = tmp_path / ".dango" / "state" / "sync_status_prog1.json"
         assert status_file.exists()
         data = json.loads(status_file.read_text())
         assert data["phase"] == "completed"
+        assert data["rows_loaded"] == 42
+
+
+@pytest.mark.unit
+class TestMainEntrypoint:
+    """Tests for the __main__ block JSON parsing."""
+
+    def test_parses_minimal_args(self, tmp_path):
+        """The __main__ block should parse minimal JSON and call run_manual_sync."""
+        args_json = json.dumps({"project_root": str(tmp_path), "sources": ["src1"]})
+
+        with patch(
+            f"{_PATCH_HISTORY}.run_manual_sync",
+            return_value={"status": "success"},
+        ) as mock_run:
+            import dango.platform.scheduling.sync_trigger as mod
+
+            parsed = json.loads(args_json)
+            mod.run_manual_sync(
+                project_root=tmp_path,
+                sources=parsed["sources"],
+                full_refresh=parsed.get("full_refresh", False),
+            )
+
+        mock_run.assert_called_once()
+
+    def test_all_optional_fields_accepted(self):
+        """All optional fields in JSON args should be parseable without error."""
+        args = {
+            "project_root": "/tmp/test",
+            "sources": ["src1"],
+            "full_refresh": True,
+            "backfill_days": 7,
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-31",
+            "write_progress": True,
+            "source_label": "scheduler",
+            "skip_dbt": True,
+            "max_lock_wait": 300,
+            "sync_id": "abc123",
+            "record_id": 42,
+        }
+        parsed = json.loads(json.dumps(args))
+        assert parsed["sources"] == ["src1"]
+        assert parsed.get("sync_id") == "abc123"
+        assert parsed.get("record_id") == 42


### PR DESCRIPTION
## Summary

- **Run sync operations in a subprocess** instead of in-process within the web server. The web server process no longer holds the DuckDB write lock during syncs, so notebooks and the UI remain responsive.
- **New `sync_process.py`** with subprocess launch + polling utilities (`launch_sync_subprocess`, `poll_sync_status`, `poll_sync_status_blocking`, `cleanup_sync_status`)
- **Extended `sync_trigger.py`** as the subprocess entrypoint — added progress file writing (`sync_status.json`), OAuth validation before lock, lock retry with configurable `max_lock_wait`, and new params (`start_date`, `end_date`, `skip_dbt`, `source_label`)
- **Refactored `sync.py`** (558 → 362 lines) — replaced in-process `run_sync()` + DbtLock with subprocess launch + poll. Removed from file-exemptions.
- **Refactored `jobs.py`** (895 → 849 lines) — replaced direct `run_sync()` + DbtLock with `launch_sync_subprocess` + `poll_sync_status_blocking`

## Architecture

```
Web Server (FastAPI)                    Subprocess (sync_trigger.py)
─────────────────────                   ────────────────────────────
POST /api/sources/{name}/sync
  → validate source/options
  → launch_sync_subprocess()  ────────→  python -m dango.platform.scheduling.sync_trigger
  → asyncio.create_task(                   → validate OAuth tokens
      poll_sync_status())                  → acquire DbtLock
                                           → write status: phase="data_load"
  ← reads .dango/state/sync_status.json   → run_sync(...)
  → broadcasts WebSocket events            → write status: phase="completed"/"failed"
  → emits 30s heartbeat
  ← detects final state                  → release lock, exit
  → saves sync history
  → cleans up status file
```

## Test plan

- [x] 20 new tests in `test_sync_process.py` (status file CRUD, subprocess launch args, async poll phase transitions, sync poll, crash detection)
- [x] 11 tests in `test_sync_trigger.py` (existing + new: skip_dbt, start/end dates, OAuth failure, write_progress, atomic file writing)
- [x] 26 tests in `test_sync_jobs.py` (updated to mock subprocess instead of run_sync)
- [x] 24 adjacent tests pass (test_web_imports, test_sync_trigger_api)
- [x] 44 scheduler tests pass (test_scheduler)
- [x] `ruff check` + `ruff format` + `mypy` clean
- [x] All pre-commit hooks pass
- [x] File-size checker passes (sync.py removed from exemptions, jobs.py count updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)