### PR TITLE
R12-K: Add dango remote auth commands for cloud user management

### DIFF
--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -691,8 +691,10 @@ def domain_remove(ctx: click.Context) -> None:
 import dango.cli.commands.remote_mgmt as _remote_mgmt  # noqa: E402, F401
 import dango.cli.commands.remote_ops as _remote_ops  # noqa: E402, F401
 import dango.cli.commands.remote_sync as _remote_sync  # noqa: E402, F401
+from dango.cli.commands.remote_auth import auth_group  # noqa: E402
 from dango.cli.commands.remote_backup import backup_group  # noqa: E402
 from dango.cli.commands.remote_env import env  # noqa: E402
 
+remote.add_command(auth_group)
 remote.add_command(backup_group)
 remote.add_command(env)

--- a/dango/cli/commands/remote_auth.py
+++ b/dango/cli/commands/remote_auth.py
@@ -137,7 +137,7 @@ def auth_add_user(ctx: click.Context, email: str, role: str) -> None:
     _cloud_cfg, ssh = _connect_ssh_or_fail(ctx)
     try:
         safe_email = shlex.quote(email)
-        args = f"add-user {safe_email} --role {role} --password"
+        args = f"add-user {safe_email} --role {shlex.quote(role)} --password"
         if not _run_remote_auth_cmd(ssh, args):
             raise SystemExit(1)
     finally:

