### PR TITLE
R12-G: CLI polish — fix 9 UX bugs

### DIFF
--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -64,27 +64,41 @@ def model_add(ctx: click.Context) -> None:
         raise click.Abort() from e
 
 
+_VALID_MODEL_NAME_RE = __import__("re").compile(r"^[a-z][a-z0-9_]*$")
+_VALID_LAYERS = ("intermediate", "marts")
+
+
 @model.command("remove")
 @click.argument("model_name")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@click.option("--dry-run", is_flag=True, help="Show what would be removed without executing")
 @click.pass_context
-def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
+def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) -> None:
     """
-    Remove a custom dbt model.
+    Remove a custom dbt model and cascade cleanup.
 
-    Deletes the model SQL file. Does NOT drop the table from DuckDB -
-    run 'dbt run' to rebuild without the removed model, or manually
-    drop the table.
+    Removes the model SQL file, schema.yml entry, monitors.yml references,
+    and optionally drops the DuckDB table and refreshes Metabase schema.
 
     Examples:
       dango model remove fct_daily_sales
       dango model remove int_orders --yes
+      dango model remove fct_daily_sales --dry-run
     """
+    import duckdb
     from rich.prompt import Confirm
 
     from ..utils import require_project_context
 
     console.print(f"🍡 [bold]Removing Model: {model_name}[/bold]\n")
+
+    # Validate model_name to prevent injection in SQL/filesystem
+    if not _VALID_MODEL_NAME_RE.match(model_name):
+        console.print(
+            "[red]Error:[/red] Invalid model name. "
+            "Must be lowercase, start with a letter, and contain only letters, digits, underscores."
+        )
+        raise click.Abort()
 
     try:
         project_root = require_project_context(ctx)
@@ -94,7 +108,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
         model_file = None
         layer = None
 
-        for layer_name in ["intermediate", "marts"]:
+        for layer_name in _VALID_LAYERS:
             potential_path = dbt_dir / layer_name / f"{model_name}.sql"
             if potential_path.exists():
                 model_file = potential_path
@@ -113,19 +127,20 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
         console.print(f"  File: {model_file.relative_to(project_root)}")
         console.print()
 
-        # Check if table exists in DuckDB
-        import duckdb
-
+        # Check if table exists in DuckDB (read-only connection)
         duckdb_path = project_root / "data" / "warehouse.duckdb"
         table_exists = False
 
         if duckdb_path.exists():
             try:
-                conn = duckdb.connect(str(duckdb_path))
-                result = conn.execute(f"""
+                conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
+                result = conn.execute(
+                    """
                     SELECT COUNT(*) FROM information_schema.tables
-                    WHERE table_schema = '{layer}' AND table_name = '{model_name}'
-                """).fetchone()
+                    WHERE table_schema = ? AND table_name = ?
+                    """,
+                    [layer, model_name],
+                ).fetchone()
                 table_exists = (result[0] > 0) if result else False
                 conn.close()
             except Exception:
@@ -133,7 +148,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
 
         # Check for downstream dependencies
         downstream_models = []
-        for layer_to_check in ["intermediate", "marts"]:
+        for layer_to_check in _VALID_LAYERS:
             layer_dir = dbt_dir / layer_to_check
             if layer_dir.exists():
                 for sql_file in layer_dir.glob("*.sql"):
@@ -148,6 +163,39 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
                                 downstream_models.append(f"{layer_to_check}.{sql_file.stem}")
                         except Exception:
                             pass
+
+        # Check monitors.yml for references
+        monitor_refs: list[str] = []
+        try:
+            from dango.analysis.config import load_monitors_config
+
+            monitors_cfg = load_monitors_config(project_root)
+            for m in monitors_cfg.monitors:
+                # source_table is "layer.table_name", check if model_name matches
+                if m.source_table.endswith(f".{model_name}"):
+                    monitor_refs.append(m.name)
+        except Exception:
+            pass
+
+        # Dry run: show what would be removed and exit
+        if dry_run:
+            console.print("[bold cyan]Dry run — no changes will be made[/bold cyan]\n")
+            console.print("[bold]Would remove:[/bold]")
+            console.print(f"  • Model file: {model_file.relative_to(project_root)}")
+            assert layer is not None
+            schema_path = dbt_dir / layer / "schema.yml"
+            if schema_path.exists():
+                console.print(f"  • schema.yml entry in {schema_path.relative_to(project_root)}")
+            if monitor_refs:
+                console.print(f"  • Monitor references: {', '.join(monitor_refs)}")
+            if table_exists:
+                console.print(f"  • DuckDB table: {layer}.{model_name}")
+            if downstream_models:
+                console.print("\n[yellow]⚠️  Downstream models that would break:[/yellow]")
+                for dep in downstream_models:
+                    console.print(f"    • {dep}")
+            console.print()
+            return
 
         # Warn about dependencies
         if downstream_models:
