### PR TITLE
9.1: Security audit & hardening (7 fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ dango/                          # Python package source
 ├── web/                        # Level 2 — FastAPI web server
 │   ├── app.py                  # Entry point (~449 lines) — routers, middleware, admin bootstrap
 │   ├── models.py               # Pydantic request/response DTOs (incl. auth DTOs)
-│   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (851 lines)
+│   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (868 lines)
 │   ├── middleware/             # Request middleware
 │   │   ├── auth.py             # Session/API key auth + CSRF check (~324 lines)
 │   │   └── rate_limit.py       # Rate limiting (~235 lines)
@@ -177,13 +177,13 @@ dango/                          # Python package source
 │   │   ├── sync.py             # /api/sources/{name}/sync + run_sync_task()
 │   │   ├── logs.py             # /api/logs, /api/sources/{name}/logs
 │   │   ├── dbt.py              # /api/dbt/models, /api/dbt/models/{name}/run + dbt docs proxy
-│   │   ├── upload.py           # CSV upload/list/delete (705 lines)
+│   │   ├── upload.py           # CSV upload/list/delete (711 lines)
 │   │   ├── websocket.py        # ConnectionManager, ws_manager, /ws
 │   │   ├── ui.py               # /, /health, /logs, /login, /account, /admin/users
 │   │   ├── metabase_proxy.py   # Metabase reverse proxy + SSO session
 │   │   ├── secrets.py          # Secrets + OAuth credential management (admin-only)
 │   │   ├── oauth_connect.py    # Web-based OAuth connect/callback
-│   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact, models, search (1336 lines)
+│   │   ├── catalog.py          # Data catalog: columns, profiling, lineage, impact, models, search (1338 lines)
 │   │   ├── governance.py       # Schema drift + PII results API
 │   │   ├── monitoring.py       # Monitor results, run trigger, history
 │   │   ├── notebooks.py        # Notebook management API + page route
@@ -343,13 +343,13 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/platform.py` | 1038 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 886 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
-| `web/helpers.py` | 851 | — (extracted from app.py by TASK-085) |
+| `web/helpers.py` | 868 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 849 | — (module-level job functions) |
 | `utils/post_sync.py` | 661 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 518 | — (schedule read-only, history, trigger, notifications) |
 | `web/routes/notebooks.py` | 506 | — (notebook management API + heartbeat lock expiry + WS notify) |
-| `web/routes/upload.py` | 705 | — (extracted from app.py by TASK-085) |
+| `web/routes/upload.py` | 711 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
 | `cli/commands/source.py` | 833 | — (extracted from main.py by TASK-005) |
@@ -360,7 +360,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `config/models.py` | 606 | — (Pydantic config models) |
 | `cli/commands/deploy_wizard.py` | 828 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 613 | — |
-| `web/routes/catalog.py` | 1336 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
+| `web/routes/catalog.py` | 1338 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `cli/commands/deploy_provision.py` | 897 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |
 | `platform/cloud/server_setup.py` | 690 | — (server setup + install source detection) |

--- a/dango/security/token_storage.py
+++ b/dango/security/token_storage.py
@@ -4,6 +4,7 @@ Encrypts OAuth tokens using OS keychain for key storage and Fernet for encryptio
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -78,11 +79,12 @@ class SecureTokenStorage:
                 return key_file.read_bytes()
             else:
                 key = Fernet.generate_key()
-                # TOCTOU: file is briefly world-readable between write_bytes
-                # and chmod. For a more secure pattern, use os.open() with
-                # mode at creation time (see cloud/ssh.py generate_key()).
-                key_file.write_bytes(key)
-                key_file.chmod(0o600)  # Restrict permissions
+                # Atomic: file created with 0o600 permissions from the start
+                fd = os.open(str(key_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                try:
+                    os.write(fd, key)
+                finally:
+                    os.close(fd)
                 return key
 
     def encrypt_token(self, token_data: dict[str, Any]) -> str:

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -10,7 +10,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 |------|---------|----------------------|
 | `app.py` | Entry point: `create_app()`, middleware, router registration, lifespan context manager (incl. first-run admin creation), global exception handlers (`DangoError` → structured JSON, generic `Exception` → 500) | `create_app()`, `app` (global FastAPI instance), `lifespan()`, `dango_error_handler()`, `unhandled_error_handler()` |
 | `models.py` | Pydantic request/response DTOs | `TableInfo`, `SourceStatus`, `ServiceHealth`, `SyncRequest`, `SyncResponse`, `LogEntry`, `WatcherStatus`, `LoginRequest`, `AcceptInviteRequest`, `TwoFAVerifyRequest` |
-| `helpers.py` | Shared helpers: DuckDB queries, config loading, service health, logging (851 lines) | `get_project_root()`, `load_sources_config()`, `get_duckdb_path()`, `get_dbt_models()`, `mask_sensitive_config()`, `get_source_freshness()`, `append_log_entry()`, `load_all_logs()`, `check_service_status_async()`, `get_platform_health_data()`, `get_source_status_data()` |
+| `helpers.py` | Shared helpers: DuckDB queries, config loading, service health, logging (868 lines) | `get_project_root()`, `load_sources_config()`, `get_duckdb_path()`, `get_dbt_models()`, `mask_sensitive_config()`, `get_source_freshness()`, `append_log_entry()`, `load_all_logs()`, `check_service_status_async()`, `get_platform_health_data()`, `get_source_status_data()` |
 | `__init__.py` | Public exports | `app` module |
 | `middleware/auth.py` | Session/API key auth + CSRF check on every request (~324 lines) | `AuthMiddleware`, `is_secure_request()`, `COOKIE_NAME` |
 | `middleware/rate_limit.py` | Rate limiting (login 10/min, API 200/min, localhost exempt, ~235 lines) | `RateLimitMiddleware` |
@@ -45,7 +45,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule list/get, trigger, reload, cancel, history, notification config/test, `/schedules` page (read-only, ~518 lines). Config mutations removed by R10-C (BUG-175) — use CLI instead. | `router` |
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~506 lines) | `router` |
-| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1336 lines) | `router` |
+| `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1338 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~203 lines) | `router` |
 | `routes/monitoring.py` | Monitor results, run trigger, history, dbt test results + backward-compat redirects for old `/api/insights*` paths (~398 lines) | `router` |
 | `routes/ai.py` | Agent/AI interface: /api/catalog/summary, /api/tools (~496 lines) | `router` |

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -82,11 +82,11 @@ def get_dbt_model_row_count(schema: str, model_name: str) -> int | None:
         conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
         try:
             # Check if table exists
