### PR TITLE
fix: T12-B fix round — 16 bug fixes + 6 improvements

### DIFF
--- a/dango/cli/commands/cleanup.py
+++ b/dango/cli/commands/cleanup.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import click
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 
 
 def _format_size(size_bytes: int) -> str:
@@ -276,7 +277,7 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool, docke
 
         # --- Confirmation ---
         if not yes:
-            if not click.confirm(f"Delete {_format_size(grand_total)} of files?"):
+            if not safe_confirm(f"Delete {_format_size(grand_total)} of files?"):
                 console.print("[yellow]Cancelled.[/yellow]")
                 return
 

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -22,20 +22,20 @@ import click
 from dango.cli import console
 
 # ---------------------------------------------------------------------------
-# BUG-252: Non-interactive confirm helper
+# BUG-252: Non-interactive confirm helper (now delegated to cli/utils.py)
 # ---------------------------------------------------------------------------
 
 
 def _safe_confirm(prompt: str, default: bool = True, *, non_interactive: bool = False) -> bool:
-    """Prompt with ``(yes/no)`` format and a non-interactive bypass.
+    """Thin wrapper around :func:`dango.cli.utils.safe_confirm`.
 
     When *non_interactive* is ``True``, returns *default* without prompting.
     """
     if non_interactive:
         return default
-    default_str = "yes" if default else "no"
-    result = click.prompt(f"{prompt} (yes/no)", default=default_str, show_default=True)
-    return str(result).lower().strip() in ("yes", "y")
+    from dango.cli.utils import safe_confirm
+
+    return safe_confirm(prompt, default=default)
 
 
 # ---------------------------------------------------------------------------

--- a/dango/cli/commands/metabase_cmd.py
+++ b/dango/cli/commands/metabase_cmd.py
@@ -6,6 +6,7 @@ Metabase asset management commands (save, load, refresh).
 import click
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 
 
 @click.group()
@@ -198,7 +199,7 @@ def metabase_load(ctx: click.Context, overwrite: bool, dry_run: bool) -> None:
             console.print("This will replace existing dashboards/questions in Metabase")
             console.print("with versions from files. Unsaved Metabase changes will be lost!\n")
 
-            if not click.confirm("Continue?"):
+            if not safe_confirm("Continue?"):
                 console.print("[yellow]Cancelled[/yellow]")
                 return
 

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -6,6 +6,7 @@ Platform lifecycle commands (start, stop, status) and port helpers.
 import click
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
@@ -193,7 +194,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                     "[yellow]   Starting locally will run a SEPARATE instance. "
                     "Your cloud server is unaffected.[/yellow]"
                 )
-                if not click.confirm("Continue?", default=True):
+                if not safe_confirm("Continue?", default=True):
                     raise click.Abort()
                 console.print()
 
@@ -409,7 +410,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                 manager.stop_all_dango_containers()
                 console.print()
         except Exception:
-            logger.debug("orphan_docker_cleanup_failed", exc_info=True)
+            logger.debug("orphan_docker_cleanup_failed")
 
         # Check Docker service ports (Metabase and dbt-docs)
         _check_docker_ports(platform_config)
@@ -664,7 +665,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                     break
 
             except Exception:
-                logger.debug("health_poll_failed", exc_info=True)
+                logger.debug("health_poll_failed")
 
             time.sleep(1)
 

--- a/dango/cli/commands/remote.py
+++ b/dango/cli/commands/remote.py
@@ -40,6 +40,7 @@ from typing import Any
 import click
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 
 # ---------------------------------------------------------------------------
 # Top-level group
@@ -238,7 +239,7 @@ def remote_rollback(ctx: click.Context, backup: str | None, yes: bool) -> None:
     from dango.platform.cloud.backup import rollback
 
     if not yes:
-        if not click.confirm(
+        if not safe_confirm(
             "This will restore the server from a backup. "
             "Current data will be overwritten. Continue?"
         ):
@@ -352,7 +353,7 @@ def remote_push(
     git_info_param = git_info if git_info.is_git_repo else None
 
     if not dry_run and not yes:
-        if not click.confirm(
+        if not safe_confirm(
             "This will push local files to the remote server and rebuild. Continue?"
         ):
             console.print("[yellow]Push cancelled.[/yellow]")

--- a/dango/cli/commands/remote_backup.py
+++ b/dango/cli/commands/remote_backup.py
@@ -23,6 +23,7 @@ from typing import Any
 import click
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 from dango.exceptions import format_structured_error
 
 # ---------------------------------------------------------------------------
@@ -394,7 +395,7 @@ def backup_restore(ctx: click.Context, source: str, yes: bool) -> None:
     from rich.status import Status
 
     if not yes:
-        if not click.confirm(
+        if not safe_confirm(
             f"This will restore the server from Spaces backup '{source}'. "
             "Current data will be overwritten. Continue?"
         ):

--- a/dango/cli/commands/remote_ops.py
+++ b/dango/cli/commands/remote_ops.py
@@ -13,6 +13,7 @@ import click
 
 from dango.cli import console
 from dango.cli.commands.remote import remote
+from dango.cli.utils import safe_confirm
 
 # ---------------------------------------------------------------------------
 # dango remote upgrade
@@ -81,7 +82,7 @@ def remote_upgrade(
             console.print()
             if skip_backup:
                 console.print("[yellow]Warning:[/yellow] Pre-upgrade backup will be skipped.")
-            if not click.confirm("Proceed with upgrade?"):
+            if not safe_confirm("Proceed with upgrade?"):
                 console.print("[yellow]Upgrade cancelled.[/yellow]")
                 return
 
@@ -264,7 +265,7 @@ def remote_resize(ctx: click.Context, size: str | None, yes: bool) -> None:
     )
 
     if not yes:
-        if not click.confirm("\nProceed with resize?"):
+        if not safe_confirm("\nProceed with resize?"):
             console.print("[yellow]Resize cancelled.[/yellow]")
             return
 
@@ -426,7 +427,7 @@ def remote_migrate(
         )
 
     if not yes:
-        if not click.confirm("\nProceed with migration?"):
+        if not safe_confirm("\nProceed with migration?"):
             console.print("[yellow]Migration cancelled.[/yellow]")
             return
 

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -17,6 +17,7 @@ import click
 import yaml
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
@@ -534,12 +535,15 @@ def schedule_add(ctx: click.Context) -> None:
     existing_names = {s.get("name") for s in schedules}
 
     # 1. Name (validate after prompt to avoid per-keystroke flicker)
+    console.print(
+        "[dim]Format: lowercase, start with letter, only letters/digits/underscores[/dim]"
+    )
     while True:
         answers = inquirer.prompt(
             [
                 inquirer.Text(
                     "name",
-                    message="Schedule name (lowercase, alphanumeric + underscore)",
+                    message="Schedule name",
                 ),
             ]
         )
@@ -725,7 +729,7 @@ def schedule_remove(ctx: click.Context, name: str, yes: bool) -> None:
     console.print(f"  Type: {sched.get('type', 'sync')}  Cron: {sched.get('cron', '?')}")
 
     if not yes:
-        if not click.confirm("Remove this schedule?"):
+        if not safe_confirm("Remove this schedule?"):
             console.print("[dim]Cancelled.[/dim]")
             return
 

--- a/dango/cli/commands/schedule_webhook.py
+++ b/dango/cli/commands/schedule_webhook.py
@@ -26,6 +26,7 @@ from dango.cli.commands.schedule import (
     _save_schedules_yaml,
     webhook,
 )
+from dango.cli.utils import safe_confirm
 
 # ---------------------------------------------------------------------------
 # webhook list
@@ -168,7 +169,7 @@ def webhook_remove(ctx: click.Context, name: str, yes: bool) -> None:
         raise SystemExit(1)
 
     if not yes:
-        if not click.confirm(f"Remove webhook '{name}'?"):
+        if not safe_confirm(f"Remove webhook '{name}'?"):
             console.print("[dim]Cancelled.[/dim]")
             return
 

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -167,8 +167,7 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
 
     if not has_editor:
         console.print(f"[bold]Edit your sources at:[/bold] {sources_file}")
-        if not has_editor:
-            console.print("[dim]Tip: Set $EDITOR to open in your preferred editor[/dim]")
+        console.print("[dim]Tip: Set $EDITOR to open in your preferred editor[/dim]")
         return
 
     original = sources_file.read_text()

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -8,6 +8,7 @@ import re
 import click
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 from dango.config.helpers import (
     check_unreferenced_custom_sources,
     format_unreferenced_sources_warning,
@@ -159,12 +160,23 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
         except Exception:
             pass  # Fall through to editor
 
+    import os
+
+    # Check if an editor is available — $EDITOR or $VISUAL
+    has_editor = bool(os.environ.get("EDITOR") or os.environ.get("VISUAL"))
+
+    if not has_editor:
+        console.print(f"[bold]Edit your sources at:[/bold] {sources_file}")
+        if not has_editor:
+            console.print("[dim]Tip: Set $EDITOR to open in your preferred editor[/dim]")
+        return
+
     original = sources_file.read_text()
     edited = click.edit(original, extension=".yml")
 
     if edited is None:
         if name:
-            console.print("[yellow]No editor or no changes.[/yellow]")
+            console.print("[yellow]No changes made.[/yellow]")
             # Print just the named source section
             try:
                 data = yaml.safe_load(original) or {}
@@ -176,7 +188,7 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
                         return
             except Exception:
                 pass
-        console.print("[yellow]No editor or no changes.[/yellow]")
+        console.print("[yellow]No changes made.[/yellow]")
         console.print(f"[dim]Edit manually: {sources_file}[/dim]")
         return
 
@@ -330,10 +342,23 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
                 # If we can't read metadata, just skip - last_sync will show "never"
                 pass
 
+        # Build sync mode lookup from registry capabilities
+        from dango.ingestion.sources.registry import get_source_capabilities
+
+        def _get_sync_mode(source_type: str) -> str:
+            """Determine sync mode badge for a source type."""
+            if source_type in ("csv", "local_files"):
+                return "Full Refresh"
+            caps = get_source_capabilities(source_type)
+            if caps and caps.get("incremental"):
+                return "Incremental"
+            return "Full Refresh"
+
         # Create table
         table = Table(show_header=True, header_style="bold cyan")
         table.add_column("Name", style="white")
         table.add_column("Type", style="dim")
+        table.add_column("Mode", style="dim")
         table.add_column("Status", style="white")
         table.add_column("Last Sync", style="dim")
         table.add_column("Rows", style="dim", justify="right")
@@ -369,7 +394,8 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
                 last_sync = "[dim]never[/dim]"
 
             rows_str = f"{row_counts[src.name]:,}" if src.name in row_counts else "[dim]-[/dim]"
-            table.add_row(src.name, src.type.value, status, last_sync, rows_str)
+            mode = _get_sync_mode(src.type.value)
+            table.add_row(src.name, src.type.value, mode, status, last_sync, rows_str)
 
         console.print(table)
         console.print()
@@ -648,7 +674,7 @@ def sync(
                     "[yellow]   `dango sync` syncs data LOCALLY, not on your cloud server.[/yellow]"
                 )
                 console.print("[yellow]   Use `dango remote sync` for cloud.[/yellow]")
-                if not click.confirm("Continue?", default=False):
+                if not safe_confirm("Continue?", default=False):
                     raise click.Abort()
                 console.print()
 
@@ -728,7 +754,7 @@ def sync(
         if not yes and not dry_run:
             warehouse_path = project_root / "data" / "warehouse.duckdb"
             if not warehouse_path.exists():
-                if not click.confirm(
+                if not safe_confirm(
                     f"This will sync {len(sources_to_sync)} source(s). Continue?",
                     default=True,
                 ):
@@ -753,7 +779,7 @@ def sync(
 
         if full_refresh:
             console.print("[yellow]⚠️  Full refresh mode: existing data will be dropped[/yellow]")
-            if not yes and not click.confirm(
+            if not yes and not safe_confirm(
                 "Full refresh will reload all data. Continue?", default=False
             ):
                 raise click.Abort()

--- a/dango/cli/commands/upgrade.py
+++ b/dango/cli/commands/upgrade.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import click
 
 from dango.cli import console
+from dango.cli.utils import safe_confirm
 
 _VERSION_CACHE_TTL = 86400  # 24 hours in seconds
 _NEGATIVE_CACHE_TTL = 300  # 5 minutes — avoid hammering a down PyPI
@@ -164,15 +165,15 @@ def upgrade(ctx: click.Context, target_version: str | None, yes: bool) -> None:
     # Confirmation prompts (unless --yes)
     if not yes:
         console.print("[dim]Tip: Run 'dango stop' first if services are running.[/dim]")
-        if click.confirm("Pause to create a manual backup first?", default=True):
+        if safe_confirm("Pause to create a manual backup first?", default=True):
             console.print(
                 "\n  Copy your [cyan].dango/[/cyan] directory or run your "
                 "backup procedure in another terminal, then continue.\n"
             )
-            if not click.confirm("Ready to proceed with upgrade?"):
+            if not safe_confirm("Ready to proceed with upgrade?"):
                 console.print("[yellow]Upgrade cancelled.[/yellow]")
                 return
-        elif not click.confirm(f"Proceed with {direction}?"):
+        elif not safe_confirm(f"Proceed with {direction}?"):
             console.print("[yellow]Upgrade cancelled.[/yellow]")
             return
 

--- a/dango/cli/env_helpers.py
+++ b/dango/cli/env_helpers.py
@@ -7,6 +7,7 @@ import platform
 import subprocess
 from pathlib import Path
 
+import click
 from rich.console import Console
 
 console = Console()
@@ -232,7 +233,7 @@ def guide_env_setup(
 
     # Wait for user to finish
     console.print("\n[bold yellow]⚠️  Press Enter AFTER you've saved the .env file[/bold yellow]")
-    input()
+    click.pause("")
 
     # Validate
     var_names = [v.get("name", "") for v in required_vars if v.get("name")]
@@ -298,7 +299,7 @@ def handle_validation_result(
             console.print("[green]✅ Reopened .env[/green]")
 
         console.print("\n[bold]Press Enter when ready to retry validation...[/bold]")
-        input()
+        click.pause("")
 
         # Retry validation
         is_valid_retry, missing_retry = validate_env_file(env_file, missing_vars)

--- a/dango/cli/env_helpers.py
+++ b/dango/cli/env_helpers.py
@@ -233,7 +233,7 @@ def guide_env_setup(
 
     # Wait for user to finish
     console.print("\n[bold yellow]⚠️  Press Enter AFTER you've saved the .env file[/bold yellow]")
-    click.pause("")
+    click.prompt("", default="", show_default=False, prompt_suffix="")
 
     # Validate
     var_names = [v.get("name", "") for v in required_vars if v.get("name")]
@@ -299,7 +299,7 @@ def handle_validation_result(
             console.print("[green]✅ Reopened .env[/green]")
 
         console.print("\n[bold]Press Enter when ready to retry validation...[/bold]")
-        click.pause("")
+        click.prompt("", default="", show_default=False, prompt_suffix="")
 
         # Retry validation
         is_valid_retry, missing_retry = validate_env_file(env_file, missing_vars)

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -89,9 +89,52 @@ def print_panel(content: str, title: str, border_style: str = "blue") -> None:
     console.print(Panel(content, title=title, border_style=border_style))
 
 
-def confirm(message: str, default: bool = False) -> bool:
+def safe_confirm(
+    text: str,
+    default: bool = False,
+    *,
+    abort: bool = False,
+) -> bool:
+    """Prompt with ``(yes/no)`` format instead of click.confirm's ``[y/N]``.
+
+    Uses ``click.prompt`` under the hood so the prompt is explicit and
+    unambiguous in non-interactive / CI environments.
+
+    When stdin is not a TTY the *default* value is returned without
+    prompting (prevents hangs in non-interactive contexts).
+
+    Args:
+        text: The confirmation question to display.
+        default: Value returned when user presses Enter (or stdin is not a TTY).
+        abort: If *True* and the user answers "no", raise ``click.Abort``.
+
+    Returns:
+        ``True`` if the user answered yes, ``False`` otherwise.
+
+    Raises:
+        click.Abort: When *abort* is ``True`` and the answer is no.
     """
-    Ask for confirmation.
+    default_str = "yes" if default else "no"
+    try:
+        result = click.prompt(f"{text} (yes/no)", default=default_str, show_default=True)
+    except (click.Abort, EOFError):
+        # Non-interactive context with no input available
+        if not default and abort:
+            raise click.Abort() from None
+        return default
+    answered_yes = str(result).lower().strip() in ("yes", "y")
+
+    if not answered_yes and abort:
+        raise click.Abort()
+
+    return answered_yes
+
+
+def confirm(message: str, default: bool = False) -> bool:
+    """Ask for confirmation.
+
+    Delegates to :func:`safe_confirm` which uses the explicit ``(yes/no)``
+    prompt format.
 
     Args:
         message: Confirmation message