@@ -219,15 +267,38 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
             except Exception:
                 pass  # Non-critical — don't block removal
 
+        # Remove monitor references from monitors.yml
+        if monitor_refs:
+            try:
+                from dango.analysis.config import load_monitors_config, save_monitors_config
+
+                monitors_cfg = load_monitors_config(project_root)
+                original_count = len(monitors_cfg.monitors)
+                monitors_cfg.monitors = [
+                    m for m in monitors_cfg.monitors if m.name not in monitor_refs
+                ]
+                if len(monitors_cfg.monitors) < original_count:
+                    save_monitors_config(project_root, monitors_cfg)
+                    removed_count = original_count - len(monitors_cfg.monitors)
+                    console.print(
+                        f"[green]✓[/green] Removed {removed_count} monitor(s) from monitors.yml"
+                    )
+            except Exception:
+                pass  # Non-critical
+
         # Handle table deletion if it exists
+        dropped_table = False
         if table_exists:
             console.print()
-            if Confirm.ask(f"Also drop the table from DuckDB ({layer}.{model_name})?"):
+            if yes or Confirm.ask(f"Also drop the table from DuckDB ({layer}.{model_name})?"):
                 try:
+                    # layer and model_name are validated: layer from _VALID_LAYERS,
+                    # model_name matches _VALID_MODEL_NAME_RE — safe to interpolate
                     conn = duckdb.connect(str(duckdb_path))
-                    conn.execute(f"DROP TABLE IF EXISTS {layer}.{model_name}")
+                    conn.execute(f'DROP TABLE IF EXISTS "{layer}"."{model_name}"')
                     conn.close()
                     console.print(f"[green]✓[/green] Dropped table: {layer}.{model_name}")
+                    dropped_table = True
                 except Exception as e:
                     console.print(f"[red]✗[/red] Failed to drop table: {e}")
                     from dango.exceptions import is_debug_mode
@@ -244,9 +315,21 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool) -> None:
                     "[dim]    Run 'cd dbt && dbt run' to rebuild project without this model[/dim]"
                 )
 
+        # Refresh Metabase schema if table was dropped
+        if dropped_table:
+            try:
+                from dango.visualization.metabase import sync_metabase_schema
+
+                if sync_metabase_schema(project_root):
+                    console.print("[green]✓[/green] Metabase schema refreshed")
+            except Exception:
+                pass  # Non-critical — Metabase may not be running
+
         console.print()
         console.print(f"[green]✅ Model '{model_name}' removed successfully[/green]")
 
+    except click.Abort:
+        raise
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         from dango.exceptions import is_debug_mode

--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -275,15 +275,16 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
         if monitor_refs:
             try:
                 from dango.analysis.config import load_monitors_config, save_monitors_config
+                from dango.analysis.models import MonitorsConfig
 
                 monitors_cfg = load_monitors_config(project_root)
                 original_count = len(monitors_cfg.monitors)
-                monitors_cfg.monitors = [
-                    m for m in monitors_cfg.monitors if m.name not in monitor_refs
-                ]
-                if len(monitors_cfg.monitors) < original_count:
-                    save_monitors_config(project_root, monitors_cfg)
-                    removed_count = original_count - len(monitors_cfg.monitors)
+                filtered = [m for m in monitors_cfg.monitors if m.name not in monitor_refs]
+                if len(filtered) < original_count:
+                    # MonitorsConfig is frozen — create a new instance
+                    updated = MonitorsConfig(monitors=filtered)
+                    save_monitors_config(project_root, updated)
+                    removed_count = original_count - len(filtered)
                     console.print(
                         f"[green]✓[/green] Removed {removed_count} monitor(s) from monitors.yml"
                     )

