### PR TITLE
Fix 6 cloud deployment bugs (P0-3/4/5/6, P1-10/11)

### DIFF
--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -3,6 +3,7 @@
 Data source management commands (add, list, remove) and sync.
 """
 
+import os
 import re
 
 import click
@@ -658,6 +659,7 @@ def sync(
     console.print()
 
     lock = None
+    _cloud_mode = False
     try:
         # Get project context
         project_root = require_project_context(ctx)
@@ -846,6 +848,35 @@ def sync(
                 console.print(f"\n[red]{oauth_err.user_message}[/red]")
                 raise click.Abort() from oauth_err
 
+        # Stop Metabase on cloud to prevent DuckDB lock conflicts
+        _cloud_mode = os.environ.get("DANGO_CLOUD_MODE") == "true"
+        if _cloud_mode:
+            try:
+                import subprocess as _sp
+
+                from dango.platform.docker import get_compose_project_name
+
+                _proj_name = get_compose_project_name(project_root)
+                _env = {**os.environ, "COMPOSE_PROJECT_NAME": _proj_name}
+                _sp.run(
+                    [
+                        "docker",
+                        "compose",
+                        "-f",
+                        str(project_root / "docker-compose.yml"),
+                        "stop",
+                        "metabase",
+                    ],
+                    capture_output=True,
+                    timeout=60,
+                    env=_env,
+                )
+                import time
+
+                time.sleep(3)
+            except Exception:
+                pass
+
         # Run sync
         try:
             summary = run_sync(
@@ -909,5 +940,29 @@ def sync(
         if lock is not None and lock._acquired:
             try:
                 lock.release()
+            except Exception:
+                pass
+        # Restart Metabase on cloud
+        if _cloud_mode:
+            try:
+                import subprocess as _sp
+
+                from dango.platform.docker import get_compose_project_name
+
+                _proj_name = get_compose_project_name(project_root)
+                _env = {**os.environ, "COMPOSE_PROJECT_NAME": _proj_name}
+                _sp.run(
+                    [
+                        "docker",
+                        "compose",
+                        "-f",
+                        str(project_root / "docker-compose.yml"),
+                        "start",
+                        "metabase",
+                    ],
+                    capture_output=True,
+                    timeout=120,
+                    env=_env,
+                )
             except Exception:
                 pass

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -875,7 +875,7 @@ def sync(
 
                 time.sleep(3)
             except Exception:
-                pass
+                console.print("[dim]ℹ Could not pause Metabase (continuing anyway)[/dim]")
 
         # Run sync
         try:
@@ -893,8 +893,10 @@ def sync(
             console.print("[green]Resume with the same command.[/green]")
             return
 
-        # Trigger Metabase schema sync (if Metabase is running)
-        if summary["failed_count"] == 0:
+        # Trigger Metabase schema sync (if Metabase is running).
+        # Skip on cloud — Metabase is stopped; the finally block restarts it
+        # and Metabase auto-syncs schema on startup.
+        if summary["failed_count"] == 0 and not _cloud_mode:
             console.print()
             console.print("[dim]Updating Metabase schema...[/dim]")
             from dango.visualization.metabase import sync_metabase_schema
@@ -965,4 +967,7 @@ def sync(
                     env=_env,
                 )
             except Exception:
-                pass
+                console.print(
+                    "[yellow]Warning: Could not restart Metabase — "
+                    "run 'docker compose start metabase' manually[/yellow]"
+                )

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -3,6 +3,7 @@
 dbt transformation commands (run, docs, generate).
 """
 
+import os
 from typing import Any
 
 import click
@@ -40,6 +41,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
     from ..utils import require_project_context
 
     lock = None
+    _cloud_mode = False
     try:
         project_root = require_project_context(ctx)
         dbt_dir = project_root / "dbt"
@@ -67,6 +69,35 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
             raise click.Abort() from e
 
         console.print(f"[dim]Running: {' '.join(cmd)}[/dim]\n")
+
+        # Stop Metabase on cloud to prevent DuckDB lock conflicts
+        _cloud_mode = os.environ.get("DANGO_CLOUD_MODE") == "true"
+        if _cloud_mode:
+            try:
+                import subprocess as _sp
+
+                from dango.platform.docker import get_compose_project_name
+
+                _proj_name = get_compose_project_name(project_root)
+                _env = {**os.environ, "COMPOSE_PROJECT_NAME": _proj_name}
+                _sp.run(
+                    [
+                        "docker",
+                        "compose",
+                        "-f",
+                        str(project_root / "docker-compose.yml"),
+                        "stop",
+                        "metabase",
+                    ],
+                    capture_output=True,
+                    timeout=60,
+                    env=_env,
+                )
+                import time
+
+                time.sleep(3)
+            except Exception:
+                pass
 
         # Run dbt command from dbt directory for correct path resolution
         result = subprocess.run(cmd, cwd=str(dbt_dir))
