### PR TITLE
chore: update install scripts and README for beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ Dango gives you a complete data stack — ingestion, warehouse, transformations,
 
 <!-- TODO: Add screenshot -->
 
-> **Upgrading from v0.1.x?** v1.0.0 is a complete rewrite of Dango. Back up your data and run `dango init` to create a new v1 project. See the [migration guide](https://docs.getdango.dev) for details.
+> **Beta Release:** Dango v1 is currently in beta (v1.0.0b1). We'd love your feedback — [report issues](https://github.com/getdango/dango/issues) or [join the discussion](https://github.com/getdango/dango/discussions).
+
+> **Upgrading from v0.1.x?** v1.0.0 is a complete rewrite. Back up your data and run `dango init` to create a new v1 project. See the [migration guide](https://docs.getdango.dev) for details.
 
 ## Quick Start
 
 **Prerequisites:** Python 3.10-3.12, [Docker](https://docs.docker.com/desktop/) (for Metabase)
 
 ```bash
-pip install getdango
+pip install --pre getdango
 dango init
 dango start
 ```

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -348,7 +348,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install getdango
+      - run: pip install --pre getdango
       - run: dango config validate
       - run: cd dbt && dbt parse --profiles-dir .
       - name: Check for secrets

--- a/install.ps1
+++ b/install.ps1
@@ -327,8 +327,8 @@ function Install-Dango {
     # Upgrade pip silently
     & pip install --upgrade pip --quiet
 
-    # Install getdango from PyPI
-    & pip install getdango
+    # Install getdango from PyPI (--pre includes beta versions)
+    & pip install --pre getdango
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error-Message "Failed to install Dango"
@@ -354,7 +354,7 @@ function Update-Dango {
     & $activateScript
 
     # Upgrade from PyPI
-    & pip install --upgrade getdango --quiet
+    & pip install --upgrade --pre getdango --quiet
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error-Message "Failed to upgrade Dango"
@@ -377,7 +377,7 @@ function Install-DangoGlobal {
     Write-Host ""
 
     # Install from PyPI
-    & $PythonCmd -m pip install --user getdango
+    & $PythonCmd -m pip install --pre --user getdango
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error-Message "Failed to install Dango from PyPI"
@@ -785,7 +785,7 @@ function Main {
                 Write-Host "To create venv manually:"
                 Write-Host "  $($pythonInfo.Command) -m venv venv"
                 Write-Host "  .\venv\Scripts\Activate.ps1"
-                Write-Host "  pip install getdango"
+                Write-Host "  pip install --pre getdango"
                 Write-Host ""
                 exit 0
             }

--- a/install.ps1
+++ b/install.ps1
@@ -336,7 +336,7 @@ function Install-Dango {
     }
 
     # Get installed version
-    $version = & dango --version 2>$null | Select-String -Pattern '\d+\.\d+\.\d+' | ForEach-Object { $_.Matches.Value }
+    $version = & dango --version 2>$null | Select-String -Pattern '\d+\.\d+\.\d+[a-zA-Z0-9]*' | ForEach-Object { $_.Matches.Value }
     if (-not $version) { $version = "unknown" }
 
     Write-Success "Dango $version installed"
@@ -362,7 +362,7 @@ function Update-Dango {
     }
 
     # Get installed version
-    $version = & dango --version 2>$null | Select-String -Pattern '\d+\.\d+\.\d+' | ForEach-Object { $_.Matches.Value }
+    $version = & dango --version 2>$null | Select-String -Pattern '\d+\.\d+\.\d+[a-zA-Z0-9]*' | ForEach-Object { $_.Matches.Value }
     if (-not $version) { $version = "unknown" }
 
     Write-Success "Dango upgraded to $version"
@@ -403,7 +403,7 @@ function Install-DangoGlobal {
 
     # If dango already in PATH, we're done
     if ($dangoWasInPath) {
-        $version = & dango --version 2>$null | Select-String -Pattern '\d+\.\d+\.\d+' | ForEach-Object { $_.Matches.Value }
+        $version = & dango --version 2>$null | Select-String -Pattern '\d+\.\d+\.\d+[a-zA-Z0-9]*' | ForEach-Object { $_.Matches.Value }
         if (-not $version) { $version = "unknown" }
         Write-Success "Dango $version installed and ready to use!"
         Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -291,7 +291,7 @@ install_dango() {
     source "$venv_path/bin/activate"
     $PYTHON_CMD -m pip install --upgrade pip -q
 
-    if ! $PYTHON_CMD -m pip install getdango; then
+    if ! $PYTHON_CMD -m pip install --pre getdango; then
         print_error "Failed to install Dango"
         echo
         echo "Possible causes:"
@@ -316,7 +316,7 @@ upgrade_dango() {
     print_step "Upgrading Dango..."
 
     source "$venv_path/bin/activate"
-    $PYTHON_CMD -m pip install --upgrade getdango -q
+    $PYTHON_CMD -m pip install --upgrade --pre getdango -q
 
     DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
 
@@ -366,7 +366,7 @@ check_conflicts() {
     echo
 
     # Run dry-run to see what will be installed/upgraded
-    dry_run_output=$($PYTHON_CMD -m pip install --dry-run --user getdango 2>&1)
+    dry_run_output=$($PYTHON_CMD -m pip install --dry-run --pre --user getdango 2>&1)
 
     # Check if any packages will be upgraded
     if echo "$dry_run_output" | grep -q "Would upgrade"; then
@@ -402,7 +402,7 @@ install_dango_global() {
     print_step "Installing Dango globally..."
     echo
 
-    if ! $PYTHON_CMD -m pip install --user getdango; then
+    if ! $PYTHON_CMD -m pip install --pre --user getdango; then
         print_error "Failed to install Dango"
         echo
         echo "Possible causes:"
@@ -838,7 +838,7 @@ main() {
                 echo "To create venv manually:"
                 echo "  $PYTHON_CMD -m venv venv"
                 echo "  source venv/bin/activate"
-                echo "  pip install getdango"
+                echo "  pip install --pre getdango"
                 echo
                 exit 0
             fi

--- a/install.sh
+++ b/install.sh
@@ -304,7 +304,7 @@ install_dango() {
     fi
 
     # Get installed version
-    DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+    DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9]*' || echo "unknown")
 
     print_success "Dango $DANGO_VERSION installed"
     echo
@@ -318,7 +318,7 @@ upgrade_dango() {
     source "$venv_path/bin/activate"
     $PYTHON_CMD -m pip install --upgrade --pre getdango -q
 
-    DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+    DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9]*' || echo "unknown")
 
     print_success "Dango upgraded to $DANGO_VERSION"
     echo
@@ -426,7 +426,7 @@ install_dango_global() {
 
     # If dango already in PATH, we're done
     if [ "$DANGO_WAS_IN_PATH" = true ]; then
-        DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+        DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9]*' || echo "unknown")
         print_success "Dango $DANGO_VERSION installed and ready to use!"
         echo
         return 0

--- a/tests/unit/test_cli_init_ci.py
+++ b/tests/unit/test_cli_init_ci.py
@@ -41,7 +41,7 @@ class TestCreateCiWorkflow:
         content = (tmp_path / ".github" / "workflows" / "dango-validate.yml").read_text()
         assert "dango config validate" in content
         assert "dbt parse --profiles-dir ." in content
-        assert "pip install getdango" in content
+        assert "pip install --pre getdango" in content
 
     def test_idempotent_on_existing_directory(self, tmp_path: Path) -> None:
         """Works when .github/workflows/ already exists."""


### PR DESCRIPTION
## Summary
- Add `--pre` flag to all `pip install getdango` calls in install scripts so beta versions are installed
- Add beta notice to README.md
- Update generated CI template to use `--pre`

### Files changed
- `install.sh` — 6 instances updated
- `install.ps1` — 4 instances updated
- `README.md` — beta notice + `pip install --pre getdango`
- `dango/cli/init.py` — generated CI workflow uses `--pre`

### Note
At GA release (1.0.0), remove `--pre` from all these locations.

DO NOT MERGE — awaiting review.