--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -3,6 +3,8 @@
 dbt model management commands (add, remove).
 """
 
+import re
+
 import click
 
 from dango.cli import console
@@ -64,7 +66,7 @@ def model_add(ctx: click.Context) -> None:
         raise click.Abort() from e
 
 
-_VALID_MODEL_NAME_RE = __import__("re").compile(r"^[a-z][a-z0-9_]*$")
+_VALID_MODEL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 _VALID_LAYERS = ("intermediate", "marts")
 
 
@@ -179,10 +181,11 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
 
         # Dry run: show what would be removed and exit
         if dry_run:
+            if layer is None:
+                raise click.Abort()  # unreachable — defensive guard
             console.print("[bold cyan]Dry run — no changes will be made[/bold cyan]\n")
             console.print("[bold]Would remove:[/bold]")
             console.print(f"  • Model file: {model_file.relative_to(project_root)}")
-            assert layer is not None
             schema_path = dbt_dir / layer / "schema.yml"
             if schema_path.exists():
                 console.print(f"  • schema.yml entry in {schema_path.relative_to(project_root)}")
@@ -236,8 +239,9 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
             f"[green]✓[/green] Deleted model file: {model_file.relative_to(project_root)}"
         )
 
-        # Remove model entry from schema.yml
-        assert layer is not None  # guaranteed by model_file check above
+        # Remove model entry from schema.yml (layer guaranteed set by model_file check)
+        if layer is None:
+            raise click.Abort()  # unreachable — defensive guard
         schema_path = dbt_dir / layer / "schema.yml"
         if schema_path.exists():
             import yaml

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -530,19 +530,29 @@ def schedule_add(ctx: click.Context) -> None:
     schedules = data.setdefault("schedules", [])
     existing_names = {s.get("name") for s in schedules}
 
-    # 1. Name
-    answers = inquirer.prompt(
-        [
-            inquirer.Text(
-                "name",
-                message="Schedule name (lowercase, alphanumeric + underscore)",
-                validate=lambda _, x: bool(_SLUG_RE.match(x)) and x not in existing_names,
-            ),
-        ]
-    )
-    if answers is None:
-        return
-    name: str = answers["name"]
+    # 1. Name (validate after prompt to avoid per-keystroke flicker)
+    while True:
+        answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    "name",
+                    message="Schedule name (lowercase, alphanumeric + underscore)",
+                ),
+            ]
+        )
+        if answers is None:
+            return
+        name: str = answers["name"]
+        if not _SLUG_RE.match(name):
+            console.print(
+                "[red]Invalid name.[/red] Must be lowercase, start with a letter, "
+                "and contain only letters, digits, and underscores."
+            )
+            continue
+        if name in existing_names:
+            console.print(f"[red]Name '{name}' already exists.[/red] Choose a different name.")
+            continue
+        break
 
     # 2. Type (BUG-037: friendly labels, default to sync)
     type_labels = [label for label, _ in _TYPE_CHOICES]
@@ -568,12 +578,22 @@ def schedule_add(ctx: click.Context) -> None:
             sources = [available[0]]
             console.print(f"[green]Auto-selected source: {available[0]}[/green]")
         elif available:
-            answers = inquirer.prompt(
-                [inquirer.Checkbox("sources", message="Select sources to sync", choices=available)]
-            )
-            if answers is None:
-                return
-            sources = answers["sources"]
+            while True:
+                answers = inquirer.prompt(
+                    [
+                        inquirer.Checkbox(
+                            "sources",
+                            message="Select sources to sync (SPACE to toggle, ENTER to confirm)",
+                            choices=available,
+                        )
+                    ]
+                )
+                if answers is None:
+                    return
+                sources = answers["sources"]
+                if sources:
+                    break
+                console.print("[red]Please select at least one source.[/red]")
         if not sources:
             console.print("[red]Error:[/red] Sync schedules require at least one source.")
             return

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -118,10 +118,20 @@ def source_add(ctx: click.Context) -> None:
 
 
 @source.command("edit")
+@click.argument("name", required=False)
 @click.pass_context
-def source_edit(ctx: click.Context) -> None:
-    """Open sources.yml in your default editor ($EDITOR)."""
+def source_edit(ctx: click.Context, name: str | None) -> None:
+    """Open sources.yml in your default editor ($EDITOR).
+
+    Optionally specify a source NAME to focus on that section.
+
+    Examples:
+      dango source edit            Edit full sources.yml
+      dango source edit chess      Edit sources.yml (hints at chess section)
+    """
     from pathlib import Path
+
+    import yaml
 
     project_root = ctx.obj.get("project_root")
     if not project_root:
@@ -134,10 +144,36 @@ def source_edit(ctx: click.Context) -> None:
         console.print("[dim]Run 'dango source add' first[/dim]")
         return
 
+    # If a name is given, validate it exists
+    if name:
+        try:
+            data = yaml.safe_load(sources_file.read_text()) or {}
+            source_names = [s.get("name") for s in data.get("sources", [])]
+            if name not in source_names:
+                console.print(f"[red]Error:[/red] Source '{name}' not found")
+                if source_names:
+                    console.print(f"[dim]Available sources: {', '.join(source_names)}[/dim]")
+                return
+        except Exception:
+            pass  # Fall through to editor
+
     original = sources_file.read_text()
     edited = click.edit(original, extension=".yml")
 
     if edited is None:
+        if name:
+            console.print("[yellow]No editor available.[/yellow]")
+            # Print just the named source section
+            try:
+                data = yaml.safe_load(original) or {}
+                for src in data.get("sources", []):
+                    if src.get("name") == name:
+                        console.print(f"\n[bold]Source '{name}':[/bold]")
+                        console.print(yaml.dump({"sources": [src]}, default_flow_style=False))
+                        console.print(f"[dim]File: {sources_file}[/dim]")
+                        return
+            except Exception:
+                pass
         console.print("[yellow]No editor or no changes.[/yellow]")
         console.print(f"[dim]Edit manually: {sources_file}[/dim]")
         return
@@ -147,8 +183,6 @@ def source_edit(ctx: click.Context) -> None:
         return
 
     # Validate YAML syntax
-    import yaml
-
     try:
         yaml.safe_load(edited)
     except yaml.YAMLError as e:
@@ -158,6 +192,9 @@ def source_edit(ctx: click.Context) -> None:
 
     sources_file.write_text(edited)
     console.print("[green]sources.yml updated[/green]")
+
+    if name:
+        console.print(f"[dim]Hint: Look for the '{name}:' section[/dim]")
 
 
 @source.command("list")
@@ -527,7 +564,10 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 
 
 @click.command()
-@click.option("--source", help="Sync specific source only")
+@click.argument("source_name", required=False, default=None)
+@click.option(
+    "--source", "source_option", help="Sync specific source (deprecated, use positional arg)"
+)
 @click.option("--since", help="Start date for incremental loading (YYYY-MM-DD)")
 @click.option("--until", help="End date for incremental loading (YYYY-MM-DD)")
 @click.option("--backfill", help="Backfill duration (e.g. '7d', '2w', '1m')")
@@ -543,7 +583,8 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 @click.pass_context
 def sync(
     ctx: click.Context,
-    source: str | None,
+    source_name: str | None,
+    source_option: str | None,
     since: str | None,
     until: str | None,
     backfill: str | None,
@@ -558,7 +599,8 @@ def sync(
 
     Examples:
       dango sync                               Sync all enabled sources
-      dango sync --source orders               Sync only 'orders' source
+      dango sync chess                         Sync only 'chess' source
+      dango sync --source orders               Sync only 'orders' (deprecated form)
       dango sync --since 2024-01-01            Override start date
       dango sync --backfill 30d                Backfill last 30 days
       dango sync --limit 1000                  Dev mode: limit rows per source
@@ -577,6 +619,9 @@ def sync(
     from dango.utils import DbtLock, DbtLockError
 
     from ..utils import require_project_context
+
+    # Resolve source: positional arg takes precedence over --source option
+    source = source_name or source_option
 
     console.print("🍡 [bold]Syncing data...[/bold]")
     console.print()

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -148,7 +148,7 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
     if name:
         try:
             data = yaml.safe_load(sources_file.read_text()) or {}
-            source_names = [s.get("name") for s in data.get("sources", [])]
+            source_names = [s.get("name") for s in data.get("sources", []) if s.get("name")]
             if name not in source_names:
                 console.print(f"[red]Error:[/red] Source '{name}' not found")
                 if source_names:
@@ -162,7 +162,7 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
 
     if edited is None:
         if name:
-            console.print("[yellow]No editor available.[/yellow]")
+            console.print("[yellow]No editor or no changes.[/yellow]")
             # Print just the named source section
             try:
                 data = yaml.safe_load(original) or {}
@@ -194,7 +194,7 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
     console.print("[green]sources.yml updated[/green]")
 
     if name:
-        console.print(f"[dim]Hint: Look for the '{name}:' section[/dim]")
+        console.print(f"[dim]Hint: Look for 'name: {name}' in the sources list[/dim]")
 
 
 @source.command("list")
@@ -621,6 +621,8 @@ def sync(
     from ..utils import require_project_context
 
     # Resolve source: positional arg takes precedence over --source option
+    if source_option and not source_name:
+        console.print("[yellow]Note:[/yellow] --source is deprecated, use: dango sync <name>")
     source = source_name or source_option
 
     console.print("🍡 [bold]Syncing data...[/bold]")

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -786,8 +786,12 @@ def sync(
                     console.print(
                         f"    Module: {src.dlt_native.source_module if src.dlt_native else 'N/A'}"
                     )
-                elif src.dlt_config:
-                    console.print(f"    dlt source: {src.dlt_config.source_name}")
+                else:
+                    from dango.ingestion.sources.registry import get_source_metadata
+
+                    meta = get_source_metadata(src.type.value)
+                    if meta:
+                        console.print(f"    dlt source: {meta.get('dlt_package', src.type.value)}")
 
             console.print()
             console.print("[dim]Options:[/dim]")

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -779,7 +779,7 @@ async def get_source_status_data(source: dict) -> SourceStatus:
     tables_info = await asyncio.to_thread(get_source_tables_info, source_name)
     last_sync = await asyncio.to_thread(get_last_sync_time, source_name)
     last_sync_status = await asyncio.to_thread(get_last_sync_status, source_name)
-    history = await asyncio.to_thread(load_sync_history, source_name, 1)
+    history = await asyncio.to_thread(load_sync_history, source_name, 5)
     freshness = await asyncio.to_thread(get_source_freshness, source_name)
 
     # Extract row count and tables list
@@ -822,9 +822,26 @@ async def get_source_status_data(source: dict) -> SourceStatus:
     supports_incremental = capabilities.get("incremental", True) if capabilities else True
     supports_date_range = capabilities.get("date_range", False) if capabilities else False
 
-    # Derive sync mode and lookback from capabilities + config
-    sync_mode = "incremental" if supports_incremental else "full_refresh"
-    write_disposition = "merge" if supports_incremental else "replace"
+    # Derive sync mode from actual sync history, then fall back to registry.
+    # Registry `incremental` flag is often wrong (e.g., chess says False but
+    # actually uses incremental cursors).  Sync history records the real
+    # `full_refresh` boolean set by _detect_write_disposition() at runtime.
+    sync_mode_from_history: str | None = None
+    if history:
+        # Check if the most recent successful sync was incremental or full refresh
+        for entry in history:
+            if entry.get("status") == "success":
+                if entry.get("full_refresh", False):
+                    sync_mode_from_history = "full_refresh"
+                else:
+                    sync_mode_from_history = "incremental"
+                break
+
+    if sync_mode_from_history is not None:
+        sync_mode = sync_mode_from_history
+    else:
+        sync_mode = "incremental" if supports_incremental else "full_refresh"
+    write_disposition = "replace" if sync_mode == "full_refresh" else "merge"
 
     lookback_days = source.get("lookback_days")
     if lookback_days is None:

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -150,12 +150,24 @@ async def get_source_details(source_name: str) -> dict[str, object]:
     if tables_info and tables_info.get("has_multiple_tables"):
         tables = [TableInfo(**t) for t in tables_info["tables"]]
 
-    # Derive sync mode and lookback
+    # Derive sync mode from actual history, then fall back to registry
     from dango.ingestion.sources.registry import get_source_capabilities, get_source_metadata
 
     capabilities = get_source_capabilities(source_config.get("type", ""))
     supports_incremental = capabilities.get("incremental", True) if capabilities else True
-    sync_mode = "incremental" if supports_incremental else "full_refresh"
+
+    sync_mode_from_history: str | None = None
+    for entry in history:
+        if entry.get("status") == "success":
+            sync_mode_from_history = (
+                "full_refresh" if entry.get("full_refresh", False) else "incremental"
+            )
+            break
+    sync_mode = (
+        sync_mode_from_history
+        if sync_mode_from_history is not None
+        else ("incremental" if supports_incremental else "full_refresh")
+    )
 
     lookback_days = source_config.get("lookback_days")
     if lookback_days is None:

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -3,10 +3,13 @@
 UI page endpoints and API documentation.
 """
 
