### PR TITLE
fix: T12-D Session A — quick fixes for BYOS deploy issues

### DIFF
--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -674,7 +674,10 @@ def _step_byos_server(project_root: Path) -> tuple[str, str, str]:
 
     server_ip = click.prompt("  Server IP or hostname")
 
-    ssh_user = click.prompt("  SSH user", default="root", show_default=True)
+    console.print(
+        "  [dim]Common SSH users: root (DO/Hetzner), ubuntu (AWS), your username (GCP)[/dim]"
+    )
+    ssh_user = click.prompt("  SSH user")
 
     console.print("\n  SSH key options:")
     console.print("    1. Use an existing SSH key")

--- a/dango/cli/commands/remote_mgmt.py
+++ b/dango/cli/commands/remote_mgmt.py
@@ -121,17 +121,19 @@ def remote_status(ctx: click.Context) -> None:
     latest_version = check_latest_pypi_version()
 
     # --- Server info ---
-    tier_info = ""
-    for tier in SIZE_TIERS:
-        if tier.slug == cloud_cfg.size:
-            tier_info = f" ({tier.name}, ${tier.price_monthly}/mo)"
-            break
-
     server_lines = [
         f"  IP: [bold]{cloud_cfg.droplet_ip}[/bold]",
-        f"  Region: {cloud_cfg.region}",
-        f"  Size: {cloud_cfg.size}{tier_info}",
     ]
+    if cloud_cfg.provider != "byos":
+        tier_info = ""
+        for tier in SIZE_TIERS:
+            if tier.slug == cloud_cfg.size:
+                tier_info = f" ({tier.name}, ${tier.price_monthly}/mo)"
+                break
+        server_lines.append(f"  Region: {cloud_cfg.region}")
+        server_lines.append(f"  Size: {cloud_cfg.size}{tier_info}")
+    else:
+        server_lines.append("  Provider: BYOS")
     if cloud_cfg.domain:
         server_lines.append(f"  Domain: {cloud_cfg.domain}")
     console.print(Panel("\n".join(server_lines), title="Server", border_style="blue"))

--- a/dango/platform/cloud/ssh.py
+++ b/dango/platform/cloud/ssh.py
@@ -485,8 +485,8 @@ class SSHManager:
             stdin, stdout_chan, stderr_chan = self._client.exec_command(
                 command, timeout=effective_timeout
             )
-            stdout_data = stdout_chan.read().decode("utf-8")
-            stderr_data = stderr_chan.read().decode("utf-8")
+            stdout_data = stdout_chan.read().decode("utf-8", errors="replace")
+            stderr_data = stderr_chan.read().decode("utf-8", errors="replace")
             exit_code: int = stdout_chan.channel.recv_exit_status()
         except pm.ChannelException as exc:
             raise CloudSSHError(f"SSH channel error: {exc}") from exc
@@ -640,7 +640,7 @@ class SSHManager:
                 if timeout is not None:
                     sftp.get_channel().settimeout(timeout)
                 with sftp.open(remote_path, "r") as remote_file:
