### PR TITLE
fix: P0-1, P0-2, P0-7, P0-8 — core infrastructure bugs

### DIFF
--- a/dango/cli/commands/config_cmd.py
+++ b/dango/cli/commands/config_cmd.py
@@ -230,11 +230,17 @@ def do_token() -> None:
 
 
 @do_token.command("clear")
-def do_token_clear() -> None:
+@click.pass_context
+def do_token_clear(ctx: click.Context) -> None:
     """Remove the stored DigitalOcean API token."""
     from dango.config.cloud_credentials import clear_do_token
 
-    if clear_do_token():
+    project_root = ctx.obj.get("project_root")
+    cleared = clear_do_token(project_root=project_root)
+    if not cleared and project_root is not None:
+        # Fall back to global if no project-level token
+        cleared = clear_do_token()
+    if cleared:
         console.print("[green]DigitalOcean API token removed.[/green]")
     else:
         console.print("[dim]No stored token found.[/dim]")

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -103,7 +103,7 @@ def _step_prereqs(project_root: Path) -> None:
             new_token = click.prompt("  Enter new DigitalOcean API token", hide_input=True)
             if new_token.strip():
                 token = new_token.strip()
-                save_do_token(token)
+                save_do_token(token, project_root=project_root)
     elif token and token_from_env:
         console.print("  [dim]Using DigitalOcean token from environment variable.[/dim]")
     else:
@@ -118,7 +118,7 @@ def _step_prereqs(project_root: Path) -> None:
             raise SystemExit(1)
         token = token.strip()
         # BUG-127: Persist token so subsequent commands don't re-prompt
-        save_do_token(token)
+        save_do_token(token, project_root=project_root)
 
     # BUG-238c: Validate token upfront with lightweight API call
     import httpx

--- a/dango/config/cloud_credentials.py
+++ b/dango/config/cloud_credentials.py
@@ -102,12 +102,31 @@ def save_do_token(token: str, project_root: Path | None = None) -> None:
         _write_config(config)
 
 
-def clear_do_token() -> bool:
+def clear_do_token(project_root: Path | None = None) -> bool:
     """Remove the stored DigitalOcean token.
+
+    When *project_root* is given, clears the project-level credential.
+    Otherwise clears the global ``~/.dango/credentials``.
 
     Returns:
         ``True`` if a token was removed, ``False`` if none was stored.
     """
