### PR TITLE
fix: Ubuntu 24.04 SSH service compatibility

### DIFF
--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -343,7 +343,7 @@ def _setup_ssh_hardening(
         " && sed -i 's/^#\\?KbdInteractiveAuthentication.*"
         "/KbdInteractiveAuthentication no/'"
         " /etc/ssh/sshd_config"
-        " && systemctl reload sshd",
+        " && (systemctl reload sshd 2>/dev/null || systemctl reload ssh)",
         step=step,
     )
     result.steps_completed.append(step)


### PR DESCRIPTION
## Summary
Ubuntu 24.04 uses `ssh.service` instead of `sshd.service`. The SSH hardening step's `systemctl reload sshd` was failing silently, causing the deploy to exit after the python_venv step.

Fix: `(systemctl reload sshd 2>/dev/null || systemctl reload ssh)` — tries 22.04 name first, falls back to 24.04 name.

## Test plan
- [x] `test_server_setup.py` — 44 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual: deploy to Ubuntu 24.04 server completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)