@@ -100,7 +143,7 @@ def confirm(message: str, default: bool = False) -> bool:
     Returns:
         True if confirmed, False otherwise
     """
-    return click.confirm(message, default=default)
+    return safe_confirm(message, default=default)
 
 
 def get_git_branch(project_root: Path | None = None) -> str | None:

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -292,6 +292,9 @@ def scan_table_for_pii(
     findings: list[dict[str, Any]] = []
 
     for col_name, data_type in columns:
+        # Skip internal dlt metadata columns — they never contain user PII.
+        if col_name.startswith("_dlt_"):
+            continue
         if not _is_string_type(data_type):
             continue
 

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -293,7 +293,8 @@ def scan_table_for_pii(
 
     for col_name, data_type in columns:
         # Skip internal dlt metadata columns — they never contain user PII.
-        if col_name.startswith("_dlt_"):
+        # Case-insensitive: DuckDB may return uppercase identifiers.
+        if col_name.lower().startswith("_dlt_"):
             continue
         if not _is_string_type(data_type):
             continue

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Callable
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -195,7 +195,7 @@ class DltPipelineRunner:
 
         source_name = source_config.name
         source_type = source_config.type
-        start_time = datetime.now()
+        start_time = datetime.now(tz=timezone.utc)
 
         console.print(f"\n{'=' * 60}")
         console.print(f"🍡 Syncing: [bold]{source_name}[/bold] ({source_type.value})")
@@ -362,7 +362,7 @@ class DltPipelineRunner:
                     )
 
                     # Return failure result
-                    duration = (datetime.now() - start_time).total_seconds()
+                    duration = (datetime.now(tz=timezone.utc) - start_time).total_seconds()
                     history_entry = {
                         "timestamp": start_time.isoformat(),
                         "status": "failed",
@@ -406,7 +406,7 @@ class DltPipelineRunner:
                     )
 
                     # Return failure result
-                    duration = (datetime.now() - start_time).total_seconds()
+                    duration = (datetime.now(tz=timezone.utc) - start_time).total_seconds()
                     history_entry = {
                         "timestamp": start_time.isoformat(),
                         "status": "failed",
@@ -432,7 +432,7 @@ class DltPipelineRunner:
                     }
 
             # Calculate duration
-            duration = (datetime.now() - start_time).total_seconds()
+            duration = (datetime.now(tz=timezone.utc) - start_time).total_seconds()
 
             # Save sync history and log result
             result_status = result.get("status", "failed")
@@ -506,7 +506,7 @@ class DltPipelineRunner:
             console.print(f"[red]{friendly_error}[/red]")
 
             # Log error
-            duration = (datetime.now() - start_time).total_seconds()
+            duration = (datetime.now(tz=timezone.utc) - start_time).total_seconds()
             error_message = str(e)
 
             # CSV/local_files are always full refresh regardless of the flag

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -11,7 +11,7 @@ import logging
 import os
 import subprocess
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from dango.utils.dango_db import connect
@@ -46,6 +46,17 @@ def get_marimo_pid_file_path(project_root: Path) -> Path:
         Path to the Marimo PID file.
     """
     return project_root / ".dango" / "marimo.pid"
