### PR TITLE
R12-N1: Fix cloud deploy infrastructure (BUG-249–252)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `cli/commands/deploy_provision.py` | 897 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |
-| `platform/cloud/server_setup.py` | 688 | — (server setup + install source detection) |
+| `platform/cloud/server_setup.py` | 690 | — (server setup + install source detection) |
 | `cli/commands/auth.py` | 660 | — (13 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 531 | — (admin user CRUD + invite) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,8 @@ dango/                          # Python package source
 │   │   ├── web.py              # web dev server
 │   │   ├── serve.py            # serve production foreground server
 │   │   ├── deploy.py           # deploy group (wizard default, --byos, destroy)
-│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (813 lines)
-│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (849 lines)
+│   │   ├── deploy_wizard.py    # Interactive deploy wizard + BYOS (828 lines)
+│   │   ├── deploy_provision.py # Provisioning orchestration + BYOS (897 lines)
 │   │   ├── dev.py              # dev group (default run + clean) — branch-based dbt dev
 │   │   ├── migrate.py          # migrate group (status, run)
 │   │   ├── remote.py           # remote group + push/rollback/firewall/domain (698 lines)
@@ -239,7 +239,7 @@ dango/                          # Python package source
 │   │   ├── file_sync.py        # Project file sync (SFTP + rsync)
 │   │   ├── deployer.py         # Push deploy workflow + deploy lock (595 lines)
 │   │   ├── deploy_journal.py   # Append-only JSONL deployment history
-│   │   ├── scheduled_backup.py # Server-side scheduled backup (505 lines)
+│   │   ├── scheduled_backup.py # Server-side scheduled backup (508 lines)
 │   │   ├── resize.py           # In-place droplet resize
 │   │   ├── migrate.py          # Server migration via Spaces
 │   │   ├── upgrade.py          # Remote Dango version upgrade
@@ -358,19 +358,19 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `platform/cloud/deployer.py` | 595 | — (push deploy workflow + deploy lock + journal) |
 | `cli/validate.py` | 652 | — |
 | `config/models.py` | 606 | — (Pydantic config models) |
-| `cli/commands/deploy_wizard.py` | 813 | — (interactive deploy wizard + BYOS) |
+| `cli/commands/deploy_wizard.py` | 828 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 613 | — |
 | `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
-| `cli/commands/deploy_provision.py` | 849 | — (provisioning orchestration + BYOS) |
+| `cli/commands/deploy_provision.py` | 897 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |
-| `platform/cloud/server_setup.py` | 666 | — (server setup + install source detection) |
+| `platform/cloud/server_setup.py` | 688 | — (server setup + install source detection) |
 | `cli/commands/auth.py` | 660 | — (13 auth subcommands) |
 | `auth/database.py` | 529 | — (SQLite CRUD) |
 | `web/routes/users.py` | 531 | — (admin user CRUD + invite) |
 | `platform/local/watcher.py` | 518 | — |
 | `cli/commands/schedule.py` | 743 | — (schedule wizard + time customization) |
 | `cli/model_wizard.py` | 507 | — |
-| `platform/cloud/scheduled_backup.py` | 505 | — (server-side scheduled backup) |
+| `platform/cloud/scheduled_backup.py` | 508 | — (server-side scheduled backup) |
 | `governance/schema_drift.py` | 654 | — (R9-D: breaking drift protection + accept flow) |
 | `governance/pii_detector.py` | 614 | — (BUG-027/BUG-133/BUG-139/BUG-185: spaCy fallback + PERSON threshold + override application + structured data heuristic) |
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -28,9 +28,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote.py` (698 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~205 lines) | `serve` production foreground server with `--workers` option. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
-| `commands/deploy.py` (705 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
-| `commands/deploy_wizard.py` (813 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
-| `commands/deploy_provision.py` (849 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
+| `commands/deploy.py` (710 lines) | `deploy` group (wizard default, --byos, destroy) | `deploy`, `deploy_destroy()` |
+| `commands/deploy_wizard.py` (828 lines) | Interactive wizard steps 1-8 + BYOS wizard + non-interactive | `run_wizard()`, `run_non_interactive()`, `WizardConfig`, `run_byos_wizard()`, `run_byos_non_interactive()`, `BYOSConfig` |
+| `commands/deploy_provision.py` (897 lines) | Provisioning orchestration (DO + BYOS) + cleanup | `run_provisioning()`, `run_byos_setup()`, `ProvisionResult`, `BYOSResult`, `_ResourceTracker` |
 | `commands/remote_env.py` | `remote env` subgroup (set, get, list, delete) | `env` (Click group) |
 | `commands/remote_ops.py` | `remote upgrade`, `remote resize`, `remote migrate` | `remote_upgrade()`, `remote_resize()`, `remote_migrate()` |
 | `commands/remote_backup.py` | `remote backup` subgroup (list, enable, disable, download, restore) | `backup_group` |

--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -225,7 +225,7 @@ def _handle_byos(
     )
 
     try:
-        result = run_byos_setup(project_root, config)
+        result = run_byos_setup(project_root, config, non_interactive=True)
     except Exception:
         raise SystemExit(1) from None
 
@@ -256,15 +256,20 @@ def _handle_do_deploy(
         skip_backups=skip_backups,
         skip_initial_sync=skip_initial_sync,
     )
-    _handle_do_deploy_with_config(project_root, config)
+    _handle_do_deploy_with_config(project_root, config, non_interactive=True)
 
 
-def _handle_do_deploy_with_config(project_root: Path, config: Any) -> None:
+def _handle_do_deploy_with_config(
+    project_root: Path,
+    config: Any,
+    *,
+    non_interactive: bool = False,
+) -> None:
     """Execute DO provisioning with a completed WizardConfig."""
     from dango.cli.commands.deploy_provision import run_provisioning
 
     try:
-        result = run_provisioning(project_root, config)
+        result = run_provisioning(project_root, config, non_interactive=non_interactive)
     except Exception:
         raise SystemExit(1) from None
 

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -107,12 +107,15 @@ class BYOSResult:
 def run_provisioning(
     project_root: Path,
     config: WizardConfig,
+    *,
+    non_interactive: bool = False,
 ) -> ProvisionResult:
     """Execute the full provisioning pipeline (sub-steps 1-10).
 
     Args:
         project_root: Path to the local Dango project root.
         config: Wizard configuration from steps 1-9.
+        non_interactive: When ``True``, auto-confirm prompts (BUG-252).
 
     Returns:
         ``ProvisionResult`` with deployment details.
@@ -122,6 +125,9 @@ def run_provisioning(
     """
     from dango.platform.cloud.digitalocean import DigitalOceanClient
     from dango.platform.cloud.ssh import SSHManager
+
+    # BUG-251: Resolve project_root so Path(".").name is never empty
+    project_root = project_root.resolve()
 
     tracker = _ResourceTracker()
 
@@ -216,7 +222,9 @@ def run_provisioning(
         # --- Sub-step 7: Push secrets ---
         warnings: list[str] = []
         # BUG-122: Confirm BEFORE opening SSH to avoid timeout during prompt
-        secrets_confirmed = _confirm_secrets_push(project_root, warnings)
+        secrets_confirmed = _confirm_secrets_push(
+            project_root, warnings, non_interactive=non_interactive
+        )
         if secrets_confirmed:
             _status("Pushing secrets to server...")
             ssh.connect(droplet_ip, username="root")
@@ -328,6 +336,8 @@ def run_provisioning(
 def run_byos_setup(
     project_root: Path,
     config: BYOSConfig,
+    *,
+    non_interactive: bool = False,
 ) -> BYOSResult:
     """Execute server setup for BYOS deployments (no cloud provisioning).
 
@@ -337,6 +347,7 @@ def run_byos_setup(
     Args:
         project_root: Path to the local Dango project root.
         config: BYOS configuration from the wizard.
+        non_interactive: When ``True``, auto-confirm prompts (BUG-252).
 
     Returns:
         ``BYOSResult`` with deployment details.
@@ -347,6 +358,9 @@ def run_byos_setup(
     from dango.platform.cloud.file_sync import sync_project_files
     from dango.platform.cloud.server_setup import setup_server
     from dango.platform.cloud.ssh import SSHManager
+
+    # BUG-251: Resolve project_root so Path(".").name is never empty
+    project_root = project_root.resolve()
 
     warnings: list[str] = []
     key_path = Path(config.ssh_key_path).expanduser()
@@ -396,7 +410,9 @@ def run_byos_setup(
 
         # --- Sub-step 3: Push secrets ---
         # BUG-122: Confirm BEFORE opening SSH to avoid timeout during prompt
-        secrets_confirmed = _confirm_secrets_push(project_root, warnings)
+        secrets_confirmed = _confirm_secrets_push(
+            project_root, warnings, non_interactive=non_interactive
+        )
         if secrets_confirmed:
             _status("Pushing secrets to server...")
             ssh.connect(config.server_ip, username=config.ssh_user)
@@ -505,11 +521,14 @@ def _extract_ip(droplet: dict[str, Any]) -> str:
 def _confirm_secrets_push(
     project_root: Path,
     warnings: list[str],
+    *,
+    non_interactive: bool = False,
 ) -> bool:
     """List secret files and prompt for confirmation (no SSH required).
 
     BUG-122: This runs BEFORE SSH connect to avoid SSH timeout during
     interactive prompt.
+    BUG-252: When *non_interactive* is ``True``, auto-confirm.
 
     Returns:
         ``True`` if the user confirmed, ``False`` if no files or declined.
@@ -526,6 +545,10 @@ def _confirm_secrets_push(
     if not files_to_push:
         warnings.append("No .dlt/secrets.toml or .env found locally — skipped.")
         return False
+
+    # BUG-252: Skip interactive prompt in non-interactive mode
+    if non_interactive:
+        return True
 
     console.print("\n[bold]Secrets to push:[/bold]")
     for f in files_to_push:
@@ -791,7 +814,7 @@ def _generate_cloud_profiles(
             dbt_cfg = yaml.safe_load(dbt_project_path.read_text()) or {}
             project_name = dbt_cfg.get("name", "dango")
         except Exception:
-            pass
+            _logger.debug("dbt_project_yml_parse_failed", exc_info=True)
 
     if size_slug:
         # Known DO size — look up tier specs

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -22,6 +22,21 @@ import click
 from dango.cli import console
 
 # ---------------------------------------------------------------------------
+# BUG-252: Non-interactive confirm helper
+# ---------------------------------------------------------------------------
+
+
+def _safe_confirm(prompt: str, default: bool = True, *, non_interactive: bool = False) -> bool:
+    """Wrap ``click.confirm`` with a non-interactive bypass.
+
+    When *non_interactive* is ``True``, returns *default* without prompting.
+    """
+    if non_interactive:
+        return default
+    return click.confirm(prompt, default=default)
+
+
+# ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
 
@@ -195,7 +210,7 @@ def _step_size() -> tuple[str, Any | None]:
                 console.print(
                     "  [red]Invalid slug format.[/red] Expected format: s-{vcpus}vcpu-{ram}gb"
                 )
-                if not click.confirm("  Try again?", default=True):
+                if not _safe_confirm("  Try again?", default=True):
                     console.print(f"  Using default: {DEFAULT_TIER.name}")
                     return DEFAULT_TIER.slug, DEFAULT_TIER
 
@@ -327,7 +342,7 @@ def _step_backups() -> tuple[bool, str | None, str | None]:
     console.print("\n[bold]Step 7: Automated Backups[/bold]")
     console.print("  Daily backups to DigitalOcean Spaces ($5/mo for storage).\n")
 
-    enable = click.confirm("  Enable automated backups?", default=True)
+    enable = _safe_confirm("  Enable automated backups?", default=True)
     if not enable:
         return False, None, None
 
@@ -413,7 +428,7 @@ def _step_cost_summary(
         " not through Dango.[/dim]\n"
     )
 
-    if not click.confirm("  Proceed with deployment?", default=True):
+    if not _safe_confirm("  Proceed with deployment?", default=True):
         console.print("[yellow]Aborted.[/yellow]")
         raise SystemExit(0)
 
@@ -709,7 +724,7 @@ def run_byos_wizard(project_root: Path) -> BYOSConfig:
     console.print(f"  Admin:     {admin_email}")
     console.print()
 
-    if not click.confirm("  Proceed with deployment?", default=True):
+    if not _safe_confirm("  Proceed with deployment?", default=True):
         console.print("[yellow]Aborted.[/yellow]")
         raise SystemExit(0)
 

--- a/dango/platform/cloud/scheduled_backup.py
+++ b/dango/platform/cloud/scheduled_backup.py
@@ -19,6 +19,9 @@ from pathlib import Path
 from typing import Any
 
 from dango.exceptions import CloudProvisioningError
+from dango.logging import get_logger
+
+_logger = get_logger(__name__)
 
 PROJECT_DIR = Path("/srv/dango/project")
 BACKUP_DIR = Path("/srv/dango/backups/deploy")
@@ -321,7 +324,7 @@ def _apply_retention(spaces_config: dict[str, Any]) -> int:
                 client.delete(obj["Key"].replace(".tar.gz", ".json"))
                 deleted += 1
             except Exception:
-                pass
+                _logger.debug("backup_rotation_delete_failed", key=obj["Key"], exc_info=True)
     return deleted
 
 

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from dango.exceptions import CloudProvisioningError
+from dango.logging import get_logger
 from dango.platform.cloud._server_templates import (
     DOCKER_DAEMON_JSON,
     FAIL2BAN_JAIL,
@@ -31,6 +32,8 @@ from dango.platform.cloud._server_templates import (
 
 if TYPE_CHECKING:
     from dango.platform.cloud.ssh import SSHManager
+
+_logger = get_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -146,15 +149,20 @@ def _setup_apt_packages(
         'DPkg::Lock::Timeout "120";\n',
         step=step,
     )
+    # BUG-250: Wait for any cloud-init apt locks before running apt commands.
+    # fuser is pre-installed on Ubuntu 22.04; if absent, the while loop exits
+    # immediately (safe fallback).
     _run_checked(
         ssh,
-        "add-apt-repository -y universe 2>/dev/null || true"
+        "while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend"
+        " >/dev/null 2>&1; do sleep 5; done"
+        " && add-apt-repository -y universe 2>/dev/null || true"
         " && DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 update -qq"
         " && DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y -qq"
         " python3-pip python3-venv fail2ban unattended-upgrades"
         " logrotate curl",
         step=step,
-        timeout=300,
+        timeout=420,
     )
     result.steps_completed.append(step)
     _notify(on_progress, step, "done")
@@ -495,8 +503,22 @@ def _setup_ufw(
 
 
 # ---------------------------------------------------------------------------
-# Install source detection (BUG-123)
+# Install source detection (BUG-123 / BUG-249)
 # ---------------------------------------------------------------------------
+
+
+def _normalize_git_url(url: str) -> str:
+    """Convert SSH-format Git URLs to pip-compatible ``ssh://`` URLs.
+
+    ``git@github.com:org/repo.git`` → ``ssh://git@github.com/org/repo.git``
+
+    HTTPS and already-normalized URLs are returned unchanged.
+    """
+    # SSH shorthand: user@host:path (no ://)
+    if "://" not in url and ":" in url and "@" in url.split(":")[0]:
+        host_part, path_part = url.split(":", 1)
+        return f"ssh://{host_part}/{path_part}"
+    return url
 
 
 def resolve_install_source() -> tuple[str, str]:
@@ -543,9 +565,9 @@ def resolve_install_source() -> tuple[str, str]:
         url = data.get("url", "")
         commit = vcs_info.get("commit_id", "")
         if url and commit:
-            return ("git", f"{vcs}+{url}@{commit}#egg=getdango")
+            return ("git", f"{vcs}+{_normalize_git_url(url)}@{commit}#egg=getdango")
         if url:
-            return ("git", f"{vcs}+{url}#egg=getdango")
+            return ("git", f"{vcs}+{_normalize_git_url(url)}#egg=getdango")
 
     # Editable install (pip install -e .)
     dir_info = data.get("dir_info", {})
@@ -568,9 +590,9 @@ def resolve_install_source() -> tuple[str, str]:
                 if remote.returncode == 0 and head.returncode == 0:
                     url = remote.stdout.strip()
                     commit = head.stdout.strip()
-                    return ("git", f"git+{url}@{commit}#egg=getdango")
+                    return ("git", f"git+{_normalize_git_url(url)}@{commit}#egg=getdango")
             except Exception:
-                pass
+                _logger.debug("editable_install_git_info_failed", exc_info=True)
 
     return ("editable", "getdango")
 

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -152,6 +152,8 @@ def _setup_apt_packages(
     # BUG-250: Wait for any cloud-init apt locks before running apt commands.
     # fuser is pre-installed on Ubuntu 22.04; if absent, the while loop exits
     # immediately (safe fallback).
+    # Note: "|| true" scopes to add-apt-repository only (left-to-right
+    # associativity), so apt-get update/install still fail on real errors.
     _run_checked(
         ssh,
         "while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend"
@@ -664,7 +666,7 @@ def setup_server(
         if nproc_result.success:
             vcpu_count = int(nproc_result.stdout.strip())
     except (ValueError, AttributeError, OSError):
-        pass  # Fall back to single worker
+        _logger.debug("nproc_detection_failed", exc_info=True)
 
     for step_fn in _SETUP_STEPS:
         if step_fn is _setup_caddyfile:

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -245,7 +245,9 @@ def setup_metabase_if_needed(
                 if admins and admins[0].email != "admin@localhost":
                     admin_email = admins[0].email
         except Exception:
-            pass
+            from dango.logging import get_logger as _get_logger_admin
+
+            _get_logger_admin(__name__).debug("admin_email_lookup_failed", exc_info=True)
     if not admin_email:
         from dango.logging import get_logger as _get_logger
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -267,7 +267,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/cloud/server_setup.py
-    lines: 688
+    lines: 690
     category: exempt
     reason: "TASK-075e+R9-C: 17 idempotent setup steps + optional UFW. R9-C added resolve_install_source() and system-wide apt lock timeout config. R12-N1 added _normalize_git_url, fuser wait loop, logging."
     review_by: "v1.1"
@@ -303,7 +303,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_deploy_provision.py
-    lines: 850
+    lines: 971
     category: exempt
     reason: "TASK-029+R9-C+R12-N1: 16 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, sync trigger, admin email persistence, cloud profiles generation, confirm_secrets_push, error handling, non-interactive confirm, and project root resolution."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -74,21 +74,21 @@ exemptions:
 
   # --- Phase 3 cloud deployment (TASK-029 + TASK-107) ---
   - file: dango/cli/commands/deploy_wizard.py
-    lines: 813
+    lines: 828
     category: exempt
-    reason: "TASK-029+075e: Interactive wizard steps 1-8 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps. R9-C added cloud_credentials integration."
+    reason: "TASK-029+075e: Interactive wizard steps 1-8 + BYOS wizard + non-interactive modes. Sequential prompt flow — splitting would scatter closely coupled wizard steps. R9-C added cloud_credentials integration. R12-N1 added _safe_confirm helper."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy_provision.py
-    lines: 849
+    lines: 897
     category: exempt
-    reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery. R8-F added _generate_cloud_profiles + DANGO_ADMIN_EMAIL persistence. R9-C added _confirm_secrets_push, install source detection, empty error handling."
+    reason: "TASK-029+075e: DO provisioning + BYOS setup with ResourceTracker cleanup. Linear pipeline — splitting would scatter tightly coupled provisioning steps and error recovery. R8-F added _generate_cloud_profiles + DANGO_ADMIN_EMAIL persistence. R9-C added _confirm_secrets_push, install source detection, empty error handling. R12-N1 added non_interactive param, project_root resolve."
     review_by: "v1.1"
 
   - file: dango/cli/commands/deploy.py
-    lines: 705
+    lines: 710
     category: exempt
-    reason: "TASK-029+075e: Deploy group with DO + BYOS routing, destroy command for both providers. Splitting would scatter the provider selection and destroy dispatch logic."
+    reason: "TASK-029+075e: Deploy group with DO + BYOS routing, destroy command for both providers. Splitting would scatter the provider selection and destroy dispatch logic. R12-N1 threaded non_interactive flag."
     review_by: "v1.1"
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
@@ -267,15 +267,15 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/cloud/server_setup.py
-    lines: 666
+    lines: 688
     category: exempt
-    reason: "TASK-075e+R9-C: 17 idempotent setup steps + optional UFW. R9-C added resolve_install_source() and system-wide apt lock timeout config."
+    reason: "TASK-075e+R9-C: 17 idempotent setup steps + optional UFW. R9-C added resolve_install_source() and system-wide apt lock timeout config. R12-N1 added _normalize_git_url, fuser wait loop, logging."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/scheduled_backup.py
-    lines: 505
+    lines: 508
     category: exempt
-    reason: "TASK-103: Server-side scheduled backup to Spaces with list/restore/enable/disable. Marginally over limit."
+    reason: "TASK-103: Server-side scheduled backup to Spaces with list/restore/enable/disable. R12-N1 added logging import + debug to bare exception."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/ssh.py
@@ -297,15 +297,15 @@ exemptions:
     review_by: "v1.1"
 
   - file: tests/unit/test_server_setup.py
-    lines: 735
+    lines: 850
     category: exempt
-    reason: "TASK-026+R9-C: Tests for server setup, version pinning, apt lock timeout, _resolve_install_source. Each test requires isolated mock setup with full exec_results map."
+    reason: "TASK-026+R9-C+R12-N1: Tests for server setup, version pinning, apt lock timeout, _resolve_install_source, _normalize_git_url, fuser wait loop. Each test requires isolated mock setup with full exec_results map."
     review_by: "v1.1"
 
   - file: tests/unit/test_deploy_provision.py
-    lines: 771
+    lines: 850
     category: exempt
-    reason: "TASK-029+R9-C: 14 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, sync trigger, admin email persistence, cloud profiles generation, confirm_secrets_push, and error handling."
+    reason: "TASK-029+R9-C+R12-N1: 16 test classes covering ResourceTracker, IP extraction, secrets push, admin creation, health check, provisioning sequence, backup setup, metadata persistence, sync trigger, admin email persistence, cloud profiles generation, confirm_secrets_push, error handling, non-interactive confirm, and project root resolution."
     review_by: "v1.1"
 
   - file: tests/unit/test_sync_process.py

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -831,20 +831,141 @@ class TestProjectRootResolved:
         assert resolved.name != "", "resolved path should have a non-empty name"
         assert resolved.name != ".", "resolved path should not be '.'"
 
-    def test_run_provisioning_resolves_root(self):
-        """BUG-251: run_provisioning() calls .resolve() on project_root."""
-        import inspect
-
+    def test_run_provisioning_resolves_root(self, project_root, monkeypatch):
+        """BUG-251: run_provisioning() resolves project_root so hostname is non-empty."""
         from dango.cli.commands.deploy_provision import run_provisioning
+        from dango.cli.commands.deploy_wizard import WizardConfig
 
-        source = inspect.getsource(run_provisioning)
-        assert "project_root = project_root.resolve()" in source
+        monkeypatch.setenv("DIGITALOCEAN_TOKEN", "test-token")
 
-    def test_run_byos_setup_resolves_root(self):
-        """BUG-251: run_byos_setup() calls .resolve() on project_root."""
-        import inspect
+        config = WizardConfig(
+            region="nyc1",
+            size_slug="s-2vcpu-4gb",
+            size_tier=None,
+            domain=None,
+            admin_email="admin@test.com",
+            admin_password="strongpassword123",
+            skip_oauth=True,
+            enable_backups=False,
+            skip_initial_sync=True,
+            monthly_cost=24,
+        )
 
+        # Create required files
+        dlt_dir = project_root / ".dlt"
+        dlt_dir.mkdir()
+        (dlt_dir / "secrets.toml").write_text("[sources]\n")
+
+        mock_client = MagicMock()
+        mock_client.upload_ssh_key.return_value = {"id": 111}
+        mock_ssh = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_ssh.exec_command.return_value = mock_result
+        mock_ssh.generate_key_pair.return_value = "ssh-ed25519 AAAA..."
+
+        droplet_dict = {
+            "id": 222,
+            "networks": {"v4": [{"type": "public", "ip_address": "1.2.3.4"}]},
+        }
+
+        captured_hostname: list[str] = []
+
+        def _capture_provision(client, *, name, region, size, ssh_key_ids):
+            captured_hostname.append(name)
+            return droplet_dict
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        from pathlib import Path
+
+        with (
+            patch(
+                "dango.platform.cloud.digitalocean.DigitalOceanClient",
+                return_value=mock_client,
+            ),
+            patch("dango.platform.cloud.ssh.SSHManager", return_value=mock_ssh),
+            patch(
+                "dango.platform.cloud.provisioning.provision_droplet",
+                side_effect=_capture_provision,
+            ),
+            patch(
+                "dango.platform.cloud.firewall.create_default_firewall",
+                return_value={"id": "fw-333"},
+            ),
+            patch("dango.platform.cloud.server_setup.setup_server") as mock_setup,
+            patch("dango.platform.cloud.file_sync.sync_project_files"),
+            patch("dango.platform.cloud.provisioning.save_provisioning_metadata"),
+            patch("dango.cli.commands.deploy_provision.click.confirm", return_value=True),
+            patch("httpx.get") as mock_get,
+            patch("dango.cli.commands.deploy_provision.time.sleep"),
+        ):
+            mock_setup.return_value = MagicMock(warnings=[])
+            mock_get.return_value = mock_resp
+
+            # Pass Path(".") — before the fix, this produced empty hostname
+            run_provisioning(Path("."), config, non_interactive=True)
+
+        assert captured_hostname, "provision_droplet should have been called"
+        assert captured_hostname[0] != "", "hostname must not be empty"
+        assert captured_hostname[0] != "dango-", "hostname must not have empty project name"
+        assert captured_hostname[0].startswith("dango-")
+
+    def test_run_byos_setup_resolves_root(self, project_root, monkeypatch):
+        """BUG-251: run_byos_setup() resolves project_root so bucket name is non-empty."""
         from dango.cli.commands.deploy_provision import run_byos_setup
+        from dango.cli.commands.deploy_wizard import BYOSConfig
 
-        source = inspect.getsource(run_byos_setup)
-        assert "project_root = project_root.resolve()" in source
+        mock_ssh = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+        mock_result.exit_code = 0
+        mock_ssh.exec_command.return_value = mock_result
+
+        config = BYOSConfig(
+            server_ip="10.0.0.1",
+            ssh_user="root",
+            ssh_key_path=str(project_root / ".dango" / "cloud_key"),
+            domain=None,
+            admin_email="admin@test.com",
+            admin_password="strongpassword123",
+            skip_oauth=True,
+            skip_initial_sync=True,
+        )
+
+        # Create SSH key file
+        key_path = project_root / ".dango" / "cloud_key"
+        key_path.write_text("fake-key")
+
+        # Create required files
+        dlt_dir = project_root / ".dlt"
+        dlt_dir.mkdir(exist_ok=True)
+        (dlt_dir / "secrets.toml").write_text("[sources]\n")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        with (
+            patch("dango.platform.cloud.ssh.SSHManager", return_value=mock_ssh),
+            patch("dango.platform.cloud.server_setup.setup_server") as mock_setup,
+            patch(
+                "dango.platform.cloud.server_setup.resolve_install_source",
+                return_value=("pypi", "getdango==1.0.0"),
+            ),
+            patch("dango.platform.cloud.file_sync.sync_project_files"),
+            patch("httpx.get") as mock_get,
+            patch("dango.cli.commands.deploy_provision.time.sleep"),
+        ):
+            mock_setup.return_value = MagicMock(warnings=[])
+            mock_get.return_value = mock_resp
+
+            # Pass project_root (tmp_path) — resolve should work correctly
+            result = run_byos_setup(project_root, config, non_interactive=True)
+
+        assert result.server_ip == "10.0.0.1"

--- a/tests/unit/test_deploy_provision.py
+++ b/tests/unit/test_deploy_provision.py
@@ -787,3 +787,64 @@ class TestAdminUpsertSemantics:
         assert "UserUpdate(password_hash=pw_hash)" in source, (
             "Must update password_hash with wizard-provided password on race condition"
         )
+
+
+# ---------------------------------------------------------------------------
+# 15. BUG-252: Non-interactive mode auto-confirms secrets push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNonInteractiveConfirm:
+    def test_auto_confirms_in_non_interactive(self, project_root):
+        """BUG-252: non_interactive=True skips click.confirm and returns True."""
+        dlt_dir = project_root / ".dlt"
+        dlt_dir.mkdir()
+        (dlt_dir / "secrets.toml").write_text("[sources]\n")
+
+        warnings: list[str] = []
+        # Should NOT call click.confirm at all
+        with patch("dango.cli.commands.deploy_provision.click.confirm") as mock_confirm:
+            result = _confirm_secrets_push(project_root, warnings, non_interactive=True)
+
+        assert result is True
+        assert warnings == []
+        mock_confirm.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 16. BUG-251: Project root resolved for hostname
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProjectRootResolved:
+    def test_project_root_resolved(self):
+        """BUG-251: Path('.') is resolved to produce a non-empty hostname."""
+        from pathlib import Path
+
+        # Path(".").name is "" which produces empty hostname.
+        # After .resolve(), the name is the actual directory name.
+        dot_path = Path(".")
+        assert dot_path.name == "", "Path('.').name should be empty (the bug)"
+        resolved = dot_path.resolve()
+        assert resolved.name != "", "resolved path should have a non-empty name"
+        assert resolved.name != ".", "resolved path should not be '.'"
+
+    def test_run_provisioning_resolves_root(self):
+        """BUG-251: run_provisioning() calls .resolve() on project_root."""
+        import inspect
+
+        from dango.cli.commands.deploy_provision import run_provisioning
+
+        source = inspect.getsource(run_provisioning)
+        assert "project_root = project_root.resolve()" in source
+
+    def test_run_byos_setup_resolves_root(self):
+        """BUG-251: run_byos_setup() calls .resolve() on project_root."""
+        import inspect
+
+        from dango.cli.commands.deploy_provision import run_byos_setup
+
+        source = inspect.getsource(run_byos_setup)
+        assert "project_root = project_root.resolve()" in source

--- a/tests/unit/test_server_setup.py
+++ b/tests/unit/test_server_setup.py
@@ -733,3 +733,118 @@ class TestResolveInstallSource:
 
         assert source_type == "editable"
         assert pip_arg == "getdango"
+
+
+# ---------------------------------------------------------------------------
+# BUG-249: _normalize_git_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNormalizeGitUrl:
+    """BUG-249: SSH shorthand URLs must be converted to pip-compatible ssh:// form."""
+
+    def test_ssh_shorthand_converted(self):
+        from dango.platform.cloud.server_setup import _normalize_git_url
+
+        result = _normalize_git_url("git@github.com:getdango/dango.git")
+        assert result == "ssh://git@github.com/getdango/dango.git"
+
+    def test_https_unchanged(self):
+        from dango.platform.cloud.server_setup import _normalize_git_url
+
+        url = "https://github.com/getdango/dango"
+        assert _normalize_git_url(url) == url
+
+    def test_ssh_protocol_unchanged(self):
+        from dango.platform.cloud.server_setup import _normalize_git_url
+
+        url = "ssh://git@github.com/getdango/dango.git"
+        assert _normalize_git_url(url) == url
+
+    def test_no_at_sign_unchanged(self):
+        from dango.platform.cloud.server_setup import _normalize_git_url
+
+        url = "github.com:getdango/dango.git"
+        assert _normalize_git_url(url) == url
+
+
+@pytest.mark.unit
+class TestSshRemoteConversion:
+    """BUG-249: SSH remotes in vcs_info and editable installs produce ssh:// URLs."""
+
+    def test_ssh_remote_converted_in_vcs_info(self):
+        """SSH shorthand in vcs_info is normalized to ssh://."""
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from dango.platform.cloud.server_setup import resolve_install_source
+
+        direct_url = json.dumps(
+            {
+                "url": "git@github.com:getdango/dango.git",
+                "vcs_info": {"vcs": "git", "commit_id": "abc123"},
+            }
+        )
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = direct_url
+
+        with patch("importlib.metadata.distribution", return_value=mock_dist):
+            source_type, pip_arg = resolve_install_source()
+
+        assert source_type == "git"
+        assert pip_arg == "git+ssh://git@github.com/getdango/dango.git@abc123#egg=getdango"
+
+    def test_ssh_remote_converted_in_editable(self):
+        """SSH shorthand in editable install is normalized to ssh://."""
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from dango.platform.cloud.server_setup import resolve_install_source
+
+        direct_url = json.dumps(
+            {
+                "url": "file:///home/user/code/dango",
+                "dir_info": {"editable": True},
+            }
+        )
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = direct_url
+
+        mock_remote = MagicMock(returncode=0, stdout="git@github.com:getdango/dango.git\n")
+        mock_head = MagicMock(returncode=0, stdout="def456\n")
+
+        with (
+            patch("importlib.metadata.distribution", return_value=mock_dist),
+            patch("subprocess.run", side_effect=[mock_remote, mock_head]),
+        ):
+            source_type, pip_arg = resolve_install_source()
+
+        assert source_type == "git"
+        assert pip_arg == "git+ssh://git@github.com/getdango/dango.git@def456#egg=getdango"
+
+
+# ---------------------------------------------------------------------------
+# BUG-250: apt lock wait
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAptLockWait:
+    """BUG-250: apt step waits for fuser lock before running apt commands."""
+
+    def test_apt_packages_waits_for_locks(self):
+        from dango.platform.cloud.server_setup import SetupResult, _setup_apt_packages
+
+        ssh = _make_ssh_mock()
+        result = SetupResult()
+        _setup_apt_packages(ssh, result, None)
+
+        cmds = [c[0][0] for c in ssh.exec_command.call_args_list]
+        apt_cmds = [c for c in cmds if "apt-get" in c and "install" in c]
+        assert apt_cmds
+        cmd = apt_cmds[0]
+        assert "fuser" in cmd
+        assert "/var/lib/apt/lists/lock" in cmd
+        assert "/var/lib/dpkg/lock" in cmd
+        assert "sleep 5" in cmd


### PR DESCRIPTION
## Summary
- **BUG-249:** SSH-format Git URLs (`git@host:path`) now converted to pip-compatible `ssh://` form in `resolve_install_source()` via new `_normalize_git_url()` helper
- **BUG-250:** Added `fuser` wait loop before apt commands to handle cloud-init apt locks on fresh VMs; timeout increased 300s→420s
- **BUG-251:** `project_root.resolve()` in `run_provisioning()` and `run_byos_setup()` so `Path(".").name` produces a non-empty hostname
- **BUG-252:** `non_interactive` flag threaded through deploy pipeline to auto-confirm `click.confirm()` prompts; `_safe_confirm()` helper added in `deploy_wizard.py`
- **Silent exception sweep:** Added `_logger.debug()` to 4 bare `except: pass` blocks in deploy/cloud code
- Updated file-exemptions.yml and CLAUDE.md line counts

## Test plan
- [x] All 3508 unit tests pass
- [x] Integration test (5/5 stages) passes
- [x] ruff check + format + mypy clean on all changed files
- [x] New tests: `TestNormalizeGitUrl` (4 cases), `TestSshRemoteConversion` (2 cases), `TestAptLockWait`, `TestNonInteractiveConfirm`, `TestProjectRootResolved` (3 cases)
- [ ] Fresh VM verification (user handles after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)