### PR TITLE
chore: release prep — CHANGELOG, v0.1.x detection, registry fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,108 @@ All notable changes to Dango will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - Unreleased
+
+### Added
+
+#### Complete Data Platform
+
+- Pre-configured stack: dlt (ingestion) + DuckDB (warehouse) + dbt (transformation) + Metabase (visualization) + Marimo (notebooks)
+- One-command install and setup (`pip install getdango && dango init && dango start`)
+- 33 data sources across 9 categories (Stripe, Google Sheets, Google Analytics, HubSpot, Salesforce, PostgreSQL, CSV, REST APIs, and more)
+- Auto-generated dbt staging models from ingested sources
+- Web dashboard for monitoring syncs, browsing data, and managing sources
+- Metabase integration with auto-configured connections and schema sync
+- DuckDB single-writer serialization for safe concurrent access
+
+#### Authentication & Security
+
+- User authentication with bcrypt password hashing and strength validation
+- Role-based access control (admin, editor, viewer) with 29 granular permissions
+- Two-factor authentication (TOTP) with QR code setup and recovery codes
+- API key authentication for programmatic access (`dango_ak_*` prefix)
+- Brute-force protection with account lockout (5 attempts / 15-minute window)
+- Audit logging with 22 event types (login, logout, user CRUD, role changes, etc.)
+- OAuth social login (Google, GitHub) with automatic account linking
+- Session management with configurable idle and absolute timeouts
+- CSRF protection on all state-mutating endpoints
+- Invite-based user onboarding with expiring tokens
+- First-login password change enforcement
+
+#### Cloud Deployment
+
+- One-command DigitalOcean provisioning (`dango deploy`)
+- Bring Your Own Server support (`dango deploy --byos`) for any cloud provider
+- Auto-TLS via Caddy with Let's Encrypt
+- SSH key-based access (Ed25519) with trust-on-first-use validation
+- IP allowlisting and firewall management (DO firewall + UFW for BYOS)
+- Push-based deployment model with deploy lock and deployment journal
+- Pre-deploy backups with rollback support
+- Scheduled backups to DigitalOcean Spaces (S3-compatible)
+- Remote server management (`dango remote status/logs/ssh/query`)
+- Remote environment variable management (`dango remote env set/get/list/delete`)
+- Domain management with DNS validation and auto-HTTPS
+- In-place droplet resize and server migration
+- Remote Dango version upgrade (`dango remote upgrade`)
+- Git guardrails with branch and dirty-state checks before deploy
+
+#### Data Catalog & Governance
+
+- Interactive data catalog with column profiling and full-text search
+- Schema drift detection with breaking-change protection and admin acceptance workflow
+- PII scanning with Presidio and spaCy (targeted entity types for low false positives)
+- Column-level data lineage visualization
+- Impact analysis for downstream models
+- PII override management for false positive suppression
+- Drift and PII webhook notifications
+
+#### Scheduling & Monitoring
+
+- Cron-based scheduling with APScheduler and human-readable presets
+- Schedule types: Sync + Transform, Sync Only, Transform Only
+- Automatic retry with exponential backoff and configurable timeouts
+- Thread-kill timeout enforcement with cancellation support
+- Webhook notifications for sync results, schema drift, and PII detection
+- Slack Block Kit message formatting
+- SQL-based metric monitoring with trend detection (linear regression)
+- Drill-down analysis with top contributor ranking
+- Pre-built monitor templates for common sources
+- Execution history tracking with 90-day retention
+
+#### Notebooks
+
+- Marimo notebook integration with headless server management
+- Three starter templates (explore, quality, blank)
+- DuckDB snapshot isolation for concurrent sync and notebook use
+- File-level notebook locking with heartbeat refresh
+- Idle auto-shutdown for notebook server
+- HTTP and WebSocket reverse proxy to Marimo
+
+#### Developer Experience
+
+- 50+ CLI commands organized into logical groups
+- Branch-based dbt development (`dango dev`) with isolated copy of production database
+- Project validation (`dango validate`) for config, sources, dbt, and credentials
+- Config validation for CI (`dango config validate`)
+- File watcher for auto-syncing on local file changes
+- CSV upload via web UI with schema mismatch detection
+- Database health checks with disk usage breakdown
+- Log rotation with gzip compression and configurable retention
+- `dango cleanup` for removing old logs, dbt artifacts, and cache
+- dbt snapshot support (`dango snapshot add/list/run`) for SCD Type 2 change tracking
+- DuckDB snapshot management (`dango snapshot db`)
+- Database migration framework (`dango migrate status/run`)
+- Local Dango version upgrade (`dango upgrade`)
+
+### Changed
+
+- Complete rewrite from v0.1.x (not backwards compatible)
+
+### Migration from v0.1.x
+
+- v1.0.0 requires a new project. Run `dango init` to get started.
+- Back up any v0.1.x data before upgrading.
+- See [docs.getdango.dev](https://docs.getdango.dev) for the migration guide.
 
 ## [0.1.0] - 2025-12-17
 
@@ -173,7 +274,7 @@ This release focuses on Windows compatibility and installer improvements. All pl
 ### Notes
 This is a **preview release** for early feedback. Not recommended for production use.
 
-[Unreleased]: https://github.com/getdango/dango/compare/v0.1.0...HEAD
+[1.0.0]: https://github.com/getdango/dango/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/getdango/dango/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/getdango/dango/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/getdango/dango/compare/v0.0.3...v0.0.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,9 @@ dango/                          # Python package source
 │   │   ├── data.py             # db group (status/clean) + validate
 │   │   ├── metabase_cmd.py     # metabase group (save/load/refresh)
 │   │   ├── model.py            # model group (add/remove)
-│   │   ├── platform.py         # start/stop/status + port helpers (1061 lines)
+│   │   ├── platform.py         # start/stop/status + port helpers (1067 lines)
 │   │   ├── project.py          # init/rename/info
-│   │   ├── source.py           # source group (add/list/remove/edit) + sync (884 lines)
+│   │   ├── source.py           # source group (add/list/remove/edit) + sync (888 lines)
 │   │   ├── transform.py        # run/docs/generate
 │   │   ├── upgrade.py          # local Dango upgrade via pip + migrations
 │   │   ├── web.py              # web dev server
@@ -341,7 +341,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `visualization/metabase.py` | 1152 | — |
 | `cli/init.py` | 1334 | — |
 | `visualization/dashboard_manager.py` | 1112 | — |
-| `cli/commands/platform.py` | 1061 | — (extracted from main.py by TASK-005) |
+| `cli/commands/platform.py` | 1067 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 886 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
 | `web/helpers.py` | 868 | — (extracted from app.py by TASK-085) |
@@ -353,7 +353,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/upload.py` | 711 | — (extracted from app.py by TASK-085) |
 | `oauth/providers.py` | 670 | — |
 | `platform/cloud/ssh.py` | 665 | — (SSH key mgmt, TOFU, exec/SFTP) |
-| `cli/commands/source.py` | 884 | — (extracted from main.py by TASK-005) |
+| `cli/commands/source.py` | 888 | — (extracted from main.py by TASK-005) |
 | `cli/commands/remote.py` | 700 | — (remote group + push/rollback/firewall/domain) |
 | `cli/commands/remote_mgmt.py` | 509 | — (remote status/logs/ssh/query + deployment history) |
 | `platform/cloud/deployer.py` | 598 | — (push deploy workflow + deploy lock + journal) |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Dango gives you a complete data stack — ingestion, warehouse, transformations,
 
 <!-- TODO: Add screenshot -->
 
+> **Upgrading from v0.1.x?** v1.0.0 is a complete rewrite of Dango. Back up your data and run `dango init` to create a new v1 project. See the [migration guide](https://docs.getdango.dev) for details.
+
 ## Quick Start
 
 **Prerequisites:** Python 3.10-3.12, [Docker](https://docs.docker.com/desktop/) (for Metabase)

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -13,8 +13,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | **commands/** | | |
 | `commands/__init__.py` (4 lines) | Package marker | — |
 | `commands/project.py` (307 lines) | `init`, `rename`, `info` | `init()`, `rename()`, `info()` |
-| `commands/source.py` (833 lines) | `source` group (`add`, `list`, `remove`, `edit`) + `sync` | `source`, `sync()` |
-| `commands/platform.py` (1038 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
+| `commands/source.py` (888 lines) | `source` group (`add`, `list`, `remove`, `edit`) + `sync` | `source`, `sync()` |
+| `commands/platform.py` (1067 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (660 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (388 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/oauth.py` (813 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -156,7 +156,9 @@ def start(ctx: click.Context, yes: bool) -> None:
     )
 
     from ..helpers.process_manager import start_fastapi_server
-    from ..utils import require_project_context
+    from ..utils import check_v01x_project, require_project_context
+
+    check_v01x_project()
 
     console.print("🍡 [bold]Starting Dango Platform...[/bold]")
     console.print()

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -99,7 +99,9 @@ def source_add(ctx: click.Context) -> None:
     """
     from dango.cli.source_wizard import add_source
 
-    from ..utils import check_git_branch_warning
+    from ..utils import check_git_branch_warning, check_v01x_project
+
+    check_v01x_project()
 
     project_root = ctx.obj.get("project_root")
     if not project_root:
@@ -618,7 +620,9 @@ def sync(
     from dango.ingestion import run_sync
     from dango.utils import DbtLock, DbtLockError
 
-    from ..utils import require_project_context
+    from ..utils import check_v01x_project, require_project_context
+
+    check_v01x_project()
 
     # Resolve source: positional arg takes precedence over --source option
     if source_option and not source_name:

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -16,6 +16,22 @@ from dango.config.helpers import find_project_root
 console = Console()
 
 
+def check_v01x_project() -> None:
+    """Check if current directory is a v0.1.x project and exit with migration guidance."""
+    cwd = Path.cwd()
+    if (cwd / "dango.yml").exists():
+        console.print(
+            "[yellow]This project was created with Dango v0.1.x. "
+            "v1.0 requires a new project.[/yellow]\n\n"
+            "To get started with v1:\n"
+            "  1. Back up your data\n"
+            "  2. Create a new directory\n"
+            "  3. Run: dango init\n\n"
+            "See https://docs.getdango.dev for the migration guide."
+        )
+        raise SystemExit(1)
+
+
 def require_project_context(ctx: click.Context) -> Path:
     """
     Ensure command is run in a Dango project.

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -17,9 +17,21 @@ console = Console()
 
 
 def check_v01x_project() -> None:
-    """Check if current directory is a v0.1.x project and exit with migration guidance."""
+    """Check if current directory is a v0.1.x project and exit with migration guidance.
+
+    Detection heuristics:
+    1. ``dango.yml`` in cwd — legacy single-file config.
+    2. ``.dango/project.yml`` exists but ``.dango/dango.db`` (created by v1's
+       ``dango init``) is missing AND ``data/warehouse.duckdb`` exists (ruling
+       out a freshly cloned v1 project that hasn't been initialised yet).
+    """
     cwd = Path.cwd()
-    if (cwd / "dango.yml").exists():
+    is_v01x = (cwd / "dango.yml").exists() or (
+        (cwd / ".dango" / "project.yml").exists()
+        and not (cwd / ".dango" / "dango.db").exists()
+        and (cwd / "data" / "warehouse.duckdb").exists()
+    )
+    if is_v01x:
         console.print(
             "[yellow]This project was created with Dango v0.1.x. "
             "v1.0 requires a new project.[/yellow]\n\n"
@@ -29,7 +41,7 @@ def check_v01x_project() -> None:
             "  3. Run: dango init\n\n"
             "See https://docs.getdango.dev for the migration guide."
         )
-        raise SystemExit(1)
+        raise click.Abort()
 
 
 def require_project_context(ctx: click.Context) -> Path:

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -781,7 +781,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            "incremental": True,
+            "incremental": False,
             "custom_queries": False,
         },
     },

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -93,7 +93,7 @@ exemptions:
 
   # --- Post-TASK-005 split results (from cli/main.py 4119 → cli/commands/) ---
   - file: dango/cli/commands/platform.py
