### PR TITLE
fix: CSV 0-row sync detection + downstream model profiling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ dango/                          # Python package source
 │   └── watcher_runner.py       # → local/watcher_runner.py
 │
 ├── ingestion/                  # Level 1 — Data loading
-│   ├── dlt_runner.py           # ⚠ 2534 lines — orchestrates full sync pipeline
+│   ├── dlt_runner.py           # ⚠ 2579 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # Multi-format file loading with dedup (922 lines)
 │   ├── sources/
 │   │   └── registry.py         # Source metadata (33 source types)
@@ -289,7 +289,7 @@ dango/                          # Python package source
 │   ├── data_validation.py      # Data validation utilities
 │   ├── env_file.py             # .env file parsing and serialization
 │   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
-│   ├── post_sync.py            # Post-sync hook dispatcher (~661 lines)
+│   ├── post_sync.py            # Post-sync hook dispatcher (~763 lines)
 │   └── git_info.py             # Git repository info + deployment guardrails
 │
 ├── migrations/                 # Level 0 — Database migration framework
@@ -347,7 +347,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/helpers.py` | 868 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 860 | — (module-level job functions) |
-| `utils/post_sync.py` | 661 | — (post-sync hooks + sync notification) |
+| `utils/post_sync.py` | 763 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 519 | — (schedule read-only, history, trigger, notifications) |
 | `web/routes/notebooks.py` | 506 | — (notebook management API + heartbeat lock expiry + WS notify) |
 | `web/routes/upload.py` | 711 | — (extracted from app.py by TASK-085) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ dango/                          # Python package source
 │   ├── data_validation.py      # Data validation utilities
 │   ├── env_file.py             # .env file parsing and serialization
 │   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
-│   ├── post_sync.py            # Post-sync hook dispatcher (~763 lines)
+│   ├── post_sync.py            # Post-sync hook dispatcher (~762 lines)
 │   └── git_info.py             # Git repository info + deployment guardrails
 │
 ├── migrations/                 # Level 0 — Database migration framework
@@ -347,7 +347,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/helpers.py` | 868 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 860 | — (module-level job functions) |
-| `utils/post_sync.py` | 763 | — (post-sync hooks + sync notification) |
+| `utils/post_sync.py` | 762 | — (post-sync hooks + sync notification) |
 | `web/routes/schedules.py` | 519 | — (schedule read-only, history, trigger, notifications) |
 | `web/routes/notebooks.py` | 506 | — (notebook management API + heartbeat lock expiry + WS notify) |
 | `web/routes/upload.py` | 711 | — (extracted from app.py by TASK-085) |

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -586,7 +586,7 @@ class DltPipelineRunner:
             allow_schema_changes=getattr(self, "allow_schema_changes", False),
         )
 
