### PR TITLE
fix: v0.1.x detection false positive + bump to 1.0.0b2

### DIFF
--- a/dango/__init__.py
+++ b/dango/__init__.py
@@ -4,7 +4,7 @@ Dango - Open source data platform
 Professional analytics stack built with production-grade tools.
 """
 
-__version__ = "1.0.0b1"
+__version__ = "1.0.0b2"
 __author__ = "Dango Team"
 __license__ = "Apache-2.0"
 

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -21,14 +21,14 @@ def check_v01x_project() -> None:
 
     Detection heuristics:
     1. ``dango.yml`` in cwd — legacy single-file config.
-    2. ``.dango/project.yml`` exists but ``.dango/dango.db`` (created by v1's
+    2. ``.dango/project.yml`` exists but ``.dango/auth.db`` (created by v1's
        ``dango init``) is missing AND ``data/warehouse.duckdb`` exists (ruling
        out a freshly cloned v1 project that hasn't been initialised yet).
     """
     cwd = Path.cwd()
     is_v01x = (cwd / "dango.yml").exists() or (
         (cwd / ".dango" / "project.yml").exists()
-        and not (cwd / ".dango" / "dango.db").exists()
+        and not (cwd / ".dango" / "auth.db").exists()
         and (cwd / "data" / "warehouse.duckdb").exists()
     )
     if is_v01x:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "getdango"
-version = "1.0.0b1"
+version = "1.0.0b2"
 description = "Open source data platform built with production-grade tools - dlt, dbt, DuckDB, and Metabase"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/tests/unit/test_v01x_detection.py
+++ b/tests/unit/test_v01x_detection.py
@@ -57,11 +57,11 @@ def test_no_detection_without_dango_yml(tmp_path, monkeypatch):
 
 
 def test_no_detection_with_v1_project(tmp_path, monkeypatch):
-    """check_v01x_project does nothing for a v1 project (.dango/dango.db exists)."""
+    """check_v01x_project does nothing for a v1 project (.dango/auth.db exists)."""
     dango_dir = tmp_path / ".dango"
     dango_dir.mkdir()
     (dango_dir / "project.yml").write_text("project:\n  name: myproject\n")
-    (dango_dir / "dango.db").write_bytes(b"")
+    (dango_dir / "auth.db").write_bytes(b"")
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "warehouse.duckdb").write_bytes(b"")


### PR DESCRIPTION
## Summary
Fresh v1 projects created by `dango init` were incorrectly flagged as v0.1.x projects. `dango start` would abort with a migration warning.

**Root cause:** Detection checked for `.dango/dango.db` which is created lazily on first sync, not during init. Changed to check `.dango/auth.db` which IS created during init.

**Also bumps to 1.0.0b2** — this is a critical bug fix for v1.0.0b1.

### Files changed
- `dango/cli/utils.py` — detection heuristic: `dango.db` → `auth.db`
- `dango/__init__.py` — version bump
- `pyproject.toml` — version bump
- `tests/unit/test_v01x_detection.py` — updated test