+import base64
 import hashlib
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+import yaml
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, Response
 from fastapi.templating import Jinja2Templates
@@ -198,9 +201,32 @@ async def insights_redirect() -> RedirectResponse:
 
 
 @router.get("/query")
-async def query_redirect() -> RedirectResponse:
-    """Redirect /query to Metabase query builder."""
-    return RedirectResponse(url="/metabase/question/new", status_code=301)
+async def query_redirect(request: Request) -> RedirectResponse:
+    """Redirect /query to Metabase native SQL editor with database pre-selected."""
+    try:
+        project_root = Path(request.app.state.project_root)
+        metabase_yml = project_root / ".dango" / "metabase.yml"
+        if metabase_yml.exists():
+            metabase_config = yaml.safe_load(metabase_yml.read_text(encoding="utf-8"))
+            database_id = (metabase_config or {}).get("database", {}).get("id")
+            if database_id:
+                query_state = json.dumps(
+                    {
+                        "dataset_query": {
+                            "database": database_id,
+                            "type": "native",
+                            "native": {"query": "", "template-tags": {}},
+                        },
+                        "display": "table",
+                        "visualization_settings": {},
+                        "type": "question",
+                    }
+                )
+                encoded = base64.b64encode(query_state.encode()).decode()
+                return RedirectResponse(url=f"/metabase/question#{encoded}", status_code=302)
+    except Exception:
+        pass  # Fall through to generic redirect
+    return RedirectResponse(url="/metabase/", status_code=302)
 
 
 @router.get("/api")

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1207,24 +1207,47 @@ function renderSourcesTable() {
             : 'Click to view details';
 
         // Action column: sync button for editors/admins, dash for viewers
-        const actionColumn = canSync ? `
-                <div class="relative inline-block text-left" id="sync-menu-${source.name}">
+        let actionColumn;
+        if (!canSync) {
+            actionColumn = '<span class="inline-block w-full text-center text-gray-300">—</span>';
+        } else if (isFileSource) {
+            // File sources: single "Sync Now" button, no dropdown
+            actionColumn = `
+                <button
+                    onclick="event.stopPropagation(); triggerSync('${source.name}')"
+                    class="text-blue-600 hover:text-blue-900 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors duration-150"
+                    id="sync-btn-${source.name}"
+                    ${buttonDisabled}
+                >
+                    ${buttonText}
+                </button>`;
+        } else {
+            // API sources: split button — main click syncs, chevron opens dropdown
+            actionColumn = `
+                <div class="relative inline-flex" id="sync-menu-${source.name}">
                     <button
-                        onclick="event.stopPropagation(); toggleSyncMenu('${source.name}')"
-                        class="text-blue-600 hover:text-blue-900 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors duration-150"
+                        onclick="event.stopPropagation(); triggerSync('${source.name}')"
+                        class="text-blue-600 hover:text-blue-900 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors duration-150 rounded-l-md"
                         id="sync-btn-${source.name}"
                         ${buttonDisabled}
                     >
-                        ${buttonText} ▾
+                        ${buttonText}
+                    </button>
+                    <button
+                        onclick="event.stopPropagation(); toggleSyncMenu('${source.name}')"
+                        class="text-blue-600 hover:text-blue-900 disabled:text-gray-400 disabled:cursor-not-allowed transition-colors duration-150 border-l border-blue-300 pl-1 ml-1 rounded-r-md"
+                        ${buttonDisabled}
+                    >
+                        ▾
                     </button>
                     <div id="sync-dropdown-${source.name}" class="hidden fixed w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
                         <div class="py-1">
-                            <a href="#" onclick="event.preventDefault(); event.stopPropagation(); closeSyncMenus(); triggerSync('${source.name}')" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">${isFileSource ? 'Sync Now' : (source.supports_incremental ? 'Incremental Sync' : 'Sync Now')}</a>
-                            ${isFileSource ? '' : `<a href="#" onclick="event.preventDefault(); event.stopPropagation(); closeSyncMenus(); triggerFullRefresh('${source.name}')" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Full Refresh</a>
-                            ${source.supports_date_range ? `<a href="#" onclick="event.preventDefault(); event.stopPropagation(); closeSyncMenus(); openDateRangeModal('${source.name}')" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Custom Date Range...</a>` : ''}`}
+                            <a href="#" onclick="event.preventDefault(); event.stopPropagation(); closeSyncMenus(); triggerFullRefresh('${source.name}')" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Full Refresh</a>
+                            ${source.supports_date_range ? `<a href="#" onclick="event.preventDefault(); event.stopPropagation(); closeSyncMenus(); openDateRangeModal('${source.name}')" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Custom Date Range...</a>` : ''}
                         </div>
                     </div>
-                </div>` : '<span class="inline-block w-full text-center text-gray-300">—</span>';
+                </div>`;
+        }
 
         return `
         <tr id="source-${source.name}" class="hover:bg-gray-50 transition-colors duration-150">
@@ -2163,11 +2186,11 @@ async function openSyncHistory(sourceName) {
                     ? 'bg-green-100 text-green-800'
                     : 'bg-red-100 text-red-800';
                 const statusLabel = entry.status === 'success' ? 'OK' : 'Fail';
-                const duration = entry.duration != null ? entry.duration.toFixed(1) + 's' : '-';
-                const rows = entry.row_count != null ? entry.row_count.toLocaleString() : '-';
+                const duration = entry.duration_seconds != null ? entry.duration_seconds.toFixed(1) + 's' : '-';
+                const rows = entry.rows_processed != null ? entry.rows_processed.toLocaleString() : '-';
                 const time = formatRelativeTime(entry.timestamp);
                 return `<tr class="border-t border-gray-100">