-    lines: 1061
+    lines: 1067
     category: exempt
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic. R12-I2 added cloud systemd status check."
     review_by: "v1.1"
@@ -105,7 +105,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/commands/source.py
-    lines: 884
+    lines: 888
     category: exempt
     reason: "Source management commands (add/list/remove/edit) + sync. Extracted from cli/main.py by TASK-005. TASK-040b added backfill/limit options + duration parsing + source-type validation. R12-G added source edit NAME arg, sync positional arg."
     review_by: "v1.1"

--- a/tests/unit/test_v01x_detection.py
+++ b/tests/unit/test_v01x_detection.py
@@ -6,6 +6,7 @@ Unit tests for v0.1.x project detection logic.
 import re
 
 import pytest
+from click import Abort
 
 from dango.cli.utils import check_v01x_project
 
@@ -17,11 +18,11 @@ def _strip_ansi(text: str) -> str:
 
 
 def test_v01x_detected_when_dango_yml_exists(tmp_path, capsys, monkeypatch):
-    """check_v01x_project exits with code 1 when dango.yml is present."""
+    """check_v01x_project aborts when dango.yml is present."""
     (tmp_path / "dango.yml").write_text("project:\n  name: old\n")
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(Abort):
         check_v01x_project()
 
     captured = capsys.readouterr()