-            result = conn.execute(f"""
-                SELECT COUNT(*)
-                FROM information_schema.tables
-                WHERE table_schema = '{schema}' AND table_name = '{model_name}'
-            """).fetchone()
+            result = conn.execute(
+                "SELECT COUNT(*) FROM information_schema.tables "
+                "WHERE table_schema = ? AND table_name = ?",
+                [schema, model_name],
+            ).fetchone()
 
             if result and result[0] > 0:
                 # Table exists, get row count

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -6,7 +6,7 @@ Pydantic request/response DTOs for the web API.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class TableInfo(BaseModel):
@@ -94,21 +94,21 @@ class WatcherStatus(BaseModel):
 class LoginRequest(BaseModel):
     """Login credentials."""
 
-    email: str
-    password: str
+    email: str = Field(max_length=254)
+    password: str = Field(max_length=1024)
 
 
 class ChangePasswordRequest(BaseModel):
     """Password change payload."""
 
-    current_password: str
-    new_password: str
+    current_password: str = Field(max_length=1024)
+    new_password: str = Field(max_length=1024)
 
 
 class CreateApiKeyRequest(BaseModel):
     """API key creation payload."""
 
-    name: str
+    name: str = Field(max_length=128)
     expires_at: datetime | None = None
 
 
@@ -148,8 +148,8 @@ class ApiKeyCreateResponse(ApiKeyResponse):
 class CreateUserRequest(BaseModel):
     """Admin user creation payload."""
 