@@ -122,6 +153,30 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
         if lock is not None and lock._acquired:
             try:
                 lock.release()
+            except Exception:
+                pass
+        # Restart Metabase on cloud
+        if _cloud_mode:
+            try:
+                import subprocess as _sp
+
+                from dango.platform.docker import get_compose_project_name
+
+                _proj_name = get_compose_project_name(project_root)
+                _env = {**os.environ, "COMPOSE_PROJECT_NAME": _proj_name}
+                _sp.run(
+                    [
+                        "docker",
+                        "compose",
+                        "-f",
+                        str(project_root / "docker-compose.yml"),
+                        "start",
+                        "metabase",
+                    ],
+                    capture_output=True,
+                    timeout=120,
+                    env=_env,
+                )
             except Exception:
                 pass
 

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -97,7 +97,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
 
                 time.sleep(3)
             except Exception:
-                pass
+                console.print("[dim]ℹ Could not pause Metabase (continuing anyway)[/dim]")
 
         # Run dbt command from dbt directory for correct path resolution
         result = subprocess.run(cmd, cwd=str(dbt_dir))
@@ -125,17 +125,23 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
         if models_to_update:
             update_model_schemas(project_root, models_to_update)
 
-        # Refresh Metabase connection to see new/updated tables
-        console.print("\n[dim]Refreshing Metabase connection...[/dim]")
-        from dango.visualization.metabase import refresh_metabase_connection, sync_metabase_schema
+        # Refresh Metabase connection to see new/updated tables.
+        # Skip on cloud — Metabase is stopped; the finally block restarts it
+        # and Metabase auto-syncs schema on startup.
+        if not _cloud_mode:
+            console.print("\n[dim]Refreshing Metabase connection...[/dim]")
+            from dango.visualization.metabase import (
+                refresh_metabase_connection,
+                sync_metabase_schema,
+            )
 
-        if refresh_metabase_connection(project_root):
-            console.print("[green]✓ Metabase connection refreshed[/green]")
-            # Also sync schema to discover new tables/schemas from dbt run
-            if sync_metabase_schema(project_root):
-                console.print("[green]✓ Metabase schema synced[/green]")
-        else:
-            console.print("[dim]ℹ Metabase not running (will sync when started)[/dim]")
+            if refresh_metabase_connection(project_root):
+                console.print("[green]✓ Metabase connection refreshed[/green]")
+                # Also sync schema to discover new tables/schemas from dbt run
+                if sync_metabase_schema(project_root):
+                    console.print("[green]✓ Metabase schema synced[/green]")
+            else:
+                console.print("[dim]ℹ Metabase not running (will sync when started)[/dim]")
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Cancelled[/yellow]")
@@ -178,7 +184,10 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
                     env=_env,
                 )
             except Exception:
-                pass
+                console.print(
+                    "[yellow]Warning: Could not restart Metabase — "
+                    "run 'docker compose start metabase' manually[/yellow]"
+                )
 
 
 @click.command("docs")

--- a/dango/platform/cloud/backup.py
+++ b/dango/platform/cloud/backup.py
@@ -43,10 +43,20 @@ BACKUP_FILES = [
     ".dango/logs/audit.jsonl",
     ".dlt/secrets.toml",
     "dbt/profiles.yml",
+    "dbt/dbt_project.yml",
+    "dbt/packages.yml",
+    ".env",
 ]
 
 #: Directories to back up (recursively), relative to PROJECT_DIR.