@@ -31,18 +32,61 @@ def test_v01x_detected_when_dango_yml_exists(tmp_path, capsys, monkeypatch):
     assert "Back up your data" in plain
 
 
+def test_v01x_detected_with_project_yml_and_warehouse(tmp_path, capsys, monkeypatch):
+    """Detects v0.1.x when .dango/project.yml exists + warehouse but no dango.db."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "project.yml").write_text("project:\n  name: old\n")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "warehouse.duckdb").write_bytes(b"")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(Abort):
+        check_v01x_project()
+
+    captured = capsys.readouterr()
+    plain = _strip_ansi(captured.out)
+    assert "v0.1.x" in plain
+
+
 def test_no_detection_without_dango_yml(tmp_path, monkeypatch):
     """check_v01x_project does nothing when no dango.yml exists."""
     monkeypatch.chdir(tmp_path)
-    # Should not raise
     check_v01x_project()
 
 
 def test_no_detection_with_v1_project(tmp_path, monkeypatch):
-    """check_v01x_project does nothing for a v1 project (.dango/project.yml)."""
+    """check_v01x_project does nothing for a v1 project (.dango/dango.db exists)."""
     dango_dir = tmp_path / ".dango"
     dango_dir.mkdir()
     (dango_dir / "project.yml").write_text("project:\n  name: myproject\n")
+    (dango_dir / "dango.db").write_bytes(b"")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "warehouse.duckdb").write_bytes(b"")
     monkeypatch.chdir(tmp_path)
-    # Should not raise
     check_v01x_project()
+
+
+def test_no_detection_fresh_clone_without_warehouse(tmp_path, monkeypatch):
+    """No false positive on a cloned v1 project that hasn't synced yet."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "project.yml").write_text("project:\n  name: myproject\n")
+    # No dango.db AND no warehouse — fresh clone, not v0.1.x
+    monkeypatch.chdir(tmp_path)
+    check_v01x_project()
+
+
+def test_v01x_detected_when_both_dango_yml_and_project_yml_exist(tmp_path, capsys, monkeypatch):
+    """dango.yml takes precedence even if .dango/project.yml also exists."""
+    (tmp_path / "dango.yml").write_text("project:\n  name: old\n")
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "project.yml").write_text("project:\n  name: old\n")
+    (dango_dir / "dango.db").write_bytes(b"")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(Abort):
+        check_v01x_project()

