### PR TITLE
fix: correct misleading :ro mount comment in docker-compose template

### DIFF
--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -217,9 +217,10 @@ def run_manual_sync(
             "error": error_msg,
         }
 
-    # --- Stop Metabase on cloud to release DuckDB read lock ---
-    # Metabase's JDBC driver acquires fcntl read locks even on :ro Docker
-    # volumes.  These read locks block DuckDB write locks needed by dlt.
+    # --- Stop Metabase on cloud to prevent DuckDB lock conflicts ---
+    # :ro Docker mount does NOT prevent fcntl lock acquisition. Metabase's JDBC
+    # driver acquires locks that block DuckDB writes needed by dlt.
+    # Stopping Metabase before sync is the actual prevention mechanism.
     _cloud_mode = os.environ.get("DANGO_CLOUD_MODE") == "true"
     if _cloud_mode:
         _progress("metabase_stop", "Pausing Metabase for sync")

--- a/dango/templates/docker-compose.yml.j2
+++ b/dango/templates/docker-compose.yml.j2
@@ -10,8 +10,9 @@ services:
       - "127.0.0.1:{{ metabase_port }}:3000"
     volumes:
       - metabase-data:/metabase-data
-      # :ro prevents Metabase JDBC driver from acquiring DuckDB write lock.
-      # The driver ignores read_only config; filesystem-level :ro is required.
+      # Note: :ro mount does NOT prevent DuckDB fcntl locks. Metabase stop/start
+      # before sync (sync_trigger.py) is the actual write-lock prevention mechanism.
+      # :ro is defense-in-depth only (prevents file writes, not lock acquisition).
       - ./data:/data:ro
       - ./metabase-plugins:/app/plugins
     environment:


### PR DESCRIPTION
## Summary
- Fixed misleading comment in `docker-compose.yml.j2` that claimed `:ro` mount prevents Metabase from acquiring DuckDB write locks
- Fixed related comment in `sync_trigger.py` that implied `:ro` prevents lock acquisition
- The actual protection is Metabase stop/start lifecycle in `sync_trigger.py` — `:ro` is defense-in-depth only (prevents file writes, not fcntl lock acquisition)

## Test plan
- [ ] Verify comments are accurate by reviewing DuckDB fcntl lock behavior
- [ ] No functional code changes — comment-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)