--- a/dango/cli/commands/remote_auth.py
+++ b/dango/cli/commands/remote_auth.py
@@ -1,0 +1,217 @@
+"""dango/cli/commands/remote_auth.py
+
+Remote user management via SSH.
+
+Command hierarchy::
+
+    dango remote auth (subgroup)
+    ├── add-user <email> --role <viewer|editor|admin>
+    ├── list-users
+    ├── remove-user <email>
+    └── reset-password <email>
+
+Runs ``dango auth`` subcommands on the remote server over SSH, following
+the same pattern as ``remote_env.py`` and ``remote_mgmt.py``.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any
+
+import click
+
+from dango.cli import console
+
+# Remote paths on the cloud server (set by server setup)
+_DANGO_CLI = "/srv/dango/venv/bin/dango"
+_PROJECT_ROOT = "/srv/dango/project"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _connect_ssh_or_fail(ctx: click.Context) -> tuple[Any, Any]:
+    """Load cloud config, connect SSH as root, return (cloud_cfg, ssh).
+
+    Uses root because auth commands need read/write access to the auth
+    database at ``.dango/auth.db``.
+
+    Raises:
+        SystemExit: If no deployment or SSH connection fails.
+    """
+    from dango.cli.commands.remote_mgmt import _load_cloud_config_with_ip, _make_ssh_manager
+
+    cloud_cfg, project_root = _load_cloud_config_with_ip(ctx)
+    ssh = _make_ssh_manager(cloud_cfg, project_root)
+    try:
+        ssh.connect(cloud_cfg.droplet_ip)
+    except Exception as exc:
+        console.print(
+            f"[red]Error:[/red] Cannot connect to server: {exc}\n"
+            "Check [bold]dango remote status[/bold] for connectivity."
+        )
+        raise SystemExit(1) from exc
+
+    return cloud_cfg, ssh
+
+
+def _run_remote_auth_cmd(
+    ssh: Any,
+    args: str,
+    *,
+    pipe_yes: bool = False,
+    timeout: int = 30,
+) -> bool:
+    """Execute a ``dango auth`` subcommand on the remote server.
+
+    Args:
+        ssh: Connected SSHManager instance.
+        args: Arguments to pass after ``dango auth`` (already shell-safe).
+        pipe_yes: If True, prefix with ``yes |`` to auto-confirm prompts.
+        timeout: Command timeout in seconds.
+
+    Returns:
+        True on success, False on failure (error already printed).
+    """
+    cmd = f"cd {_PROJECT_ROOT} && {_DANGO_CLI} auth {args}"
+    if pipe_yes:
+        cmd = f"yes | {cmd}"
+
+    result = ssh.exec_command(cmd, timeout=timeout, check=False)
+    if result.success:
+        if result.stdout:
+            console.print(result.stdout.rstrip())
+        return True
+
+    stderr = result.stderr.strip() if result.stderr else ""
+    stdout = result.stdout.strip() if result.stdout else ""
+    msg = stderr or stdout or "Command failed with no output."
+    console.print(f"[red]Error:[/red] {msg}")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# auth subgroup
+# ---------------------------------------------------------------------------
+
+
+@click.group("auth")
+@click.pass_context
+def auth_group(ctx: click.Context) -> None:
+    """Manage users on the remote server.
+
+    Commands:
+      add-user        Create a new user
+      list-users      List all users
+      remove-user     Remove a user
+      reset-password  Reset a user's password
+    """
+    ctx.ensure_object(dict)
+
+
+# ---------------------------------------------------------------------------
+# add-user
+# ---------------------------------------------------------------------------
+
+
+@auth_group.command("add-user")
+@click.argument("email")
+@click.option(
+    "--role",
+    type=click.Choice(["admin", "editor", "viewer"]),
+    default="viewer",
+    help="Role for the new user.",
+)
+@click.pass_context
+def auth_add_user(ctx: click.Context, email: str, role: str) -> None:
+    """Create a new user on the remote server with a temporary password.
+
+    The user will be prompted to change their password on first login.
+
+    Example:
+      dango remote auth add-user alice@example.com --role editor
+    """
+    _cloud_cfg, ssh = _connect_ssh_or_fail(ctx)
+    try:
+        safe_email = shlex.quote(email)
+        args = f"add-user {safe_email} --role {role} --password"
+        if not _run_remote_auth_cmd(ssh, args):
+            raise SystemExit(1)
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# list-users
+# ---------------------------------------------------------------------------
+
+
+@auth_group.command("list-users")
+@click.pass_context
+def auth_list_users(ctx: click.Context) -> None:
+    """List all users on the remote server.
+
+    Example:
+      dango remote auth list-users
+    """
+    _cloud_cfg, ssh = _connect_ssh_or_fail(ctx)
+    try:
+        if not _run_remote_auth_cmd(ssh, "list-users"):
+            raise SystemExit(1)
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# remove-user
+# ---------------------------------------------------------------------------
+
+
+@auth_group.command("remove-user")
+@click.argument("email")
+@click.pass_context
+def auth_remove_user(ctx: click.Context, email: str) -> None:
+    """Remove a user from the remote server.
+
+    This permanently deletes the user and cannot be undone.
+
+    Example:
+      dango remote auth remove-user alice@example.com
+    """
+    _cloud_cfg, ssh = _connect_ssh_or_fail(ctx)
+    try:
+        safe_email = shlex.quote(email)
+        args = f"delete-user {safe_email}"
+        if not _run_remote_auth_cmd(ssh, args, pipe_yes=True):
+            raise SystemExit(1)
+    finally:
+        ssh.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# reset-password
+# ---------------------------------------------------------------------------
+
+
+@auth_group.command("reset-password")
+@click.argument("email")
+@click.pass_context
+def auth_reset_password(ctx: click.Context, email: str) -> None:
+    """Reset a user's password on the remote server.
+
+    Generates a new temporary password. The user must change it on next login.
+
+    Example:
+      dango remote auth reset-password alice@example.com
+    """
+    _cloud_cfg, ssh = _connect_ssh_or_fail(ctx)
+    try:
+        safe_email = shlex.quote(email)
+        args = f"reset-password {safe_email}"
+        if not _run_remote_auth_cmd(ssh, args):
+            raise SystemExit(1)
+    finally:
+        ssh.disconnect()

--- a/tests/unit/test_remote_auth_cli.py
+++ b/tests/unit/test_remote_auth_cli.py
@@ -1,0 +1,414 @@
+"""tests/unit/test_remote_auth_cli.py
+
+Unit tests for ``dango remote auth`` CLI commands.
+
+Uses Click's CliRunner with mocked SSH modules to avoid any real
+network or filesystem access.  Follows the same pattern as
+``test_remote_management_cli.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.remote import remote
+
+# ---------------------------------------------------------------------------
+# Patch targets
+# ---------------------------------------------------------------------------
+
+_PATCH_LOAD_CFG = "dango.cli.commands.remote_mgmt._load_cloud_config_with_ip"
+_PATCH_MAKE_SSH = "dango.cli.commands.remote_mgmt._make_ssh_manager"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cloud_config(droplet_ip: str = "1.2.3.4") -> MagicMock:
+    cfg = MagicMock()
+    cfg.droplet_ip = droplet_ip
+    cfg.ssh_key_path = ".dango/cloud_key"
+    return cfg
+
+
+def _make_command_result(
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+) -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    result.stderr = stderr
+    result.exit_code = exit_code
+    result.success = exit_code == 0
+    return result
+
+
+def _run(args: list[str], tmp_path, catch_exceptions: bool = False):
+    runner = CliRunner()
+    return runner.invoke(
+        remote,
+        args,
+        obj={"project_root": tmp_path},
+        catch_exceptions=catch_exceptions,
+    )
+
+
+def _patch_ssh_success(
+    tmp_path,
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+):
+    """Return a context manager stack that patches config + SSH with a successful connection."""
+    cloud_cfg = _make_cloud_config()
+    ssh = MagicMock()
+    ssh.exec_command.return_value = _make_command_result(stdout, stderr, exit_code)
+
+    return (
+        cloud_cfg,
+        ssh,
+        patch(_PATCH_LOAD_CFG, return_value=(cloud_cfg, tmp_path)),
+        patch(_PATCH_MAKE_SSH, return_value=ssh),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestRemoteAuthAddUser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteAuthAddUser:
+    def test_add_user_default_role(self, tmp_path):
+        """add-user uses viewer role by default."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User created")
+        with p1, p2:
+            result = _run(["auth", "add-user", "test@co.com"], tmp_path)
+
+        assert result.exit_code == 0
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "add-user" in cmd
+        assert "--role viewer" in cmd
+        assert "--password" in cmd
+
+    def test_add_user_custom_role(self, tmp_path):
+        """add-user passes --role editor when specified."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User created")
+        with p1, p2:
+            result = _run(["auth", "add-user", "test@co.com", "--role", "editor"], tmp_path)
+
+        assert result.exit_code == 0
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "--role editor" in cmd
+
+    def test_add_user_email_quoting(self, tmp_path):
+        """add-user shell-quotes the email argument."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User created")
+        with p1, p2:
+            result = _run(["auth", "add-user", "user+tag@co.com"], tmp_path)
+
+        assert result.exit_code == 0
+        cmd = ssh.exec_command.call_args[0][0]
+        # shlex.quote wraps in single quotes for special chars
+        assert "user+tag@co.com" in cmd
+
+    def test_add_user_output_displayed(self, tmp_path):
+        """add-user displays remote stdout."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(
+            tmp_path, stdout="User created: test@co.com\nTemp password: abc123"
+        )
+        with p1, p2:
+            result = _run(["auth", "add-user", "test@co.com"], tmp_path)
+
+        assert result.exit_code == 0
+        assert "User created" in result.output
+
+    def test_add_user_failure(self, tmp_path):
+        """add-user shows error on failure."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stderr="User already exists", exit_code=1)
+        with p1, p2:
+            result = _run(["auth", "add-user", "test@co.com"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    def test_add_user_disconnects_on_success(self, tmp_path):
+        """SSH is disconnected after successful add-user."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User created")
+        with p1, p2:
+            _run(["auth", "add-user", "test@co.com"], tmp_path)
+
+        ssh.disconnect.assert_called_once()
+
+    def test_add_user_disconnects_on_failure(self, tmp_path):
+        """SSH is disconnected even when add-user fails."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stderr="fail", exit_code=1)
+        with p1, p2:
+            _run(["auth", "add-user", "test@co.com"], tmp_path, catch_exceptions=True)
+
+        ssh.disconnect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestRemoteAuthListUsers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteAuthListUsers:
+    def test_list_users(self, tmp_path):
+        """list-users displays remote output."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(
+            tmp_path, stdout="admin@co.com  admin  active\nuser@co.com  viewer  active"
+        )
+        with p1, p2:
+            result = _run(["auth", "list-users"], tmp_path)
+
+        assert result.exit_code == 0
+        assert "admin@co.com" in result.output
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "list-users" in cmd
+
+    def test_list_users_empty(self, tmp_path):
+        """list-users handles empty output."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="")
+        with p1, p2:
+            result = _run(["auth", "list-users"], tmp_path)
+
+        assert result.exit_code == 0
+
+    def test_list_users_failure(self, tmp_path):
+        """list-users shows error on failure."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stderr="database locked", exit_code=1)
+        with p1, p2:
+            result = _run(["auth", "list-users"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    def test_list_users_disconnects(self, tmp_path):
+        """SSH is disconnected after list-users."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="users")
+        with p1, p2:
+            _run(["auth", "list-users"], tmp_path)
+
+        ssh.disconnect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestRemoteAuthRemoveUser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteAuthRemoveUser:
+    def test_remove_user(self, tmp_path):
+        """remove-user calls delete-user on remote."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User deleted")
+        with p1, p2:
+            result = _run(["auth", "remove-user", "test@co.com"], tmp_path)
+
+        assert result.exit_code == 0
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "delete-user" in cmd
+
+    def test_remove_user_pipes_yes(self, tmp_path):
+        """remove-user pipes yes to bypass interactive confirm."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User deleted")
+        with p1, p2:
+            _run(["auth", "remove-user", "test@co.com"], tmp_path)
+
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "yes |" in cmd
+
+    def test_remove_user_email_quoting(self, tmp_path):
+        """remove-user shell-quotes the email."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User deleted")
+        with p1, p2:
+            _run(["auth", "remove-user", "user+tag@co.com"], tmp_path)
+
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "user+tag@co.com" in cmd
+
+    def test_remove_user_failure(self, tmp_path):
+        """remove-user shows error on failure."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stderr="User not found", exit_code=1)
+        with p1, p2:
+            result = _run(["auth", "remove-user", "test@co.com"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    def test_remove_user_disconnects(self, tmp_path):
+        """SSH is disconnected after remove-user."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="User deleted")
+        with p1, p2:
+            _run(["auth", "remove-user", "test@co.com"], tmp_path)
+
+        ssh.disconnect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestRemoteAuthResetPassword
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteAuthResetPassword:
+    def test_reset_password(self, tmp_path):
+        """reset-password runs reset-password on remote."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(
+            tmp_path, stdout="Password reset for test@co.com\nNew password: xyz789"
+        )
+        with p1, p2:
+            result = _run(["auth", "reset-password", "test@co.com"], tmp_path)
+
+        assert result.exit_code == 0
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "reset-password" in cmd
+
+    def test_reset_password_output_displayed(self, tmp_path):
+        """reset-password displays remote stdout."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(
+            tmp_path, stdout="Password reset\nNew password: secret123"
+        )
+        with p1, p2:
+            result = _run(["auth", "reset-password", "test@co.com"], tmp_path)
+
+        assert result.exit_code == 0
+        assert "Password reset" in result.output
+
+    def test_reset_password_failure(self, tmp_path):
+        """reset-password shows error on failure."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stderr="User not found", exit_code=1)
+        with p1, p2:
+            result = _run(
+                ["auth", "reset-password", "test@co.com"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+    def test_reset_password_email_quoting(self, tmp_path):
+        """reset-password shell-quotes the email."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="Password reset")
+        with p1, p2:
+            _run(["auth", "reset-password", "user+tag@co.com"], tmp_path)
+
+        cmd = ssh.exec_command.call_args[0][0]
+        assert "user+tag@co.com" in cmd
+
+    def test_reset_password_disconnects(self, tmp_path):
+        """SSH is disconnected after reset-password."""
+        _cfg, ssh, p1, p2 = _patch_ssh_success(tmp_path, stdout="done")
+        with p1, p2:
+            _run(["auth", "reset-password", "test@co.com"], tmp_path)
+
+        ssh.disconnect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestRemoteAuthConnectionFailure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteAuthConnectionFailure:
+    def test_add_user_connection_failure(self, tmp_path):
+        """add-user exits when SSH connection fails."""
+        cloud_cfg = _make_cloud_config()
+        ssh = MagicMock()
+        ssh.connect.side_effect = Exception("Connection refused")
+
+        with (
+            patch(_PATCH_LOAD_CFG, return_value=(cloud_cfg, tmp_path)),
+            patch(_PATCH_MAKE_SSH, return_value=ssh),
+        ):
+            result = _run(["auth", "add-user", "test@co.com"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "Cannot connect" in result.output
+
+    def test_list_users_connection_failure(self, tmp_path):
+        """list-users exits when SSH connection fails."""
+        cloud_cfg = _make_cloud_config()
+        ssh = MagicMock()
+        ssh.connect.side_effect = Exception("Timeout")
+
+        with (
+            patch(_PATCH_LOAD_CFG, return_value=(cloud_cfg, tmp_path)),
+            patch(_PATCH_MAKE_SSH, return_value=ssh),
+        ):
+            result = _run(["auth", "list-users"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "Cannot connect" in result.output
+
+    def test_remove_user_connection_failure(self, tmp_path):
+        """remove-user exits when SSH connection fails."""
+        cloud_cfg = _make_cloud_config()
+        ssh = MagicMock()
+        ssh.connect.side_effect = Exception("Host unreachable")
+
+        with (
+            patch(_PATCH_LOAD_CFG, return_value=(cloud_cfg, tmp_path)),
+            patch(_PATCH_MAKE_SSH, return_value=ssh),
+        ):
+            result = _run(["auth", "remove-user", "test@co.com"], tmp_path, catch_exceptions=True)
+
+        assert result.exit_code != 0
+        assert "Cannot connect" in result.output
+
+    def test_reset_password_connection_failure(self, tmp_path):
+        """reset-password exits when SSH connection fails."""
+        cloud_cfg = _make_cloud_config()
+        ssh = MagicMock()
+        ssh.connect.side_effect = Exception("Auth failed")
+
+        with (
+            patch(_PATCH_LOAD_CFG, return_value=(cloud_cfg, tmp_path)),
+            patch(_PATCH_MAKE_SSH, return_value=ssh),
+        ):
+            result = _run(
+                ["auth", "reset-password", "test@co.com"],
+                tmp_path,
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code != 0
+        assert "Cannot connect" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestRemoteAuthHelp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRemoteAuthHelp:
+    def test_auth_group_help(self):
+        """auth group --help lists subcommands."""
+        runner = CliRunner()
+        result = runner.invoke(remote, ["auth", "--help"])
+
+        assert result.exit_code == 0
+        assert "add-user" in result.output
+        assert "list-users" in result.output
+        assert "remove-user" in result.output
+        assert "reset-password" in result.output
+
+    def test_add_user_help(self):
+        """add-user --help shows usage."""
+        runner = CliRunner()
+        result = runner.invoke(remote, ["auth", "add-user", "--help"])
+
+        assert result.exit_code == 0
+        assert "EMAIL" in result.output
+        assert "--role" in result.output


### PR DESCRIPTION
## Summary
- Adds `dango remote auth` subgroup with 4 commands: `add-user`, `list-users`, `remove-user`, `reset-password`
- SSH-proxied execution of `dango auth` on remote server (same pattern as `remote env`/`remote query`/`remote sync`)
- 27 unit tests covering all commands, connection failures, help output, and SSH disconnect guarantees

## Bug
Fixes BUG-236: Cloud user management requires manual SSH

## Files
- `dango/cli/commands/remote_auth.py` — new file (217 lines)
- `dango/cli/commands/remote.py` — +2 lines (import + registration)
- `tests/unit/test_remote_auth_cli.py` — new file (414 lines)

## Test plan
- [x] `pytest tests/unit/test_remote_auth_cli.py -v` — 27/27 pass
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy dango/cli/commands/remote_auth.py` — no errors
- [x] `pytest tests/unit/ -x` — 3471 passed
- [x] Pre-commit hooks pass
- [x] `wc -l remote.py` = 700 (was 698, doc update deferred to R12-M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)