### PR TITLE
fix: sanitize project directory name in install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -703,6 +703,9 @@ function Main {
                 break
             } while ($true)
 
+            # Sanitize: lowercase, spaces → dashes, remove special chars
+            $projectDir = ($projectDir.ToLower() -replace '\s+', '-' -replace '[^a-z0-9-]', '')
+
             Write-Host ""
             Write-Step "Creating project directory: $projectDir"
             New-Item -ItemType Directory -Path $projectDir | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -731,6 +731,9 @@ main() {
                 break
             done
 
+            # Sanitize: lowercase, spaces → dashes, remove special chars
+            PROJECT_DIR=$(echo "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-')
+
             echo
             print_step "Creating project directory: $PROJECT_DIR"
             mkdir -p "$PROJECT_DIR"


### PR DESCRIPTION
## Summary
User input with spaces/uppercase (e.g., "My Analytics") is sanitized to lowercase-dashes (e.g., "my-analytics") before directory creation.

Previously the raw input was used for mkdir but the `cd` instruction shown at the end would fail because the shell splits on spaces.

### Files changed
- `install.sh` — sanitize with tr
- `install.ps1` — sanitize with PowerShell string ops

No PyPI version bump needed — install scripts are served from GitHub raw content.