-                    return str(remote_file.read().decode("utf-8"))
+                    return str(remote_file.read().decode("utf-8", errors="replace"))
             finally:
                 sftp.close()
         except OSError as exc:

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -2433,7 +2433,7 @@ function renderDbtModelsTable() {
                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     ${actionButtons}
                     <a
-                        href="/catalog"
+                        href="/catalog?model=${encodeURIComponent(model.name)}"
                         class="text-blue-600 hover:text-blue-900 tooltip"
                         data-tooltip="View documentation"
                     >

--- a/docs/guides/deploy-any-server.md
+++ b/docs/guides/deploy-any-server.md
@@ -5,8 +5,9 @@ Dango can be deployed to any Ubuntu 22.04+ server — not just DigitalOcean. Thi
 ## Requirements
 
 - **Ubuntu 22.04+** (tested on 22.04 LTS and 24.04 LTS)
-- **Root SSH access** (key-based authentication)
-- **2+ GB RAM** (4 GB recommended)
+- **Root SSH access** (key-based authentication — see [Enabling Root SSH](#enabling-root-ssh) for GCP/AWS/Azure)
+- **4 GB RAM minimum** (Metabase alone needs ~1.5 GB)
+- **30 GB disk minimum** (Docker images ~5 GB, Python venv ~1.2 GB, plus data)
 - **Ports 22, 80, 443** open in your provider's firewall/security group
 
 ## Quick Start
@@ -52,21 +53,57 @@ All steps are idempotent — safe to re-run if deployment is interrupted.
 
 ### AWS EC2
 
-1. Launch an Ubuntu 22.04 LTS instance (t3.small or larger)
+1. Launch an Ubuntu 22.04 LTS instance (t3.small or larger, **30 GB+ disk**)
 2. Configure Security Group: allow inbound TCP 22, 80, 443
 3. Use the EC2 key pair as your `--ssh-key`
+4. SSH user: `ubuntu` — [enable root SSH](#enabling-root-ssh) before deploying
 
 ### Google Cloud Compute Engine
 
-1. Create a VM with Ubuntu 22.04 LTS image (e2-medium or larger)
+1. Create a VM with Ubuntu 22.04 LTS image (e2-medium or larger, **30 GB+ boot disk** — default 10 GB is too small)
 2. Add VPC firewall rules: allow TCP 22, 80, 443
-3. Add your SSH public key to the VM metadata
+3. Add your SSH public key to the VM metadata (Security → SSH Keys)
+4. SSH user: your username — [enable root SSH](#enabling-root-ssh) before deploying
+
+### Azure
+
+1. Create a VM with Ubuntu 22.04 LTS (Standard_B2s or larger, **30 GB+ disk**)
+2. Configure NSG: allow inbound TCP 22, 80, 443
+3. SSH user: your chosen username — [enable root SSH](#enabling-root-ssh) before deploying
 
 ### Hetzner / Linode / Vultr / Any VPS
 
-1. Create an Ubuntu 22.04 server (2+ GB RAM)
-2. Add your SSH public key during creation
-3. Most VPS providers have ports open by default — Dango's UFW handles host-level firewall
+1. Create an Ubuntu 22.04 server (4 GB+ RAM, 30 GB+ disk)
+2. Add your SSH public key during creation (make sure to **select** the key, not just add it)
+3. SSH user: `root` (works by default on most VPS providers)
+4. Most VPS providers have ports open by default — Dango's UFW handles host-level firewall
+
+## Enabling Root SSH
+
+GCP, AWS, and Azure disable root SSH by default. Dango requires root access for server setup. After creating your VM, SSH in as the default user and run:
+
+```bash
+# SSH in as the default user (ubuntu for AWS, your username for GCP/Azure)
+ssh -i ~/.ssh/id_ed25519 <your-user>@<server-ip>
+
+# Enable root SSH
+sudo cp ~/.ssh/authorized_keys /root/.ssh/authorized_keys
+sudo sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+sudo systemctl restart sshd
+exit
+```
+
+Then run `dango deploy` with SSH user `root`.
+
+## SSH Key Setup
+
+If you don't have an SSH key, create one:
+
+```bash
+ssh-keygen -t ed25519
+```
+
+Press Enter for all prompts (default path, no passphrase). Your public key is at `~/.ssh/id_ed25519.pub` — paste this into your cloud provider's SSH key settings.
 
 ## SSH Key Options
 


### PR DESCRIPTION
## Summary
- **BUG-D14**: SSH `UnicodeDecodeError` — use `errors='replace'` in 3 `.decode()` calls in `ssh.py`
- **BUG-D05**: `dango remote status` shows DO-specific region/size for BYOS — now shows "Provider: BYOS" instead
- **BUG-D12**: BYOS wizard SSH user defaults to `[root]` — removed default, added provider hint
- **BUG-D07**: Models page docs icon links to catalog root — now links to specific model
- **BUG-D10/D13**: BYOS docs understate requirements — updated to 4GB RAM, 30GB disk minimum; added root SSH guide, SSH key setup, Azure section, provider-specific SSH users

## Test plan
- [x] SSH unit tests pass (69 passed)
- [x] CLI command tests pass (29 passed)
- [x] Pre-commit hooks pass
- [ ] Manual: `dango remote status` on BYOS shows "Provider: BYOS" not "Region: nyc1"
- [ ] Manual: Models page docs icon navigates to correct catalog model page

🤖 Generated with [Claude Code](https://claude.com/claude-code)