### PR TITLE
fix: cd to project dir before sudo in remote sync

### DIFF
--- a/dango/cli/commands/remote_sync.py
+++ b/dango/cli/commands/remote_sync.py
@@ -92,8 +92,10 @@ def remote_sync(
     escaped_payload = shlex.quote(json.dumps(payload))
     # Run as dango user (not root) to avoid file ownership pollution,
     # and set DANGO_CLOUD_MODE so sync_trigger stops Metabase before writing.
+    # cd to project dir first — SSH session starts in /root/ which dango can't access.
     cmd = (
-        f"sudo -u dango -H env DANGO_CLOUD_MODE=true"
+        f"cd {_PROJECT_ROOT} &&"
+        f" sudo -u dango -H env DANGO_CLOUD_MODE=true"
         f" {_VENV_PYTHON} -m dango.platform.scheduling.sync_trigger {escaped_payload}"
     )
 

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -317,8 +317,11 @@ def _run_remote_dbt(
     Returns:
         ``CommandResult`` from the SSH command.
     """
+    # cd to project dir first — SSH session starts in /root/ which dango can't access.
+    # dbt resolves paths (incl. CWD) before processing --project-dir.
     cmd = (
-        f"sudo -u dango -H {VENV_BIN}/dbt {subcommand}"
+        f"cd {DBT_PROJECT_DIR} &&"
+        f" sudo -u dango -H {VENV_BIN}/dbt {subcommand}"
         f" --project-dir {DBT_PROJECT_DIR}"
         f" --profiles-dir {DBT_PROJECT_DIR}"
     )


### PR DESCRIPTION
## Summary
- SSH sessions start in `/root/` which the dango user can't access
- Prepend `cd /srv/dango/project` before `sudo -u dango` to fix `PermissionError: '/root'`
- Discovered during T12-C fix verification on cloud

One-line fix, follow-up to #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)