+
+
+def _is_port_responding(port: int, timeout: float = 1.0) -> bool:
+    """Check if a server is already listening on localhost:port."""
+    import socket
+
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            return True
+    except (ConnectionRefusedError, OSError, TimeoutError):
+        return False
 
 
 def start_marimo(
@@ -88,6 +99,13 @@ def start_marimo(
         loader = ConfigLoader(project_root)
         config = loader.load_config()
         port = config.platform.marimo_port
+
+    # After force-unlock, marimo may still be running on the configured port.
+    # Check if the port is already responding before starting a new instance.
+    if _is_port_responding(port):
+        logger.debug("Marimo already responding on port %d — reusing existing server", port)
+        # Re-create PID file if missing (best-effort, PID unknown)
+        return None
 
     notebooks_dir = project_root / "notebooks"
     notebooks_dir.mkdir(parents=True, exist_ok=True)
@@ -272,7 +290,7 @@ async def _broadcast_idle_warning(remaining_seconds: int) -> None:
                     f"Notebook server will shut down in {minutes_left} minutes due to inactivity."
                 ),
                 "remaining_seconds": remaining_seconds,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
     except Exception:

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -48,14 +48,21 @@ def get_marimo_pid_file_path(project_root: Path) -> Path:
     return project_root / ".dango" / "marimo.pid"
 
 
-def _is_port_responding(port: int, timeout: float = 1.0) -> bool:
-    """Check if a server is already listening on localhost:port."""
-    import socket
+def _is_marimo_responding(port: int, timeout: float = 1.0) -> bool:
+    """Check if a Marimo server is responding on localhost:port.
+
+    Uses an HTTP GET to verify the response is from Marimo (not an
+    unrelated service that happens to be on the same port).
+    """
+    import urllib.request
 
     try:
-        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
-            return True
-    except (ConnectionRefusedError, OSError, TimeoutError):
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/", method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            # Marimo returns HTML with "marimo" in the response
+            body = resp.read(4096).decode("utf-8", errors="ignore")
+            return "marimo" in body.lower()
+    except Exception:
         return False
 
 
@@ -102,7 +109,7 @@ def start_marimo(
 
     # After force-unlock, marimo may still be running on the configured port.
     # Check if the port is already responding before starting a new instance.
-    if _is_port_responding(port):
+    if _is_marimo_responding(port):
         logger.debug("Marimo already responding on port %d — reusing existing server", port)
         # PID file may be missing (e.g., after force-unlock), but we can't
         # recover it without knowing the PID. The server is reachable, so

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -104,7 +104,10 @@ def start_marimo(
     # Check if the port is already responding before starting a new instance.
     if _is_port_responding(port):
         logger.debug("Marimo already responding on port %d — reusing existing server", port)
-        # Re-create PID file if missing (best-effort, PID unknown)
+        # PID file may be missing (e.g., after force-unlock), but we can't
+        # recover it without knowing the PID. The server is reachable, so
+        # return success. stop_marimo() won't find a PID to kill — the
+        # process will exit via its own --timeout or manual kill.
         return None
 
     notebooks_dir = project_root / "notebooks"

--- a/dango/platform/local/network.py
+++ b/dango/platform/local/network.py
@@ -9,7 +9,7 @@ import json
 import os
 import socket
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -104,7 +104,7 @@ class NetworkConfig:
             "domain": domain,
             "backend_port": backend_port,
             "project_path": str(project_path.absolute()),
-            "registered_at": datetime.now().isoformat(),
+            "registered_at": datetime.now(tz=timezone.utc).isoformat(),
             "status": "running",
         }
 

--- a/dango/platform/local/watcher.py
+++ b/dango/platform/local/watcher.py
@@ -5,7 +5,7 @@ Monitors data directories for changes and triggers sync operations with debounce
 
 import threading
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -176,7 +176,13 @@ class FileWatcher:
 
     def _wrapped_callback(self, files: list):
         """Wrapper to provide additional context to callback"""
-        self.callback({"files": files, "timestamp": datetime.now().isoformat(), "trigger": "auto"})
+        self.callback(
+            {
+                "files": files,
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "trigger": "auto",
+            }
+        )
 
     def watch_directory(self, path: Path, recursive: bool = True):
         """

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -473,18 +473,21 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 raise RuntimeError(f"Sync failed for {src.name}: {error_msg}")
 
             # Accumulate rows_loaded from subprocess result
+            src_rows = 0
             if _result and isinstance(_result, dict):
-                total_rows += _result.get("rows_loaded", 0)
+                src_rows = _result.get("rows_loaded", 0)
+                total_rows += src_rows
 
             save_sync_history_entry(
                 project_root,
                 src.name,
                 {
+                    "timestamp": _ts(),
+                    "status": "success",
+                    "duration_seconds": round(time.monotonic() - src_t0, 2),
+                    "rows_processed": src_rows,
                     "trigger": "scheduler",
                     "schedule": schedule_name,
-                    "status": "completed",
-                    "completed_at": _ts(),
-                    "duration_seconds": round(time.monotonic() - src_t0, 2),
                 },
             )
             if not skip_dbt:

--- a/dango/utils/activity_log.py
+++ b/dango/utils/activity_log.py
@@ -4,7 +4,7 @@ Centralized activity logging for both CLI and Web UI.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -32,7 +32,7 @@ def log_activity(
         timestamp: ISO timestamp (defaults to now)
     """
     if timestamp is None:
-        timestamp = datetime.now().isoformat()
+        timestamp = datetime.now(tz=timezone.utc).isoformat()
 
     log_entry = {
         "timestamp": timestamp,

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -364,7 +364,12 @@ def get_component_disk_usage(project_root: Path) -> dict[str, Any]:
     try:
         if duckdb_path.exists():
             duckdb_info["file_size_mb"] = round(duckdb_path.stat().st_size / (1024**2), 2)
-            # Per-schema estimated sizes (read-only connection)
+            # Per-schema estimated sizes (read-only connection).
+            # NOTE: DuckDB stores everything in a single file; there is no true
+            # per-schema disk size.  ``estimated_size`` from ``duckdb_tables()``
+            # reflects *uncompressed in-memory* size, so it will usually be
+            # larger than the actual on-disk footprint.  We label these as
+            # "estimated data size" in the UI to avoid confusion.
             try:
                 conn = duckdb.connect(str(duckdb_path), config={"access_mode": "read_only"})
                 try:

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -10,7 +10,7 @@ import os
 import sys
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any
 
@@ -103,7 +103,7 @@ class DbtLock:
             "pid": os.getpid(),
             "source": self.source,
             "operation": self.operation,
-            "started_at": datetime.now().isoformat(),
+            "started_at": datetime.now(tz=timezone.utc).isoformat(),
             "hostname": hostname,
         }
 

--- a/dango/visualization/dashboard_manager.py
+++ b/dango/visualization/dashboard_manager.py
@@ -4,7 +4,7 @@ Simplified git-based workflow for Metabase dashboards and questions.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -354,7 +354,10 @@ class DashboardManager:
         """Update sync state file with current timestamp"""
         self.state_file.parent.mkdir(parents=True, exist_ok=True)
 
-        state = {"last_export": datetime.now().isoformat(), "exported_from": self.metabase_url}
+        state = {
+            "last_export": datetime.now(tz=timezone.utc).isoformat(),
+            "exported_from": self.metabase_url,
+        }
 
         with open(self.state_file, "w") as f:
             json.dump(state, f, indent=2)

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -7,7 +7,7 @@ import logging
 import secrets
 import string
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -902,7 +902,7 @@ def setup_metabase(
             "metabase_url": metabase_url,
             "admin": {"email": admin_email, "password": admin_password},
             "database": {"id": summary.get("duckdb_id"), "name": f"{org_name} Analytics"},
-            "setup_completed_at": datetime.now().isoformat(),
+            "setup_completed_at": datetime.now(tz=timezone.utc).isoformat(),
         }
 
         credentials_file.parent.mkdir(parents=True, exist_ok=True)

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -11,7 +11,7 @@ import signal
 import subprocess
 import sys
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -731,9 +731,10 @@ async def get_platform_health_data():
                     timestamp = datetime.fromisoformat(
                         most_recent.get("timestamp", "").replace("Z", "+00:00")
                     )
-                    hours_ago = (
-                        datetime.now() - timestamp.replace(tzinfo=None)
-                    ).total_seconds() / 3600
+                    # Ensure both sides are tz-aware UTC for correct comparison
+                    if timestamp.tzinfo is None:
+                        timestamp = timestamp.replace(tzinfo=timezone.utc)
+                    hours_ago = (datetime.now(tz=timezone.utc) - timestamp).total_seconds() / 3600
 
                     if hours_ago < 24:
                         failed_syncs.append(

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -7,7 +7,7 @@ import logging
 import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
@@ -77,7 +77,7 @@ async def run_dbt_model(
             "event": "dbt_run_started",
             "source": f"dbt:{model_name}",
             "message": f"Running dbt model: {model_name}",
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
     )
 
@@ -88,7 +88,7 @@ async def run_dbt_model(
         "success": True,
         "message": f"dbt model '{model_name}' run started",
         "model_name": model_name,
-        "started_at": datetime.now().isoformat(),
+        "started_at": datetime.now(tz=timezone.utc).isoformat(),
     }
 
 
@@ -117,7 +117,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "event": "dbt_run_failed",
                 "source": f"dbt:{model_name}",
                 "message": str(e).split("\n")[0],  # First line of error message
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
         logger.warning(f"Could not acquire dbt lock for {model_name}: {e}")
@@ -161,7 +161,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "event": "dbt_run_progress",
                 "source": f"dbt:{model_name}",
                 "message": f"Executing: {' '.join(cmd)}",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
 
@@ -186,7 +186,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                     "event": "dbt_run_completed",
                     "source": f"dbt:{model_name}",
                     "message": f"Model '{model_name}' ran successfully in {duration:.1f}s",
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 }
             )
 
@@ -201,7 +201,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                         "event": "dbt_run_progress",
                         "source": f"dbt:{model_name}",
                         "message": "Metabase connection refreshed",
-                        "timestamp": datetime.now().isoformat(),
+                        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                     }
                 )
         else:
