### PR TITLE
9.5: Dependency audit & cleanup

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -13,3 +13,11 @@ dlt==1.24.0
 # Transitive — prevent known breakage
 starlette>=1.0.0
 pydantic-core>=2.20.0
+#
+# Transitive — CVE floor pins (2026-05-14 audit)
+aiohttp>=3.13.4         # 10 CVEs (CVE-2026-34513 through CVE-2026-22815)
+deepdiff>=8.6.2         # CVE-2026-33155
+gitpython>=3.1.50       # CVE-2026-42215, CVE-2026-42284, CVE-2026-44244, GHSA-mv93-w799-cj2w
+pyasn1>=0.6.3           # CVE-2026-30922
+pygments>=2.20.0        # CVE-2026-4539
+urllib3>=2.7.0           # CVE-2026-44431, CVE-2026-44432

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     # Data governance and notebooks
     "marimo>=0.23.0",             # CVE-2026-39987 fixed in 0.23.0
     "presidio-analyzer>=2.2.0",
-    "spacy>=3.7.0,<3.8.12",
+    "spacy>=3.8.0,<3.9",          # en_core_web_sm-3.8.0 model requires >=3.8.0,<3.9.0
 
     # Security and encryption
     "keyring>=24.0.0",    # Secure credential storage in OS keychain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,29 +40,30 @@ dependencies = [
     "click>=8.1.7",
     "pyyaml>=6.0.1",
     "pydantic>=2.0.0",
-    "python-dotenv>=1.0.0",
+    "python-dotenv>=1.2.2",       # CVE-2026-28684 fixed in 1.2.2
     "jinja2>=3.1.4",
     "watchdog>=5.0.0",
     "rich>=13.7.0",
     "inquirer>=3.4.0",
-    "requests>=2.31.0",
+    "requests>=2.33.0",           # CVE-2026-25645 fixed in 2.33.0
     "httpx>=0.27.0",
     "fastapi>=0.133.0",
     "uvicorn[standard]>=0.27.0",
-    "python-multipart>=0.0.9",
+    "python-multipart>=0.0.27",   # CVE-2026-40347, CVE-2026-42561 fixed in 0.0.27
     "websockets>=12.0",
     "aiofiles>=23.2.0",
     "psutil>=5.9.0",
     "structlog>=24.1.0",
+    "tomlkit>=0.13.0",            # TOML read/write with style preservation (source_wizard, dlt_runner)
 
     # Data governance and notebooks
-    "marimo>=0.9.0",
+    "marimo>=0.23.0",             # CVE-2026-39987 fixed in 0.23.0
     "presidio-analyzer>=2.2.0",
     "spacy>=3.7.0,<3.8.12",
 
     # Security and encryption
     "keyring>=24.0.0",    # Secure credential storage in OS keychain
-    "cryptography>=41.0.0",  # Token encryption
+    "cryptography>=46.0.7",  # Token encryption; CVE-2026-26007/34073/39892 fixed in 46.0.7
     "pwdlib[bcrypt]>=0.3.0,<1.0",  # Password hashing (bcrypt)
     "pyotp>=2.9,<3.0",   # TOTP two-factor authentication
     "toml>=0.10.2",       # TOML file parsing for .dlt/secrets.toml
