### PR TITLE
fix: trigger Metabase schema scan after cloud sync

### DIFF
--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -395,8 +395,76 @@ def run_manual_sync(
                     capture_output=True,
                     timeout=120,
                 )
+                # Trigger Metabase schema scan so new tables appear immediately
+                _trigger_metabase_schema_scan(project_root)
             except Exception:
                 logger.debug("metabase_start_after_sync_failed", exc_info=True)
+
+
+def _trigger_metabase_schema_scan(project_root: Path) -> None:
+    """Wait for Metabase health, then trigger a schema sync via API.
+
+    Best-effort — failures are logged but do not affect the sync result.
+    """
+    import time
+
+    import requests
+    import yaml
+
+    metabase_url = "http://localhost:3000"
+
+    # Wait for Metabase to become healthy (up to 60 seconds)
+    for _ in range(12):
+        try:
+            resp = requests.get(f"{metabase_url}/api/health", timeout=3)
+            if resp.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(5)
+    else:
+        logger.debug("metabase_schema_scan_skipped", reason="health_timeout")
+        return
+
+    # Load credentials from metabase.yml
+    mb_yml = project_root / ".dango" / "metabase.yml"
+    if not mb_yml.exists():
+        logger.debug("metabase_schema_scan_skipped", reason="no_metabase_yml")
+        return
+
+    try:
+        with open(mb_yml) as f:
+            creds = yaml.safe_load(f)
+        admin = creds.get("admin", {})
+        email, password = admin.get("email"), admin.get("password")
+        db_id = creds.get("database_id")
+        if not email or not password or not db_id:
+            logger.debug("metabase_schema_scan_skipped", reason="missing_credentials")
+            return
+
+        # Login to get session
+        login_resp = requests.post(
+            f"{metabase_url}/api/session",
+            json={"username": email, "password": password},
+            timeout=10,
+        )
+        if login_resp.status_code != 200:
+            logger.debug("metabase_schema_scan_skipped", reason="login_failed")
+            return
+
+        session_id = login_resp.json().get("id")
+        if not session_id:
+            return
+
+        # Trigger schema sync
+        requests.post(
+            f"{metabase_url}/api/database/{db_id}/sync_schema",
+            headers={"X-Metabase-Session": session_id},
+            timeout=10,
+        )
+        logger.debug("metabase_schema_scan_triggered", database_id=db_id)
+    except Exception:
+        logger.debug("metabase_schema_scan_failed", exc_info=True)
 
 
 if __name__ == "__main__":

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -437,7 +437,7 @@ def _trigger_metabase_schema_scan(project_root: Path) -> None:
             creds = yaml.safe_load(f)
         admin = creds.get("admin", {})
         email, password = admin.get("email"), admin.get("password")
-        db_id = creds.get("database_id")
+        db_id = creds.get("database", {}).get("id")
         if not email or not password or not db_id:
             logger.debug("metabase_schema_scan_skipped", reason="missing_credentials")
             return

--- a/tests/unit/test_sync_trigger.py
+++ b/tests/unit/test_sync_trigger.py
@@ -6,6 +6,7 @@ Tests for the server-side manual sync runner (TASK-040c + R10-N subprocess).
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -616,3 +617,85 @@ class TestDbtFailureHandling:
         data = json.loads(status_file.read_text())
         assert data["phase"] == "completed"
         assert "dbt_error" not in data
+
+
+# ---------------------------------------------------------------------------
+# _trigger_metabase_schema_scan tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTriggerMetabaseSchemaSync:
+    """Tests for _trigger_metabase_schema_scan."""
+
+    def test_skips_when_no_metabase_yml(self, tmp_path: Path) -> None:
+        from dango.platform.scheduling.sync_trigger import (
+            _trigger_metabase_schema_scan,
+        )
+
+        _trigger_metabase_schema_scan(tmp_path)
+        # No exception — gracefully skips
+
+    def test_skips_when_health_timeout(self, tmp_path: Path) -> None:
+        from dango.platform.scheduling.sync_trigger import (
+            _trigger_metabase_schema_scan,
+        )
+
+        mb_yml = tmp_path / ".dango" / "metabase.yml"
+        mb_yml.parent.mkdir(parents=True, exist_ok=True)
+        mb_yml.write_text("admin:\n  email: a@b.com\n  password: pw\ndatabase:\n  id: 1\n")
+
+        mock_requests = MagicMock()
+        mock_requests.get.side_effect = Exception("connection refused")
+        with patch.dict("sys.modules", {"requests": mock_requests}):
+            _trigger_metabase_schema_scan(tmp_path)
+            # Skips after health timeout — no schema sync attempted
+
+    def test_skips_when_missing_credentials(self, tmp_path: Path) -> None:
+        from dango.platform.scheduling.sync_trigger import (
+            _trigger_metabase_schema_scan,
+        )
+
+        mb_yml = tmp_path / ".dango" / "metabase.yml"
+        mb_yml.parent.mkdir(parents=True, exist_ok=True)
+        mb_yml.write_text("admin:\n  email: a@b.com\n")  # no password, no database_id
+
+        health_resp = MagicMock()
+        health_resp.status_code = 200
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = health_resp
+        with patch.dict("sys.modules", {"requests": mock_requests}):
+            _trigger_metabase_schema_scan(tmp_path)
+            # No login attempt — missing credentials
+            mock_requests.post.assert_not_called()
+
+    def test_triggers_schema_sync_on_success(self, tmp_path: Path) -> None:
+        from dango.platform.scheduling.sync_trigger import (
+            _trigger_metabase_schema_scan,
+        )
+
+        mb_yml = tmp_path / ".dango" / "metabase.yml"
+        mb_yml.parent.mkdir(parents=True, exist_ok=True)
+        mb_yml.write_text("admin:\n  email: a@b.com\n  password: pw\ndatabase:\n  id: 2\n")
+
+        health_resp = MagicMock()
+        health_resp.status_code = 200
+        login_resp = MagicMock()
+        login_resp.status_code = 200
+        login_resp.json.return_value = {"id": "session123"}
+        sync_resp = MagicMock()
+        sync_resp.status_code = 200
+
+        mock_requests = MagicMock()
+        mock_requests.get.return_value = health_resp
+        mock_requests.post.side_effect = [login_resp, sync_resp]
+        with patch.dict("sys.modules", {"requests": mock_requests}):
+            _trigger_metabase_schema_scan(tmp_path)
+
+            # Verify schema sync was called
+            calls = mock_requests.post.call_args_list
+            assert len(calls) == 2
+            assert "/api/session" in calls[0].args[0]
+            assert "/api/database/2/sync_schema" in calls[1].args[0]
+            assert calls[1].kwargs["headers"]["X-Metabase-Session"] == "session123"


### PR DESCRIPTION
## Summary
After cloud sync restarts Metabase, new/updated tables weren't visible until manual "Sync database schema" in Metabase Admin. This adds an automatic schema scan trigger via the Metabase API.

**Flow:**
1. After `docker compose start metabase` (existing code)
2. Wait for Metabase health check (up to 60s, polling every 5s)
3. Load admin credentials from `.dango/metabase.yml`
4. `POST /api/database/{db_id}/sync_schema` to trigger table discovery

**Best-effort:** All failures logged at debug level, don't affect sync result. Handles: Metabase not ready, missing credentials, login failure.

Fixes: BUG-D15

## Test plan
- [x] `test_sync_trigger.py` — 20 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual: `dango remote sync` on cloud → tables visible in Metabase without manual scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)