-        return {
+        merged = {
             **result,
             "status": result.get("status", "success"),
             "source": source_config.name,
@@ -594,6 +594,18 @@ class DltPipelineRunner:
             "files_processed": result.get("new", 0) + result.get("updated", 0),
             "uses_replace_mode": True,  # CSV sources always do full refresh
         }
+
+        # No files found, no data loaded, no deletions → error
+        if (
+            merged["status"] == "success"
+            and merged["rows_loaded"] == 0
+            and merged["files_processed"] == 0
+            and merged.get("deleted", 0) == 0
+        ):
+            merged["status"] = "error"
+            merged["error"] = "No files found to load"
+
+        return merged
 
     def _run_local_files_source(
         self, source_config: DataSource, full_refresh: bool = False
@@ -641,7 +653,7 @@ class DltPipelineRunner:
             allow_schema_changes=getattr(self, "allow_schema_changes", False),
         )
 
-        return {
+        merged = {
             **result,
             "status": result.get("status", "success"),
             "source": source_config.name,
@@ -649,6 +661,18 @@ class DltPipelineRunner:
             "files_processed": result.get("new", 0) + result.get("updated", 0),
             "uses_replace_mode": True,  # Local file sources always do full refresh
         }
+
+        # No files found, no data loaded, no deletions → error
+        if (
+            merged["status"] == "success"
+            and merged["rows_loaded"] == 0
+            and merged["files_processed"] == 0
+            and merged.get("deleted", 0) == 0
+        ):
+            merged["status"] = "error"
+            merged["error"] = "No files found to load"
+
+        return merged
 
     def _run_dlt_native_source(
         self,

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -20,7 +20,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~210 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~661 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
+| `post_sync.py` (~763 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -20,7 +20,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~210 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~763 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
+| `post_sync.py` (~762 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -504,6 +504,77 @@ def _run_profiling(project_root: Path, sources: list[str]) -> None:
         except Exception:
             logger.warning("profiling_source_error", source=source)
 
+    # Profile downstream dbt models (intermediate + marts)
+    _profile_dbt_models(project_root, db_path)
+
+
+def _profile_dbt_models(project_root: Path, db_path: Path) -> None:
+    """Profile dbt model tables in intermediate/marts schemas.
+
+    Uses ``run_results.json`` and ``manifest.json`` from the most recent
+    dbt run to discover which models succeeded, then profiles tables that
+    are *not* already covered by the per-source raw/staging loop.
+
+    Args:
+        project_root: Path to the Dango project root.
+        db_path: Path to warehouse.duckdb.
+    """
+    target_dir = project_root / "dbt" / "target"
+
+    run_results_path = target_dir / "run_results.json"
+    if not run_results_path.exists():
+        logger.debug("profiling_dbt_no_run_results")
+        return
+
+    manifest_path = target_dir / "manifest.json"
+    if not manifest_path.exists():
+        logger.debug("profiling_dbt_no_manifest")
+        return
+
+    try:
+        run_results = json.loads(run_results_path.read_text())
+        manifest = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        logger.warning("profiling_dbt_json_error", exc_info=True)
+        return
+
+    # Collect unique_ids of successful models
+    successful_ids = [
+        r["unique_id"]
+        for r in run_results.get("results", [])
+        if r.get("unique_id", "").startswith("model.") and r.get("status") == "success"
+    ]
+
+    nodes = manifest.get("nodes", {})
+    for uid in successful_ids:
+        node = nodes.get(uid)
+        if not node:
+            continue
+
+        schema = node.get("schema", "")
+        alias = node.get("alias") or node.get("name", "")
+
+        # Skip schemas already profiled by the per-source loop
+        if schema.startswith("raw_") or schema == "staging":
+            continue
+        if not schema or not alias:
+            continue
+
+        try:
+            profile_table(
+                project_root,
+                schema,
+                validate_identifier(alias),
+                schema_override=schema,
+            )
+        except Exception:
+            logger.warning(
+                "profiling_dbt_model_error",
+                uid=uid,
+                schema=schema,
+                table=alias,
+            )
+
 
 def _run_pii_scan(project_root: Path, sources: list[str]) -> None:
     """Scan for PII in freshly synced sources.

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -505,10 +505,10 @@ def _run_profiling(project_root: Path, sources: list[str]) -> None:
             logger.warning("profiling_source_error", source=source)
 
     # Profile downstream dbt models (intermediate + marts)
-    _profile_dbt_models(project_root, db_path)
+    _profile_dbt_models(project_root)
 
 
-def _profile_dbt_models(project_root: Path, db_path: Path) -> None:
+def _profile_dbt_models(project_root: Path) -> None:
     """Profile dbt model tables in intermediate/marts schemas.
 
     Uses ``run_results.json`` and ``manifest.json`` from the most recent
@@ -517,7 +517,6 @@ def _profile_dbt_models(project_root: Path, db_path: Path) -> None:
 
     Args:
         project_root: Path to the Dango project root.
-        db_path: Path to warehouse.duckdb.
     """
     target_dir = project_root / "dbt" / "target"
 

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -341,7 +341,7 @@ exemptions:
   # --- Phase 4 scheduling ---
 
   - file: dango/utils/post_sync.py
-    lines: 763
+    lines: 762
     category: exempt
     reason: "R10-G2: Added _enrich_staging_tests for post-sync dbt test enrichment from profiling data. R12-F added _run_dbt_snapshots hook (+29 lines). M2-final: Added _profile_dbt_models for intermediate/marts schema profiling (+62 lines)."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -136,9 +136,9 @@ exemptions:
 
   # --- Exempt (stable, not modified in v1) ---
   - file: dango/ingestion/dlt_runner.py
-    lines: 2534
+    lines: 2579
     category: exempt
-    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000. P5c grew +480 lines (credential unification, resource selection, local_files routing). P8-001 added headers/data_selector/params passthrough (+8 lines). R9-I added skip_sync_notification param + sync_result passthrough to post_sync hooks. R10-F3 added _get_source_total_rows + rewrote anomaly check to use DB totals (BUG-182). R10-S added progress_callback parameter (+12 lines). R12-F added DuckDB lock error detection in _analyze_error (+30 lines)."
+    reason: "Core pipeline engine with lazy imports across 5 modules. Architectural bottleneck — too risky to refactor without comprehensive test coverage. Post-sync hook dispatch added in P7-000. P5c grew +480 lines (credential unification, resource selection, local_files routing). P8-001 added headers/data_selector/params passthrough (+8 lines). R9-I added skip_sync_notification param + sync_result passthrough to post_sync hooks. R10-F3 added _get_source_total_rows + rewrote anomaly check to use DB totals (BUG-182). R10-S added progress_callback parameter (+12 lines). R12-F added DuckDB lock error detection in _analyze_error (+30 lines). M2-final: CSV 0-row sync detection (+22 lines each in _run_csv_source and _run_local_files_source)."
     review_by: "v1.1"
 
   - file: dango/ingestion/sources/registry.py
@@ -341,9 +341,9 @@ exemptions:
   # --- Phase 4 scheduling ---
 
   - file: dango/utils/post_sync.py
-    lines: 661
+    lines: 763
     category: exempt
-    reason: "R10-G2: Added _enrich_staging_tests for post-sync dbt test enrichment from profiling data. R12-F added _run_dbt_snapshots hook (+29 lines)."
+    reason: "R10-G2: Added _enrich_staging_tests for post-sync dbt test enrichment from profiling data. R12-F added _run_dbt_snapshots hook (+29 lines). M2-final: Added _profile_dbt_models for intermediate/marts schema profiling (+62 lines)."
     review_by: "v1.1"
 
   - file: dango/web/routes/schedules.py

--- a/scripts/validate_claude_md.py
+++ b/scripts/validate_claude_md.py
@@ -130,7 +130,8 @@ def main() -> int:
             print("No CLAUDE.md files found (excluding repo root).")
             return 0
     else:
-        files = args.files
+        # Filter out repo-root CLAUDE.md (different structure, managed by DOC-000)
+        files = [f for f in args.files if str(f) not in SKIP_PATHS]
 
     # Validate
     total_errors = 0

--- a/tests/unit/test_csv_zero_rows.py
+++ b/tests/unit/test_csv_zero_rows.py
@@ -97,6 +97,27 @@ class TestCsvSourceZeroRows:
 
         assert result["status"] == "success"
 
+    @patch("dango.ingestion.dlt_runner.CSVLoader")
+    def test_existing_error_not_overwritten(self, mock_csv_cls, tmp_path):
+        """CSVLoader returning error with 0 rows keeps original error."""
+        mock_loader = MagicMock()
+        mock_loader.load.return_value = {
+            "status": "error",
+            "total_rows": 0,
+            "new": 0,
+            "updated": 0,
+            "deleted": 0,
+            "error": "Parse failed: invalid CSV",
+        }
+        mock_csv_cls.return_value = mock_loader
+
+        runner = _make_runner(tmp_path)
+        cfg = _make_source_config("test_csv", "csv")
+        result = runner._run_csv_source(cfg)
+
+        assert result["status"] == "error"
+        assert result["error"] == "Parse failed: invalid CSV"
+
 
 @pytest.mark.unit
 class TestLocalFilesSourceZeroRows:

--- a/tests/unit/test_csv_zero_rows.py
+++ b/tests/unit/test_csv_zero_rows.py
@@ -1,0 +1,123 @@
+"""tests/unit/test_csv_zero_rows.py
+
+Unit tests for CSV 0-row sync detection in dlt_runner.py.
+
+When CSVLoader returns success with 0 rows, 0 files processed, and 0 deletions,
+dlt_runner should convert to error status (first sync with no files is an error).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.ingestion.dlt_runner import DltPipelineRunner
+
+
+def _make_runner(tmp_path):
+    """Create a DltPipelineRunner without calling __init__."""
+    runner = DltPipelineRunner.__new__(DltPipelineRunner)
+    runner.project_root = tmp_path
+    runner.duckdb_path = tmp_path / "data" / "warehouse.duckdb"
+    runner.allow_schema_changes = False
+    return runner
+
+
+def _make_source_config(name="test_csv", source_type="csv"):
+    """Create a minimal mock source config."""
+    cfg = MagicMock()
+    cfg.name = name
+    cfg.source_type = source_type
+    cfg.csv = MagicMock() if source_type == "csv" else None
+    cfg.local_files = MagicMock() if source_type == "local_files" else None
+    return cfg
+
+
+@pytest.mark.unit
+class TestCsvSourceZeroRows:
+    """Tests for _run_csv_source 0-row detection."""
+
+    @patch("dango.ingestion.dlt_runner.CSVLoader")
+    def test_first_sync_no_files_is_error(self, mock_csv_cls, tmp_path):
+        """CSVLoader returns success with 0 rows/files → error."""
+        mock_loader = MagicMock()
+        mock_loader.load.return_value = {
+            "status": "success",
+            "total_rows": 0,
+            "new": 0,
+            "updated": 0,
+            "deleted": 0,
+        }
+        mock_csv_cls.return_value = mock_loader
+
+        runner = _make_runner(tmp_path)
+        cfg = _make_source_config("test_csv", "csv")
+        result = runner._run_csv_source(cfg)
+
+        assert result["status"] == "error"
+        assert "No files found" in result["error"]
+
+    @patch("dango.ingestion.dlt_runner.CSVLoader")
+    def test_with_rows_stays_success(self, mock_csv_cls, tmp_path):
+        """CSVLoader returns success with rows → stays success."""
+        mock_loader = MagicMock()
+        mock_loader.load.return_value = {
+            "status": "success",
+            "total_rows": 100,
+            "new": 1,
+            "updated": 0,
+            "deleted": 0,
+        }
+        mock_csv_cls.return_value = mock_loader
+
+        runner = _make_runner(tmp_path)
+        cfg = _make_source_config("test_csv", "csv")
+        result = runner._run_csv_source(cfg)
+
+        assert result["status"] == "success"
+        assert result["rows_loaded"] == 100
+
+    @patch("dango.ingestion.dlt_runner.CSVLoader")
+    def test_deletion_sync_stays_success(self, mock_csv_cls, tmp_path):
+        """CSVLoader returns 0 rows but deletions processed → stays success."""
+        mock_loader = MagicMock()
+        mock_loader.load.return_value = {
+            "status": "success",
+            "total_rows": 0,
+            "new": 0,
+            "updated": 0,
+            "deleted": 2,
+        }
+        mock_csv_cls.return_value = mock_loader
+
+        runner = _make_runner(tmp_path)
+        cfg = _make_source_config("test_csv", "csv")
+        result = runner._run_csv_source(cfg)
+
+        assert result["status"] == "success"
+
+
+@pytest.mark.unit
+class TestLocalFilesSourceZeroRows:
+    """Tests for _run_local_files_source 0-row detection."""
+
+    @patch("dango.ingestion.dlt_runner.CSVLoader")
+    def test_no_files_is_error(self, mock_csv_cls, tmp_path):
+        """Local files source with 0 rows/files → error."""
+        mock_loader = MagicMock()
+        mock_loader.load.return_value = {
+            "status": "success",
+            "total_rows": 0,
+            "new": 0,
+            "updated": 0,
+            "deleted": 0,
+        }
+        mock_csv_cls.return_value = mock_loader
+
+        runner = _make_runner(tmp_path)
+        cfg = _make_source_config("test_local", "local_files")
+        result = runner._run_local_files_source(cfg)
+
+        assert result["status"] == "error"
+        assert "No files found" in result["error"]

--- a/tests/unit/test_profile_dbt_models.py
+++ b/tests/unit/test_profile_dbt_models.py
@@ -30,7 +30,6 @@ class TestProfileDbtModels:
     @patch("dango.utils.post_sync.profile_table")
     def test_profiles_intermediate_and_marts_tables(self, mock_profile, tmp_path):
         """Successful models in intermediate/marts schemas get profiled."""
-        db_path = tmp_path / "data" / "warehouse.duckdb"
         _write_dbt_artifacts(
             tmp_path,
             run_results={
@@ -55,7 +54,7 @@ class TestProfileDbtModels:
             },
         )
         mock_profile.return_value = {}
-        _profile_dbt_models(tmp_path, db_path)
+        _profile_dbt_models(tmp_path)
 
         assert mock_profile.call_count == 2
         mock_profile.assert_any_call(
@@ -66,7 +65,6 @@ class TestProfileDbtModels:
     @patch("dango.utils.post_sync.profile_table")
     def test_skips_raw_and_staging_models(self, mock_profile, tmp_path):
         """Models in raw_*/staging schemas are skipped (already profiled)."""
-        db_path = tmp_path / "data" / "warehouse.duckdb"
         _write_dbt_artifacts(
             tmp_path,
             run_results={
@@ -97,7 +95,7 @@ class TestProfileDbtModels:
             },
         )
         mock_profile.return_value = {}
-        _profile_dbt_models(tmp_path, db_path)
+        _profile_dbt_models(tmp_path)
 
         assert mock_profile.call_count == 1
         mock_profile.assert_called_once_with(
@@ -107,24 +105,21 @@ class TestProfileDbtModels:
     @patch("dango.utils.post_sync.profile_table")
     def test_no_run_results_graceful(self, mock_profile, tmp_path):
         """Missing run_results.json → returns without error."""
-        db_path = tmp_path / "data" / "warehouse.duckdb"
-        _profile_dbt_models(tmp_path, db_path)
+        _profile_dbt_models(tmp_path)
         mock_profile.assert_not_called()
 
     @patch("dango.utils.post_sync.profile_table")
     def test_no_manifest_graceful(self, mock_profile, tmp_path):
         """run_results.json exists but no manifest.json → returns without error."""
-        db_path = tmp_path / "data" / "warehouse.duckdb"
         target = tmp_path / "dbt" / "target"
         target.mkdir(parents=True)
         (target / "run_results.json").write_text('{"results": []}')
-        _profile_dbt_models(tmp_path, db_path)
+        _profile_dbt_models(tmp_path)
         mock_profile.assert_not_called()
 
     @patch("dango.utils.post_sync.profile_table")
     def test_failed_models_skipped(self, mock_profile, tmp_path):
         """Models with status != 'success' are not profiled."""
-        db_path = tmp_path / "data" / "warehouse.duckdb"
         _write_dbt_artifacts(
             tmp_path,
             run_results={
@@ -149,7 +144,7 @@ class TestProfileDbtModels:
             },
         )
         mock_profile.return_value = {}
-        _profile_dbt_models(tmp_path, db_path)
+        _profile_dbt_models(tmp_path)
 
         assert mock_profile.call_count == 1
         mock_profile.assert_called_once_with(tmp_path, "marts", "fct_ok", schema_override="marts")

--- a/tests/unit/test_profile_dbt_models.py
+++ b/tests/unit/test_profile_dbt_models.py
@@ -1,0 +1,155 @@
+"""tests/unit/test_profile_dbt_models.py
+
+Unit tests for _profile_dbt_models — downstream model profiling in
+intermediate/marts schemas via dbt run_results + manifest discovery.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dango.utils.post_sync import _profile_dbt_models
+
+
+def _write_dbt_artifacts(tmp_path: Path, run_results: dict, manifest: dict) -> None:
+    """Write mock dbt target artifacts to tmp_path/dbt/target/."""
+    target = tmp_path / "dbt" / "target"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "run_results.json").write_text(json.dumps(run_results))
+    (target / "manifest.json").write_text(json.dumps(manifest))
+
+
+@pytest.mark.unit
+class TestProfileDbtModels:
+    """Tests for _profile_dbt_models — downstream model profiling."""
+
+    @patch("dango.utils.post_sync.profile_table")
+    def test_profiles_intermediate_and_marts_tables(self, mock_profile, tmp_path):
+        """Successful models in intermediate/marts schemas get profiled."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        _write_dbt_artifacts(
+            tmp_path,
+            run_results={
+                "results": [
+                    {"unique_id": "model.dango.int_orders", "status": "success"},
+                    {"unique_id": "model.dango.fct_revenue", "status": "success"},
+                ]
+            },
+            manifest={
+                "nodes": {
+                    "model.dango.int_orders": {
+                        "schema": "intermediate",
+                        "alias": "int_orders",
+                        "name": "int_orders",
+                    },
+                    "model.dango.fct_revenue": {
+                        "schema": "marts",
+                        "alias": "fct_revenue",
+                        "name": "fct_revenue",
+                    },
+                }
+            },
+        )
+        mock_profile.return_value = {}
+        _profile_dbt_models(tmp_path, db_path)
+
+        assert mock_profile.call_count == 2
+        mock_profile.assert_any_call(
+            tmp_path, "intermediate", "int_orders", schema_override="intermediate"
+        )
+        mock_profile.assert_any_call(tmp_path, "marts", "fct_revenue", schema_override="marts")
+
+    @patch("dango.utils.post_sync.profile_table")
+    def test_skips_raw_and_staging_models(self, mock_profile, tmp_path):
+        """Models in raw_*/staging schemas are skipped (already profiled)."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        _write_dbt_artifacts(
+            tmp_path,
+            run_results={
+                "results": [
+                    {"unique_id": "model.dango.stg_orders", "status": "success"},
+                    {"unique_id": "model.dango.raw_stuff", "status": "success"},
+                    {"unique_id": "model.dango.fct_sales", "status": "success"},
+                ]
+            },
+            manifest={
+                "nodes": {
+                    "model.dango.stg_orders": {
+                        "schema": "staging",
+                        "alias": "stg_orders",
+                        "name": "stg_orders",
+                    },
+                    "model.dango.raw_stuff": {
+                        "schema": "raw_shopify",
+                        "alias": "raw_stuff",
+                        "name": "raw_stuff",
+                    },
+                    "model.dango.fct_sales": {
+                        "schema": "marts",
+                        "alias": "fct_sales",
+                        "name": "fct_sales",
+                    },
+                }
+            },
+        )
+        mock_profile.return_value = {}
+        _profile_dbt_models(tmp_path, db_path)
+
+        assert mock_profile.call_count == 1
+        mock_profile.assert_called_once_with(
+            tmp_path, "marts", "fct_sales", schema_override="marts"
+        )
+
+    @patch("dango.utils.post_sync.profile_table")
+    def test_no_run_results_graceful(self, mock_profile, tmp_path):
+        """Missing run_results.json → returns without error."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        _profile_dbt_models(tmp_path, db_path)
+        mock_profile.assert_not_called()
+
+    @patch("dango.utils.post_sync.profile_table")
+    def test_no_manifest_graceful(self, mock_profile, tmp_path):
+        """run_results.json exists but no manifest.json → returns without error."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        target = tmp_path / "dbt" / "target"
+        target.mkdir(parents=True)
+        (target / "run_results.json").write_text('{"results": []}')
+        _profile_dbt_models(tmp_path, db_path)
+        mock_profile.assert_not_called()
+
+    @patch("dango.utils.post_sync.profile_table")
+    def test_failed_models_skipped(self, mock_profile, tmp_path):
+        """Models with status != 'success' are not profiled."""
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        _write_dbt_artifacts(
+            tmp_path,
+            run_results={
+                "results": [
+                    {"unique_id": "model.dango.fct_ok", "status": "success"},
+                    {"unique_id": "model.dango.fct_bad", "status": "error"},
+                ]
+            },
+            manifest={
+                "nodes": {
+                    "model.dango.fct_ok": {
+                        "schema": "marts",
+                        "alias": "fct_ok",
+                        "name": "fct_ok",
+                    },
+                    "model.dango.fct_bad": {
+                        "schema": "marts",
+                        "alias": "fct_bad",
+                        "name": "fct_bad",
+                    },
+                }
+            },
+        )
+        mock_profile.return_value = {}
+        _profile_dbt_models(tmp_path, db_path)
+
+        assert mock_profile.call_count == 1
+        mock_profile.assert_called_once_with(tmp_path, "marts", "fct_ok", schema_override="marts")


### PR DESCRIPTION
## Summary

Two bugs from R12-M2 cloud testing, both in the post-sync pipeline:

- **BUG 1 — CSV 0-row sync:** When a CSV source has no matching files AND no table exists yet (first sync), CSVLoader returns `{"status": "success", total_rows: 0}`. The "no files at all" case slipped through as success. Now `_run_csv_source()` and `_run_local_files_source()` detect 0 rows + 0 files + 0 deletions and convert to error status.

- **BUG 2 — Downstream model profiling:** `_run_profiling()` only covered `raw_{source}` and `staging` schemas. Tables in `intermediate` and `marts` schemas (built by dbt) were never profiled. Added `_profile_dbt_models()` which uses `run_results.json` + `manifest.json` to discover successful downstream models and profile them.

- **Bonus fix:** `validate_claude_md.py` didn't skip root `CLAUDE.md` when passed as a filename argument (only in `--recursive` mode). Now filters `SKIP_PATHS` in both code paths.

## Files changed

| File | Change | Lines |
|------|--------|-------|
| `dango/ingestion/dlt_runner.py` | 0-row error check in `_run_csv_source()` + `_run_local_files_source()` | 2534 → 2579 |
| `dango/utils/post_sync.py` | Added `_profile_dbt_models()` + call from `_run_profiling()` | 661 → 763 |
| `tests/unit/test_csv_zero_rows.py` | New: 4 tests for CSV 0-row detection | 123 lines |
| `tests/unit/test_profile_dbt_models.py` | New: 5 tests for dbt model profiling | 155 lines |
| `tests/unit/test_profiling.py` | Removed dbt model tests (moved to own file) | 363 → 356 |
| `docs/file-exemptions.yml` | Updated line counts | — |
| `CLAUDE.md` | Updated line counts | — |
| `dango/utils/CLAUDE.md` | Updated line count + added `_profile_dbt_models()` | — |
| `scripts/validate_claude_md.py` | Skip root CLAUDE.md in filename mode | — |

## Test plan

- [x] `pytest tests/unit/test_csv_zero_rows.py tests/unit/test_profile_dbt_models.py -x` — 9 new tests pass
- [x] `pytest tests/unit/ -x` — full unit suite (3534 passed)
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — clean
- [ ] Manual: verify CSV source with no files reports error in web UI
- [ ] Manual: verify intermediate/marts tables appear in data catalog profiling

**DO NOT MERGE — awaiting manual verification**

🤖 Generated with [Claude Code](https://claude.com/claude-code)