### PR TITLE
R12-I1: Cloud deploy orchestration fixes

### DIFF
--- a/dango/auth/lockout.py
+++ b/dango/auth/lockout.py
@@ -446,3 +446,14 @@ def cleanup_expired_login_attempts(
         return cursor.rowcount
     finally:
         conn.close()
+
+
+def cleanup_login_attempts_job(project_root: str) -> None:
+    """APScheduler-compatible wrapper for periodic login attempt cleanup."""
+    from dango.auth.admin import get_auth_db_path
+
+    auth_db = get_auth_db_path(Path(project_root))
+    if auth_db.exists():
+        deleted = cleanup_expired_login_attempts(auth_db)
+        if deleted:
+            logger.info("periodic_login_attempts_cleaned", count=deleted)

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -24,6 +24,9 @@ import click
 from dango.cli import console
 from dango.cli.commands.deploy_wizard import _EMAIL_RE, BYOSConfig, WizardConfig
 from dango.exceptions import CloudProvisioningError
+from dango.logging import get_logger
+
+_logger = get_logger(__name__)
 
 
 @dataclass
@@ -825,17 +828,13 @@ def _start_services(ssh: Any) -> None:
     ssh.exec_command("systemctl start dango-web", timeout=30)
 
 
-def _health_check(url: str, timeout: int = 30, interval: int = 3) -> bool:
+def _health_check(url: str, timeout: int = 60, interval: int = 5) -> bool:
     """Poll server health endpoint until it responds 200.
 
     Returns:
         True if healthy, False if timeout.
     """
     import httpx
-
-    from dango.logging import get_logger
-
-    _logger = get_logger(__name__)
 
     attempts = timeout // interval
     for _ in range(attempts):
@@ -856,10 +855,6 @@ def _trigger_initial_sync(url: str, deploy_token: str) -> bool:
     """
     import httpx
 
-    from dango.logging import get_logger
-
-    _logger = get_logger(__name__)
-
     try:
         resp = httpx.post(
             f"{url}/api/initial-sync/start",
@@ -870,9 +865,9 @@ def _trigger_initial_sync(url: str, deploy_token: str) -> bool:
             timeout=10,
             verify=False,
         )
-        if resp.status_code == 200:
+        if resp.is_success:
             return True
-        _logger.warning("initial_sync_trigger_non_200", status=resp.status_code)
+        _logger.warning("initial_sync_trigger_failed_status", status=resp.status_code)
         return False
     except Exception:
         _logger.warning("initial_sync_trigger_failed", exc_info=True)

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -277,13 +277,20 @@ def run_provisioning(
             ssh.disconnect()
 
         url = f"https://{config.domain}" if config.domain else f"http://{droplet_ip}"
-        health_ok = _health_check(url)
+        health_ok = _health_check(url, timeout=60, interval=5)
         if not health_ok:
             warnings.append(f"Health check failed. Server may still be starting. Try: {url}")
 
         # Trigger initial sync
         if not config.skip_initial_sync and health_ok:
-            _trigger_initial_sync(url, deploy_token)
+            sync_started = _trigger_initial_sync(url, deploy_token)
+            if sync_started:
+                _status("Initial sync started. Check status at the dashboard.")
+            else:
+                warnings.append(
+                    "Initial sync could not be started automatically. "
+                    "Run 'dango remote sync' manually after deployment."
+                )
 
         return ProvisionResult(
             droplet_ip=droplet_ip,
@@ -428,13 +435,20 @@ def run_byos_setup(
             ssh.disconnect()
 
         url = f"https://{config.domain}" if config.domain else f"http://{config.server_ip}"
-        health_ok = _health_check(url)
+        health_ok = _health_check(url, timeout=60, interval=5)
         if not health_ok:
             warnings.append(f"Health check failed. Server may still be starting. Try: {url}")
 
         # Trigger initial sync
         if not config.skip_initial_sync and health_ok:
-            _trigger_initial_sync(url, deploy_token)
+            sync_started = _trigger_initial_sync(url, deploy_token)
+            if sync_started:
+                _status("Initial sync started. Check status at the dashboard.")
+            else:
+                warnings.append(
+                    "Initial sync could not be started automatically. "
+                    "Run 'dango remote sync' manually after deployment."
+                )
 
         return BYOSResult(
             server_ip=config.server_ip,
@@ -819,6 +833,10 @@ def _health_check(url: str, timeout: int = 30, interval: int = 3) -> bool:
     """
     import httpx
 
+    from dango.logging import get_logger
+
+    _logger = get_logger(__name__)
+
     attempts = timeout // interval
     for _ in range(attempts):
         try:
@@ -826,17 +844,24 @@ def _health_check(url: str, timeout: int = 30, interval: int = 3) -> bool:
             if resp.status_code == 200:
                 return True
         except Exception:
-            pass
+            _logger.debug("health_check_poll_error", url=url)
         time.sleep(interval)
     return False
 
 
-def _trigger_initial_sync(url: str, deploy_token: str) -> None:
-    """POST to /api/initial-sync/start to trigger background sync."""
+def _trigger_initial_sync(url: str, deploy_token: str) -> bool:
+    """POST to /api/initial-sync/start to trigger background sync.
+
+    Returns True if the sync was triggered successfully.
+    """
     import httpx
 
+    from dango.logging import get_logger
+
+    _logger = get_logger(__name__)
+
     try:
-        httpx.post(
+        resp = httpx.post(
             f"{url}/api/initial-sync/start",
             headers={
                 "X-Requested-With": "XMLHttpRequest",
@@ -845,5 +870,10 @@ def _trigger_initial_sync(url: str, deploy_token: str) -> None:
             timeout=10,
             verify=False,
         )
+        if resp.status_code == 200:
+            return True
+        _logger.warning("initial_sync_trigger_non_200", status=resp.status_code)
+        return False
     except Exception:
-        pass  # Non-critical — user can trigger from dashboard
+        _logger.warning("initial_sync_trigger_failed", exc_info=True)
+        return False

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -21,6 +21,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from dango.exceptions import CloudProvisioningError
+from dango.logging import get_logger
+
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from dango.platform.cloud.backup import BackupResult
@@ -365,11 +368,11 @@ def _write_deploy_journal(
     try:
         write_local_journal(local_project_root, record)
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug("deploy_journal_local_write_failed", exc_info=True)
     try:
         write_remote_journal(ssh, record)
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug("deploy_journal_remote_write_failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -580,7 +583,7 @@ def push_deploy(
                     duration_seconds=round(time.monotonic() - start_time, 1),
                 )
             except Exception:  # noqa: BLE001
-                pass
+                logger.debug("deploy_journal_write_failed", exc_info=True)
 
     return DeployResult(
         sync_result=sync_result,

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -122,6 +122,7 @@ class SchedulerService:
         self._on_retry_callbacks.append(self._on_retry_event)
 
         self._setup_history_cleanup()
+        self._setup_login_attempts_cleanup()
         self._log_startup_summary()
         self._check_dual_scheduler()
 
@@ -391,6 +392,22 @@ class SchedulerService:
             )
         except Exception:  # noqa: BLE001
             logger.debug("history_cleanup_setup_failed", exc_info=True)
+
+    def _setup_login_attempts_cleanup(self) -> None:
+        """Register periodic login attempt cleanup (every 6 hours)."""
+        try:
+            from dango.auth.lockout import cleanup_login_attempts_job
+
+            self._scheduler.add_job(
+                cleanup_login_attempts_job,
+                "interval",
+                hours=6,
+                args=[str(self._project_root)],
+                id="dango-internal:login-attempts-cleanup",
+                replace_existing=True,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("login_attempts_cleanup_setup_failed", exc_info=True)
 
     def _log_missed_recovery(self) -> None:
         """Log count of missed jobs that will be recovered on startup."""

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -447,7 +447,7 @@ def wait_for_metabase_ready(metabase_url: str = "http://localhost:3000", timeout
             if response.status_code == 200:
                 return True
         except Exception:
-            pass
+            logger.debug("metabase_health_poll_error", exc_info=True)
         time.sleep(2)
     return False
 
@@ -574,10 +574,11 @@ def setup_metabase(
         summary["errors"].append("Metabase already configured (credentials file exists)")
         return summary
 
-    # Wait for Metabase to be ready
+    # Wait for Metabase to be ready (longer timeout for cloud cold start)
+    ready_timeout = 300 if cloud_mode else 60
     print("  ⏳ Waiting for Metabase to be ready...")
-    if not wait_for_metabase_ready(metabase_url):
-        summary["errors"].append("Metabase not ready after 60 seconds")
+    if not wait_for_metabase_ready(metabase_url, timeout=ready_timeout):
+        summary["errors"].append(f"Metabase not ready after {ready_timeout} seconds")
         return summary
 
     print("  ✓ Metabase is ready")

--- a/tests/unit/test_auth_lockout.py
+++ b/tests/unit/test_auth_lockout.py
@@ -583,3 +583,37 @@ class TestIPBasedLockout:
         # Verify entry is gone
         row = _get_login_attempt_row(db_path, key)
         assert row is None
+
+    def test_cleanup_login_attempts_job(self, tmp_path: Path) -> None:
+        """cleanup_login_attempts_job wrapper works end-to-end."""
+        from dango.auth.lockout import _make_attempt_key, cleanup_login_attempts_job
+
+        # Create auth.db in the expected .dango/ subdirectory
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        db_path = _make_db(dango_dir)
+        # _make_db creates at dango_dir/auth.db — move to .dango/auth.db
+        # Actually _make_db(dango_dir) already creates dango_dir/auth.db
+        # but get_auth_db_path expects tmp_path/.dango/auth.db
+        # Since dango_dir IS tmp_path/.dango, pass tmp_path as project_root
+
+        key = _make_attempt_key("1.2.3.4", "old@example.com")
+
+        # Insert an old entry (48 hours ago)
+        old_time = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+        conn = _connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO login_attempts (key, email, attempts, locked_until, updated_at) VALUES (?, ?, ?, ?, ?)",
+                (key, "old@example.com", 3, None, old_time),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Call the scheduler-compatible wrapper
+        cleanup_login_attempts_job(str(tmp_path))
+
+        # Verify entry is gone
+        row = _get_login_attempt_row(db_path, key)
+        assert row is None

--- a/tests/unit/test_auth_lockout.py
+++ b/tests/unit/test_auth_lockout.py
@@ -588,14 +588,10 @@ class TestIPBasedLockout:
         """cleanup_login_attempts_job wrapper works end-to-end."""
         from dango.auth.lockout import _make_attempt_key, cleanup_login_attempts_job
 
-        # Create auth.db in the expected .dango/ subdirectory
+        # _make_db(dango_dir) creates .dango/auth.db — matches get_auth_db_path(tmp_path)
         dango_dir = tmp_path / ".dango"
         dango_dir.mkdir()
         db_path = _make_db(dango_dir)
-        # _make_db creates at dango_dir/auth.db — move to .dango/auth.db
-        # Actually _make_db(dango_dir) already creates dango_dir/auth.db
-        # but get_auth_db_path expects tmp_path/.dango/auth.db
-        # Since dango_dir IS tmp_path/.dango, pass tmp_path as project_root
 
         key = _make_attempt_key("1.2.3.4", "old@example.com")
 

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -524,21 +524,38 @@ class TestSaveExtraMetadata:
 @pytest.mark.unit
 class TestTriggerInitialSync:
     @patch("httpx.post")
-    def test_posts_with_token(self, mock_post):
-        """Trigger sends POST with deploy token."""
-        _trigger_initial_sync("http://1.2.3.4", "test-token-123")
+    def test_posts_with_token_returns_true(self, mock_post):
+        """Trigger sends POST with deploy token and returns True on 200."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_post.return_value = mock_resp
 
+        result = _trigger_initial_sync("http://1.2.3.4", "test-token-123")
+
+        assert result is True
         mock_post.assert_called_once()
         call_kwargs = mock_post.call_args
         assert call_kwargs[0][0] == "http://1.2.3.4/api/initial-sync/start"
         headers = call_kwargs[1]["headers"]
         assert headers["Authorization"] == "Bearer test-token-123"
 
+    @patch("httpx.post")
+    def test_non_200_returns_false(self, mock_post):
+        """Trigger returns False on non-200 response."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_post.return_value = mock_resp
+
+        result = _trigger_initial_sync("http://1.2.3.4", "test-token-123")
+
+        assert result is False
+
     @patch("httpx.post", side_effect=ConnectionError("refused"))
-    def test_swallows_errors(self, mock_post):
-        """Trigger does not raise on connection failure."""
-        # Should not raise
-        _trigger_initial_sync("http://1.2.3.4", "test-token-123")
+    def test_connection_error_returns_false(self, mock_post):
+        """Trigger returns False on connection failure (does not raise)."""
+        result = _trigger_initial_sync("http://1.2.3.4", "test-token-123")
+
+        assert result is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -525,9 +525,9 @@ class TestSaveExtraMetadata:
 class TestTriggerInitialSync:
     @patch("httpx.post")
     def test_posts_with_token_returns_true(self, mock_post):
-        """Trigger sends POST with deploy token and returns True on 200."""
+        """Trigger sends POST with deploy token and returns True on success."""
         mock_resp = MagicMock()
-        mock_resp.status_code = 200
+        mock_resp.is_success = True
         mock_post.return_value = mock_resp
 
         result = _trigger_initial_sync("http://1.2.3.4", "test-token-123")
@@ -540,9 +540,10 @@ class TestTriggerInitialSync:
         assert headers["Authorization"] == "Bearer test-token-123"
 
     @patch("httpx.post")
-    def test_non_200_returns_false(self, mock_post):
-        """Trigger returns False on non-200 response."""
+    def test_non_success_returns_false(self, mock_post):
+        """Trigger returns False on non-success response."""
         mock_resp = MagicMock()
+        mock_resp.is_success = False
         mock_resp.status_code = 500
         mock_post.return_value = mock_resp
 

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -386,6 +386,18 @@ class TestSchedulerServiceHistoryIntegration:
         assert call_kwargs[1]["id"] == "dango-internal:history-cleanup"
         assert call_kwargs[1]["hours"] == 24
 
+    def test_setup_login_attempts_cleanup_registers_job(self, tmp_path):
+        """_setup_login_attempts_cleanup should register a 6-hourly cleanup job."""
+        svc = _make_service(tmp_path)
+        svc._project_root = tmp_path
+
+        svc._setup_login_attempts_cleanup()
+
+        svc._scheduler.add_job.assert_called_once()
+        call_kwargs = svc._scheduler.add_job.call_args
+        assert call_kwargs[1]["id"] == "dango-internal:login-attempts-cleanup"
+        assert call_kwargs[1]["hours"] == 6
+
 
 @pytest.mark.unit
 class TestSchedulerServiceCoroutineBridge:


### PR DESCRIPTION
## Summary

- **BUG-244:** `_trigger_initial_sync()` now returns `bool` and logs failures instead of fire-and-forget. Both DO and BYOS call sites show user feedback ("Initial sync started" or warning to run manually).
- **BUG-245:** Cloud deploy health check increased to 60s/5s interval (from 30s/3s). `setup_metabase()` uses 300s timeout in `cloud_mode` (was 60s) for cold Java startup on cloud VMs.
- **Except-pass audit:** Added debug logging to 4 silent `except Exception: pass` blocks in `deploy_provision.py` (`_health_check`), `deployer.py` (3 journal write blocks), and `metabase.py` (health poll).
- **Periodic cleanup:** Added `cleanup_login_attempts_job()` to `lockout.py` and registered as 6-hourly scheduler job in `scheduler.py` (follows `cleanup_history_job` pattern).

## Line count changes

| File | Before | After | Status |
|------|--------|-------|--------|
| `cli/commands/deploy_provision.py` | 849 | 879 | Exempted |
| `visualization/metabase.py` | 1151 | 1152 | Exempted |
| `platform/cloud/deployer.py` | 595 | 598 | Exempted |
| `platform/scheduling/scheduler.py` | 448 | 465 | Under 500 |
| `auth/lockout.py` | 448 | 459 | Under 500 |

## Test plan

- [x] `test_deploy_provision.py` — updated `TestTriggerInitialSync` (returns True/False), added non-200 test
- [x] `test_scheduler.py` — added `test_setup_login_attempts_cleanup_registers_job`
- [x] `test_auth_lockout.py` — added `test_cleanup_login_attempts_job` (end-to-end with real DB)
- [x] All 3447 unit tests pass
- [x] ruff check + format + mypy clean
- [x] Static validation scripts pass (file sizes, version alignment, JS null guards)
- [ ] Fresh VM deploy verification (BUG-239 admin login, BUG-244 sync status message, BUG-245 Metabase 300s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)