### PR TITLE
R12-N2: Add SYNC_ONLY schedule type + client_ip=None tests

### DIFF
--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -42,6 +42,7 @@ _FREQUENCY_CHOICES = [
 
 _TYPE_CHOICES = [
     ("Sync & Transform (recommended)", "sync"),
+    ("Sync only (no transform)", "sync_only"),
     ("Transform only (dbt)", "dbt"),
 ]
 
@@ -564,7 +565,7 @@ def schedule_add(ctx: click.Context) -> None:
     # 3a. Sources (sync only) / 3b. dbt command
     sources: list[str] = []
     dbt_command: str | None = None
-    if sched_type == "sync":
+    if sched_type in ("sync", "sync_only"):
         try:
             from dango.config.loader import ConfigLoader
 
@@ -599,7 +600,13 @@ def schedule_add(ctx: click.Context) -> None:
             return
     else:
         answers = inquirer.prompt(
-            [inquirer.Text("dbt_command", message="dbt command", default="run")]
+            [
+                inquirer.Text(
+                    "dbt_command",
+                    message="dbt command (e.g., run +model+, run --select tag:daily)",
+                    default="run",
+                )
+            ]
         )
         if answers is None:
             return

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -136,6 +136,9 @@ class ScheduleConfig(BaseModel):
         if self.type in (ScheduleType.SYNC, ScheduleType.SYNC_ONLY) and not self.sources:
             msg = "Sync schedules must specify at least one source"
             raise ValueError(msg)
+        if self.type == ScheduleType.SYNC_ONLY and self.dbt_command:
+            msg = "sync_only schedules must not specify a dbt_command"
+            raise ValueError(msg)
         if self.type == ScheduleType.DBT and not self.dbt_command:
             msg = "dbt schedules must specify a dbt_command"
             raise ValueError(msg)

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -77,6 +77,7 @@ class ScheduleType(str, Enum):
     """Type of scheduled job."""
 
     SYNC = "sync"
+    SYNC_ONLY = "sync_only"
     DBT = "dbt"
 
 
@@ -132,7 +133,7 @@ class ScheduleConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_type_fields(self) -> ScheduleConfig:
-        if self.type == ScheduleType.SYNC and not self.sources:
+        if self.type in (ScheduleType.SYNC, ScheduleType.SYNC_ONLY) and not self.sources:
             msg = "Sync schedules must specify at least one source"
             raise ValueError(msg)
         if self.type == ScheduleType.DBT and not self.dbt_command:
@@ -264,7 +265,7 @@ def validate_schedules(
     # 3. Interval vs duration check
     if average_durations:
         for sched in schedules:
-            if sched.type != ScheduleType.SYNC:
+            if sched.type not in (ScheduleType.SYNC, ScheduleType.SYNC_ONLY):
                 continue
             interval = _get_cron_interval_seconds(sched.cron)
             for src in sched.sources:
@@ -313,7 +314,7 @@ def _detect_overlaps(
     # Build source→schedule mapping (only enabled sync schedules)
     source_schedules: dict[str, list[ScheduleConfig]] = {}
     for sched in schedules:
-        if not sched.enabled or sched.type != ScheduleType.SYNC:
+        if not sched.enabled or sched.type not in (ScheduleType.SYNC, ScheduleType.SYNC_ONLY):
             continue
         for src in sched.sources:
             source_schedules.setdefault(src, []).append(sched)
@@ -460,12 +461,13 @@ def reload_schedules(
 
         func: Any
         func_kwargs: dict[str, Any]
-        if sched.type == ScheduleType.SYNC:
+        if sched.type in (ScheduleType.SYNC, ScheduleType.SYNC_ONLY):
             func = run_scheduled_sync
             func_kwargs = {
                 "schedule_name": sched.name,
                 "sources": list(sched.sources),
                 "project_root": str(project_root),
+                "skip_dbt": sched.type == ScheduleType.SYNC_ONLY,
             }
         else:
             func = run_scheduled_dbt

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -391,6 +391,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
     """
     project_root = Path(kwargs.get("project_root", "."))
     full_refresh = bool(kwargs.get("full_refresh", False))
+    skip_dbt = bool(kwargs.get("skip_dbt", False))
     t0 = time.monotonic()
 
     from dango.exceptions import JobCancelledError, JobTimeoutError
@@ -486,22 +487,24 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                     "duration_seconds": round(time.monotonic() - src_t0, 2),
                 },
             )
-            _add_pending_dbt_source(project_root, src.name)
+            if not skip_dbt:
+                _add_pending_dbt_source(project_root, src.name)
             cleanup_sync_status(project_root, sync_id=sync_id)
 
         # Run coalesced dbt (waits for coalesce window, merges pending sources)
-        dbt_ok = _run_coalesced_dbt(project_root)
+        if not skip_dbt:
+            dbt_ok = _run_coalesced_dbt(project_root)
 
-        if not dbt_ok:
-            _broadcast(
-                {
-                    "event": "dbt_run_all_failed",
-                    "schedule": schedule_name,
-                    "sources": source_names,
-                    "message": "Coalesced dbt run failed after sync",
-                    "timestamp": _ts(),
-                }
-            )
+            if not dbt_ok:
+                _broadcast(
+                    {
+                        "event": "dbt_run_all_failed",
+                        "schedule": schedule_name,
+                        "sources": source_names,
+                        "message": "Coalesced dbt run failed after sync",
+                        "timestamp": _ts(),
+                    }
+                )
 
         elapsed = time.monotonic() - t0
 

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -412,12 +412,13 @@ async def trigger_schedule(
     )
 
     func: Any
-    if sched.type == ScheduleType.SYNC:
+    if sched.type in (ScheduleType.SYNC, ScheduleType.SYNC_ONLY):
         func = run_scheduled_sync
         func_kwargs: dict[str, Any] = {
             "schedule_name": sched.name,
             "sources": list(sched.sources),
             "project_root": str(project_root),
+            "skip_dbt": sched.type == ScheduleType.SYNC_ONLY,
         }
     else:
         func = run_scheduled_dbt

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -47,7 +47,7 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap">
                                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
-                                      :class="sched.type === 'sync' ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800'"
+                                      :class="sched.type.startsWith('sync') ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800'"
                                       x-text="sched.type"></span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell"

--- a/tests/unit/test_auth_lockout.py
+++ b/tests/unit/test_auth_lockout.py
@@ -558,6 +558,45 @@ class TestIPBasedLockout:
         assert is_locked is False
         assert remaining == 0
 
+    def test_client_ip_none_uses_user_table_fallback(self, tmp_path: Path) -> None:
+        """5 failed logins with client_ip=None locks via users table."""
+        db_path = _make_db(tmp_path)
+        user = _make_user(email="lock_none@example.com")
+        create_user(db_path, user)
+
+        for _ in range(4):
+            is_locked, _ = record_failed_login(
+                db_path, "lock_none@example.com", client_ip=None, max_attempts=5
+            )
+            assert is_locked is False
+
+        # 5th attempt should lock
+        is_locked, remaining = record_failed_login(
+            db_path, "lock_none@example.com", client_ip=None, max_attempts=5
+        )
+        assert is_locked is True
+        assert remaining > 0
+
+        # Verify in users table
+        row = _get_user_row(db_path, "lock_none@example.com")
+        assert row["failed_login_attempts"] == 5
+
+    def test_check_locked_with_none_ip_uses_user_table(self, tmp_path: Path) -> None:
+        """After locking with client_ip=None, check_account_locked returns locked."""
+        db_path = _make_db(tmp_path)
+        user = _make_user(email="check_none@example.com")
+        create_user(db_path, user)
+
+        # Lock via 5 failed attempts with client_ip=None
+        for _ in range(5):
+            record_failed_login(db_path, "check_none@example.com", client_ip=None, max_attempts=5)
+
+        is_locked, remaining = check_account_locked(
+            db_path, "check_none@example.com", client_ip=None
+        )
+        assert is_locked is True
+        assert remaining > 0
+
     def test_cleanup_expired(self, tmp_path: Path) -> None:
         """cleanup_expired_login_attempts removes old entries."""
         db_path = _make_db(tmp_path)

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -125,6 +125,18 @@ class TestScheduleConfig:
                 sources=[],
             )
 
+    def test_sync_only_rejects_dbt_command(self):
+        from dango.config.schedules import ScheduleConfig, ScheduleType
+
+        with pytest.raises(Exception, match="must not specify a dbt_command"):
+            ScheduleConfig(
+                name="bad_sync_only",
+                type=ScheduleType.SYNC_ONLY,
+                cron="daily",
+                sources=["csv"],
+                dbt_command="run",
+            )
+
     def test_sync_requires_sources(self):
         from dango.config.schedules import ScheduleConfig
 

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -19,12 +19,13 @@ class TestScheduleType:
         from dango.config.schedules import ScheduleType
 
         assert ScheduleType.SYNC.value == "sync"
+        assert ScheduleType.SYNC_ONLY.value == "sync_only"
         assert ScheduleType.DBT.value == "dbt"
 
     def test_enum_count(self):
         from dango.config.schedules import ScheduleType
 
-        assert len(ScheduleType) == 2
+        assert len(ScheduleType) == 3
 
 
 @pytest.mark.unit
@@ -99,6 +100,30 @@ class TestScheduleConfig:
 
         with pytest.raises(Exception, match="Invalid notify_on"):
             ScheduleConfig(name="bad_notify", cron="daily", sources=["s"], notify_on=["invalid"])
+
+    def test_valid_sync_only_config(self):
+        from dango.config.schedules import ScheduleConfig, ScheduleType
+
+        cfg = ScheduleConfig(
+            name="sync_no_dbt",
+            type=ScheduleType.SYNC_ONLY,
+            cron="daily",
+            sources=["google_sheets"],
+        )
+        assert cfg.type == ScheduleType.SYNC_ONLY
+        assert cfg.sources == ["google_sheets"]
+        assert cfg.dbt_command is None
+
+    def test_sync_only_requires_sources(self):
+        from dango.config.schedules import ScheduleConfig, ScheduleType
+
+        with pytest.raises(Exception, match="at least one source"):
+            ScheduleConfig(
+                name="no_sources",
+                type=ScheduleType.SYNC_ONLY,
+                cron="daily",
+                sources=[],
+            )
 
     def test_sync_requires_sources(self):
         from dango.config.schedules import ScheduleConfig

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -300,6 +300,34 @@ class TestRunScheduledSync:
         mock_record.assert_called_once()
         assert mock_record.call_args[1]["status"] == "no_sources"
 
+    def test_sync_only_skips_coalesced_dbt(self, tmp_path):
+        """skip_dbt=True skips _add_pending_dbt_source and _run_coalesced_dbt."""
+        config = _make_config_with_sources("src1")
+
+        with (
+            patch(f"{_NOTIF_MOD}.load_notification_config", return_value=None),
+            patch(f"{_NOTIF_MOD}.WebhookSender"),
+            patch(f"{_CFG_MOD}.load_config", return_value=config),
+            patch(
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id"),
+            ),
+            patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
+            patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
+            patch(f"{_HIST_MOD}.save_sync_history_entry"),
+            patch(f"{_JOBS_MOD}._broadcast"),
+            patch(f"{_JOBS_MOD}._notify"),
+            patch(f"{_JOBS_MOD}._check_freshness"),
+            patch(f"{_JOBS_MOD}._add_pending_dbt_source") as mock_pending,
+            patch(f"{_JOBS_MOD}._run_coalesced_dbt") as mock_dbt,
+        ):
+            from dango.platform.scheduling.jobs import run_scheduled_sync
+
+            run_scheduled_sync("daily", ["src1"], project_root=str(tmp_path), skip_dbt=True)
+
+        mock_pending.assert_not_called()
+        mock_dbt.assert_not_called()
+
     def test_is_pickle_serializable(self):
         """Job function must be pickle-serializable (APScheduler requirement)."""
         import pickle


### PR DESCRIPTION
## Summary

- Add `SYNC_ONLY` schedule type that syncs sources without triggering dbt afterward — closes the "sync only" gap where 10 sources forced 10 full dbt runs
- Wire `skip_dbt` kwarg through `run_scheduled_sync()` to skip `_add_pending_dbt_source()` and `_run_coalesced_dbt()`
- Add "Sync only (no transform)" option to CLI schedule wizard between existing choices
- Improve dbt command prompt text in wizard
- Fix web UI manual trigger dispatch to handle `SYNC_ONLY` (was falling through to dbt)
- Fix schedule badge styling so `sync_only` gets blue coloring like `sync`
- Add validator rejecting `dbt_command` on `SYNC_ONLY` schedules
- Add missing `client_ip=None` fallback tests for lockout functions (user-table-only behavior)
- Add `SYNC_ONLY` config validation tests and `skip_dbt=True` job test

## Files changed

| File | Lines | Change |
|------|-------|--------|
| `dango/config/schedules.py` | 493→497 | `SYNC_ONLY` enum, validator (rejects `dbt_command`), `reload_schedules()`, `validate_schedules()`, `_detect_overlaps()` |
| `dango/platform/scheduling/jobs.py` | 849→860 | `skip_dbt` kwarg in `run_scheduled_sync()` |
| `dango/cli/commands/schedule.py` | 763→770 | Wizard type choice + source conditional + dbt prompt |
| `dango/web/routes/schedules.py` | 518→519 | Manual trigger dispatch handles `SYNC_ONLY` with `skip_dbt` |
| `dango/web/templates/schedules.html` | — | Badge color uses `startsWith('sync')` |
| `tests/unit/test_schedules_config.py` | 351→385 | Enum count, `SYNC_ONLY` validation tests (valid, no sources, rejects dbt_command) |
| `tests/unit/test_sync_jobs.py` | 668→697 | `test_sync_only_skips_coalesced_dbt` |
| `tests/unit/test_auth_lockout.py` | 616→656 | `client_ip=None` fallback tests |

## Test plan

- [x] `ruff check` + `ruff format --check` pass
- [x] `mypy` passes on all modified source files
- [x] Targeted tests pass (99 passed)
- [x] Full unit suite passes: `pytest tests/unit/ -x` (3503 passed)
- [x] Pre-commit hooks pass
- [x] No source files exceed 500 lines without exemption
- [x] Doc changes recorded in `v1-planning/phase8-fixes/r12-doc-changes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)