### PR TITLE
R12-C: Fix WebSocket sync lifecycle (BUG-225, BUG-230)

### DIFF
--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -252,7 +252,12 @@ def run_manual_sync(
 
         _progress("data_load", "Loading data from source")
 
+        _dbt_failed = False
+
         def _sync_progress_cb(phase: str, message: str) -> None:
+            nonlocal _dbt_failed
+            if phase == "dbt_failed":
+                _dbt_failed = True
             _progress(phase, message)
 
         sync_result = run_sync(
@@ -274,8 +279,21 @@ def run_manual_sync(
                 if isinstance(r, dict)
             )
 
-        record_completion(db_path, record_id)
         duration = round(time.time() - start_time, 1)
+
+        if _dbt_failed:
+            error_msg = "dbt models failed"
+            record_failure(db_path, record_id, error_msg)
+            _progress("failed", error_msg, rows_loaded=rows_loaded, dbt_error=True)
+            return {
+                "record_id": record_id,
+                "status": "failed",
+                "duration_seconds": duration,
+                "error": error_msg,
+                "rows_loaded": rows_loaded,
+            }
+
+        record_completion(db_path, record_id)
         _progress("completed", "Sync completed successfully", rows_loaded=rows_loaded)
         return {
             "record_id": record_id,

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -289,15 +289,17 @@ def poll_sync_status_blocking(
 
             # Broadcast on phase transitions
             if current_phase != last_phase and broadcast_fn is not None:
-                broadcast_fn(
-                    {
-                        "event": _phase_to_event(current_phase),
-                        "source": source_name,
-                        "phase": current_phase,
-                        "message": status.get("message", ""),
-                        "timestamp": _ts(),
-                    }
-                )
+                msg = {
+                    "event": _phase_to_event(current_phase),
+                    "source": source_name,
+                    "phase": current_phase,
+                    "message": status.get("message", ""),
+                    "timestamp": _ts(),
+                }
+                if current_phase == "failed" and status.get("dbt_error"):
+                    msg["event"] = "dbt_run_all_failed"
+                    msg["source"] = f"dbt (triggered by {source_name})"
+                broadcast_fn(msg)
                 last_phase = current_phase
 
             # Detect terminal state
@@ -378,6 +380,9 @@ async def _broadcast_phase_transition(
         message["rows_loaded"] = status.get("rows_loaded", 0)
         message["duration_seconds"] = status.get("elapsed_seconds", 0)
     elif phase == "failed":
+        if status.get("dbt_error"):
+            message["event"] = "dbt_run_all_failed"
+            message["source"] = f"dbt (triggered by {source_name})"
         message["error"] = status.get("error")
 
     await ws_manager.broadcast(message)

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -437,18 +437,31 @@ async function handleWebSocketMessage(data) {
             }
 
             // Suppress success toast during batch operations (multi-file uploads)
-            // The final toast will show when dbt completes
             if (!activeFileOperations.has(source)) {
                 showToast(`${source} synced successfully`, 'success');
             } else {
                 console.log('✅ [WS] Suppressing toast - batch upload operation in progress');
             }
 
-            // DON'T clear activeSyncs here - dbt will run next and dbt_run_all_completed will clear it
-            // New flow: all files uploaded to disk → sync once → dbt once
-            console.log('✅ [WS] Sync completed, but keeping activeSyncs (dbt will run next)');
+            // sync_completed is the terminal event — clear sync state and update row
+            // (dbt_run_all_completed may have already done this; checks are idempotent)
+            if (activeSyncs.has(source)) {
+                activeSyncs.delete(source);
+                stopSyncTimer(source);
+                const btn = document.getElementById(`sync-btn-${source}`);
+                if (btn) btn.textContent = 'Sync Now';
+                updateSyncCounter();
+            }
 
-            // Don't call loadSources() - wait for dbt to complete
+            // Update row with sync results
+            if (data.rows_loaded !== undefined) {
+                updateSourceRowAfterSync(source, {
+                    rows_loaded: data.rows_loaded,
+                    timestamp: data.timestamp,
+                    duration_seconds: data.duration_seconds,
+                });
+                syncResults.delete(source);
+            }
             break;
 
         case 'sync_failed':
@@ -576,10 +589,8 @@ async function handleWebSocketMessage(data) {
                     if (result) {
                         updateSourceRowAfterSync(triggeredSource, result);
                         syncResults.delete(triggeredSource);
-                    } else {
-                        // Fallback if sync_completed didn't include data
-                        if (!isLoadingSources) loadSources();
                     }
+                    // No loadSources() fallback — sync_completed handles final row update
                 } else {
                     // Reset ALL sync buttons when no specific source
                     for (const src of activeSyncs.keys()) {

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -461,6 +461,10 @@ async function handleWebSocketMessage(data) {
                     duration_seconds: data.duration_seconds,
                 });
                 syncResults.delete(source);
+            } else {
+                // No rows_loaded in event — refresh from backend
+                // Safe to call here: sync_completed is terminal, data is committed
+                if (!isLoadingSources) loadSources();
             }
             break;
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -309,9 +309,15 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_sync_process.py
-    lines: 674
+    lines: 740
     category: exempt
-    reason: "R10-S: Added watcher tests (locally_polled, mtime efficiency, start_returns_task). Test files are verbose by design."
+    reason: "R10-S+R12-C: Watcher tests + BUG-230 dbt_error broadcast tests. Test files are verbose by design."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_sync_trigger.py
+    lines: 618
+    category: exempt
+    reason: "R12-C: BUG-230 dbt failure handling tests (3 new test classes). Test files are verbose by design."
     review_by: "v1.1"
 
   - file: tests/unit/test_sync_jobs.py

--- a/tests/unit/test_client_ip.py
+++ b/tests/unit/test_client_ip.py
@@ -1,0 +1,27 @@
+"""tests/unit/test_client_ip.py
+
+Tests for _get_client_ip() in web/routes/auth.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestGetClientIp:
+    def test_returns_none_when_client_is_none(self):
+        from dango.web.routes.auth import _get_client_ip
+
+        request = MagicMock()
+        request.client = None
+        assert _get_client_ip(request) is None
+
+    def test_returns_host_when_client_present(self):
+        from dango.web.routes.auth import _get_client_ip
+
+        request = MagicMock()
+        request.client.host = "192.168.1.1"
+        assert _get_client_ip(request) == "192.168.1.1"

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -672,3 +672,69 @@ class TestSyncStatusWatcher:
             pass
 
         assert task.done()
+
+
+@pytest.mark.unit
+class TestBroadcastDbtError:
+    """Tests for BUG-230: dbt_error flag in broadcast functions."""
+
+    @pytest.mark.anyio
+    async def test_broadcast_dbt_error_sends_dbt_run_all_failed(self):
+        """_broadcast_phase_transition with dbt_error should emit dbt_run_all_failed."""
+        from dango.platform.sync_process import _broadcast_phase_transition
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        status = {"message": "dbt models failed", "error": "dbt models failed", "dbt_error": True}
+        await _broadcast_phase_transition(mock_ws, "hubspot", "failed", status)
+
+        call_msg = mock_ws.broadcast.call_args[0][0]
+        assert call_msg["event"] == "dbt_run_all_failed"
+        assert call_msg["source"] == "dbt (triggered by hubspot)"
+        assert call_msg["error"] == "dbt models failed"
+
+    @pytest.mark.anyio
+    async def test_broadcast_generic_failure_sends_sync_failed(self):
+        """_broadcast_phase_transition without dbt_error should emit sync_failed."""
+        from dango.platform.sync_process import _broadcast_phase_transition
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        status = {"message": "DuckDB crash", "error": "DuckDB crash"}
+        await _broadcast_phase_transition(mock_ws, "hubspot", "failed", status)
+
+        call_msg = mock_ws.broadcast.call_args[0][0]
+        assert call_msg["event"] == "sync_failed"
+        assert call_msg["source"] == "hubspot"
+
+    def test_blocking_poll_dbt_error_overrides_event(self, tmp_path):
+        """poll_sync_status_blocking with dbt_error should emit dbt_run_all_failed."""
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(
+            tmp_path,
+            phase="failed",
+            sync_id="dbt_err",
+            error="dbt models failed",
+            dbt_error=True,
+        )
+        process = MagicMock()
+        process.poll.return_value = 1
+        broadcast_fn = MagicMock()
+
+        with patch(f"{_MOD}.time.sleep"):
+            success, result = poll_sync_status_blocking(
+                tmp_path,
+                process,
+                source_name="hubspot",
+                sync_id="dbt_err",
+                broadcast_fn=broadcast_fn,
+                poll_interval=0.01,
+            )
+
+        assert success is False
+        call_msg = broadcast_fn.call_args[0][0]
+        assert call_msg["event"] == "dbt_run_all_failed"
+        assert call_msg["source"] == "dbt (triggered by hubspot)"

--- a/tests/unit/test_sync_trigger.py
+++ b/tests/unit/test_sync_trigger.py
@@ -495,3 +495,124 @@ class TestMainEntrypoint:
         assert parsed["sources"] == ["src1"]
         assert parsed.get("sync_id") == "abc123"
         assert parsed.get("record_id") == 42
+
+
+@pytest.mark.unit
+class TestDbtFailureHandling:
+    """Tests for BUG-230: dbt failure should record failure, not completion."""
+
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_failure")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=20)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_dbt_failed_records_failure_not_completion(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_failure,
+        mock_lock_cls,
+        mock_config,
+        tmp_path,
+    ):
+        """When dbt fails, run_manual_sync should record failure, not completion."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        def _fake_sync(**kwargs):
+            # Simulate dbt failure via progress callback
+            cb = kwargs.get("progress_callback")
+            if cb:
+                cb("dbt_failed", "dbt models failed")
+            return {"results": [{"rows_loaded": 50}], "failed_count": 1}
+
+        with patch(f"{_PATCH_INGESTION}.run_sync", side_effect=_fake_sync):
+            result = run_manual_sync(tmp_path, sources=["src1"])
+
+        assert result["status"] == "failed"
+        assert result["error"] == "dbt models failed"
+        assert result["rows_loaded"] == 50
+        mock_failure.assert_called_once()
+        mock_complete.assert_not_called()
+
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_failure")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=21)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_dbt_failed_writes_dbt_error_flag(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_failure,
+        mock_lock_cls,
+        mock_config,
+        tmp_path,
+    ):
+        """Status file should have phase='failed' and dbt_error=True on dbt failure."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        def _fake_sync(**kwargs):
+            cb = kwargs.get("progress_callback")
+            if cb:
+                cb("dbt_failed", "dbt models failed")
+            return {"results": [{"rows_loaded": 30}], "failed_count": 1}
+
+        with patch(f"{_PATCH_INGESTION}.run_sync", side_effect=_fake_sync):
+            result = run_manual_sync(
+                tmp_path, sources=["src1"], write_progress=True, sync_id="dbt_err1"
+            )
+
+        assert result["status"] == "failed"
+        status_file = tmp_path / ".dango" / "state" / "sync_status_dbt_err1.json"
+        assert status_file.exists()
+        data = json.loads(status_file.read_text())
+        assert data["phase"] == "failed"
+        assert data["dbt_error"] is True
+        assert data["rows_loaded"] == 30
+
+    @patch(
+        f"{_PATCH_INGESTION}.run_sync",
+        return_value={"results": [{"rows_loaded": 75}], "failed_count": 0},
+    )
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=22)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_dbt_success_writes_completed(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_lock_cls,
+        mock_config,
+        mock_sync,
+        tmp_path,
+    ):
+        """Successful sync should write phase='completed' with no dbt_error."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        result = run_manual_sync(tmp_path, sources=["src1"], write_progress=True, sync_id="dbt_ok1")
+
+        assert result["status"] == "success"
+        status_file = tmp_path / ".dango" / "state" / "sync_status_dbt_ok1.json"
+        assert status_file.exists()
+        data = json.loads(status_file.read_text())
+        assert data["phase"] == "completed"
+        assert "dbt_error" not in data


### PR DESCRIPTION
## Summary

- **BUG-230** (Critical): `dbt_run_all_failed` never sent — `sync_trigger.py` now tracks dbt failure via `nonlocal` flag and writes `phase="failed"` with `dbt_error=True` instead of unconditionally writing `"completed"`. `sync_process.py` broadcast functions detect `dbt_error` and emit `dbt_run_all_failed` event.
- **BUG-225**: Sources show "empty" after dbt completion — `sync_completed` is now the true terminal event handler in `app.js`, clearing `activeSyncs` and updating the source row. Removed `loadSources()` fallback from `dbt_run_all_completed`.
- **BUG-214**: Verified no code change needed — sync status watcher already broadcasts to all WS clients.
- **BUG-210**: Verified button reset holds in all event sequences (R12-B fix confirmed).
- Adds `_get_client_ip()` None path test and updates file-exemptions.yml.

## Files Changed

| File | Change |
|------|--------|
| `dango/platform/scheduling/sync_trigger.py` | dbt_failed flag + conditional terminal phase (330→348 lines) |
| `dango/platform/sync_process.py` | dbt_error handling in both broadcast functions (488→492 lines) |
| `dango/web/static/js/app.js` | sync_completed as terminal handler, remove loadSources fallback |
| `docs/file-exemptions.yml` | Updated test_sync_process.py count + added test_sync_trigger.py |
| `tests/unit/test_sync_trigger.py` | 3 new dbt failure tests |
| `tests/unit/test_sync_process.py` | 3 new dbt_error broadcast tests |
| `tests/unit/test_client_ip.py` | New: 2 tests for _get_client_ip None path |

## Test plan

- [x] All 60 targeted tests pass (`test_sync_trigger.py`, `test_sync_process.py`, `test_client_ip.py`)
- [x] Full unit suite: 3452 passed, 7 skipped
- [x] Integration test gate: all 5/5 stages pass
- [x] Ruff lint + format clean
- [x] mypy clean on modified source files
- [ ] Manual: Trigger sync → verify both browser tabs see progress
- [ ] Manual: Break dbt model → trigger sync → verify error banner
- [ ] Manual: Successful sync → verify source row shows correct row count
- [ ] Manual: After sync → verify button shows "Sync Now" with no timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)