### PR TITLE
fix: pre-flight server validation, spaCy install, PII retry cache

### DIFF
--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -43,6 +43,7 @@ _STRUCTURED_DATA_MIN_AVG_LEN = 100
 _STRUCTURED_DATA_DELIMITERS = frozenset({"[", "]", "{", "\n"})
 
 _analyzer: Any = None
+_analyzer_init_failed: bool = False
 
 _SPACY_MODEL = "en_core_web_sm"
 _SPACY_MODEL_URL = (
@@ -85,9 +86,11 @@ def _get_analyzer() -> Any | None:
     Returns ``None`` if the spaCy model cannot be loaded or downloaded,
     allowing callers to gracefully skip PII scanning.
     """
-    global _analyzer  # noqa: PLW0603
+    global _analyzer, _analyzer_init_failed  # noqa: PLW0603
     if _analyzer is not None:
         return _analyzer
+    if _analyzer_init_failed:
+        return None
 
     import spacy  # lazy import
 
@@ -119,6 +122,7 @@ def _get_analyzer() -> Any | None:
                 except OSError:
                     pass
         except Exception:
+            _analyzer_init_failed = True
             logger.warning(
                 "pii_spacy_download_failed",
                 model=_SPACY_MODEL,
@@ -163,6 +167,7 @@ def _get_analyzer() -> Any | None:
         _analyzer = AnalyzerEngine(nlp_engine=provider.create_engine())
         _register_intl_phone_recognizer(_analyzer)
     except Exception:
+        _analyzer_init_failed = True
         logger.warning("pii_analyzer_init_failed", exc_info=True)
         return None
     finally:

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -310,6 +310,17 @@ def _setup_venv(
         step=step,
         timeout=300,
     )
+    # Install spaCy model for PII scanning (best-effort, non-fatal)
+    spacy_result = ssh.exec_command(
+        "/srv/dango/venv/bin/python -m spacy download en_core_web_sm -q",
+        timeout=120,
+    )
+    if not spacy_result.success:
+        result.warnings.append(
+            "spaCy model 'en_core_web_sm' could not be installed. "
+            "PII scanning will be unavailable until installed manually: "
+            "/srv/dango/venv/bin/python -m spacy download en_core_web_sm"
+        )
     result.steps_completed.append(step)
     _notify(on_progress, step, "done")
 
@@ -637,7 +648,39 @@ def resolve_install_source() -> tuple[str, str]:
 # Public orchestrator
 # ---------------------------------------------------------------------------
 
+
 # Ordered list of step functions for the setup sequence.
+def _preflight_check(ssh: SSHManager, result: SetupResult) -> None:
+    """Check server meets minimum requirements before setup.
+
+    Warns (does not abort) if RAM < 4 GB or available disk < 20 GB.
+    """
+    # Check RAM (total in MB)
+    ram_result = ssh.exec_command("free -m | awk '/Mem:/ {print $2}'", timeout=10)
+    if ram_result.success and ram_result.stdout.strip().isdigit():
+        ram_mb = int(ram_result.stdout.strip())
+        if ram_mb < 3800:  # ~4 GB with overhead
+            result.warnings.append(
+                f"Low RAM: {ram_mb} MB detected (4 GB minimum recommended). "
+                "Metabase and Docker may not run reliably."
+            )
+            _logger.warning("preflight_low_ram", ram_mb=ram_mb, minimum=4096)
+
+    # Check available disk (in MB)
+    disk_result = ssh.exec_command(
+        "df / --output=avail -BM 2>/dev/null | tail -1 | tr -d ' M'",
+        timeout=10,
+    )
+    if disk_result.success and disk_result.stdout.strip().isdigit():
+        disk_mb = int(disk_result.stdout.strip())
+        if disk_mb < 20000:  # 20 GB
+            result.warnings.append(
+                f"Low disk: {disk_mb} MB available (20 GB minimum recommended). "
+                "Docker images, Python venv, and data may not fit."
+            )
+            _logger.warning("preflight_low_disk", available_mb=disk_mb, minimum_mb=20000)
+
+
 _SETUP_STEPS: list[
     Callable[
         [SSHManager, SetupResult, Callable[[str, str], None] | None],
@@ -692,6 +735,9 @@ def setup_server(
         CloudProvisioningError: If any step fails.
     """
     result = SetupResult()
+
+    # --- Pre-flight checks: RAM and disk ---
+    _preflight_check(ssh, result)
 
     # Single worker for v1 — multi-worker breaks WebSocket broadcasts
     # (ws_manager is per-process, so broadcasts only reach clients on the

--- a/tests/unit/test_pii_detection.py
+++ b/tests/unit/test_pii_detection.py
@@ -75,6 +75,17 @@ class TestIsStringType:
 class TestGetAnalyzer:
     """Unit tests for _get_analyzer singleton."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_analyzer_globals(self) -> None:
+        """Reset module-level globals before each test."""
+        import dango.governance.pii_detector as pii_module
+
+        pii_module._analyzer = None
+        pii_module._analyzer_init_failed = False
+        yield
+        pii_module._analyzer = None
+        pii_module._analyzer_init_failed = False
+
     def test_caches_analyzer(self) -> None:
         import sys
 


### PR DESCRIPTION
## Summary
- **BUG-D09/GAP-4**: Pre-flight RAM and disk checks after SSH connects in `server_setup.py`. Warns if RAM < 4GB or disk < 20GB. Non-fatal — warnings flow through `SetupResult` to user display.
- **BUG-D06**: Install `en_core_web_sm` spaCy model during server venv setup. Best-effort — warns on failure. Eliminates the 35x `pii_spacy_download_failed` spam on cloud servers.
- **BUG-D06**: Cache spaCy/Presidio init failure via `_analyzer_init_failed` flag in `pii_detector.py`. After first failure, all subsequent calls return `None` immediately instead of retrying download.

## Test plan
- [x] `test_server_setup.py` — 72 tests pass
- [x] `test_pii_detection.py` — 19 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual: deploy to server with < 4GB RAM — verify warning shown
- [ ] Manual: deploy to server — verify spaCy model installed, PII scan works

🤖 Generated with [Claude Code](https://claude.com/claude-code)