### PR TITLE
fix: T12-D retest fixes — Metabase SSO, cache, site URL, UX

### DIFF
--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -427,9 +427,12 @@ def _destroy_byos(cloud_cfg: Any, project_root: Path, force: bool) -> None:
         )
     )
 
-    # Offer backup download
-    if not force and cloud_cfg.droplet_ip:
-        _offer_backup_download(cloud_cfg, project_root)
+    # Static backup warning (no server check needed)
+    if not force:
+        console.print(
+            "\n[yellow]All data on the server will be permanently deleted. "
+            "Back up first if needed.[/yellow]"
+        )
 
     # Confirm
     if not force:

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -677,7 +677,7 @@ def _step_byos_server(project_root: Path) -> tuple[str, str, str]:
     console.print(
         "  [dim]Common SSH users: root (DO/Hetzner), ubuntu (AWS), your username (GCP)[/dim]"
     )
-    ssh_user = click.prompt("  SSH user")
+    ssh_user = click.prompt("  SSH user", default="root", show_default=True)
 
     console.print("\n  SSH key options:")
     console.print("    1. Use an existing SSH key")

--- a/dango/cli/commands/remote_repair.py
+++ b/dango/cli/commands/remote_repair.py
@@ -238,11 +238,11 @@ def remote_reset_metabase(ctx: click.Context) -> None:
         ssh.exec_command("systemctl start dango-web", timeout=30)
 
         # 5. Wait for Metabase to become ready, then re-sync all users
+        import time
+
         console.print("Waiting for Metabase to initialize...")
         _server_project_dir = "/srv/dango/project"
         for _attempt in range(24):  # up to 2 minutes
-            import time
-
             time.sleep(5)
             health = ssh.exec_command(
                 "curl -sf http://localhost:3000/api/health -o /dev/null && echo ok",

--- a/dango/cli/commands/remote_repair.py
+++ b/dango/cli/commands/remote_repair.py
@@ -237,9 +237,50 @@ def remote_reset_metabase(ctx: click.Context) -> None:
         console.print("Restarting dango-web (this may take a few minutes)...")
         ssh.exec_command("systemctl start dango-web", timeout=30)
 
+        # 5. Wait for Metabase to become ready, then re-sync all users
+        console.print("Waiting for Metabase to initialize...")
+        _server_project_dir = "/srv/dango/project"
+        for _attempt in range(24):  # up to 2 minutes
+            import time
+
+            time.sleep(5)
+            health = ssh.exec_command(
+                "curl -sf http://localhost:3000/api/health -o /dev/null && echo ok",
+                timeout=5,
+            )
+            if health.success and "ok" in health.stdout:
+                break
+        else:
+            console.print(
+                "[yellow]Warning:[/yellow] Metabase did not become ready in time. "
+                "SSO may need manual re-sync."
+            )
+
+        # Re-sync all Dango users to fresh Metabase instance
+        console.print("Re-syncing users to Metabase...")
+        sync_result = ssh.exec_command(
+            f"cd {_server_project_dir} && "
+            '/srv/dango/venv/bin/python -c "'
+            "from pathlib import Path; "
+            "from dango.auth.admin import get_auth_db_path; "
+            "from dango.auth.metabase_sync import sync_all_users_to_metabase; "
+            "p = Path('.'); "
+            "r = sync_all_users_to_metabase(get_auth_db_path(p), p, 'http://localhost:3000'); "
+            'print(f\'Synced: {r[\\"synced\\"]}, Created: {r[\\"created\\"]}\')'
+            '"',
+            timeout=60,
+        )
+        if sync_result.success:
+            console.print(f"  [green]OK[/green] — {sync_result.stdout.strip()}")
+        else:
+            console.print(
+                "[yellow]Warning:[/yellow] User re-sync failed. "
+                "Users may need to be re-added to Metabase manually."
+            )
+
         console.print(
             "\n[green]Metabase reset complete.[/green]\n"
-            "Metabase is rebuilding. It may take 2-3 minutes to become available.\n"
+            "Log out and log back in to restore Metabase SSO.\n"
             "Run [bold]dango remote status[/bold] to check progress."
         )
 

--- a/dango/templates/docker-compose.yml.j2
+++ b/dango/templates/docker-compose.yml.j2
@@ -19,6 +19,7 @@ services:
       MB_DB_TYPE: h2
       MB_DB_FILE: /metabase-data/metabase.db
       MB_SITE_NAME: "{{ project_name }}"
+      MB_SITE_URL: "http://localhost:3000"
       MB_ENABLE_PUBLIC_SHARING: false
       MB_ANON_TRACKING_ENABLED: false
       MB_PLUGINS_DIR: /app/plugins

--- a/dango/web/routes/metabase_proxy.py
+++ b/dango/web/routes/metabase_proxy.py
@@ -166,7 +166,11 @@ async def proxy_to_metabase(
 
     except Exception:
         logger.error("Metabase proxy error for %s", target_path, exc_info=True)
-        return Response(content="Failed to connect to Metabase", status_code=502)
+        return Response(
+            content="Failed to connect to Metabase",
+            status_code=502,
+            headers={"Cache-Control": "no-store"},
+        )
 
 
 async def _do_proxy(


### PR DESCRIPTION
## Summary
Fixes 5 issues found during T12-D retest round.

**NEW-1 (Critical): reset-metabase breaks SSO**
- After resetting Metabase, user passwords in auth.db are stale
- Fix: wait for Metabase health (up to 2 min), then run `sync_all_users_to_metabase()` via SSH to re-create all users in fresh Metabase instance
- Tells user to re-login for SSO

**NEW-2: Browser caches 502 during sync**
- Metabase proxy 502 responses lacked cache headers, browser cached broken JS assets
- Fix: `Cache-Control: no-store` on 502 response in `metabase_proxy.py`

**NEW-3: Metabase site URL auto-detection**
- Metabase auto-detected site URL from localhost API calls during setup
- Fix: Set `MB_SITE_URL: http://localhost:3000` explicitly in `docker-compose.yml.j2`

**SSH user default restored**
- Restored `[root]` default per discussion — all providers use root after docs workaround

**Destroy backup warning**
- Replaced dynamic backup file check with static warning: "All data will be permanently deleted"

## Test plan
- [x] `test_cli_commands.py` — 13 pass
- [x] `test_web_imports.py` — 16 pass
- [x] `test_deploy_destroy.py` — 13 pass
- [x] Pre-commit hooks pass
- [ ] Manual: reset-metabase → SSO works after re-login
- [ ] Manual: sync during Metabase visit → no cached blank page

🤖 Generated with [Claude Code](https://claude.com/claude-code)