@@ -74,7 +75,7 @@ dependencies = [
 
     # Cloud deployment
     "boto3>=1.34.0",      # DigitalOcean Spaces (S3-compatible)
-    "paramiko>=3.0.0",    # SSH key management and remote execution
+    "paramiko>=3.0.0",    # SSH key management and remote execution; CVE-2026-44405 has no fix yet
 
     # Scheduling
     "apscheduler>=3.11,<4",   # Job scheduling (AsyncIOScheduler + SQLAlchemy job store)
@@ -84,7 +85,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0.0",
+    "pytest>=9.0.3",              # CVE-2025-71176 fixed in 9.0.3
     "pytest-cov>=5.0.0",
     "black>=24.0.0",  # CVE-2026-32274 in <26.3.1; bump blocked by dbt-core pydantic<2 conflict
     "ruff>=0.6.0",

--- a/scripts/check_python_compat.py
+++ b/scripts/check_python_compat.py
@@ -1,0 +1,102 @@
+"""scripts/check_python_compat.py
+
+Check that all installed packages support Python 3.10, 3.11, and 3.12.
+Uses package metadata (Requires-Python) to verify compatibility without
+needing multiple Python interpreters installed.
+
+Transitive dependencies that have dropped a Python version are flagged as
+warnings (not failures) because pip resolves per-platform — on Python 3.10
+it would install an older compatible version automatically.
+
+Exit codes:
+    0 — all direct deps compatible (transitive warnings are OK)
+    1 — a direct dependency dropped support for a required Python version
+"""
+
+import importlib.metadata
+import sys
+from pathlib import Path
+
+import tomllib
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+# Python versions that getdango must support (see pyproject.toml requires-python)
+REQUIRED_VERSIONS = [Version("3.10.0"), Version("3.11.0"), Version("3.12.0")]
+
+# Packages to skip (not real PyPI packages)
+SKIP_PACKAGES = {"getdango", "en-core-web-sm", "en-core-web-lg"}
+
+
+def _get_direct_dep_names() -> set[str]:
+    """Extract direct dependency names from pyproject.toml."""
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with open(pyproject, "rb") as f:
+        data = tomllib.load(f)
+
+    names: set[str] = set()
+    for dep_str in data.get("project", {}).get("dependencies", []):
+        # Extract package name (everything before first version specifier or bracket)
+        name = dep_str.split(">=")[0].split("<=")[0].split("~=")[0].split("==")[0]
+        name = name.split("[")[0].strip().strip('"').strip("'")
+        names.add(name.lower().replace("-", "_").replace(".", "_"))
+    return names
+
+
+def _normalize(name: str) -> str:
+    return name.lower().replace("-", "_").replace(".", "_")
+
+
+def main() -> int:
+    """Check all installed packages for Python version compatibility."""
+    direct_deps = _get_direct_dep_names()
+
+    direct_failures = []
+    transitive_warnings = []
+    checked = 0
+    skipped = 0
+
+    for dist in importlib.metadata.distributions():
+        name = dist.metadata["Name"]
+        if name in SKIP_PACKAGES:
+            continue
+
+        requires_python = dist.metadata.get("Requires-Python")
+        if not requires_python:
+            skipped += 1
+            continue
+
+        checked += 1
+        spec = SpecifierSet(requires_python)
+        unsupported = [v for v in REQUIRED_VERSIONS if v not in spec]
+
+        if unsupported:
+            versions_str = ", ".join(str(v) for v in unsupported)
+            entry = (name, dist.metadata["Version"], requires_python, versions_str)
+            if _normalize(name) in direct_deps:
+                direct_failures.append(entry)
+            else:
+                transitive_warnings.append(entry)
+
+    print(f"Checked {checked} packages ({skipped} without Requires-Python metadata)")
+
+    if transitive_warnings:
+        print(
+            f"\nWARN: {len(transitive_warnings)} transitive package(s) installed at versions "
+            "that drop a target Python (pip resolves per-platform, so this is informational):"
+        )
+        for name, version, spec, unsupported in sorted(transitive_warnings):
+            print(f"  {name}=={version} (requires {spec}) — drops Python {unsupported}")
+
+    if direct_failures:
+        print(f"\nFAIL: {len(direct_failures)} direct dependency(s) incompatible:")
+        for name, version, spec, unsupported in sorted(direct_failures):
+            print(f"  {name}=={version} (requires {spec}) — drops Python {unsupported}")
+        return 1
+
+    print("\nOK: All direct dependencies support Python 3.10, 3.11, and 3.12")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_python_compat.py
+++ b/scripts/check_python_compat.py
@@ -14,10 +14,10 @@ Exit codes:
 """
 
 import importlib.metadata
+import re
 import sys
 from pathlib import Path
 
-import tomllib
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
@@ -29,17 +29,34 @@ SKIP_PACKAGES = {"getdango", "en-core-web-sm", "en-core-web-lg"}
 
 
 def _get_direct_dep_names() -> set[str]:
-    """Extract direct dependency names from pyproject.toml."""
-    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
-    with open(pyproject, "rb") as f:
-        data = tomllib.load(f)
+    """Extract direct dependency names from pyproject.toml.
 
+    Uses string parsing (not tomllib) so the script works on Python 3.10.
+    """
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+
+    # Extract lines between `dependencies = [` and the closing `]`
     names: set[str] = set()
-    for dep_str in data.get("project", {}).get("dependencies", []):
-        # Extract package name (everything before first version specifier or bracket)
-        name = dep_str.split(">=")[0].split("<=")[0].split("~=")[0].split("==")[0]
-        name = name.split("[")[0].strip().strip('"').strip("'")
-        names.add(name.lower().replace("-", "_").replace(".", "_"))
+    in_deps = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "dependencies = [":
+            in_deps = True
+            continue
+        if in_deps and stripped == "]":
+            break
+        if not in_deps:
+            continue
+        # Extract quoted dependency string
+        match = re.match(r'\s*"([^"]+)"', line)
+        if not match:
+            continue
+        dep_str = match.group(1)
+        # Package name is everything before the first version specifier or bracket
+        name = re.split(r"[>=<~!\[]", dep_str)[0].strip()
+        if name:
+            names.add(_normalize(name))
     return names
 
 


### PR DESCRIPTION
## Summary
- Fix 28 of 34 CVEs found by pip-audit: bump version floors for 6 direct deps (cryptography, requests, python-dotenv, python-multipart, marimo, pytest) and add transitive floor pins for 6 indirect deps (aiohttp, deepdiff, gitpython, pyasn1, pygments, urllib3)
- Remaining 6 are documented exceptions: black (blocked by dbt-core), paramiko (no fix), pip (tool, not dep)
- Add `tomlkit>=0.13.0` as explicit dependency (directly imported in source_wizard/dlt_runner but was only transitive)
- Add `scripts/check_python_compat.py` for CI Python 3.10-3.12 compatibility validation

## Verification
- `pip-audit`: clean (6 remaining = documented exceptions)
- `integration_test.sh`: all 5 stages pass (3529 tests, 0 failures)
- `check_python_compat.py`: all direct deps support 3.10-3.12
- spaCy model lazy download: verified working after uninstall

## Test plan
- [x] pip-audit returns only documented exceptions
- [x] integration_test.sh passes all 5 stages
- [x] Python compat script confirms 3.10-3.12 support
- [x] spaCy model lazy download works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)