### PR TITLE
fix: T12-C cloud deploy bugs

### DIFF
--- a/dango/cli/commands/remote_auth.py
+++ b/dango/cli/commands/remote_auth.py
@@ -88,7 +88,7 @@ def _run_remote_auth_cmd(
 
     stderr = result.stderr.strip() if result.stderr else ""
     stdout = result.stdout.strip() if result.stdout else ""
-    msg = stderr or stdout or "Command failed with no output."
+    msg = stdout or stderr or "Command failed with no output."
     console.print(f"[red]Error:[/red] {msg}")
     return False
 

--- a/dango/cli/commands/remote_sync.py
+++ b/dango/cli/commands/remote_sync.py
@@ -90,7 +90,12 @@ def remote_sync(
         payload["backfill_days"] = backfill_days
 
     escaped_payload = shlex.quote(json.dumps(payload))
-    cmd = f"{_VENV_PYTHON} -m dango.platform.scheduling.sync_trigger {escaped_payload}"
+    # Run as dango user (not root) to avoid file ownership pollution,
+    # and set DANGO_CLOUD_MODE so sync_trigger stops Metabase before writing.
+    cmd = (
+        f"sudo -u dango -H env DANGO_CLOUD_MODE=true"
+        f" {_VENV_PYTHON} -m dango.platform.scheduling.sync_trigger {escaped_payload}"
+    )
 
     try:
         if wait:

--- a/dango/notebooks/proxy.py
+++ b/dango/notebooks/proxy.py
@@ -105,8 +105,6 @@ async def proxy_to_marimo(
         body = await request.body()
 
     # Retry on connect errors — Marimo may still be starting up
-    import asyncio
-
     for attempt in range(3):
         try:
             async with httpx.AsyncClient(follow_redirects=False, timeout=30.0) as client:

--- a/dango/notebooks/proxy.py
+++ b/dango/notebooks/proxy.py
@@ -104,25 +104,34 @@ async def proxy_to_marimo(
     if request.method in ("POST", "PUT", "PATCH"):
         body = await request.body()
 
-    try:
-        async with httpx.AsyncClient(follow_redirects=False, timeout=30.0) as client:
-            resp = await client.request(
-                method=request.method, url=url, headers=headers, content=body
+    # Retry on connect errors — Marimo may still be starting up
+    import asyncio
+
+    for attempt in range(3):
+        try:
+            async with httpx.AsyncClient(follow_redirects=False, timeout=30.0) as client:
+                resp = await client.request(
+                    method=request.method, url=url, headers=headers, content=body
+                )
+
+            resp_headers: dict[str, str] = {}
+            for key, value in resp.headers.items():
+                if key.lower() not in _HOP_BY_HOP:
+                    resp_headers[key] = value
+
+            return Response(
+                content=resp.content,
+                status_code=resp.status_code,
+                headers=resp_headers,
             )
-
-        resp_headers: dict[str, str] = {}
-        for key, value in resp.headers.items():
-            if key.lower() not in _HOP_BY_HOP:
-                resp_headers[key] = value
-
-        return Response(
-            content=resp.content,
-            status_code=resp.status_code,
-            headers=resp_headers,
-        )
-    except Exception:
-        logger.error("Marimo proxy error for %s", target_path, exc_info=True)
-        return Response(content="Failed to connect to Marimo", status_code=502)
+        except httpx.ConnectError:
+            if attempt < 2:
+                await asyncio.sleep(1)
+        except Exception:
+            logger.error("Marimo proxy error for %s", target_path, exc_info=True)
+            return Response(content="Failed to connect to Marimo", status_code=502)
+    logger.error("Marimo proxy connect failed after retries for %s", target_path)
+    return Response(content="Notebook server is starting, please refresh.", status_code=502)
 
 
 async def proxy_websocket_to_marimo(

--- a/dango/platform/cloud/_server_templates.py
+++ b/dango/platform/cloud/_server_templates.py
@@ -45,7 +45,10 @@ def build_caddyfile(domain: str | None = None, marimo_port: int = 7805) -> str:
             "\n\t}",
             f"\n{_HSTS_HEADER}\n\t}}",
         )
-        return f"{domain} {{\n{marimo_ws}\n\thandle {{\n\t\treverse_proxy localhost:8800\n\t}}\n{headers}\n}}\n"
+        domain_block = f"{domain} {{\n{marimo_ws}\n\thandle {{\n\t\treverse_proxy localhost:8800\n\t}}\n{headers}\n}}\n"
+        # Block direct IP access — prevent unencrypted credential exposure
+        ip_block = ':80 {\n\trespond "Use the configured domain to access this server." 403\n}\n'
+        return f"{domain_block}\n{ip_block}"
     # HTTP-only mode (IP access, no HSTS)
     return f":80 {{\n{marimo_ws}\n\thandle {{\n\t\treverse_proxy localhost:8800\n\t}}\n{_COMMON_HEADERS}\n}}\n"
 

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -318,7 +318,7 @@ def _run_remote_dbt(
         ``CommandResult`` from the SSH command.
     """
     cmd = (
-        f"sudo -u dango {VENV_BIN}/dbt {subcommand}"
+        f"sudo -u dango -H {VENV_BIN}/dbt {subcommand}"
         f" --project-dir {DBT_PROJECT_DIR}"
         f" --profiles-dir {DBT_PROJECT_DIR}"
     )

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -245,6 +245,16 @@ def _upload_file_if_exists(
         return False
     if dry_run:
         return True
+    # Skip upload if remote file is identical (MD5 hash check).
+    # Avoids re-uploading large files like the ~80MB Metabase DuckDB driver.
+    import hashlib
+
+    local_hash = hashlib.md5(local_path.read_bytes(), usedforsecurity=False).hexdigest()
+    hash_result = ssh.exec_command(f"md5sum {remote_path} 2>/dev/null", timeout=10, check=False)
+    if hash_result.success and hash_result.stdout.strip():
+        remote_hash = hash_result.stdout.strip().split(None, 1)[0]
+        if local_hash == remote_hash:
+            return False
     # Ensure remote parent directory exists
     remote_dir = remote_path.rsplit("/", 1)[0]
     mkdir_result = ssh.exec_command(f"mkdir -p {remote_dir}")

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -247,8 +247,6 @@ def _upload_file_if_exists(
         return True
     # Skip upload if remote file is identical (MD5 hash check).
     # Avoids re-uploading large files like the ~80MB Metabase DuckDB driver.
-    import hashlib
-
     local_hash = hashlib.md5(local_path.read_bytes(), usedforsecurity=False).hexdigest()
     hash_result = ssh.exec_command(f"md5sum {remote_path} 2>/dev/null", timeout=10, check=False)
     if hash_result.success and hash_result.stdout.strip():

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -480,7 +480,7 @@ def _run_profiling(project_root: Path, sources: list[str]) -> None:
                 stg_tables = conn_stg.execute(
                     "SELECT table_name FROM information_schema.tables "
                     "WHERE table_schema = 'staging' "
-                    f"AND table_name LIKE 'stg_{source}%' "
+                    f"AND table_name LIKE 'stg_{source}__%' "
                     "ORDER BY table_name"
                 ).fetchall()
             finally:

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -480,7 +480,7 @@ def _run_profiling(project_root: Path, sources: list[str]) -> None:
                 stg_tables = conn_stg.execute(
                     "SELECT table_name FROM information_schema.tables "
                     "WHERE table_schema = 'staging' "
-                    f"AND table_name LIKE 'stg_{source}__%' "
+                    f"AND table_name LIKE 'stg_{source}\\_\\_%' ESCAPE '\\' "
                     "ORDER BY table_name"
                 ).fetchall()
             finally:

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -1039,7 +1039,7 @@ async def get_catalog_model(
         # Derive source from staging model name: stg_{source}__{table}
         import re
 
-        m = re.match(r"^stg_([^_]+)__", table)
+        m = re.match(r"^stg_(.+?)__", table)
         if m:
             source_name = m.group(1)
     if source_name:

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -163,11 +163,12 @@ async def get_source_details(source_name: str) -> dict[str, object]:
                 "full_refresh" if entry.get("full_refresh", False) else "incremental"
             )
             break
-    sync_mode = (
-        sync_mode_from_history
-        if sync_mode_from_history is not None
-        else ("incremental" if supports_incremental else "full_refresh")
-    )
+    if not supports_incremental:
+        sync_mode = "full_refresh"
+    elif sync_mode_from_history is not None:
+        sync_mode = sync_mode_from_history
+    else:
+        sync_mode = "incremental"
 
     lookback_days = source_config.get("lookback_days")
     if lookback_days is None:

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -127,7 +127,7 @@
                                         <template x-for="r in searchResults" :key="r.unique_id">
                                             <tr class="hover:bg-gray-50 cursor-pointer" @click="openModel(r.name)">
                                                 <td class="px-6 py-4 whitespace-nowrap">
-                                                    <span class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="r.name"></span>
+                                                    <a :href="'/catalog?model=' + encodeURIComponent(r.name)" @click.prevent class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="r.name"></a>
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     <span class="model-badge" :class="'model-badge-' + r.type" x-text="r.type"></span>
@@ -184,7 +184,7 @@
                                         <template x-for="item in filteredItems" :key="item.unique_id">
                                             <tr class="hover:bg-gray-50 cursor-pointer" @click="openModel(item.name)">
                                                 <td class="px-6 py-4 whitespace-nowrap">
-                                                    <span class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="item.name"></span>
+                                                    <a :href="'/catalog?model=' + encodeURIComponent(item.name)" @click.prevent class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="item.name"></a>
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     <span class="model-badge" :class="'model-badge-' + item.type" x-text="item.type"></span>
@@ -839,15 +839,15 @@ function catalogPage() {
             // Staging/models: derive source from name (stg_{source}__{table}).
             let srcName = item.source_name || (item.schema || '').replace(/^raw_/, '');
             if (!srcName || srcName === item.schema) {
-                const m = (item.name || '').match(/^stg_([^_]+)__/);
+                const m = (item.name || '').match(/^stg_(.+?)__/);
                 if (m) srcName = m[1];
             }
             const f = this.overview.freshness.find(f => f.source === srcName);
             if (!f || f.hours_since_sync == null) return '--';
             const h = f.hours_since_sync;
             if (h < 1) return Math.round(h * 60) + 'm ago';
-            if (h < 24) return h.toFixed(1) + 'h ago';
-            return (h / 24).toFixed(1) + 'd ago';
+            if (h < 24) return Math.round(h) + 'h ago';
+            return Math.round(h / 24) + 'd ago';
         },
 
         toggleLineageView() {

--- a/tests/unit/test_file_sync.py
+++ b/tests/unit/test_file_sync.py
@@ -1,10 +1,6 @@
 """tests/unit/test_file_sync.py
 
-Unit tests for project file sync (dango/platform/cloud/file_sync.py).
-
-Uses mocked SSHManager and subprocess to avoid real network or
-filesystem access.
-"""
+Unit tests for project file sync."""
 
 from __future__ import annotations
 
@@ -75,27 +71,15 @@ def _make_project(tmp_path: Path, *, with_packages: bool = True) -> Path:
     return root
 
 
-# ---------------------------------------------------------------------------
-# SyncResult tests
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 class TestSyncConfigFiles:
     """Test SYNC_CONFIG_FILES list contents."""
 
     def test_project_yml_in_sync_list(self):
-        """BUG-098: .dango/project.yml must be synced to the server."""
-        local_paths = [local for local, _ in SYNC_CONFIG_FILES]
-        assert ".dango/project.yml" in local_paths
-
-    def test_project_yml_remote_path(self):
-        """project.yml remote path matches standard layout."""
-        for local, remote in SYNC_CONFIG_FILES:
-            if local == ".dango/project.yml":
-                assert remote == f"{REMOTE_PROJECT_DIR}/.dango/project.yml"
-                return
-        pytest.fail(".dango/project.yml not found in SYNC_CONFIG_FILES")
+        """BUG-098: .dango/project.yml synced with correct remote path."""
+        match = [(lp, rp) for lp, rp in SYNC_CONFIG_FILES if lp == ".dango/project.yml"]
+        assert match, ".dango/project.yml not found in SYNC_CONFIG_FILES"
+        assert match[0][1] == f"{REMOTE_PROJECT_DIR}/.dango/project.yml"
 
     def test_docker_files_in_sync_list(self):
         """Docker build context files are synced (R8-B)."""
@@ -323,6 +307,30 @@ class TestSyncProjectFiles:
         assert ".dango/sources.yml" in result.synced_files
         assert "dbt/dbt_project.yml" in result.synced_files
         assert "dbt/packages.yml" in result.synced_files
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_unchanged_file_skipped_by_hash(self, mock_run, mock_which, tmp_path):
+        """Files with matching remote MD5 hash are not re-uploaded."""
+        import hashlib
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        project = _make_project(tmp_path)
+        local_hash = hashlib.md5(
+            (project / ".dango" / "sources.yml").read_bytes(), usedforsecurity=False
+        ).hexdigest()
+        ssh = _make_ssh_mock()
+        orig = ssh.exec_command.side_effect
+
+        def _with_hash(cmd: str, **kw: object) -> CommandResult:
+            if "md5sum" in cmd and "sources.yml" in cmd and "packages" not in cmd:
+                return CommandResult(stdout=f"{local_hash}  x", stderr="", exit_code=0)
+            return orig(cmd, **kw)
+
+        ssh.exec_command.side_effect = _with_hash
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+        assert ".dango/sources.yml" not in result.synced_files
+        assert "dbt/dbt_project.yml" in result.synced_files
 
     @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
     @patch("dango.platform.cloud.file_sync.subprocess.run")


### PR DESCRIPTION
## Summary

- **C02/C06 (critical):** `dango remote sync` now runs as `dango` user with `DANGO_CLOUD_MODE=true` — fixes DuckDB lock from Metabase and file ownership pollution that blocked web UI syncs
- **C14 (critical):** Caddy blocks direct IP access (403) when a domain is configured — prevents unencrypted credential exposure
- **C13:** `sudo -H` in `_run_remote_dbt` so dbt resolves HOME correctly (fixes PermissionError on `/root/dbt_project.yml`)
- **C12:** MD5 hash check before SFTP upload skips unchanged files (avoids re-uploading ~80MB Metabase driver)
- **C01/C03/C05/C08-C11:** Minor fixes — error message priority, sync mode display, Marimo proxy retry, catalog UX (freshness formatting, regex for multi-word sources, cmd+click support)

## Test plan

- [x] 3676 unit tests pass (0 failures)
- [x] Ruff check + format clean
- [ ] Re-deploy to DO and verify C02/C06 (sync works without DuckDB lock)
- [ ] Verify C14 (IP URL returns 403 after domain set)
- [ ] Verify C13 (`dango remote push` dbt compile succeeds)
- [ ] Verify C15 (`dango remote query` works with new API-based approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)