-    email: str
-    role: str = "viewer"
+    email: str = Field(max_length=254)
+    role: str = Field(default="viewer", max_length=32)
     generate_password: bool = False
 
     @field_validator("email", mode="before")
@@ -165,20 +165,20 @@ class CreateUserRequest(BaseModel):
 class AcceptInviteRequest(BaseModel):
     """Invite acceptance payload."""
 
-    token: str
-    password: str
+    token: str = Field(max_length=1024)
+    password: str = Field(max_length=1024)
 
 
 class ChangeRoleRequest(BaseModel):
     """Admin role change payload."""
 
-    role: str
+    role: str = Field(max_length=32)
 
 
 class DeleteUserConfirmation(BaseModel):
     """Delete user confirmation payload."""
 
-    confirm_email: str
+    confirm_email: str = Field(max_length=254)
 
 
 # ---------------------------------------------------------------------------
@@ -189,33 +189,33 @@ class DeleteUserConfirmation(BaseModel):
 class TwoFASetupRequest(BaseModel):
     """Request to begin 2FA setup (verifies current password)."""
 
-    password: str
+    password: str = Field(max_length=1024)
 
 
 class TwoFAVerifySetupRequest(BaseModel):
     """Verify a TOTP code to complete 2FA setup."""
 
-    code: str
+    code: str = Field(max_length=10)
 
 
 class TwoFAVerifyRequest(BaseModel):
     """Verify a TOTP or recovery code during login."""
 
-    code: str
+    code: str = Field(max_length=10)
     is_recovery: bool = False
 
 
 class TwoFADisableRequest(BaseModel):
     """Request to disable 2FA (verifies current password)."""
 
-    password: str
+    password: str = Field(max_length=1024)
 
 
 class TwoFARegenerateRequest(BaseModel):
     """Request to regenerate recovery codes (verifies password + TOTP)."""
 
-    password: str
-    code: str
+    password: str = Field(max_length=1024)
+    code: str = Field(max_length=10)
 
 
 # ---------------------------------------------------------------------------

--- a/dango/web/routes/auth_2fa.py
+++ b/dango/web/routes/auth_2fa.py
@@ -247,6 +247,7 @@ async def verify_2fa(request: Request) -> JSONResponse:
 
     user = validate_partial_session(db_path, cookie_token)
     if user is None:
+        _2fa_attempt_counts.pop(cookie_token, None)
         return JSONResponse(status_code=401, content={"message": "Invalid or expired session"})
 
     # Re-read user for current TOTP state

--- a/dango/web/routes/auth_2fa.py
+++ b/dango/web/routes/auth_2fa.py
@@ -53,6 +53,21 @@ from dango.web.routes.auth import _bridge_metabase_session
 router = APIRouter(tags=["auth-2fa"])
 logger = get_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# 2FA brute-force protection
