### PR TITLE
fix: credential protection — gitignore, validate warning, CI secret check, pre-push hook

### DIFF
--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -130,8 +130,11 @@ class ProjectInitializer:
             self._rollback_initialization()
             raise
 
-        # Install pre-push hook if .git exists
-        self._create_pre_push_hook()
+        # Install pre-push hook if .git exists (non-critical)
+        try:
+            self._create_pre_push_hook()
+        except Exception:
+            pass  # Never fail init over a convenience hook
 
         # Print success message
         self._print_success_message(warnings=warnings, failures=failures, auth_success=auth_success)
@@ -308,9 +311,6 @@ secrets/
         hooks_dir.mkdir(exist_ok=True)
 
         hook_path = hooks_dir / "pre-push"
-        if hook_path.exists():
-            return
-
         hook_content = """\
 #!/bin/bash
 echo ""
@@ -322,7 +322,10 @@ echo ""
 """
         import os
 
-        fd = os.open(str(hook_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o755)
+        try:
+            fd = os.open(str(hook_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o755)
+        except FileExistsError:
+            return
         try:
             os.write(fd, hook_content.encode())
         finally:

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -130,6 +130,9 @@ class ProjectInitializer:
             self._rollback_initialization()
             raise
 
+        # Install pre-push hook if .git exists
+        self._create_pre_push_hook()
+
         # Print success message
         self._print_success_message(warnings=warnings, failures=failures, auth_success=auth_success)
 
@@ -271,6 +274,8 @@ Thumbs.db
 .env
 .env.local
 secrets/
+.dlt/secrets.toml
+*.key
 """
 
         gitignore_path = self.project_dir / ".gitignore"
@@ -288,6 +293,42 @@ secrets/
             with open(gitignore_path, "w", encoding="utf-8") as f:
                 f.write(gitignore_content)
             print_success("Created .gitignore")
+
+    def _create_pre_push_hook(self):
+        """Create git pre-push hook with checklist reminder.
+
+        Only creates the hook if .git/ exists and the hook file doesn't
+        already exist (never overwrites user hooks).
+        """
+        git_dir = self.project_dir / ".git"
+        if not git_dir.is_dir():
+            return
+
+        hooks_dir = git_dir / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+
+        hook_path = hooks_dir / "pre-push"
+        if hook_path.exists():
+            return
+
+        hook_content = """\
+#!/bin/bash
+echo ""
+echo "  ⚠ Dango pre-push checklist:"
+echo "    • Run 'dango validate' to check config and models"
+echo "    • Run 'dango dev' to verify model changes against data"
+echo "    • Ensure no credentials are committed (.dlt/secrets.toml, .env)"
+echo ""
+"""
+        import os
+
+        fd = os.open(str(hook_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o755)
+        try:
+            os.write(fd, hook_content.encode())
+        finally:
+            os.close(fd)
+
+        console.print("[green]✓[/green] Created .git/hooks/pre-push checklist")
 
     def _create_ci_workflow(self):
         """Create GitHub Actions CI workflow for PR validation."""
@@ -307,6 +348,14 @@ jobs:
       - run: pip install getdango
       - run: dango config validate
       - run: cd dbt && dbt parse --profiles-dir .
+      - name: Check for secrets
+        run: |
+          # Fail if sensitive files are tracked
+          if git ls-files | grep -qE '\\.dlt/secrets\\.toml|\\.env$|\\.env\\.local|cloud_key|\\.key$'; then
+            echo "ERROR: Sensitive files detected in repository"
+            git ls-files | grep -E '\\.dlt/secrets\\.toml|\\.env$|\\.env\\.local|cloud_key|\\.key$'
+            exit 1
+          fi
 """
         workflow_dir = self.project_dir / ".github" / "workflows"
         workflow_dir.mkdir(parents=True, exist_ok=True)
@@ -1321,6 +1370,16 @@ on-run-end:
                 message += "5. Open http://localhost:8800"
 
         console.print(Panel(message, title=title, border_style=border_style))
+
+        # Print detect-secrets recommendation after main panel
+        if not failures:
+            console.print(
+                "[dim]Tip: Add secret scanning to prevent accidentally committing credentials:\n"
+                "  pip install pre-commit detect-secrets\n"
+                "  detect-secrets scan > .secrets.baseline\n"
+                "  # Add detect-secrets hook to .pre-commit-config.yaml[/dim]"
+            )
+
         console.print()
 
 

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -69,6 +69,7 @@ class ProjectValidator:
         self._check_database()
         self._check_dependencies()
         self._check_permissions()
+        self._check_tracked_secrets()
 
         # Summarize results
         summary = self._create_summary()
@@ -558,6 +559,51 @@ class ProjectValidator:
                             f"Permissions: {dir_path}", "fail", "Directory is not writable"
                         )
                     )