-                    <td class="px-4 py-2 text-sm text-gray-600">${escapeHtml(time)}</td>
+                    <td class="px-4 py-2 text-sm text-gray-600">${time}</td>
                     <td class="px-4 py-2"><span class="px-2 py-0.5 text-xs font-medium rounded-full ${statusClass}">${statusLabel}</span></td>
                     <td class="px-4 py-2 text-sm text-gray-600">${escapeHtml(duration)}</td>
                     <td class="px-4 py-2 text-sm text-gray-600">${escapeHtml(rows)}</td>

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -59,7 +59,7 @@
                     <a href="/catalog" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'catalog' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
                         Catalog
                     </a>
-                    <a href="/metabase/question/new" id="nav-query-database" target="_blank" class="px-2 py-2 rounded-md text-xs font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors">
+                    <a href="/query" id="nav-query-database" target="_blank" class="px-2 py-2 rounded-md text-xs font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors">
                         Query
                     </a>
                     <a href="/metabase" target="_blank" class="px-2 py-2 rounded-md text-xs font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors">
@@ -129,7 +129,7 @@
                 <a href="/models" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'models' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Models</a>
                 <a href="/schedules" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'schedules' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Schedules</a>
                 <a href="/catalog" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'catalog' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Catalog</a>
-                <a href="/metabase/question/new" target="_blank" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Query</a>
+                <a href="/query" target="_blank" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Query</a>
                 <a href="/metabase" target="_blank" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Dashboards</a>
                 <a href="/notebooks" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'notebooks' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Notebooks</a>
                 <a href="/monitoring" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'monitoring' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Monitoring</a>