+    if project_root is not None:
+        cred_file = project_root / ".dango" / "credentials"
+        if not cred_file.is_file():
+            return False
+        config = configparser.ConfigParser()
+        config.read(str(cred_file))
+        if not config.has_option(_SECTION, _TOKEN_KEY):
+            return False
+        config.remove_option(_SECTION, _TOKEN_KEY)
+        if not config.options(_SECTION):
+            config.remove_section(_SECTION)
+        fd = os.open(str(cred_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            config.write(f)
+        return True
+
     config = _read_config()
     if not config.has_option(_SECTION, _TOKEN_KEY):
         return False

--- a/dango/config/cloud_credentials.py
+++ b/dango/config/cloud_credentials.py
@@ -75,13 +75,31 @@ def get_do_token(project_root: Path | None = None) -> str | None:
     return None
 
 
-def save_do_token(token: str) -> None:
-    """Persist *token* to ``~/.dango/credentials``."""
-    config = _read_config()
-    if not config.has_section(_SECTION):
-        config.add_section(_SECTION)
-    config.set(_SECTION, _TOKEN_KEY, token)
-    _write_config(config)
+def save_do_token(token: str, project_root: Path | None = None) -> None:
+    """Persist *token* to project-level or global credentials.
+
+    When *project_root* is given, saves to ``<project>/.dango/credentials``.
+    Otherwise falls back to ``~/.dango/credentials``.
+    """
+    if project_root is not None:
+        cred_dir = project_root / ".dango"
+        cred_dir.mkdir(parents=True, exist_ok=True)
+        cred_file = cred_dir / "credentials"
+        config = configparser.ConfigParser()
+        if cred_file.is_file():
+            config.read(str(cred_file))
+        if not config.has_section(_SECTION):
+            config.add_section(_SECTION)
+        config.set(_SECTION, _TOKEN_KEY, token)
+        fd = os.open(str(cred_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            config.write(f)
+    else:
+        config = _read_config()
+        if not config.has_section(_SECTION):
+            config.add_section(_SECTION)
+        config.set(_SECTION, _TOKEN_KEY, token)
+        _write_config(config)
 
 
 def clear_do_token() -> bool:

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2537,9 +2537,15 @@ def run_sync(
             else:
                 if progress_callback is not None:
                     progress_callback("dbt_failed", "dbt run failed")
-                console.print("[red]✗ dbt run failed[/red]")
-                console.print(f"[dim]{dbt_output}[/dim]")
+                _logging.getLogger(__name__).error("dbt_transform_failed: %s", dbt_output[:500])
+                console.print("[red bold]✗ dbt transform failed[/red bold]")
+                console.print(f"[red]{dbt_output}[/red]")
                 console.print("[yellow]⚠️  Staging/marts tables were not created[/yellow]")
+                # Update sync history with transform error
+                from dango.utils.sync_history import update_last_sync_entry
+
+                for src in success_sources:
+                    update_last_sync_entry(project_root, src, {"transform_error": dbt_output[:500]})
             console.print()
         else:
             console.print("[dim]⏭  Skipping dbt run (will be coalesced)[/dim]\n")
@@ -2567,9 +2573,7 @@ def run_sync(
                 skip_sync_notification=skip_sync_notification,
             )
         except Exception:
-            import logging as _logging
-
-            _logging.getLogger(__name__).debug("post_sync_hooks_failed", exc_info=True)
-            console.print("[dim]Post-sync hooks skipped (non-critical)[/dim]")
+            _logging.getLogger(__name__).error("post_sync_hooks_failed", exc_info=True)
+            console.print("[red]⚠ Post-sync hooks failed[/red]")
 
     return summary

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -121,6 +121,21 @@ class SchedulerService:
 
         self._on_retry_callbacks.append(self._on_retry_event)
 
+        # Load user-defined schedules from .dango/schedules.yml
+        try:
+            from dango.config.schedules import load_schedules_config, reload_schedules
+
+            config = load_schedules_config(self._project_root)
+            if config.schedules:
+                result = reload_schedules(self, config.schedules, self._project_root)
+                logger.info(
+                    "schedules_loaded",
+                    added=len(result.added),
+                    skipped_disabled=len(config.schedules) - len(result.added),
+                )
+        except Exception:  # noqa: BLE001
+            logger.error("schedules_load_failed", exc_info=True)
+
         self._setup_history_cleanup()
         self._setup_login_attempts_cleanup()
         self._log_startup_summary()

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -548,10 +548,12 @@ class DbtModelGenerator:
                 sources_file = None
                 staging_schema_file = None
                 if generate_schema_yml and tables_for_yml:
-                    sources_yml = self.generate_sources_yml(source, schema_name, tables_for_yml)
                     sources_file = self.staging_dir / f"sources_{source.name}.yml"
-                    with open(sources_file, "w") as f:
-                        f.write(sources_yml)
+                    # Only write if file doesn't exist (don't overwrite user customizations)
+                    if not sources_file.exists():
+                        sources_yml = self.generate_sources_yml(source, schema_name, tables_for_yml)
+                        with open(sources_file, "w") as f:
+                            f.write(sources_yml)
 
                     # Generate staging schema.yml (documents staging models)
                     # Uses staging_columns (excludes _dlt_*/_dango_* internal columns)

--- a/dango/utils/__init__.py
+++ b/dango/utils/__init__.py
@@ -11,6 +11,7 @@ from .sync_history import (
     get_sync_history_file,
     load_sync_history,
     save_sync_history_entry,
+    update_last_sync_entry,
 )
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "load_sync_history",
     "get_earliest_start_date",
     "get_sync_history_file",
+    "update_last_sync_entry",
     "ensure_dbt_schemas",
     "DbtLock",
     "DbtLockError",

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -303,9 +303,9 @@ def _run_dbt_snapshots(project_root: Path) -> None:
         if success:
             logger.info("dbt_snapshots_complete")
         else:
-            logger.warning("dbt_snapshots_failed", output=output[:500])
+            logger.error("dbt_snapshots_failed", output=output[:500])
     except Exception:
-        logger.warning("dbt_snapshots_error", exc_info=True)
+        logger.error("dbt_snapshots_error", exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/dango/utils/sync_history.py
+++ b/dango/utils/sync_history.py
@@ -71,6 +71,22 @@ def get_earliest_start_date(project_root: Path, source_name: str) -> str | None:
         return None
 
 
+def update_last_sync_entry(project_root: Path, source_name: str, updates: dict[str, Any]) -> None:
+    """Update the most recent sync history entry with additional fields."""
+    history_file = get_sync_history_file(project_root, source_name)
+    try:
+        if not history_file.exists():
+            return
+        with open(history_file) as f:
+            history = json.load(f)
+        if history:
+            history[-1].update(updates)
+            with open(history_file, "w") as f:
+                json.dump(history, f, indent=2)
+    except Exception as e:
+        print(f"Warning: Failed to update sync history for {source_name}: {e}")
+
+
 def load_sync_history(
     project_root: Path, source_name: str, limit: int = 10
 ) -> list[dict[str, Any]]:

--- a/tests/unit/test_cloud_credentials.py
+++ b/tests/unit/test_cloud_credentials.py
@@ -211,3 +211,61 @@ class TestSaveDoTokenProjectLevel:
 
         assert cc.get_do_token(project_root=proj_a) == "token-a"
         assert cc.get_do_token(project_root=proj_b) == "token-b"
+
+
+@pytest.mark.unit
+class TestClearDoTokenProjectLevel:
+    """Test project-level clear_do_token()."""
+
+    def test_clears_project_level_token(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """clear_do_token with project_root should remove the project-level token."""
+        import dango.config.cloud_credentials as cc
+
+        # Isolate from real global credentials
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        monkeypatch.setattr(cc, "_CREDENTIALS_DIR", global_dir)
+        monkeypatch.setattr(cc, "_CREDENTIALS_FILE", global_dir / "credentials")
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cc.save_do_token("proj-token", project_root=project)
+
+        assert cc.clear_do_token(project_root=project) is True
+        assert cc.get_do_token(project_root=project) is None
+
+    def test_clear_project_does_not_touch_global(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Clearing project-level should not affect the global credential."""
+        import dango.config.cloud_credentials as cc
+
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        monkeypatch.setattr(cc, "_CREDENTIALS_DIR", global_dir)
+        monkeypatch.setattr(cc, "_CREDENTIALS_FILE", global_dir / "credentials")
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+        cc.save_do_token("global-token")
+        project = tmp_path / "project"
+        project.mkdir()
+        cc.save_do_token("proj-token", project_root=project)
+
+        cc.clear_do_token(project_root=project)
+
+        # Global still present
+        assert cc.get_do_token() == "global-token"
+
+    def test_returns_false_when_no_project_token(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Returns False when no project-level token exists."""
+        import dango.config.cloud_credentials as cc
+
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+        project = tmp_path / "project"
+        project.mkdir()
+
+        assert cc.clear_do_token(project_root=project) is False

--- a/tests/unit/test_cloud_credentials.py
+++ b/tests/unit/test_cloud_credentials.py
@@ -129,3 +129,85 @@ class TestClearDoToken:
         cc.save_do_token("nested-token")
         assert nested.is_dir()
         assert (nested / "credentials").is_file()
+
+
+@pytest.mark.unit
+class TestSaveDoTokenProjectLevel:
+    """Test project-level credential storage (P0-8 fix)."""
+
+    def test_save_to_project_level(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """Passing project_root saves to project/.dango/credentials."""
+        import dango.config.cloud_credentials as cc
+
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+        project = tmp_path / "myproject"
+        project.mkdir()
+
+        cc.save_do_token("proj-token", project_root=project)
+
+        cred_file = project / ".dango" / "credentials"
+        assert cred_file.is_file()
+        mode = stat.S_IMODE(os.stat(cred_file).st_mode)
+        assert mode == 0o600
+
+    def test_save_project_level_does_not_touch_global(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Project-level save should not modify global credentials."""
+        import dango.config.cloud_credentials as cc
+
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        monkeypatch.setattr(cc, "_CREDENTIALS_DIR", global_dir)
+        monkeypatch.setattr(cc, "_CREDENTIALS_FILE", global_dir / "credentials")
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+        # Save global token first
+        cc.save_do_token("global-token")
+
+        # Save project-level token
+        project = tmp_path / "project"
+        project.mkdir()
+        cc.save_do_token("proj-token", project_root=project)
+
+        # Global should still have original token
+        assert cc.get_do_token() == "global-token"
+
+    def test_get_reads_project_level_first(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """get_do_token with project_root should prefer project-level token."""
+        import dango.config.cloud_credentials as cc
+
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        monkeypatch.setattr(cc, "_CREDENTIALS_DIR", global_dir)
+        monkeypatch.setattr(cc, "_CREDENTIALS_FILE", global_dir / "credentials")
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+        # Save different tokens at each level
+        cc.save_do_token("global-token")
+        project = tmp_path / "project"
+        project.mkdir()
+        cc.save_do_token("proj-token", project_root=project)
+
+        # Project-level should win
+        assert cc.get_do_token(project_root=project) == "proj-token"
+        # Without project_root, global is returned
+        assert cc.get_do_token() == "global-token"
+
+    def test_two_projects_different_tokens(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        """Two projects should have independent tokens."""
+        import dango.config.cloud_credentials as cc
+
+        monkeypatch.delenv("DIGITALOCEAN_TOKEN", raising=False)
+
+        proj_a = tmp_path / "project_a"
+        proj_a.mkdir()
+        proj_b = tmp_path / "project_b"
+        proj_b.mkdir()
+
+        cc.save_do_token("token-a", project_root=proj_a)
+        cc.save_do_token("token-b", project_root=proj_b)
+
+        assert cc.get_do_token(project_root=proj_a) == "token-a"
+        assert cc.get_do_token(project_root=proj_b) == "token-b"

--- a/tests/unit/test_dbt_generator.py
+++ b/tests/unit/test_dbt_generator.py
@@ -1,11 +1,13 @@
 """tests/unit/test_dbt_generator.py
 
-Tests for DbtModelGenerator nested table discovery (BUG-152).
+Tests for DbtModelGenerator nested table discovery (BUG-152) and
+sources/stg yml protection (P0-2).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import duckdb
 import pytest
@@ -62,3 +64,90 @@ class TestFindDltNestedTable:
 
         result = gen._find_dlt_nested_table("parent_child_grandchild", "raw_src")
         assert result == "parent__child__grandchild"
+
+
+def _make_generator_mocked(tmp_path: Path):
+    """Create a DbtModelGenerator with DuckDB connection mocked out."""
+    with patch("duckdb.connect"):
+        from dango.transformation.generator import DbtModelGenerator
+
+        gen = DbtModelGenerator(tmp_path)
+
+    gen.staging_dir.mkdir(parents=True, exist_ok=True)
+    return gen
+
+
+@pytest.mark.unit
+class TestSourcesYmlProtection:
+    """Test that sources_*.yml is not overwritten when it already exists (P0-2)."""
+
+    def _setup_source_mocks(self, gen, source_name: str = "my_source"):
+        """Set up common mocks for a source going through generate_all_models."""
+        source = MagicMock()
+        source.name = source_name
+        source.source_type = MagicMock()
+        source.source_type.value = "csv"
+
+        gen._get_source_endpoints = MagicMock(return_value=["orders"])
+        gen.get_table_schema = MagicMock(return_value=[{"name": "id", "type": "INTEGER"}])
+        gen.infer_dedup_strategy = MagicMock(return_value=(None, []))
+        gen.generate_staging_model = MagicMock(return_value="-- model sql")
+        gen.generate_sources_yml = MagicMock(return_value="version: 2\nsources:\n")
+        gen.generate_staging_schema_yml = MagicMock(return_value="version: 2\nmodels:\n")
+        gen._enrich_columns_from_profiling = MagicMock()
+        return source
+
+    def test_sources_yml_not_overwritten_when_exists(self, tmp_path: Path) -> None:
+        """Existing sources_*.yml should NOT be overwritten by generate."""
+        gen = _make_generator_mocked(tmp_path)
+        source = self._setup_source_mocks(gen)
+
+        # Create an existing sources file with custom content
+        sources_file = gen.staging_dir / f"sources_{source.name}.yml"
+        custom_content = "# User-customized sources config\nversion: 2\n"
+        sources_file.write_text(custom_content)
+
+        gen.generate_all_models(
+            sources=[source],
+            skip_customized=False,
+            generate_schema_yml=True,
+        )
+
+        # Verify the file was NOT overwritten
+        assert sources_file.read_text() == custom_content
+        # generate_sources_yml should NOT have been called
+        gen.generate_sources_yml.assert_not_called()
+
+    def test_sources_yml_created_when_missing(self, tmp_path: Path) -> None:
+        """sources_*.yml should be created when it doesn't exist."""
+        gen = _make_generator_mocked(tmp_path)
+        source = self._setup_source_mocks(gen, "new_source")
+
+        gen.generate_all_models(
+            sources=[source],
+            skip_customized=False,
+            generate_schema_yml=True,
+        )
+
+        sources_file = gen.staging_dir / "sources_new_source.yml"
+        assert sources_file.exists()
+        assert sources_file.read_text() == "version: 2\nsources:\n"
+
+    def test_stg_yml_protection_still_works(self, tmp_path: Path) -> None:
+        """Existing stg_*.yml should also NOT be overwritten (regression check)."""
+        gen = _make_generator_mocked(tmp_path)
+        source = self._setup_source_mocks(gen)
+
+        # Create an existing stg file
+        stg_file = gen.staging_dir / f"stg_{source.name}.yml"
+        custom_stg = "# Custom staging schema\nversion: 2\n"
+        stg_file.write_text(custom_stg)
+
+        gen.generate_all_models(
+            sources=[source],
+            skip_customized=False,
+            generate_schema_yml=True,
+        )
+
+        # stg file should be unchanged
+        assert stg_file.read_text() == custom_stg

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -668,3 +668,87 @@ class TestGetSchedulerStatus:
             app.state.scheduler = original_scheduler
 
         assert result2["running"] is False
+
+
+@pytest.mark.unit
+class TestSchedulerScheduleLoading:
+    """Test that start() loads schedules from schedules.yml."""
+
+    def test_start_loads_schedules_from_config(self, tmp_path):
+        """start() should call load_schedules_config and reload_schedules."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        mock_config = MagicMock()
+        mock_schedule = MagicMock()
+        mock_config.schedules = [mock_schedule]
+        mock_result = MagicMock()
+        mock_result.added = ["schedule:my-sync"]
+
+        with (
+            patch(
+                "dango.config.schedules.load_schedules_config", return_value=mock_config
+            ) as mock_load,
+            patch(
+                "dango.config.schedules.reload_schedules", return_value=mock_result
+            ) as mock_reload,
+        ):
+            svc.start(loop)
+
+        mock_load.assert_called_once_with(tmp_path)
+        mock_reload.assert_called_once_with(svc, [mock_schedule], tmp_path)
+
+    def test_start_handles_missing_schedules_file(self, tmp_path):
+        """start() should not crash when schedules.yml is missing (empty config)."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        mock_config = MagicMock()
+        mock_config.schedules = []
+
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=mock_config),
+            patch("dango.config.schedules.reload_schedules") as mock_reload,
+        ):
+            svc.start(loop)
+
+        # reload_schedules should NOT be called when no schedules
+        mock_reload.assert_not_called()
+
+    def test_start_handles_schedules_load_error(self, tmp_path):
+        """start() should catch exceptions and still complete startup."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        with patch(
+            "dango.config.schedules.load_schedules_config",
+            side_effect=RuntimeError("YAML parse error"),
+        ):
+            # Should not raise
+            svc.start(loop)
+
+        # Scheduler should still be marked as started
+        assert svc._started is True
+
+    def test_start_logs_schedule_count(self, tmp_path):
+        """start() should log the number of loaded schedules."""
+        svc = _make_service(tmp_path)
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+
+        mock_config = MagicMock()
+        mock_config.schedules = [MagicMock(), MagicMock()]
+        mock_result = MagicMock()
+        mock_result.added = ["schedule:s1"]
+
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=mock_config),
+            patch("dango.config.schedules.reload_schedules", return_value=mock_result),
+            patch(f"{_SCHEDULER_MOD}.logger") as mock_logger,
+        ):
+            svc.start(loop)
+
+        # Check that schedules_loaded was logged
+        info_calls = [c for c in mock_logger.info.call_args_list if c[0][0] == "schedules_loaded"]
+        assert len(info_calls) == 1
+        assert info_calls[0][1]["added"] == 1
+        assert info_calls[0][1]["skipped_disabled"] == 1

--- a/tests/unit/test_sync_history.py
+++ b/tests/unit/test_sync_history.py
@@ -1,0 +1,78 @@
+"""tests/unit/test_sync_history.py
+
+Tests for dango.utils.sync_history — update_last_sync_entry().
+"""
+
+import json
+
+import pytest
+
+
+@pytest.mark.unit
+class TestUpdateLastSyncEntry:
+    """Test update_last_sync_entry() for adding fields to the most recent entry."""
+
+    def test_adds_field_to_last_entry(self, tmp_path):
+        """Should add transform_error to the most recent history entry."""
+        from dango.utils.sync_history import (
+            save_sync_history_entry,
+            update_last_sync_entry,
+        )
+
+        save_sync_history_entry(tmp_path, "my_source", {"status": "success", "rows": 100})
+        save_sync_history_entry(tmp_path, "my_source", {"status": "success", "rows": 200})
+
+        update_last_sync_entry(tmp_path, "my_source", {"transform_error": "dbt failed"})
+
+        history_file = tmp_path / ".dango" / "history" / "my_source.json"
+        with open(history_file) as f:
+            history = json.load(f)
+
+        # Only the last entry should have transform_error
+        assert "transform_error" not in history[0]
+        assert history[1]["transform_error"] == "dbt failed"
+        # Original fields preserved
+        assert history[1]["rows"] == 200
+
+    def test_no_crash_when_file_missing(self, tmp_path):
+        """Should silently return when history file doesn't exist."""
+        from dango.utils.sync_history import update_last_sync_entry
+
+        # Should not raise
+        update_last_sync_entry(tmp_path, "nonexistent", {"transform_error": "dbt failed"})
+
+    def test_no_crash_on_empty_history(self, tmp_path):
+        """Should handle empty history list gracefully."""
+        from dango.utils.sync_history import get_sync_history_file, update_last_sync_entry
+
+        history_file = get_sync_history_file(tmp_path, "empty_source")
+        with open(history_file, "w") as f:
+            json.dump([], f)
+
+        # Should not raise
+        update_last_sync_entry(tmp_path, "empty_source", {"transform_error": "dbt failed"})
+
+        with open(history_file) as f:
+            history = json.load(f)
+        assert history == []
+
+    def test_preserves_existing_fields(self, tmp_path):
+        """Existing fields in the entry should not be removed."""
+        from dango.utils.sync_history import (
+            save_sync_history_entry,
+            update_last_sync_entry,
+        )
+
+        save_sync_history_entry(tmp_path, "src", {"status": "success", "rows": 50, "duration": 3.5})
+
+        update_last_sync_entry(tmp_path, "src", {"transform_error": "column missing"})
+
+        history_file = tmp_path / ".dango" / "history" / "src.json"
+        with open(history_file) as f:
+            history = json.load(f)
+
+        entry = history[0]
+        assert entry["status"] == "success"
+        assert entry["rows"] == 50
+        assert entry["duration"] == 3.5
+        assert entry["transform_error"] == "column missing"


### PR DESCRIPTION
## Summary

Fixes 4 P0 bugs blocking core Dango workflows (beta fix session 1):

- **P0-1: Scheduler never loads jobs from schedules.yml at startup** — `SchedulerService.start()` now calls `load_schedules_config()` + `reload_schedules()` after the APScheduler start, with error handling so a bad YAML never blocks startup.
- **P0-2: sources_*.yml overwritten on every sync** — Added `if not sources_file.exists()` guard matching the existing `stg_*.yml` protection pattern.
- **P0-7: dbt transform failures logged at wrong level / hidden** — Changed WARNING→ERROR in `post_sync.py`, DEBUG→ERROR in `dlt_runner.py`, dim→red console output, and added `update_last_sync_entry()` to persist `transform_error` in sync history.
- **P0-8: save_do_token() always overwrites global credential** — Added `project_root` parameter to `save_do_token()` for project-level credential storage; updated both callers in `deploy_wizard.py`.

## Test plan

- [x] 15 new unit tests covering all 4 fixes
- [x] 3590 unit tests pass (0 failures, 0 regressions)
- [x] `ruff check dango/` — all checks passed
- [ ] Manual: `dango start` with schedules.yml → `dango schedule status` shows jobs (P0-1)
- [ ] Manual: edit `sources_*.yml`, run sync, verify edits preserved (P0-2)
- [ ] Manual: break dbt SQL, sync, verify ERROR in logs + red output (P0-7)
- [ ] Manual: `dango deploy` from two projects, verify separate tokens (P0-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)