+
+    def _check_tracked_secrets(self):
+        """Warn if sensitive files are tracked by git."""
+        git_dir = self.project_root / ".git"
+        if not git_dir.is_dir():
+            return  # Not a git repo — skip
+
+        try:
+            result = subprocess.run(
+                ["git", "ls-files"],
+                cwd=str(self.project_root),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return  # git command failed — skip silently
+
+            import re
+
+            tracked = result.stdout.strip().splitlines()
+            sensitive_patterns = [
+                re.compile(r"^\.dlt/secrets\.toml$"),
+                re.compile(r"^\.env$"),
+                re.compile(r"^\.env\.local$"),
+                re.compile(r".*\.key$"),
+                re.compile(r"^cloud_key$"),
+            ]
+
+            for filepath in tracked:
+                for pattern in sensitive_patterns:
+                    if pattern.match(filepath):
+                        self.results.append(
+                            ValidationResult(
+                                f"Security: {filepath}",
+                                "warn",
+                                f"Sensitive file tracked by git: {filepath}. "
+                                f"Remove with: git rm --cached {filepath} "
+                                f"&& echo '{filepath}' >> .gitignore",
+                            )
+                        )
+                        break  # One match per file is enough
+
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass  # git not installed or timed out — skip silently
 
     def _create_summary(self) -> dict[str, Any]:
         """Create validation summary"""

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -585,7 +585,7 @@ class ProjectValidator:
                 re.compile(r"^\.env$"),
                 re.compile(r"^\.env\.local$"),
                 re.compile(r".*\.key$"),
-                re.compile(r"(^|/)cloud_key$"),
+                re.compile(r"(.*/)?cloud_key$"),
             ]
 
             for filepath in tracked:

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -585,7 +585,7 @@ class ProjectValidator:
                 re.compile(r"^\.env$"),
                 re.compile(r"^\.env\.local$"),
                 re.compile(r".*\.key$"),
-                re.compile(r"^cloud_key$"),
+                re.compile(r"(^|/)cloud_key$"),
             ]
 
             for filepath in tracked:


### PR DESCRIPTION
## Summary

Six security/config improvements for projects created by `dango init`. Existing projects are not affected.

### Changes

1. **`.gitignore` — add `.dlt/secrets.toml` and `*.key`** to the generated Secrets section. Previously, `git add -A` would commit credentials.

2. **`dango validate` — warn if secrets tracked by git.** New `_check_tracked_secrets()` runs `git ls-files` and warns (not errors) if `.dlt/secrets.toml`, `.env`, `.env.local`, `*.key`, or `cloud_key` are tracked. Includes remediation guidance (`git rm --cached`). Gracefully skips if not a git repo.

3. **detect-secrets recommendation.** Prints a tip after `dango init` success suggesting `detect-secrets` + `pre-commit` for secret scanning. Lightweight — a recommendation, not a dependency.

4. **Docker-compose `:ro` comment — already correct.** Both `docker-compose.yml.j2` and `sync_trigger.py` already say `:ro` does NOT prevent DuckDB locks. No change needed.

5. **Pre-push hook.** Creates `.git/hooks/pre-push` with a checklist reminder (validate, dev, no credentials). Only if `.git/` exists; never overwrites existing hooks; uses `O_EXCL` for safe creation.

6. **CI secret check.** Adds a "Check for secrets" step to the generated GitHub Actions workflow that fails the build if sensitive files are tracked.

### Line count changes (exempt files)

| File | Before | After | Delta |
|------|--------|-------|-------|
| `dango/cli/init.py` | 1334 | 1396 | +62 |
| `dango/cli/validate.py` | 652 | 698 | +46 |

### Verification

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy` clean on changed files
- [x] `pytest tests/unit/ -x` — 3575 passed, 7 skipped
- [x] All pre-commit hooks pass

**DO NOT MERGE — awaiting review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)