### PR TITLE
R10-Q: upgrade pip before pip-audit to avoid pip CVE false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+      - run: pip install --upgrade pip
       - run: pip install -c constraints.txt -e ".[dev]"
       - name: pip-audit
         run: pip-audit --ignore-vuln CVE-2026-32274


### PR DESCRIPTION
## Summary

- Adds `pip install --upgrade pip` before `pip install -c constraints.txt -e ".[dev]"` in the `security` (pip-audit) CI job
- Prevents pip's own CVEs from being flagged as false positives by `pip-audit`
- Only the security job is modified — other jobs don't run `pip-audit`

## R10 Integration Verification

All quality gates pass on `v1` at commit 5fe69c0 (post-PR #239):

### Quality Gates
- **pytest:** 3396 passed, 7 skipped ✅
- **ruff check:** All checks passed ✅
- **mypy:** Success, no issues in 211 source files ✅

### 4 Critical Bug Fixes Confirmed
| Bug | Fix | Verified |
|-----|-----|----------|
| BUG-167 | `_DEFAULT_MISFIRE_GRACE_TIME = None` in `scheduler.py:36` | ✅ |
| BUG-168 | `_build_insert_select()` + `allow_schema_changes` in `csv_loader.py` | ✅ |
| BUG-175 | No config-mutation endpoints — only operational POST (trigger/reload/cancel/test) | ✅ |
| BUG-178 | `config={"access_mode": "read_only"}` in all 3 notebook templates | ✅ |

### 7 Features Confirmed
| Feature | Location | Verified |
|---------|----------|----------|
| FEAT-001/002: dbt tests in monitoring | `web/routes/monitoring.py` (`DbtTestResult`) | ✅ |
| FEAT-003: `dango dev` | `cli/commands/dev.py` | ✅ |
| FEAT-004: DuckDB capacity | `utils/db_health.py` + `web/routes/health.py` | ✅ |
| FEAT-005: Multi-worker uvicorn | `config/models.py:481` + `cli/commands/serve.py` | ✅ |
| FEAT-006: `dango snapshot add` | `cli/commands/snapshot.py` | ✅ |
| FEAT-007: Process separation | `platform/sync_process.py` | ✅ |

## Test plan
- [ ] CI pip-audit job passes on this PR (no pip CVE false positives)
- [ ] Fresh test project: `dango start` → `scripts/smoke_test.sh` passes 66 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)