### PR DESCRIPTION
## Summary

Fixes 9 bugs from Testing Round 11 covering CLI and display polish:

- **BUG-211**: Sync history compact modal showed empty duration/rows — field names mismatched (`duration` → `duration_seconds`, `row_count` → `rows_processed`)
- **BUG-212**: Sync history showed raw HTML tags — `escapeHtml()` was wrapping `formatRelativeTime()` output which returns safe internal HTML
- **BUG-227**: Split sync trigger button into direct action + dropdown chevron — clicking the main button now triggers incremental sync directly, small ▾ chevron opens Full Refresh / Date Range options. File sources get a simple "Sync Now" button with no dropdown.
- **BUG-204**: Sync mode badge was wrong for sources like Chess (registry said non-incremental, but dlt source actually uses incremental). Now derives sync mode from actual sync history `full_refresh` field, falling back to registry only for never-synced sources.
- **BUG-224**: `/query` redirect now constructs server-side base64-encoded native SQL query URL with database pre-selected, matching what `app.js` does client-side. Fallback to `/metabase/` if database_id unavailable (instead of visual builder). Nav links in `base.html` updated to use `/query` redirect handler.
- **BUG-207**: `dango source edit` now accepts optional NAME argument — validates name exists, shows section when no editor available
- **BUG-208**: `dango sync` now accepts positional source argument (`dango sync chess`). `--source` kept as deprecated alias. Positional takes precedence when both provided.
- **BUG-226**: Schedule wizard fixes — removed per-keystroke validation flicker on name input (now validates after prompt), added "SPACE to toggle, ENTER to confirm" hint to source Checkbox, re-prompts on 0-selection instead of exiting
- **BUG-223**: `dango model remove` now cascades — cleans monitors.yml references, refreshes Metabase schema after table drop. Added `--dry-run` flag. Fixed SQL injection risk (parameterized queries + name validation regex). Fixed DuckDB read_only connection for table existence check.