+#
+# Track failed verification attempts per partial session token.  After
+# _MAX_2FA_ATTEMPTS failures the partial session is invalidated, forcing
+# the user to re-authenticate with credentials.
+#
+# In-memory is acceptable: partial sessions live ≤5 min and server restart
+# clears both counters and sessions.  Multi-worker: each worker tracks
+# independently — worst case 5×N attempts across N workers, still finite.
+# ---------------------------------------------------------------------------
+
+_MAX_2FA_ATTEMPTS = 5
+_2fa_attempt_counts: dict[str, int] = {}
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers (same pattern as auth.py — small, redefined here to
@@ -217,6 +232,19 @@ async def verify_2fa(request: Request) -> JSONResponse:
     if not cookie_token:
         return JSONResponse(status_code=401, content={"message": "Invalid or expired session"})
 
+    # Check brute-force counter before validating session
+    if _2fa_attempt_counts.get(cookie_token, 0) >= _MAX_2FA_ATTEMPTS:
+        # Invalidate partial session to force re-authentication
+        token_hash = hash_token(cookie_token)
+        partial = get_session_by_token(db_path, token_hash)
+        if partial:
+            invalidate_session(db_path, partial.id)
+        _2fa_attempt_counts.pop(cookie_token, None)
+        return JSONResponse(
+            status_code=401,
+            content={"message": "Too many failed attempts. Please log in again."},
+        )
+
     user = validate_partial_session(db_path, cookie_token)
     if user is None:
         return JSONResponse(status_code=401, content={"message": "Invalid or expired session"})
@@ -238,10 +266,23 @@ async def verify_2fa(request: Request) -> JSONResponse:
         verified = verify_totp_code(current_user.totp_secret, data.code)
 
     if not verified:
-        # TODO: Add failed-attempt tracking on partial sessions to prevent
-        # brute-force TOTP guessing within the 5-minute window. Requires
-        # a migration to add failed_2fa_attempts column to sessions table.
+        _2fa_attempt_counts[cookie_token] = _2fa_attempt_counts.get(cookie_token, 0) + 1
+        remaining = _MAX_2FA_ATTEMPTS - _2fa_attempt_counts[cookie_token]
+        if remaining <= 0:
+            # Invalidate partial session immediately
+            token_hash = hash_token(cookie_token)
+            partial = get_session_by_token(db_path, token_hash)
+            if partial:
+                invalidate_session(db_path, partial.id)
+            _2fa_attempt_counts.pop(cookie_token, None)
+            return JSONResponse(
+                status_code=401,
+                content={"message": "Too many failed attempts. Please log in again."},
+            )
         return JSONResponse(status_code=400, content={"message": "Invalid verification code"})
+
+    # Success — clean up brute-force counter
+    _2fa_attempt_counts.pop(cookie_token, None)
 
     # Invalidate the partial session
     token_hash = hash_token(cookie_token)

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -152,7 +152,8 @@ def _source_schema_exists(db_path: Path, source: str) -> bool:
     conn = duckdb.connect(str(db_path), config={"access_mode": "read_only"})
     try:
         result = conn.execute(
-            f"SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = '{schema}'"
+            "SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = ?",
+            [schema],
         ).fetchone()
     finally:
         conn.close()
@@ -175,8 +176,9 @@ def _table_exists(db_path: Path, source: str, table: str) -> bool:
     try:
         result = conn.execute(
             "SELECT COUNT(*) FROM information_schema.tables "
-            f"WHERE table_schema = '{schema}' AND table_name = '{table}' "
-            "AND table_name NOT LIKE '_dlt_%'"
+            "WHERE table_schema = ? AND table_name = ? "
+            "AND table_name NOT LIKE '_dlt_%'",
+            [schema, table],
         ).fetchone()
     finally:
         conn.close()

--- a/dango/web/routes/query.py
+++ b/dango/web/routes/query.py
@@ -21,7 +21,7 @@ from typing import Any
 import duckdb
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
@@ -49,7 +49,7 @@ _QUERY_TIMEOUT_SECONDS = 30
 class QueryRequest(BaseModel):
     """Ad-hoc SQL query request."""
 
-    sql: str
+    sql: str = Field(max_length=102_400)
 
 
 class QueryResponse(BaseModel):

--- a/dango/web/routes/query.py
+++ b/dango/web/routes/query.py
@@ -37,7 +37,6 @@ router = APIRouter(tags=["query"])
 # Constants
 # ---------------------------------------------------------------------------
 
-_MAX_SQL_LENGTH = 102_400  # 100 KB
 _MAX_ROWS = 10_000
 _QUERY_TIMEOUT_SECONDS = 30
 
@@ -187,15 +186,6 @@ async def execute_query(
         return JSONResponse(
             status_code=400,
             content={"error_code": "DANGO-Q001", "message": "SQL query is empty"},
-        )
-
-    if len(sql) > _MAX_SQL_LENGTH:
-        return JSONResponse(
-            status_code=400,
-            content={
-                "error_code": "DANGO-Q001",
-                "message": f"SQL query exceeds maximum length ({_MAX_SQL_LENGTH} bytes)",
-            },
         )
 
     try:

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -128,8 +128,14 @@ async def upload_csv_to_source(
                 status_code=409,
                 detail=f"File '{safe_filename}' already exists. Delete the existing file first or rename your file.",
             )
+        content = await file.read()
+        _max_upload_bytes = 100 * 1024 * 1024  # 100 MB
+        if len(content) > _max_upload_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File too large. Maximum upload size is {_max_upload_bytes // (1024 * 1024)} MB.",
+            )
         async with aiofiles.open(file_path, "wb") as buffer:
-            content = await file.read()
             await buffer.write(content)
 
         logger.info(f"Uploaded file for source '{source_name}': {file_path}")

--- a/dango/web/routes/websocket.py
+++ b/dango/web/routes/websocket.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["websocket"])
 
+_MAX_WS_MESSAGE_SIZE = 4096  # 4 KB
+
 
 class ConnectionManager:
     """Manages WebSocket connections for real-time updates."""
@@ -100,6 +102,10 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         while True:
             # Wait for messages from client (ping/pong for keepalive)
             data = await websocket.receive_text()
+
+            if len(data) > _MAX_WS_MESSAGE_SIZE:
+                await websocket.send_json({"event": "error", "message": "Message too large"})
+                continue
 
             # Echo back for now (can add client commands later)
             await websocket.send_json(

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -12,13 +12,13 @@ limit: 500  # Informational — scripts/check_file_sizes.py owns the enforced th
 exemptions:
   # --- Post-TASK-085 split results (from web/app.py 3032 → web/routes/) ---
   - file: dango/web/helpers.py
-    lines: 851
+    lines: 868
     category: exempt
     reason: "Shared helper functions for web routes. Consolidates DuckDB queries, config loading, service health checks, and log management. Extracted from web/app.py by TASK-085. Mirrors cli/utils.py pattern."
     review_by: "v1.1"
 
   - file: dango/web/routes/upload.py
-    lines: 705
+    lines: 711
     category: exempt
     reason: "CSV upload/list/delete endpoints. Extracted from web/app.py by TASK-085. DELETE endpoint alone has ~300 lines of DuckDB cleanup logic."
     review_by: "v1.1"
@@ -349,7 +349,7 @@ exemptions:
   # Removed: dango/web/routes/sync.py — now ~370 lines after R10-N (sync moved to subprocess)
 
   - file: dango/web/routes/catalog.py
-    lines: 1336
+    lines: 1338
     category: exempt
     reason: "P7-001+P7-002+BUG-016+R9-G+R10-E1+R10-E2: Column schema, profiling, lineage DAG, impact analysis, model list/detail/search, raw table discovery, overview summary, per-source stats. Single router file — manifest parsing helpers are private to the same module."
     review_by: "v1.1"

--- a/tests/unit/test_web_auth_2fa.py
+++ b/tests/unit/test_web_auth_2fa.py
@@ -28,6 +28,7 @@ from dango.auth.totp import (
 from dango.migrations.runner import MigrationRunner
 from dango.web.middleware.auth import COOKIE_NAME
 from dango.web.routes.auth import router as auth_router
+from dango.web.routes.auth_2fa import _2fa_attempt_counts
 from dango.web.routes.auth_2fa import router as auth_2fa_router
 
 _TEST_PASSWORD = "securepassword123"
@@ -253,6 +254,73 @@ class TestTwoFAVerify:
         conn.execute("UPDATE sessions SET expires_at = ? WHERE is_partial = 1", (past,))
         conn.commit()
         conn.close()
+        code = pyotp.TOTP(secret).now()
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": code, "is_recovery": False},
+            cookies={COOKIE_NAME: cookie},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.unit
+class TestTwoFABruteForce:
+    """2FA brute-force protection — lockout after 5 failed attempts."""
+
+    def _partial_login(self, tmp_path: Path) -> tuple[TestClient, Path, User, str, str]:
+        """Create user with 2FA, login to get partial session cookie."""
+        db_path = _make_db(tmp_path)
+        secret = generate_totp_secret()
+        user = _make_user(db_path, totp_secret=secret, totp_enabled=True)
+        hashed = hash_and_store_codes(["AAAA-BBBB", "CCCC-DDDD"])
+        db.update_user(db_path, user.id, UserUpdate(recovery_codes=hashed))
+        app = _make_app(db_path)
+        tc = _client(app)
+        resp = tc.post(
+            "/api/auth/login",
+            json={"email": "test@example.com", "password": _TEST_PASSWORD},
+        )
+        assert resp.status_code == 200 and resp.json()["requires_2fa"] is True
+        cookie = resp.cookies.get(COOKIE_NAME)
+        assert cookie is not None
+        # Clear any stale counters
+        _2fa_attempt_counts.clear()
+        return tc, db_path, user, secret, cookie
+
+    def test_lockout_after_5_failures(self, tmp_path: Path) -> None:
+        tc, _, _, _, cookie = self._partial_login(tmp_path)
+        # 4 failures → still 400 (invalid code)
+        for _ in range(4):
+            resp = tc.post(
+                "/api/auth/2fa/verify",
+                json={"code": "000000", "is_recovery": False},
+                cookies={COOKIE_NAME: cookie},
+                headers=_hdrs(),
+            )
+            assert resp.status_code == 400
+
+        # 5th failure → 401 lockout
+        resp = tc.post(
+            "/api/auth/2fa/verify",
+            json={"code": "000000", "is_recovery": False},
+            cookies={COOKIE_NAME: cookie},
+            headers=_hdrs(),
+        )
+        assert resp.status_code == 401
+        assert "Too many failed attempts" in resp.json()["message"]
+
+    def test_subsequent_request_after_lockout_also_401(self, tmp_path: Path) -> None:
+        tc, _, _, secret, cookie = self._partial_login(tmp_path)
+        # Exhaust attempts
+        for _ in range(5):
+            tc.post(
+                "/api/auth/2fa/verify",
+                json={"code": "000000", "is_recovery": False},
+                cookies={COOKIE_NAME: cookie},
+                headers=_hdrs(),
+            )
+        # Even a valid code should fail — session invalidated
         code = pyotp.TOTP(secret).now()
         resp = tc.post(
             "/api/auth/2fa/verify",

--- a/tests/unit/test_web_query.py
+++ b/tests/unit/test_web_query.py
@@ -176,12 +176,12 @@ class TestInputValidation:
         assert resp.status_code == 400
         assert resp.json()["error_code"] == "DANGO-Q001"
 
-    def test_sql_too_long_returns_400(self, tmp_path: Path) -> None:
+    def test_sql_too_long_returns_422(self, tmp_path: Path) -> None:
         client, _ = _setup_client(tmp_path)
         long_sql = "SELECT " + "x" * 200_000
         resp = client.post("/api/query", json={"sql": long_sql})
-        assert resp.status_code == 400
-        assert resp.json()["error_code"] == "DANGO-Q001"
+        # Pydantic max_length validation fires before the endpoint handler
+        assert resp.status_code == 422
 
     def test_insert_rejected(self, tmp_path: Path) -> None:
         client, _ = _setup_client(tmp_path)


### PR DESCRIPTION
## Summary

Phase 9.1 security audit — systematic review of 29 items before v1.0.0 release.

- **22 items passed** with no changes needed (bcrypt, sessions, cookies, CSRF, rate limiting, XSS, path traversal, SSH, firewall, HTTPS, audit logging, etc.)
- **7 fixes applied:**
  - TOCTOU in `token_storage.py` — atomic `os.open()` with 0o600 permissions
  - 2FA brute-force protection — 5-attempt lockout on partial sessions
  - SQL parameterization — f-string WHERE values → `?` params in `helpers.py` and `catalog.py`
  - Pydantic `max_length` on all request model string fields
  - WebSocket 4KB message size limit
  - File upload 100MB explicit size limit
  - Test updated for Pydantic-level SQL length validation (400→422)
- **pip-audit:** black (dev-only), paramiko (no fix yet), pip (tooling) — no production vulnerabilities

## Test plan

- [x] All pre-commit hooks pass
- [x] 3531 unit tests pass (including 2 new 2FA brute-force tests)
- [x] `scripts/integration_test.sh` — all 5/5 stages pass
- [x] mypy clean on all modified files
- [x] File exemption line counts verified and updated in all 4 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)