### PR TITLE
fix: audit and correct source registry capability flags

### DIFF
--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -317,7 +317,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            "incremental": True,
+            # rest_api is a generic source — whether it's incremental depends
+            # entirely on per-endpoint user configuration. Not incremental by
+            # default.
+            "incremental": False,
             "custom_queries": True,
         },
     },
@@ -628,6 +631,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
+            # Mixed: account, opportunity, task, event use merge+incremental;
+            # contact, lead, campaign use replace. Marked True because the
+            # highest-volume CRM objects (accounts, opportunities) are
+            # incremental.
             "incremental": True,
             "custom_queries": False,
         },
@@ -1436,7 +1443,9 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": True,
-            "incremental": True,
+            # workable_source uses write_disposition="replace" for 7/8
+            # resources. Only candidates uses merge+incremental(updated_at).
+            "incremental": False,
             "custom_queries": False,
         },
     },
@@ -1479,10 +1488,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            # asana_source uses write_disposition="replace" for most resources
+            # asana_source uses write_disposition="replace" for 6/8 resources
             # (workspaces, projects, sections, tags, users, teams). Only tasks
-            # uses merge with incremental(modified_at). Not truly incremental
-            # overall.
+            # uses merge+incremental(modified_at); stories uses append (no
+            # cursor). Not truly incremental overall.
             "incremental": False,
             "custom_queries": False,
         },
@@ -1634,7 +1643,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            "incremental": True,
+            # mongodb() accepts an optional incremental parameter (defaults to
+            # None). Without explicit configuration, it does a full load — not
+            # incremental by default.
+            "incremental": False,
             "custom_queries": False,
         },
     },

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -689,7 +689,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": True,
-            "incremental": True,
+            # stripe_source uses write_disposition="replace" for all resources
+            # (full refresh every sync). incremental_stripe_source exists but
+            # dango calls stripe_source via the registry's dlt_function.
+            "incremental": False,
             "custom_queries": False,
         },
     },
@@ -1476,7 +1479,11 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            "incremental": True,
+            # asana_source uses write_disposition="replace" for most resources
+            # (workspaces, projects, sections, tags, users, teams). Only tasks
+            # uses merge with incremental(modified_at). Not truly incremental
+            # overall.
+            "incremental": False,
             "custom_queries": False,
         },
     },

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -431,6 +431,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": True,
             "date_range": False,
+            # Mixed: 5/6 resources (campaigns, ads, ad_sets, ad_creatives,
+            # leads) use replace. Only facebook_insights uses
+            # merge+incremental(date_start). Marked True because insights —
+            # the primary analytics payload — are incremental.
             "incremental": True,
             "custom_queries": False,
         },
@@ -631,8 +635,9 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            # Mixed: account, opportunity, task, event use merge+incremental;
-            # contact, lead, campaign use replace. Marked True because the
+            # Mixed: 7/15 resources use merge+incremental (account, opportunity,
+            # opportunity_line_item, opportunity_contact_role, campaign_member,
+            # task, event); 8/15 use replace. Marked True because the
             # highest-volume CRM objects (accounts, opportunities) are
             # incremental.
             "incremental": True,
@@ -1702,7 +1707,10 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            "incremental": True,
+            # sql_database() accepts an optional incremental parameter per
+            # table (defaults to None). Without explicit configuration, it
+            # loads all rows on every run — not incremental by default.
+            "incremental": False,
             "custom_queries": False,
         },
     },


### PR DESCRIPTION
## Summary

Audited all 33 source registry `incremental` capability flags against actual dlt source code (`write_disposition` values in `dlt_sources/`). Fixed 6 incorrect flags, added explanatory comments for mixed-behavior sources.

**DO NOT MERGE — awaiting review.**

## Changes

| Source | Old | New | Reason |
|--------|-----|-----|--------|
| **Stripe** | `True` | `False` | `stripe_source` uses `replace` for all resources. `incremental_stripe_source` exists but dango calls `stripe_source`. |
| **Asana** | `True` | `False` | 6/8 resources use `replace`. Only `tasks` uses merge+incremental(modified_at); `stories` uses append (no cursor). |
| **Workable** | `True` | `False` | 7/8 resources use `replace`. Only `candidates` uses merge+incremental(updated_at). |
| **MongoDB** | `True` | `False` | Accepts optional `incremental` param (defaults to None). Not incremental by default — requires user configuration. |
| **rest_api** | `True` | `False` | Generic source — incremental depends entirely on per-endpoint user configuration. |
| **postgres** | `True` | `False` | `sql_database()` accepts optional `incremental` per table (defaults to None). Full load without explicit config. |

Comments added (no flag change):
| Source | Note |
|--------|------|
| **Salesforce** | 7/15 resources merge+incremental, 8/15 replace. Left True — highest-volume CRM objects are incremental. |
| **Facebook Ads** | 5/6 resources replace, only `facebook_insights` incremental. Left True — insights are the primary analytics payload. |

## Full Audit Table

| Source | Registry `incremental` | Actual `write_disposition` | Changed? |
|--------|----------------------|--------------------------|----------|
| csv | `True` | Custom loader (incremental) | No |
| local_files | `True` | Custom loader (incremental) | No |
| dlt_native | `False` | Depends on user code | No |
| filesystem | `False` | No incremental cursor | No |
| **rest_api** | ~~`True`~~ → **`False`** | Depends on user config | **Yes** |
| google_sheets | `False` | `replace` (all sheet data) | No |
| facebook_ads | `True` (comment added) | Insights=incremental, entities=replace | Comment |
| google_analytics | `True` | Reports=`append`+incremental | No |
| hubspot | `True` | `merge` for all core CRM objects | No |
| salesforce | `True` (comment added) | 7/15 incremental, 8/15 replace | Comment |
| **stripe** | ~~`True`~~ → **`False`** | `replace` for ALL resources | **Yes** |
| shopify | `True` | `merge`+incremental(updated_at) | No |
| github | `False` | `replace` (github_reactions) | No |
| slack | `True` | Messages: incremental(ts) | No |
| zendesk | `True` | `merge`+incremental(updated_at) | No |
| google_ads | `False` | `replace` (query-driven) | No |
| matomo | `True` | `append`+incremental for reports | No |
| mux | `False` | merge but no incremental cursor | No |
| airtable | `False` | `replace` | No |
| pipedrive | `True` | `merge`+incremental(update_time) | No |
| freshdesk | `True` | `merge`+incremental(updated_at) | No |
| jira | `False` | `replace` | No |
| **workable** | ~~`True`~~ → **`False`** | 7/8 replace, only candidates incremental | **Yes** |
| **asana** | ~~`True`~~ → **`False`** | 6/8 replace, only tasks merge+incremental | **Yes** |
| notion | `False` | `replace` | No |
| inbox | `True` | `append`+incremental(message_uid) | No |
| **mongodb** | ~~`True`~~ → **`False`** | Optional incremental, defaults to full load | **Yes** |
| **postgres** | ~~`True`~~ → **`False`** | Optional incremental per table, defaults to full load | **Yes** |
| kafka | `True` | Offset-based state tracking | No |
| kinesis | `True` | Shard sequence tracking | No |
| chess | `False` | No incremental cursor | No |
| strapi | `False` | `replace` | No |
| personio | `True` | `merge`+incremental(last_modified_at) | No |

## Test plan

- [x] `pytest tests/unit/ -x` — 3541 passed, 7 skipped
- [ ] Manual: verify changed sources show "Full Refresh" badge in web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)