@@ -212,7 +212,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                     "event": "dbt_run_failed",
                     "source": f"dbt:{model_name}",
                     "message": f"Model '{model_name}' failed: {error_msg[:200]}",
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 }
             )
 
@@ -222,7 +222,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "event": "dbt_run_failed",
                 "source": f"dbt:{model_name}",
                 "message": f"Model '{model_name}' timed out after 5 minutes",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
     except Exception as e:
@@ -232,7 +232,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "event": "dbt_run_failed",
                 "source": f"dbt:{model_name}",
                 "message": f"Model '{model_name}' failed: {str(e)}",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
     finally:

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -172,7 +172,7 @@ async def get_platform_health() -> dict[str, Any]:
 
     result: dict[str, Any] = {
         "status": "healthy",  # set below
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         "database": db_health,
         "disk": disk,
         "disk_breakdown": data.get("disk_breakdown", {}),

--- a/dango/web/routes/initial_sync.py
+++ b/dango/web/routes/initial_sync.py
@@ -17,7 +17,7 @@ import hmac
 import json
 import shutil
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -133,7 +133,7 @@ async def _save_and_broadcast() -> None:
         {
             "event": "initial_sync_progress",
             "data": _sync_state.to_dict(),
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
     )
 
@@ -207,14 +207,14 @@ async def _run_initial_sync(project_root: Path, sources: list[dict[str, str]]) -
 
     _sync_state.phase = SyncPhase.SYNCING
     _sync_state.total_sources = len(sources)
-    _sync_state.started_at = datetime.now().isoformat()
+    _sync_state.started_at = datetime.now(tz=timezone.utc).isoformat()
     await _save_and_broadcast()
 
     for i, source in enumerate(sources):
         # Check cancel
         if _sync_state.cancel_requested:
             _sync_state.phase = SyncPhase.CANCELLED
-            _sync_state.completed_at = datetime.now().isoformat()
+            _sync_state.completed_at = datetime.now(tz=timezone.utc).isoformat()
             await _save_and_broadcast()
             return
 
@@ -224,7 +224,7 @@ async def _run_initial_sync(project_root: Path, sources: list[dict[str, str]]) -
             _sync_state.phase = SyncPhase.FAILED
             disk_pct = _get_disk_usage_pct()
             _sync_state.error = f"Disk at {disk_pct:.0f}%. Free space or resize the server."
-            _sync_state.completed_at = datetime.now().isoformat()
+            _sync_state.completed_at = datetime.now(tz=timezone.utc).isoformat()
             await _save_and_broadcast()
             return
 
@@ -265,7 +265,7 @@ async def _run_initial_sync(project_root: Path, sources: list[dict[str, str]]) -
         _refresh_metabase(project_root)
 
     _sync_state.phase = SyncPhase.COMPLETE
-    _sync_state.completed_at = datetime.now().isoformat()
+    _sync_state.completed_at = datetime.now(tz=timezone.utc).isoformat()
     await _save_and_broadcast()
 
 

--- a/dango/web/routes/logs.py
+++ b/dango/web/routes/logs.py
@@ -4,7 +4,7 @@ Log retrieval endpoints.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException
 
@@ -50,7 +50,9 @@ async def get_source_logs(source_name: str, limit: int = 100) -> list[LogEntry]:
                     # Fallback for unparseable lines
                     logs.append(
                         LogEntry(
-                            timestamp=datetime.now().isoformat(), level="INFO", message=line.strip()
+                            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                            level="INFO",
+                            message=line.strip(),
                         )
                     )
 

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -174,7 +174,7 @@ def _create_notebook_blocking(
     shutil.copy2(str(template_file), str(target))
 
     new_id = str(uuid.uuid4())
-    now = datetime.now().isoformat()
+    now = datetime.now(tz=timezone.utc).isoformat()
 
     with connect(project_root) as conn:
         conn.execute(
@@ -221,7 +221,13 @@ async def notebooks_page(
 async def list_notebooks(
     user: User = Depends(require_permission("notebooks.view")),
 ) -> JSONResponse:
-    """List all notebooks with metadata and lock status."""
+    """List all notebooks with metadata and lock status.
+
+    NOTE: Lock state is always fresh on each request (queried from the
+    ``notebook_locks`` table).  CLI-acquired locks are immediately visible
+    after a page refresh.  Real-time push notification of lock changes
+    (e.g., via WebSocket) is a post-v1 enhancement.
+    """
     project_root = get_project_root()
     notebooks = await asyncio.to_thread(_list_notebooks_blocking, project_root)
     return JSONResponse(content=notebooks)
@@ -488,7 +494,7 @@ async def force_release_notebook_lock(
             "event": "notebook_lock_revoked",
             "notebook": name,
             "message": f"Lock on notebook '{name}' was force-released by an administrator.",
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
     )
 

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -8,7 +8,7 @@ exclusively via the CLI (``dango schedule add``, ``dango schedule webhook add``)
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -432,7 +432,7 @@ async def trigger_schedule(
         func,
         DateTrigger(),
         kwargs=func_kwargs,
-        id=f"manual:{name}:{datetime.now().isoformat()}",
+        id=f"manual:{name}:{datetime.now(tz=timezone.utc).isoformat()}",
         name=f"manual-{name}",
     )
 

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -106,14 +106,15 @@ async def run_sync_task(
     db_path = get_scheduler_db_path(project_root)
     record_id = record_start(db_path, "ui", sources=[source_name])
 
-    # Immediate UI feedback
+    # Immediate UI feedback (log=False — we write our own entry below)
     await ws_manager.broadcast(
         {
             "event": "sync_started",
             "source": source_name,
             "message": f"Starting sync for {source_name}",
             "timestamp": sync_timestamp,
-        }
+        },
+        log=False,
     )
     append_log_entry(
         {

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -34,7 +34,6 @@ from dango.validation import (
 from dango.web.helpers import (
     append_log_entry,
     get_project_root,
-    get_source_row_count,
     load_sources_config,
     save_sync_history_entry,
 )
@@ -85,7 +84,7 @@ async def trigger_sync(source_name: str, sync_request: SyncRequest) -> SyncRespo
         success=True,
         message=f"Sync started for {source_name}",
         source_name=source_name,
-        started_at=datetime.now().isoformat(),
+        started_at=datetime.now(tz=timezone.utc).isoformat(),
     )
 
 
@@ -100,7 +99,7 @@ async def run_sync_task(
     )
 
     start_time = time.time()
-    sync_timestamp = datetime.now().isoformat()
+    sync_timestamp = datetime.now(tz=timezone.utc).isoformat()
     project_root = get_project_root()
 
     # Create execution history record (passed to subprocess to avoid double records)
@@ -148,37 +147,15 @@ async def run_sync_task(
         duration = time.time() - start_time
         error_message = result.get("error") if result else None
 
-        # Get row count after sync (only if successful)
-        rows_processed = 0
-        if success:
-            rows_processed = get_source_row_count(source_name) or 0
-
         # Sync history is saved by the subprocess (dlt_runner.py run_source).
         # Do NOT save again here — it creates duplicate records.
         # WebSocket broadcasts are handled by poll_sync_status via
         # _broadcast_phase_transition — do NOT broadcast here either,
         # as that creates duplicate sync_completed/sync_failed events.
 
-        # Log completion
-        if success:
-            append_log_entry(
-                {
-                    "timestamp": datetime.now().isoformat(),
-                    "level": "success",
-                    "source": source_name,
-                    "message": f"Sync completed in {round(duration, 1)}s - {rows_processed:,} rows",
-                }
-            )
-        else:
-            append_log_entry(
-                {
-                    "timestamp": datetime.now().isoformat(),
-                    "level": "error",
-                    "source": source_name,
-                    "message": f"Sync failed after {round(duration, 1)}s"
-                    + (f": {error_message}" if error_message else ""),
-                }
-            )
+        # Activity log entries are written by the subprocess (dlt_runner.py
+        # run_source → log_activity). Do NOT write again here — it creates
+        # duplicate entries in activity.jsonl.
 
         # Cleanup status file
         cleanup_sync_status(project_root, sync_id=sync_id)
@@ -190,7 +167,7 @@ async def run_sync_task(
         duration = time.time() - start_time
         append_log_entry(
             {
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 "level": "error",
                 "source": source_name,
                 "message": f"Sync failed: {error_message}",
@@ -215,7 +192,7 @@ async def run_sync_task(
                 "event": "sync_failed",
                 "source": source_name,
                 "message": f"Sync failed: {error_message}",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
 

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import duckdb
@@ -146,7 +146,7 @@ async def upload_csv_to_source(
                 "event": "file_uploaded",
                 "source": source_name,
                 "message": f"File {safe_filename} uploaded to {source_name}",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
 
@@ -504,14 +504,14 @@ async def delete_csv_file(
                 "event": "csv_deleted",
                 "source": source_name,
                 "message": f"Deleted {filename}",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
 
         # Log activity
         append_log_entry(
             {
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 "level": "info",
                 "source": source_name,
                 "message": f"Deleted file: {filename}",
@@ -549,7 +549,7 @@ async def run_dbt_after_delete(source_name: str):
     from dango.utils import DbtLock, DbtLockError
 
     start_time = time.time()
-    sync_timestamp = datetime.now().isoformat()
+    sync_timestamp = datetime.now(tz=timezone.utc).isoformat()
     project_root = get_project_root()
 
     # Try to acquire lock before running dbt
@@ -569,12 +569,12 @@ async def run_dbt_after_delete(source_name: str):
                 "event": "dbt_run_all_failed",
                 "source": f"dbt (triggered by {source_name} delete)",
                 "message": error_msg,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
         append_log_entry(
             {
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 "level": "error",
                 "source": f"dbt (triggered by {source_name} delete)",
                 "message": f"dbt run blocked: {error_msg}",
@@ -623,7 +623,7 @@ async def run_dbt_after_delete(source_name: str):
             # Log success
             append_log_entry(
                 {
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                     "level": "success",
                     "source": f"dbt (triggered by {source_name} delete)",
                     "message": "dbt models updated successfully",
@@ -636,7 +636,7 @@ async def run_dbt_after_delete(source_name: str):
                     "event": "dbt_run_all_completed",
                     "source": f"dbt (triggered by {source_name} delete)",
                     "message": "Models updated after file deletion",
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 }
             )
 
@@ -654,7 +654,7 @@ async def run_dbt_after_delete(source_name: str):
             # Log failure - dbt_output already contains "dbt run failed:" prefix
             append_log_entry(
                 {
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                     "level": "error",
                     "source": f"dbt (triggered by {source_name} delete)",
                     "message": dbt_output,  # Don't add extra "dbt run failed:" prefix
@@ -667,7 +667,7 @@ async def run_dbt_after_delete(source_name: str):
                     "event": "dbt_run_all_failed",
                     "source": f"dbt (triggered by {source_name} delete)",
                     "message": "dbt run failed",
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 }
             )
 
@@ -688,7 +688,7 @@ async def run_dbt_after_delete(source_name: str):
 
         append_log_entry(
             {
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 "level": "error",
                 "source": f"dbt (triggered by {source_name} delete)",
                 "message": f"Error running dbt: {str(e)}",

--- a/dango/web/routes/websocket.py
+++ b/dango/web/routes/websocket.py
@@ -4,11 +4,9 @@ WebSocket connection manager and endpoint for real-time updates.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-
-from dango.web.helpers import append_log_entry
 
 logger = logging.getLogger(__name__)
 
@@ -35,16 +33,12 @@ class ConnectionManager:
         logger.info(f"WebSocket disconnected. Total connections: {len(self.active_connections)}")
 
     async def broadcast(self, message: dict) -> None:
-        """Broadcast message to all connected clients and persist to logs."""
-        # Persist to logs
-        log_entry = {
-            "timestamp": message.get("timestamp", datetime.now().isoformat()),
-            "level": self._get_log_level(message.get("event", "")),
-            "source": message.get("source", "system"),
-            "message": message.get("message", str(message.get("event", ""))),
-        }
-        append_log_entry(log_entry)
+        """Broadcast message to all connected WebSocket clients.
 
+        Note: This method does NOT write to the activity log. Activity log
+        entries are written by the originating subsystem (e.g. dlt_runner,
+        sync.py) to avoid duplicate entries.
+        """
         # Broadcast to WebSocket clients
         disconnected = []
         for connection in self.active_connections:
@@ -60,17 +54,6 @@ class ConnectionManager:
                 self.active_connections.remove(connection)
             except ValueError:
                 pass
-
-    def _get_log_level(self, event: str) -> str:
-        """Determine log level from event type."""
-        if "completed" in event or "success" in event:
-            return "success"
-        elif "failed" in event or "error" in event:
-            return "error"
-        elif "warning" in event:
-            return "warning"
-        else:
-            return "info"
 
 
 # Global WebSocket manager
@@ -94,7 +77,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             {
                 "event": "connected",
                 "message": "Connected to Dango real-time updates",
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
 
@@ -109,7 +92,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
             # Echo back for now (can add client commands later)
             await websocket.send_json(
-                {"event": "echo", "data": data, "timestamp": datetime.now().isoformat()}
+                {
+                    "event": "echo",
+                    "data": data,
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                }
             )
 
     except WebSocketDisconnect:

--- a/dango/web/routes/websocket.py
+++ b/dango/web/routes/websocket.py
@@ -32,13 +32,37 @@ class ConnectionManager:
         self.active_connections.remove(websocket)
         logger.info(f"WebSocket disconnected. Total connections: {len(self.active_connections)}")
 
-    async def broadcast(self, message: dict) -> None:
+    async def broadcast(self, message: dict, *, log: bool = True) -> None:
         """Broadcast message to all connected WebSocket clients.
 
-        Note: This method does NOT write to the activity log. Activity log
-        entries are written by the originating subsystem (e.g. dlt_runner,
-        sync.py) to avoid duplicate entries.
+        Args:
+            message: The message dict to broadcast.
+            log: If True (default), also write to activity log. Callers that
+                 already write their own activity log entries should pass
+                 ``log=False`` to avoid duplicates.
         """
+        if log:
+            from dango.web.helpers import append_log_entry
+
+            event = message.get("event", "")
+            _LOG_LEVELS = {
+                "sync_completed": "success",
+                "sync_failed": "error",
+                "dbt_run_all_completed": "success",
+                "dbt_run_all_failed": "error",
+            }
+            level = _LOG_LEVELS.get(event, "info")
+            append_log_entry(
+                {
+                    "timestamp": message.get(
+                        "timestamp", datetime.now(tz=timezone.utc).isoformat()
+                    ),
+                    "level": level,
+                    "source": message.get("source", "system"),
+                    "message": message.get("message", event),
+                }
+            )
+
         # Broadcast to WebSocket clients
         disconnected = []
         for connection in self.active_connections:

--- a/dango/web/static/css/catalog.css
+++ b/dango/web/static/css/catalog.css
@@ -110,12 +110,22 @@
     pointer-events: none;
 }
 
-/* Description truncation */
+/* Description truncation — responsive max-width so name+type stay visible */
 .desc-truncate {
-    max-width: 300px;
+    max-width: 150px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+@media (min-width: 768px) {
+    .desc-truncate {
+        max-width: 250px;
+    }
+}
+@media (min-width: 1024px) {
+    .desc-truncate {
+        max-width: 300px;
+    }
 }
 
 /* Test status indicators */

--- a/dango/web/static/css/main.css
+++ b/dango/web/static/css/main.css
@@ -112,8 +112,9 @@ code {
     }
 }
 
-/* Prevent action button text from wrapping on narrow viewports */
-button {
+/* Prevent action button text from wrapping in table cells */
+td button,
+th button {
     white-space: nowrap;
 }
 

--- a/dango/web/static/css/main.css
+++ b/dango/web/static/css/main.css
@@ -112,6 +112,11 @@ code {
     }
 }
 
+/* Prevent action button text from wrapping on narrow viewports */
+button {
+    white-space: nowrap;
+}
+
 /* Touch-friendly buttons on mobile */
 @media (max-width: 768px) {
     button {
@@ -200,4 +205,41 @@ pre.log-message {
     100% {
         background-position: 100% 50%;
     }
+}
+
+/* Instant tooltip — replaces browser-native title (which has ~2s delay).
+   Uses data-tooltip attribute. Works with Alpine.js dynamic binding:
+   :data-tooltip="variable" or x-bind:data-tooltip="variable" */
+.tooltip {
+    position: relative;
+}
+.tooltip::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 0;
+    top: 100%;
+    margin-top: 4px;
+    background: #1f2937;
+    color: #f9fafb;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 400;
+    line-height: 1.4;
+    white-space: normal;
+    word-break: break-word;
+    width: max-content;
+    max-width: min(400px, 90vw);
+    z-index: 50;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.1s;
+}
+.tooltip:hover::after {
+    opacity: 1;
+}
+/* Hide tooltip when data-tooltip is empty or absent */
+.tooltip:not([data-tooltip])::after,
+.tooltip[data-tooltip=""]::after {
+    display: none;
 }

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -45,6 +45,10 @@ let activeFileOperations = new Map();
 // Track elapsed time intervals for active syncs: Map<sourceName, intervalId>
 let syncTimers = new Map();
 let syncResults = new Map();  // Stores sync_completed data for in-place updates
+// Track recent sync completion to prevent loadSources() from timing out
+// after sync_completed already cleared activeSyncs
+let recentSyncComplete = false;
+let recentSyncCompleteTimeout = null;
 
 /**
  * Format a file size in bytes to a human-readable string (B/KB/MB/GB).
@@ -70,7 +74,9 @@ function formatElapsed(seconds) {
 }
 
 /**
- * Start an elapsed timer for a syncing source
+ * Start an elapsed timer for a syncing source.
+ * Timer audit: paired with stopSyncTimer(). Cleanup on sync_completed,
+ * sync_failed, and dbt_error WebSocket events.
  */
 function startSyncTimer(sourceName) {
     stopSyncTimer(sourceName);
@@ -159,8 +165,8 @@ function getTotalFileOperations() {
 function formatRelativeTime(timestamp) {
     if (!timestamp) return 'Never';
 
-    // Server stores UTC timestamps without timezone suffix.
-    // Append 'Z' so the browser interprets them as UTC, not local time.
+    // Server sends UTC timestamps (with +00:00 or Z suffix).
+    // For legacy naive timestamps, append 'Z' so the browser treats them as UTC.
     let ts = String(timestamp);
     if (!ts.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(ts)) {
         ts += 'Z';
@@ -170,34 +176,36 @@ function formatRelativeTime(timestamp) {
 
     const now = new Date();
     const seconds = Math.floor((now - date) / 1000);
-
-    // Future dates
-    if (seconds < 0) {
-        return `<span title="${date.toLocaleString()}">Just now</span>`;
-    }
-
-    // Relative time ranges
-    const intervals = [
-        { seconds: 31536000, label: 'year' },
-        { seconds: 2592000, label: 'month' },
-        { seconds: 86400, label: 'day' },
-        { seconds: 3600, label: 'hour' },
-        { seconds: 60, label: 'minute' },
-    ];
-
-    for (const interval of intervals) {
-        const count = Math.floor(seconds / interval.seconds);
-        if (count >= 1) {
-            const plural = count > 1 ? 's' : '';
-            const relativeText = `${count} ${interval.label}${plural} ago`;
-            const fullTimestamp = date.toLocaleString();
-            return `<span title="${fullTimestamp}" class="cursor-help">${relativeText}</span>`;
-        }
-    }
-
-    // Less than a minute
     const fullTimestamp = date.toLocaleString();
-    return `<span title="${fullTimestamp}" class="cursor-help">Just now</span>`;
+
+    // Small negative values (clock skew up to 60s) → "Just now"
+    // Large negative values → show the actual date (something is wrong)
+    if (seconds < -60) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${date.toLocaleDateString()}</span>`;
+    }
+    if (seconds < 0) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">Just now</span>`;
+    }
+
+    // Compact relative time
+    if (seconds < 60) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">Just now</span>`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${minutes}m ago</span>`;
+    }
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${hours}h ago</span>`;
+    }
+    const days = Math.floor(hours / 24);
+    if (days < 7) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${days}d ago</span>`;
+    }
+
+    // Older than 7 days — show formatted date
+    return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${date.toLocaleDateString()}</span>`;
 }
 
 // Initialize on page load — conditionally based on which page elements exist
@@ -230,12 +238,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Service status cards (dashboard overview)
+    // Timer audit: page-level interval — cleared on page navigation (standard browser behavior).
     if (hasServiceCards) {
         loadServiceStatus();
         setInterval(loadServiceStatus, 30000);
     }
 
     // Health widget (dashboard overview)
+    // Timer audit: page-level interval — cleared on page navigation.
     if (hasHealthWidget) {
         fetchPlatformHealth();
         setInterval(fetchPlatformHealth, 30000);
@@ -257,6 +267,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Update sync counter periodically (only if sources table exists)
+    // Timer audit: page-level 1s interval — lightweight (early-returns when no
+    // status text element exists). Cleared on page navigation.
     if (hasSources) {
         setInterval(updateSyncCounter, 1000);
     }
@@ -378,6 +390,7 @@ function connectWebSocket() {
             wsDisconnectedLogged = true;
         }
 
+        // Timer audit: reconnectInterval — cleared on successful ws.onopen.
         // Attempt to reconnect every 5 seconds
         if (!reconnectInterval) {
             reconnectInterval = setInterval(() => {
@@ -464,6 +477,12 @@ async function handleWebSocketMessage(data) {
             // Clean up sync state and refresh
             activeSyncs.delete(source);
             updateSyncCounter();
+            // Mark that a sync recently completed — helps loadSources()
+            // show a loading spinner if the DuckDB query times out right
+            // after the sync finishes (activeSyncs is already cleared).
+            recentSyncComplete = true;
+            if (recentSyncCompleteTimeout) clearTimeout(recentSyncCompleteTimeout);
+            recentSyncCompleteTimeout = setTimeout(() => { recentSyncComplete = false; }, 10000);
             loadSources();  // Reload from API to get correct status
             // Fallback: if activeSyncs wasn't set (e.g. upload-triggered sync),
             // the cleanup above is harmless (delete on missing key is a no-op).
@@ -778,9 +797,10 @@ async function loadSources() {
             if (!tbody) return;
 
             // Only show loading message if we actually have active operations
-            // This prevents flickering when timeout happens at the tail end
+            // or a sync just completed (DuckDB may still be releasing the lock)
             const totalFileOps = getTotalFileOperations();
-            if (activeSyncs.size > 0 || totalFileOps > 0 || dbtRunStartTime !== null) {
+            const hasActiveWork = activeSyncs.size > 0 || totalFileOps > 0 || dbtRunStartTime !== null || recentSyncComplete;
+            if (hasActiveWork) {
                 tbody.innerHTML = `
                     <tr>
                         <td colspan="7" class="px-6 py-8 text-center text-gray-500">
@@ -792,6 +812,17 @@ async function loadSources() {
                         </td>
                     </tr>
                 `;
+            }
+
+            // If a sync recently completed, retry quickly (database may still be busy)
+            if (recentSyncComplete && activeSyncs.size === 0 && dbtRunStartTime === null && totalFileOps === 0) {
+                isLoadingSources = false;
+                console.log('⏸️ [loadSources] Scheduling retry in 2s (recent sync complete)');
+                loadSourcesRetryTimeout = setTimeout(() => {
+                    loadSourcesRetryTimeout = null;
+                    loadSources();
+                }, 2000);
+                return;
             }
 
             // DON'T retry if there are active syncs, dbt runs, or file operations
@@ -1233,7 +1264,7 @@ function renderSourcesTable() {
 
         return `
         <tr id="source-${source.name}" class="hover:bg-gray-50 transition-colors duration-150">
-            <td class="px-6 py-4 whitespace-nowrap cursor-pointer" onclick="${rowClickHandler}" title="${rowClickHelp}">
+            <td class="px-6 py-4 whitespace-nowrap cursor-pointer tooltip" onclick="${rowClickHandler}" data-tooltip="${rowClickHelp}">
                 <div class="flex items-center">
                     <div class="text-sm font-medium text-gray-900">${escapeHtml(source.name)}</div>
                     ${source.needs_attention ? '<span class="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Needs Attention</span>' : ''}
@@ -1245,7 +1276,7 @@ function renderSourcesTable() {
                 </span>
                 <div class="text-xs text-gray-400 mt-0.5">${source.sync_mode === 'full_refresh' ? 'Full Refresh' : 'Incremental'}${source.lookback_days ? ` (${source.lookback_days}d)` : ''}</div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap cursor-pointer" data-col="status" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" title="Click to view sync history">
+            <td class="px-6 py-4 whitespace-nowrap cursor-pointer tooltip" data-col="status" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" data-tooltip="Click to view sync history">
                 ${renderStatusPill(source, isSyncing, hasFileOps)}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="rows">
@@ -1255,7 +1286,7 @@ function renderSourcesTable() {
                 ${formatRelativeTime(source.last_sync)}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
-                ${source.has_schedule ? `<span title="${source.schedule_display || ''}">${source.schedule_display || 'Scheduled'}</span>` : '<span class="inline-block w-full text-center text-gray-300">—</span>'}
+                ${source.has_schedule ? `<span class="tooltip" data-tooltip="${source.schedule_display || ''}">${source.schedule_display || 'Scheduled'}</span>` : '<span class="inline-block w-full text-center text-gray-300">—</span>'}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                 ${actionColumn}
@@ -1535,6 +1566,7 @@ function showToast(message, type = 'info') {
 
     container.appendChild(toast);
 
+    // Timer audit: fire-and-forget animation timeouts. Toast self-removes from DOM.
     // Trigger animation
     setTimeout(() => {
         toast.classList.remove('opacity-0', 'translate-x-full');
@@ -1676,8 +1708,8 @@ async function loadCsvFilesList(sourceName) {
                 `<button
                     id="delete-btn-${safeFilename}"
                     onclick="handleFileDelete('${sourceName}', '${file.path}', '${file.filename}', '${safeFilename}')"
-                    class="ml-2 text-red-600 hover:text-red-800 text-xs font-medium"
-                    title="Delete file">
+                    class="ml-2 text-red-600 hover:text-red-800 text-xs font-medium tooltip"
+                    data-tooltip="Delete file">
                     Delete
                 </button>` : '';
 
@@ -2387,9 +2419,9 @@ function renderDbtModelsTable() {
                     </button>
                     <button
                         onclick="runDbtModel('${model.name}', true)"
-                        class="text-green-600 hover:text-green-900 disabled:text-gray-400 disabled:cursor-not-allowed mr-3"
+                        class="text-green-600 hover:text-green-900 disabled:text-gray-400 disabled:cursor-not-allowed mr-3 tooltip"
                         ${buttonDisabled}
-                        title="Run with downstream models"
+                        data-tooltip="Run with downstream models"
                     >
                         Run+
                     </button>` : '';
@@ -2420,8 +2452,8 @@ function renderDbtModelsTable() {
                     ${actionButtons}
                     <a
                         href="/catalog"
-                        class="text-blue-600 hover:text-blue-900"
-                        title="View documentation"
+                        class="text-blue-600 hover:text-blue-900 tooltip"
+                        data-tooltip="View documentation"
                     >
                         📖
                     </a>

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -277,7 +277,7 @@
             <!-- Columns sub-tab -->
             <div x-show="detailTab === 'columns'">
                 <template x-if="selectedModel.columns && selectedModel.columns.length > 0">
-                    <div class="bg-white shadow rounded-lg overflow-hidden">
+                    <div class="bg-white shadow rounded-lg overflow-x-hidden">
                         <div class="catalog-table-wrapper overflow-x-auto">
                             <table class="min-w-full divide-y divide-gray-200">
                                 <thead class="bg-gray-50">
@@ -309,9 +309,9 @@
                                                 <template x-if="col.tests && col.tests.length > 0">
                                                     <div class="flex flex-wrap gap-1">
                                                         <template x-for="t in col.tests" :key="t.name">
-                                                            <span class="text-xs px-1.5 py-0.5 rounded truncate inline-block align-middle catalog-tooltip" style="max-width: 200px"
+                                                            <span class="text-xs px-1.5 py-0.5 rounded truncate inline-block align-middle tooltip" style="max-width: 200px"
                                                                   :class="t.status === 'pass' ? 'bg-green-100 text-green-800' : t.status === 'fail' || t.status === 'error' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-600'"
-                                                                  :data-tip="t.name"
+                                                                  x-bind:data-tooltip="t.name"
                                                                   x-text="(t.status === 'pass' ? '✓ ' : t.status === 'fail' || t.status === 'error' ? '✗ ' : '') + t.name.replace(/^(not_null|unique|accepted_values)_/, '$1: ')"></span>
                                                         </template>
                                                     </div>
@@ -456,9 +456,9 @@
                 <div class="lineage-wrapper bg-white shadow rounded-lg overflow-hidden" style="height:600px">
                     <div id="lineage-container" style="width:100%;height:100%"></div>
                     <div class="lineage-controls">
-                        <button @click="lineageZoomIn()" title="Zoom in">+</button>
-                        <button @click="lineageZoomOut()" title="Zoom out">&minus;</button>
-                        <button @click="lineageFitAll()" title="Fit all">&#8694;</button>
+                        <button @click="lineageZoomIn()" class="tooltip" data-tooltip="Zoom in">+</button>
+                        <button @click="lineageZoomOut()" class="tooltip" data-tooltip="Zoom out">&minus;</button>
+                        <button @click="lineageFitAll()" class="tooltip" data-tooltip="Fit all">&#8694;</button>
                     </div>
                     <div class="lineage-detail" x-show="selectedNode" x-cloak x-transition.opacity>
                         <div class="lineage-detail-header">
@@ -703,11 +703,22 @@ function catalogPage() {
                     // Attach PII and drift indicators to columns
                     if (model.columns) {
                         const tblName = model.name;
+                        // For staging tables (stg_{source}__{raw_table}), also check
+                        // PII findings from the corresponding raw source table.
+                        let rawSource = null;
+                        let rawTable = null;
+                        const stgMatch = tblName.match(/^stg_([^_]+)__(.+)$/);
+                        if (stgMatch) {
+                            rawSource = stgMatch[1];
+                            rawTable = stgMatch[2];
+                        }
                         for (const col of model.columns) {
                             const pii = this.piiFindings.find(f => {
                                 const sourceMatch = model.source_name ? f.source === model.source_name : true;
                                 return sourceMatch && f.table_name === tblName && f.column_name === col.name;
-                            });
+                            }) || (rawSource && rawTable ? this.piiFindings.find(f =>
+                                f.source === rawSource && f.table_name === rawTable && f.column_name === col.name
+                            ) : null);
                             col._pii = pii ? pii.entity_type : null;
                             const override = this.piiOverrides.find(o => {
                                 const sourceMatch = model.source_name ? o.source === model.source_name : true;

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -298,9 +298,9 @@
                                         <tr>
                                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                                                 <span x-text="col.name"></span>
-                                                <span x-show="col._pii && col._piiProvenance === 'auto'" class="ml-1 px-1.5 py-0.5 text-xs rounded bg-amber-100 text-amber-800 catalog-tooltip" :data-tip="'Auto-detected: ' + (col._pii || '') + ' — Manage via CLI: dango governance pii-set'">PII ⚑</span>
-                                                <span x-show="col._pii && col._piiProvenance === 'confirmed'" class="ml-1 px-1.5 py-0.5 text-xs rounded bg-green-100 text-green-800 catalog-tooltip" :data-tip="'Confirmed: ' + (col._pii || '')">PII ✓</span>
-                                                <span x-show="col._drift" class="ml-1 px-1.5 py-0.5 text-xs rounded bg-orange-100 text-orange-800 catalog-tooltip" x-text="col._drift" :data-tip="'Schema drift: ' + (col._drift || '')"></span>
+                                                <span x-show="col._pii && col._piiProvenance === 'auto'" class="ml-1 px-1.5 py-0.5 text-xs rounded bg-amber-100 text-amber-800 tooltip" :data-tooltip="'Auto-detected: ' + (col._pii || '') + ' — Manage via CLI: dango governance pii-set'">PII ⚑</span>
+                                                <span x-show="col._pii && col._piiProvenance === 'confirmed'" class="ml-1 px-1.5 py-0.5 text-xs rounded bg-green-100 text-green-800 tooltip" :data-tooltip="'Confirmed: ' + (col._pii || '')">PII ✓</span>
+                                                <span x-show="col._drift" class="ml-1 px-1.5 py-0.5 text-xs rounded bg-orange-100 text-orange-800 tooltip" x-text="col._drift" :data-tooltip="'Schema drift: ' + (col._drift || '')"></span>
                                             </td>
                                             <td class="px-6 py-4 whitespace-nowrap"><span class="col-type text-gray-600" x-text="col.type || '--'"></span></td>
                                             <td class="px-6 py-4 text-sm text-gray-500 hidden sm:table-cell" x-text="col.description || '--'"></td>
@@ -707,7 +707,7 @@ function catalogPage() {
                         // PII findings from the corresponding raw source table.
                         let rawSource = null;
                         let rawTable = null;
-                        const stgMatch = tblName.match(/^stg_([^_]+)__(.+)$/);
+                        const stgMatch = tblName.match(/^stg_(.+?)__(.+)$/);
                         if (stgMatch) {
                             rawSource = stgMatch[1];
                             rawTable = stgMatch[2];

--- a/dango/web/templates/health.html
+++ b/dango/web/templates/health.html
@@ -365,10 +365,14 @@
                         <dd class="text-sm font-medium text-gray-900">${fmtMB(bd.duckdb.file_size_mb)}</dd>
                     </div>`;
                     if (bd.duckdb.schema_sizes && Object.keys(bd.duckdb.schema_sizes).length > 0) {
+                        rows += `<div class="flex justify-between pl-4">
+                            <dt class="text-xs text-gray-400 italic" colspan="2">Estimated data size (uncompressed)</dt>
+                            <dd></dd>
+                        </div>`;
                         for (const [schema, bytes] of Object.entries(bd.duckdb.schema_sizes)) {
                             rows += `<div class="flex justify-between pl-4">
                                 <dt class="text-xs text-gray-500">${escapeHtml(schema)}</dt>
-                                <dd class="text-xs text-gray-700">${fmtMB(bytes / (1024 * 1024))}</dd>
+                                <dd class="text-xs text-gray-700">~${fmtMB(bytes / (1024 * 1024))}</dd>
                             </div>`;
                         }
                     }

--- a/dango/web/templates/health.html
+++ b/dango/web/templates/health.html
@@ -366,7 +366,7 @@
                     </div>`;
                     if (bd.duckdb.schema_sizes && Object.keys(bd.duckdb.schema_sizes).length > 0) {
                         rows += `<div class="flex justify-between pl-4">
-                            <dt class="text-xs text-gray-400 italic" colspan="2">Estimated data size (uncompressed)</dt>
+                            <dt class="text-xs text-gray-400 italic">Estimated data size (uncompressed)</dt>
                             <dd></dd>
                         </div>`;
                         for (const [schema, bytes] of Object.entries(bd.duckdb.schema_sizes)) {

--- a/dango/web/templates/monitoring.html
+++ b/dango/web/templates/monitoring.html
@@ -181,7 +181,7 @@
                             <div x-show="expandedGroups[group.model]" x-cloak class="border-t border-gray-100">
                                 <template x-for="t in group.tests" :key="t.test_name">
                                     <div class="flex items-center justify-between px-3 py-1.5 text-xs">
-                                        <span class="text-gray-700 font-mono truncate" :title="t.test_name" x-text="t.test_name"></span>
+                                        <span class="text-gray-700 font-mono truncate tooltip" :data-tooltip="t.test_name" x-text="t.test_name"></span>
                                         <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-semibold flex-shrink-0 ml-2"
                                               :class="t.status === 'pass' ? 'bg-green-100 text-green-800' : t.status === 'fail' || t.status === 'error' ? 'bg-red-100 text-red-800' : 'bg-gray-100 text-gray-600'"
                                               x-text="t.status || 'not run'"></span>

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -219,34 +219,16 @@
                     <h3 class="text-lg font-medium text-gray-900 mb-4">
                         Trigger <span class="font-mono" x-text="triggerTarget?.name"></span>
                     </h3>
-                    <form @submit.prevent="triggerSchedule()">
-                        <div class="mb-4">
-                            <label class="flex items-center">
-                                <input type="checkbox" x-model="triggerOpts.full_refresh"
-                                       class="h-4 w-4 text-dango-600 focus:ring-dango-500 border-gray-300 rounded mr-2">
-                                <span class="text-sm text-gray-700">Full refresh</span>
-                            </label>
-                        </div>
-                        <div class="mb-4">
-                            <label class="block text-sm font-medium text-gray-700 mb-1">Start Date (optional)</label>
-                            <input type="datetime-local" x-model="triggerOpts.start_date"
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
-                        </div>
-                        <div class="mb-4">
-                            <label class="block text-sm font-medium text-gray-700 mb-1">End Date (optional)</label>
-                            <input type="datetime-local" x-model="triggerOpts.end_date"
-                                   class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-dango-500">
-                        </div>
-                        <div class="flex justify-end space-x-3">
-                            <button type="button" @click="showTriggerModal = false"
-                                    class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
-                            <button type="submit" :disabled="triggerLoading"
-                                    class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">
-                                <span x-show="!triggerLoading">Trigger Now</span>
-                                <span x-show="triggerLoading" x-cloak>Triggering...</span>
-                            </button>
-                        </div>
-                    </form>
+                    <p class="text-sm text-gray-500 mb-4">This will run the schedule immediately with default settings.</p>
+                    <div class="flex justify-end space-x-3">
+                        <button type="button" @click="showTriggerModal = false"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="triggerSchedule()" :disabled="triggerLoading"
+                                class="px-4 py-2 text-sm text-white bg-dango-600 rounded-md hover:bg-dango-700 disabled:opacity-50">
+                            <span x-show="!triggerLoading">Run Now</span>
+                            <span x-show="triggerLoading" x-cloak>Triggering...</span>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -280,7 +262,6 @@ function schedulesPage() {
         // Trigger modal
         showTriggerModal: false,
         triggerTarget: null,
-        triggerOpts: { full_refresh: false, start_date: '', end_date: '' },
         triggerLoading: false,
 
         // WebSocket
@@ -333,23 +314,19 @@ function schedulesPage() {
         // --- Trigger ---
         openTriggerModal(sched) {
             this.triggerTarget = sched;
-            this.triggerOpts = { full_refresh: false, start_date: '', end_date: '' };
             this.showTriggerModal = true;
         },
         async triggerSchedule() {
             this.triggerLoading = true; this.error = '';
+            const scheduleName = this.triggerTarget?.name || '';
             try {
-                const body = {};
-                if (this.triggerOpts.full_refresh) body.full_refresh = true;
-                if (this.triggerOpts.start_date) body.start_date = this.triggerOpts.start_date;
-                if (this.triggerOpts.end_date) body.end_date = this.triggerOpts.end_date;
-                const res = await fetch(`/api/schedules/${this.triggerTarget.name}/trigger`, {
-                    method: 'POST', headers, body: JSON.stringify(body)
+                const res = await fetch(`/api/schedules/${scheduleName}/trigger`, {
+                    method: 'POST', headers, body: JSON.stringify({})
                 });
                 const data = await res.json();
                 if (!res.ok) { this.error = data.message || 'Failed to trigger schedule'; this.triggerLoading = false; return; }
                 this.showTriggerModal = false;
-                this.success = `Schedule "${this.triggerTarget.name}" triggered.`;
+                this.success = `Schedule "${scheduleName}" triggered.`;
                 setTimeout(() => this.success = '', 3000);
             } catch (e) { this.error = 'Failed to trigger schedule'; }
             this.triggerLoading = false;

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Guard script: prevent running pytest when another instance is already active.
+# This avoids zombie processes, DuckDB lock conflicts, and flaky test results.
+
+if pgrep -f "pytest" > /dev/null 2>&1; then
+    echo "ERROR: pytest is already running (PID: $(pgrep -f pytest))"
+    echo "Wait for it to finish or kill it: kill $(pgrep -f pytest)"
+    exit 1
+fi
+exec pytest "$@"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,9 +2,11 @@
 # Guard script: prevent running pytest when another instance is already active.
 # This avoids zombie processes, DuckDB lock conflicts, and flaky test results.
 
-if pgrep -f "pytest" > /dev/null 2>&1; then
-    echo "ERROR: pytest is already running (PID: $(pgrep -f pytest))"
-    echo "Wait for it to finish or kill it: kill $(pgrep -f pytest)"
+# Use [p]ytest regex trick to avoid pgrep matching itself
+if pgrep -f "[p]ytest" > /dev/null 2>&1; then
+    PIDS=$(pgrep -f "[p]ytest" | head -1)
+    echo "ERROR: pytest is already running (PID: $PIDS)"
+    echo "Wait for it to finish or kill it: kill $PIDS"
     exit 1
 fi
 exec pytest "$@"

--- a/tests/unit/test_source_edit.py
+++ b/tests/unit/test_source_edit.py
@@ -63,16 +63,18 @@ class TestSourceEdit:
         assert "No sources.yml found" in result.output
 
     def test_no_editor_shows_path(self, tmp_path: pytest.TempPathFactory) -> None:
-        """Without $EDITOR or TTY, shows file path instead of opening editor."""
+        """Without $EDITOR, shows file path instead of opening editor."""
         dango_dir = tmp_path / ".dango"
         dango_dir.mkdir()
         sources_file = dango_dir / "sources.yml"
         sources_file.write_text("sources:\n  - name: test\n")
 
         runner = CliRunner()
-        result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
+        with patch.dict("os.environ", {"EDITOR": "", "VISUAL": ""}, clear=False):
+            result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
         assert result.exit_code == 0
         assert "sources.yml" in result.output
+        assert "EDITOR" in result.output  # Shows tip about setting $EDITOR
 
     def test_editor_returns_none(self, tmp_path: pytest.TempPathFactory) -> None:
         """Editor returns None when user doesn't save."""
@@ -88,6 +90,7 @@ class TestSourceEdit:
         ):
             result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
         assert result.exit_code == 0
+        assert "No changes" in result.output or "sources.yml" in result.output
 
     def test_no_changes(self, tmp_path: pytest.TempPathFactory) -> None:
         """Editor returns same content."""

--- a/tests/unit/test_source_edit.py
+++ b/tests/unit/test_source_edit.py
@@ -62,6 +62,18 @@ class TestSourceEdit:
         assert result.exit_code == 0
         assert "No sources.yml found" in result.output
 
+    def test_no_editor_shows_path(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Without $EDITOR or TTY, shows file path instead of opening editor."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        sources_file = dango_dir / "sources.yml"
+        sources_file.write_text("sources:\n  - name: test\n")
+
+        runner = CliRunner()
+        result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
+        assert result.exit_code == 0
+        assert "sources.yml" in result.output
+
     def test_editor_returns_none(self, tmp_path: pytest.TempPathFactory) -> None:
         """Editor returns None when user doesn't save."""
         dango_dir = tmp_path / ".dango"
@@ -70,11 +82,12 @@ class TestSourceEdit:
         sources_file.write_text("sources:\n  - name: test\n")
 
         runner = CliRunner()
-        with patch("click.edit", return_value=None):
+        with (
+            patch("click.edit", return_value=None),
+            patch.dict("os.environ", {"EDITOR": "vim"}),
+        ):
             result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
         assert result.exit_code == 0
-        assert "No editor or no changes" in result.output
-        assert "sources.yml" in result.output
 
     def test_no_changes(self, tmp_path: pytest.TempPathFactory) -> None:
         """Editor returns same content."""
@@ -85,7 +98,10 @@ class TestSourceEdit:
         sources_file.write_text(original)
 
         runner = CliRunner()
-        with patch("click.edit", return_value=original):
+        with (
+            patch("click.edit", return_value=original),
+            patch.dict("os.environ", {"EDITOR": "vim"}),
+        ):
             result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
         assert result.exit_code == 0
         assert "No changes detected" in result.output
@@ -100,7 +116,10 @@ class TestSourceEdit:
         sources_file.write_text(original)
 
         runner = CliRunner()
-        with patch("click.edit", return_value=edited):
+        with (
+            patch("click.edit", return_value=edited),
+            patch.dict("os.environ", {"EDITOR": "vim"}),
+        ):
             result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
         assert result.exit_code == 0
         assert "sources.yml updated" in result.output
@@ -116,10 +135,12 @@ class TestSourceEdit:
         sources_file.write_text(original)
 
         runner = CliRunner()
-        with patch("click.edit", return_value=invalid):
+        with (
+            patch("click.edit", return_value=invalid),
+            patch.dict("os.environ", {"EDITOR": "vim"}),
+        ):
             result = runner.invoke(source_edit, obj={"project_root": str(tmp_path)})
         assert result.exit_code == 0
         assert "Invalid YAML" in result.output
         assert "Changes NOT saved" in result.output
-        # File should be unchanged
         assert sources_file.read_text() == original


### PR DESCRIPTION
## Summary
- Fixes all 16 failures identified in T12-B local verification testing
- 6 additional improvements (click.confirm migration, tooltips, timer audit, button CSS, health display, pytest guard)
- 42 files changed, 3562 unit tests pass (0 failures)

## Bug Fixes

### High Priority
- **N7: Schedule history corruption** — `jobs.py` wrote `completed_at` instead of `timestamp`, `"completed"` instead of `"success"`. Caused "Invalid Date", "never" on Sources page
- **Item 3: WebSocket status delay** — `loadSources()` catch block misclassified timeout after sync_completed cleared activeSyncs. Added `recentSyncComplete` grace flag
- **N9/N10: Negative freshness + "Just now" for old syncs** — `datetime.now()` (naive local) treated as UTC by frontend. Fixed 18 files to use `datetime.now(tz=timezone.utc)`

### Medium Priority  
- **N8: Duplicate log entries** — Three systems writing same events. Removed redundant writes from `websocket.py` broadcast and `sync.py` completion
- **Item 28: Sync mode badge** — Added "Mode" column to `dango source list` (Incremental/Full Refresh)
- **Item 29: Source edit** — Check `$EDITOR`, fallback to printing path instead of opening vim
- **Items 31/32: Schedule UX** — Shortened name prompt, simplified trigger to "Run now" + confirm
- **N6: Trigger toast "undefined"** — Fixed schedule name reference in success notification
- **Item 11: PII propagation** — Catalog now shows PII badges on staging tables by matching raw column names
- **N3: _dlt_id false positive** — Exclude `_dlt_*` columns from PII scan
- **Item 12: Test name tooltip** — Use `x-bind:title` instead of CSS `data-tip` (Alpine.js compatible)
- **N1: Startup tracebacks** — Remove `exc_info=True` from health poll and orphan cleanup handlers

### Low Priority
- **N2: Narrow viewport columns** — Responsive `.desc-truncate` breakpoints
- **N4: Double scrollbar** — Remove inner overflow-y on table detail
- **Item 21: Force unlock slow** — Detect existing marimo on port before starting new process

## Additional Improvements
- CLI-wide `click.confirm` → `safe_confirm` migration (18 instances across 11 files)
- Custom CSS tooltips replacing browser-native `title=` delay across all templates
- Sync timer audit with documenting comments in app.js
- Action button `white-space: nowrap` for narrow viewports
- Health page: clarify per-schema sizes are estimates (not actual disk usage)
- `scripts/run_tests.sh` pytest guard (prevents overlapping test processes)

## Test plan
- [x] All 3562 unit tests pass (0 failures, 7 skipped)
- [x] Ruff check clean, ruff format clean
- [x] Pre-commit hooks pass
- [ ] T12-B retest of failed items (manual verification after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)