### PR TITLE
R12-B: Fix 9 one-liner bugs from T11 testing round

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (1034 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (1038 lines)
 │   │   ├── project.py          # init/rename/info
 │   │   ├── source.py           # source group (add/list/remove/edit) + sync (833 lines)
 │   │   ├── transform.py        # run/docs/generate
@@ -336,11 +336,11 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 2497 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2008 | — (metadata-only) |
-| `cli/source_wizard.py` | 2306 | — |
+| `cli/source_wizard.py` | 2311 | — |
 | `visualization/metabase.py` | 1151 | — |
 | `cli/init.py` | 1334 | — |
 | `visualization/dashboard_manager.py` | 1112 | — |
-| `cli/commands/platform.py` | 1034 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 1038 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 852 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 851 | — (extracted from app.py by TASK-085) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -14,7 +14,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (307 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
 | `commands/source.py` (833 lines) | `source` group (`add`, `list`, `remove`, `edit`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (1034 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/platform.py` (1038 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (661 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (388 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
@@ -37,7 +37,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query` | `remote_status()`, `remote_logs()` |
 | `commands/schedule.py` (743 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/governance.py` (220 lines) | `governance` group (drift-report, pii-report, pii-set, pii-list) | `governance`, `drift_report()`, `pii_report()`, `pii_set()`, `pii_list()` |
-| `commands/notebook.py` (157 lines) | `notebook` group (new, open) | `notebook`, `notebook_new()`, `notebook_open()` |
+| `commands/notebook.py` (161 lines) | `notebook` group (new, open) | `notebook`, `notebook_new()`, `notebook_open()` |
 | `commands/snapshot.py` (383 lines) | `snapshot` group (add, list, run, db) | `snapshot`, `snapshot_add()`, `snapshot_list()`, `snapshot_run()`, `snapshot_db()` |
 | `commands/analyze.py` (~97 lines) | `monitor` group + `analyze` alias | `monitor` (group), `monitor_run()`, `analyze()` |
 | `commands/dev.py` (~429 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
@@ -45,7 +45,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | **Wizards** | | |
 | `init.py` (1334 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
-| `source_wizard.py` (2306 lines) | Source configuration wizard | `add_source()` |
+| `source_wizard.py` (2311 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |
 | `utils.py` (164 lines) | Display helpers + project context | `require_project_context()` |

--- a/dango/cli/commands/notebook.py
+++ b/dango/cli/commands/notebook.py
@@ -155,3 +155,7 @@ def notebook_open(ctx: click.Context, name: str) -> None:
     port = status.get("port") or 7805
     url = f"http://localhost:{port}/?file={name}.py"
     console.print(f"\n  [bold]Open in browser:[/bold] {url}\n")
+
+    import webbrowser
+
+    webbrowser.open(url)

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -568,8 +568,12 @@ def start(ctx: click.Context, yes: bool) -> None:
         if platform_config.auto_sync:
             console.print("[cyan]Starting file watcher...[/cyan]")
             try:
-                from dango.platform.watcher_lifecycle import start_file_watcher
+                from dango.platform.watcher_lifecycle import (
+                    start_file_watcher,
+                    stop_file_watcher,
+                )
 
+                stop_file_watcher(project_root)  # Clean up any orphaned watcher
                 watcher_pid = start_file_watcher(project_root)
                 console.print(f"[green]✓[/green] File watcher started (PID {watcher_pid})")
 

--- a/dango/cli/commands/snapshot.py
+++ b/dango/cli/commands/snapshot.py
@@ -47,11 +47,11 @@ def snapshot_add(ctx: click.Context) -> None:
     from dango.cli.utils import require_project_context
 
     project_root = require_project_context(ctx)
-    db_path = project_root / "warehouse.duckdb"
+    db_path = project_root / "data" / "warehouse.duckdb"
 
     if not db_path.exists():
         console.print(
-            "[red]Error:[/red] No warehouse.duckdb found. Run [bold]dango sync[/bold] first."
+            "[red]Error:[/red] No data/warehouse.duckdb found. Run [bold]dango sync[/bold] first."
         )
         raise SystemExit(1)
 

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -50,7 +50,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
             raise click.Abort()
 
         # Build dbt command
-        cmd = ["dbt", "run", "--project-dir", str(dbt_dir), "--profiles-dir", str(dbt_dir)]
+        cmd = ["dbt", "build", "--project-dir", str(dbt_dir), "--profiles-dir", str(dbt_dir)]
         if dbt_args:
             cmd.extend(dbt_args)
 
@@ -59,7 +59,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
             lock = DbtLock(
                 project_root=project_root,
                 source="cli",
-                operation=f"dbt run {' '.join(dbt_args) if dbt_args else ''}",
+                operation=f"dbt build {' '.join(dbt_args) if dbt_args else ''}",
             )
             lock.acquire()
         except DbtLockError as e:
@@ -72,7 +72,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
         result = subprocess.run(cmd, cwd=str(dbt_dir))
 
         if result.returncode != 0:
-            console.print(f"\n[red]dbt run failed with exit code {result.returncode}[/red]")
+            console.print(f"\n[red]dbt build failed with exit code {result.returncode}[/red]")
             raise click.Abort()
 
         # Update persistent model status

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -9,6 +9,7 @@ from typing import Any
 import inquirer
 from inquirer import themes
 from rich.console import Console
+from rich.markup import escape
 from rich.prompt import Confirm
 
 from dango.cli.env_helpers import (
@@ -404,7 +405,7 @@ class SourceWizard:
             console.print("\n\n[yellow]Wizard cancelled[/yellow]")
             return False
         except Exception as e:
-            console.print(f"\n[red]❌ Error: {e}[/red]")
+            console.print(f"\n[red]❌ Error: {escape(str(e))}[/red]")
             return False
 
     def _select_source_flat(self) -> str | None:
@@ -1935,7 +1936,7 @@ def {module_name}_resource(api_key: str):
             try:
                 value = json.loads(value)
             except json.JSONDecodeError:
-                console.print(f"[red]Invalid JSON: {value}[/red]")
+                console.print(f"[red]Invalid JSON: {escape(str(value))}[/red]")
                 return None
 
         # Cast integer/number type params with retry on invalid input
@@ -1945,7 +1946,9 @@ def {module_name}_resource(api_key: str):
                     value = int(value)
                     break
                 except ValueError:
-                    console.print(f"[red]Invalid integer: {value}. Please try again.[/red]")
+                    console.print(
+                        f"[red]Invalid integer: {escape(str(value))}. Please try again.[/red]"
+                    )
                     retry = inquirer.prompt(
                         [inquirer.Text(param_name, message=prompt)],
                         theme=themes.GreenPassion(),
@@ -1962,7 +1965,9 @@ def {module_name}_resource(api_key: str):
                     value = int(num) if num.is_integer() else num
                     break
                 except ValueError:
-                    console.print(f"[red]Invalid number: {value}. Please try again.[/red]")
+                    console.print(
+                        f"[red]Invalid number: {escape(str(value))}. Please try again.[/red]"
+                    )
                     retry = inquirer.prompt(
                         [inquirer.Text(param_name, message=prompt)],
                         theme=themes.GreenPassion(),

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -53,6 +53,19 @@ class DockerManager:
         env["COMPOSE_PROJECT_NAME"] = self.compose_project_name
         return env
 
+    def _metabase_image_exists(self) -> bool:
+        """Check if the dango-metabase Docker image already exists locally."""
+        try:
+            result = subprocess.run(
+                ["docker", "images", "--filter", "reference=dango-metabase", "-q"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0 and bool(result.stdout.strip())
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+
     def is_docker_available(self) -> bool:
         """Check if Docker is available"""
         try:
@@ -153,13 +166,20 @@ class DockerManager:
 
         cmd = self.get_compose_command() + ["-f", str(self.compose_file), "up", "-d"]
 
+        first_run = not self._metabase_image_exists()
+        if first_run:
+            console.print(
+                "[cyan]Building Metabase image (first run, may take 5-10 minutes)...[/cyan]"
+            )
+        timeout = 600 if first_run else 120
+
         try:
             result = subprocess.run(
                 cmd,
                 cwd=self.project_root,
                 capture_output=True,
                 text=True,
-                timeout=120,
+                timeout=timeout,
                 env=self._compose_env(),
             )
 
@@ -194,13 +214,16 @@ class DockerManager:
                 return False
 
         except subprocess.TimeoutExpired:
+            causes = [
+                "Docker image download is slow",
+                "Insufficient system resources",
+                "Docker daemon is unresponsive",
+            ]
+            if first_run:
+                causes.insert(0, "First-run Metabase image build can take 5-10 minutes")
             msg = format_structured_error(
                 what_failed="Timeout starting Docker services",
-                causes=[
-                    "Docker image download is slow",
-                    "Insufficient system resources",
-                    "Docker daemon is unresponsive",
-                ],
+                causes=causes,
                 suggested_fix="Check Docker status with 'docker ps' and retry",
             )
             console.print(f"[red]Error:[/red]\n{msg}")

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -568,6 +568,9 @@ async function handleWebSocketMessage(data) {
             setTimeout(() => {
                 if (triggeredSource) {
                     activeSyncs.delete(triggeredSource);
+                    stopSyncTimer(triggeredSource);
+                    const btn = document.getElementById(`sync-btn-${triggeredSource}`);
+                    if (btn) btn.textContent = 'Sync Now';
                     console.log('🟢 [WS] [DELAYED] Cleared activeSyncs for:', triggeredSource);
                     const result = syncResults.get(triggeredSource);
                     if (result) {
@@ -578,6 +581,13 @@ async function handleWebSocketMessage(data) {
                         if (!isLoadingSources) loadSources();
                     }
                 } else {
+                    // Reset ALL sync buttons when no specific source
+                    for (const src of activeSyncs) {
+                        stopSyncTimer(src);
+                        const btn = document.getElementById(`sync-btn-${src}`);
+                        if (btn) btn.textContent = 'Sync Now';
+                    }
+                    activeSyncs.clear();
                     if (!isLoadingSources) loadSources();
                 }
                 updateSyncCounter();

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -582,7 +582,7 @@ async function handleWebSocketMessage(data) {
                     }
                 } else {
                     // Reset ALL sync buttons when no specific source
-                    for (const src of activeSyncs) {
+                    for (const src of activeSyncs.keys()) {
                         stopSyncTimer(src);
                         const btn = document.getElementById(`sync-btn-${src}`);
                         if (btn) btn.textContent = 'Sync Now';
@@ -626,6 +626,9 @@ async function handleWebSocketMessage(data) {
                 // DO clear activeSyncs since the operation failed
                 if (activeSyncs.has(triggeredSource)) {
                     activeSyncs.delete(triggeredSource);
+                    stopSyncTimer(triggeredSource);
+                    const btn = document.getElementById(`sync-btn-${triggeredSource}`);
+                    if (btn) btn.textContent = 'Sync Now';
                     updateSyncCounter();
                     console.log('🔴 [WS] Cleared activeSyncs for:', triggeredSource);
                 }

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -78,7 +78,7 @@
                                     <span x-text="sd.estimated_row_total.toLocaleString()"></span> rows
                                 </div>
                             </div>
-                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium flex-shrink-0"
                                   :class="sd.freshness_status === 'fresh' ? 'bg-green-100 text-green-800' : sd.freshness_status === 'stale' ? 'bg-amber-100 text-amber-800' : 'bg-gray-100 text-gray-600'"
                                   x-text="sd.freshness_status || 'unknown'"></span>
                         </div>
@@ -633,6 +633,8 @@ function catalogPage() {
                 this.$nextTick(() => { this.$nextTick(() => this.renderLineage()); });
             } else if (filter && ['source', 'staging', 'intermediate', 'marts'].includes(filter)) {
                 this.activeTab = filter;
+            } else {
+                this.goToList();
             }
         },
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -81,7 +81,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 1034
+    lines: 1038
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic."
     review_by: "v1.1"
@@ -136,7 +136,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py
-    lines: 2306
+    lines: 2311
     category: exempt
     reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting. P7-011 added metrics generation. P5c grew +529 lines (credential unification, resource selection, dedup collection). P8-001 added REST API wizard enhancements: headers, query params, endpoint testing, data_selector/primary_key suggestions (+267 lines)."
     review_by: "v1.1"


### PR DESCRIPTION
## Summary
- **BUG-191:** Docker timeout — detect first-run (no Metabase image), use 600s timeout instead of 120s
- **BUG-192:** Notebook open — auto-open browser with `webbrowser.open()`
- **BUG-197:** Catalog badge CSS — add `flex-shrink-0` to freshness badge
- **BUG-200:** Catalog back button — add `else` branch to `restoreFromUrl()` so browser back resets view
- **BUG-205:** Snapshot wrong path — `warehouse.duckdb` is in `data/` subdir
- **BUG-209:** dbt build — change `dbt run` to `dbt build` (includes tests and snapshots)
- **BUG-210:** Sync timer reset — stop timer and reset button text on sync complete
- **BUG-221:** File watcher cleanup — stop orphaned watcher before starting new one
- **BUG-233:** Rich markup escape — wrap error messages with `escape()` to prevent crashes when error text contains brackets (also fixes BUG-234 — GA4 lookback becomes reachable)

## Test plan
- [x] `ruff check` — no lint errors
- [x] `ruff format --check` — no format errors
- [x] `mypy` on all modified Python files — no type errors
- [x] `pytest tests/unit/ -x` — 3396 passed
- [x] `scripts/integration_test.sh` — 5/5 stages passed
- [x] File-exemptions line counts updated (`platform.py` 1034→1038, `source_wizard.py` 2306→2311)
- [x] CLAUDE.md line counts updated (repo root, `cli/CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)