--- a/tests/unit/test_v01x_detection.py
+++ b/tests/unit/test_v01x_detection.py
@@ -1,0 +1,48 @@
+"""tests/unit/test_v01x_detection.py
+
+Unit tests for v0.1.x project detection logic.
+"""
+
+import re
+
+import pytest
+
+from dango.cli.utils import check_v01x_project
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def test_v01x_detected_when_dango_yml_exists(tmp_path, capsys, monkeypatch):
+    """check_v01x_project exits with code 1 when dango.yml is present."""
+    (tmp_path / "dango.yml").write_text("project:\n  name: old\n")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit, match="1"):
+        check_v01x_project()
+
+    captured = capsys.readouterr()
+    plain = _strip_ansi(captured.out)
+    assert "v0.1.x" in plain
+    assert "dango init" in plain
+    assert "Back up your data" in plain
+
+
+def test_no_detection_without_dango_yml(tmp_path, monkeypatch):
+    """check_v01x_project does nothing when no dango.yml exists."""
+    monkeypatch.chdir(tmp_path)
+    # Should not raise
+    check_v01x_project()
+
+
+def test_no_detection_with_v1_project(tmp_path, monkeypatch):
+    """check_v01x_project does nothing for a v1 project (.dango/project.yml)."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "project.yml").write_text("project:\n  name: myproject\n")
+    monkeypatch.chdir(tmp_path)
+    # Should not raise
+    check_v01x_project()


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Added v1.0.0 section with all features organized by 8 user-facing themes (Complete Data Platform, Auth & Security, Cloud Deployment, Data Catalog & Governance, Scheduling & Monitoring, Notebooks, Developer Experience). Preserves existing v0.0.1–v0.1.0 entries.
- **v0.1.x project detection**: Added `check_v01x_project()` to `cli/utils.py`. Called in `dango start`, `dango sync`, and `dango source add` — detects `dango.yml` in cwd and exits cleanly with migration guidance instead of crashing.
- **GitHub registry fix**: Changed `"incremental": True` → `False` in `registry.py` for the `github` source (actual behavior is full refresh).
- **Breaking change notice**: Added upgrade notice to `README.md` (rendered on PyPI) for v0.1.x → v1.0 migration.

## Files changed (line count deltas for exempted files)

| File | Delta |
|------|-------|
| `dango/cli/commands/platform.py` | 1061 → 1067 (+6) |
| `dango/cli/commands/source.py` | 884 → 888 (+4) |
| `dango/ingestion/sources/registry.py` | 2008 → 2008 (0) |
| `docs/file-exemptions.yml` | updated counts |
| `CLAUDE.md` | updated counts |
| `dango/cli/CLAUDE.md` | updated counts |

## Test plan

- [x] `pytest tests/unit/ -x` — 3538 passed
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy` clean on changed files
- [x] Pre-commit hooks pass
- [x] v0.1.x detection unit tests pass (3 tests)

**DO NOT MERGE — awaiting manual verification**

🤖 Generated with [Claude Code](https://claude.com/claude-code)