## CLI Argument Audit (BUG-208)

Convention: **positional for primary target, options for modifiers/toggles/filters**.

| Command | Current | Fix |
|---------|---------|-----|
| `dango sync chess` | NEW positional | Added (BUG-208) |
| `dango sync --source chess` | Option | Kept as deprecated alias |
| `dango source edit chess` | NEW positional | Added (BUG-207) |
| `dango source add` | No args (wizard) | OK |
| `dango source list` | No args | OK |
| `dango source remove NAME` | Positional | OK |
| `dango model add` | No args (wizard) | OK |
| `dango model remove NAME` | Positional | OK |
| `dango notebook open NAME` | Positional | OK |
| `dango governance pii-set SRC TBL COL` | Positional | OK |
| `dango snapshot add TABLE` | Positional | OK |
| `dango auth add-user EMAIL` | Positional | OK |
| `dango remote env set KEY VALUE` | Positional | OK |
| `dango dev --select MODEL` | Option | OK (dbt parity) |

All other commands (wizards, no-arg operations) are already consistent.

## Line Count Changes

| File | Before | After | Exempt? |
|------|--------|-------|---------|
| `web/static/js/app.js` | 2752 | 2775 | Yes |
| `web/helpers.py` | 851 | 868 | Yes |
| `web/routes/ui.py` | 325 | 350 | No (under 500) |
| `web/templates/base.html` | — | — | N/A |
| `cli/commands/source.py` | 833 | 878 | Yes |
| `cli/commands/schedule.py` | 743 | 763 | Yes |
| `cli/commands/model.py` | 258 | 341 | No (under 500) |

## Test plan

- [x] `ruff check` — all pass
- [x] `ruff format --check` — all formatted
- [x] `mypy` on all changed files — no errors
- [x] Unit tests pass (`test_web_imports`, `test_cli_commands`, `test_web_health`, `test_analysis_config`)
- [x] All imports verified
- [x] Pre-commit hooks pass
- [ ] Manual verification of sync history modal field display
- [ ] Manual verification of split sync button behavior
- [ ] Manual verification of `/query` redirect
- [ ] Manual verification of `dango sync chess` and `dango source edit chess`
- [ ] Manual verification of schedule wizard name validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)