-BACKUP_DIRS = [".dlt/pipelines"]
+BACKUP_DIRS = [
+    ".dlt/pipelines",
+    "dbt/models",
+    "dbt/macros",
+    "dbt/seeds",
+    "custom_sources",
+    "data/seeds",
+]
 
 
 @dataclass(frozen=True)

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -510,6 +510,19 @@ def push_deploy(
                 logger.warning("chown_failed", path=REMOTE_PROJECT_DIR, stderr=chown_result.stderr)
             _notify(on_progress, "fix_ownership", "done")
 
+            # Step 5b: Install project dependencies (if requirements.txt synced)
+            if "requirements.txt" in sync_result.synced_files:
+                _notify(on_progress, "install_deps", "running")
+                pip_result = ssh.exec_command(
+                    f"sudo -u dango {VENV_BIN}/pip install -r {REMOTE_PROJECT_DIR}/requirements.txt",
+                    timeout=300,
+                )
+                if pip_result.exit_code != 0:
+                    warnings.append(
+                        f"pip install -r requirements.txt failed: {pip_result.stderr.strip()}"
+                    )
+                _notify(on_progress, "install_deps", "done")
+
             # Step 6: Validate sources
             _notify(on_progress, "validate_sources", "running")
             source_errors = _validate_remote_sources(ssh)

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -75,14 +75,15 @@ SYNC_CONFIG_FILES: list[tuple[str, str]] = [
         "metabase-plugins/.driver-version",
         f"{REMOTE_PROJECT_DIR}/metabase-plugins/.driver-version",
     ),
+    ("requirements.txt", f"{REMOTE_PROJECT_DIR}/requirements.txt"),
 ]
 
 #: Directories to sync via rsync (with ``--delete``).
-SYNC_DBT_DIRS: list[str] = ["dbt/models", "dbt/macros"]
+SYNC_DBT_DIRS: list[str] = ["dbt/models", "dbt/macros", "dbt/seeds"]
 
 #: Additional directories to sync via rsync (with ``--delete``).
 #: Unlike dbt dirs, these are not part of the change-detection logic.
-SYNC_EXTRA_DIRS: list[str] = ["metabase"]
+SYNC_EXTRA_DIRS: list[str] = ["metabase", "custom_sources"]
 
 
 # ---------------------------------------------------------------------------

--- a/dango/platform/cloud/server_setup.py
+++ b/dango/platform/cloud/server_setup.py
@@ -568,33 +568,9 @@ def resolve_install_source() -> tuple[str, str]:
 
     raw = dist.read_text("direct_url.json")
     if raw is None:
-        # No direct_url.json — could be PyPI or an editable install without
-        # metadata (e.g., worktree installs).  Check if the package source
-        # is inside a git repo.
-        from pathlib import Path as _Path
-
+        # No direct_url.json → standard PyPI install.  A PyPI install never
+        # creates direct_url.json, so there is nothing more to check.
         import dango
-
-        pkg_dir = str(_Path(dango.__file__).resolve().parent)
-        try:
-            remote = subprocess.run(  # noqa: S603, S607
-                ["git", "-C", pkg_dir, "remote", "get-url", "origin"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            head = subprocess.run(  # noqa: S603, S607
-                ["git", "-C", pkg_dir, "rev-parse", "HEAD"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if remote.returncode == 0 and head.returncode == 0:
-                url = remote.stdout.strip()
-                commit = head.stdout.strip()
-                return ("git", f"git+{_normalize_git_url(url)}@{commit}#egg=getdango")
-        except Exception:
-            _logger.debug("worktree_git_info_failed", exc_info=True)
 
         return ("pypi", f"getdango=={dango.__version__}")
 


### PR DESCRIPTION
## Summary

Fixes 6 cloud deployment bugs found during beta testing:

- **P0-3:** `resolve_install_source()` git fallback walked up to wrong repo on PyPI installs — removed; PyPI installs never have `direct_url.json`
- **P0-4:** `dbt/seeds` and `custom_sources` missing from file sync dirs — added to `SYNC_DBT_DIRS` and `SYNC_EXTRA_DIRS`
- **P0-5:** Backup missing `dbt_project.yml`, `packages.yml`, `.env`, and content dirs (`dbt/models`, `dbt/macros`, `dbt/seeds`, `custom_sources`, `data/seeds`) — added to `BACKUP_FILES` and `BACKUP_DIRS`
- **P0-6:** CLI `dango sync` and `dango run` don't stop Metabase on cloud before DuckDB writes — added stop/start pattern (mirrors `sync_trigger.py`)
- **P1-10:** `requirements.txt` not synced or installed on remote — added to sync config + pip install step in deployer after file ownership fix
- **P1-11:** No code needed — existing `chown -R` in deployer Step 5 covers new synced dirs from P0-4

## Test plan

- [x] All 3680 unit tests pass
- [x] Ruff check + format pass
- [ ] Manual: deploy to test server, verify `resolve_install_source()` returns PyPI
- [ ] Manual: `dango remote push` with custom_sources/ and dbt/seeds/ dirs
- [ ] Manual: `dango remote backup` includes new files/dirs
- [ ] Manual: `dango sync` on cloud stops/starts Metabase
- [ ] Manual: `dango run` on cloud stops/starts Metabase
- [ ] Manual: push with requirements.txt triggers pip install

🤖 Generated with [Claude Code](https://claude.com/claude-code)