### PR TITLE
Fix UX and reliability issues from beta testing

### DIFF
--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -176,8 +176,10 @@ def start(ctx: click.Context, yes: bool) -> None:
             try:
                 os.kill(stale_pid, 0)
                 # Process is alive — existing server running, port check will catch it
-            except OSError:
-                # Process is dead — stale PID file
+            except ProcessLookupError:
+                # Process is dead (ESRCH) — stale PID file
+                # Note: PermissionError (EPERM) means the process exists but is
+                # owned by another user — let the port-conflict check handle it.
                 console.print("  Server was stopped. Restarting...")
                 remove_pid_file(project_root)
                 console.print()

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -6,7 +6,6 @@ Platform lifecycle commands (start, stop, status) and port helpers.
 import click
 
 from dango.cli import console
-from dango.cli.utils import safe_confirm
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
@@ -167,6 +166,22 @@ def start(ctx: click.Context, yes: bool) -> None:
     try:
         project_root = require_project_context(ctx)
 
+        # Detect stale PID file from a previous crash
+        from ..helpers.process_manager import read_pid_file, remove_pid_file
+
+        stale_pid = read_pid_file(project_root)
+        if stale_pid is not None:
+            import os
+
+            try:
+                os.kill(stale_pid, 0)
+                # Process is alive — existing server running, port check will catch it
+            except OSError:
+                # Process is dead — stale PID file
+                console.print("  Server was stopped. Restarting...")
+                remove_pid_file(project_root)
+                console.print()
+
         # Guard rail: inform if this looks like a cloned project
         sources_file = project_root / ".dango" / "sources.yml"
         dango_db = project_root / ".dango" / "dango.db"
@@ -184,19 +199,12 @@ def start(ctx: click.Context, yes: bool) -> None:
         project_name = config.project.name
         platform_config = config.platform
 
-        # Guard rail: warn if project is deployed to cloud
-        if not yes:
-            cloud_cfg = config_loader.load_cloud_config()
-            if cloud_cfg and cloud_cfg.droplet_ip:
-                target = cloud_cfg.domain or cloud_cfg.droplet_ip
-                console.print(f"[yellow]  This project is deployed to {target}.[/yellow]")
-                console.print(
-                    "[yellow]   Starting locally will run a SEPARATE instance. "
-                    "Your cloud server is unaffected.[/yellow]"
-                )
-                if not safe_confirm("Continue?", default=True):
-                    raise click.Abort()
-                console.print()
+        # Informational note if project is also deployed to cloud
+        cloud_cfg = config_loader.load_cloud_config()
+        if cloud_cfg and cloud_cfg.droplet_ip:
+            target = cloud_cfg.domain or cloud_cfg.droplet_ip
+            console.print(f"  \u2139 Also deployed to {target}. Local and cloud are independent.")
+            console.print()
 
         # Version alignment check — abort early if Python DuckDB ≠ driver major.minor
         # Must run BEFORE any DuckDB write operations (migrations, schema setup)

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -666,7 +666,9 @@ def sync(
         # Informational note if project is also deployed to cloud
         cloud_cfg = ConfigLoader(project_root).load_cloud_config()
         if cloud_cfg and cloud_cfg.droplet_ip:
-            console.print("  \u2139 Syncing locally. Use `dango remote push` to update cloud.")
+            console.print(
+                "  \u2139 Syncing locally. Use `dango remote sync <source>` to sync on cloud."
+            )
             console.print()
 
         # --- Validate option conflicts (before lock — fast failures) ---

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -663,20 +663,11 @@ def sync(
         # Get project context
         project_root = require_project_context(ctx)
 
-        # Guard rail: warn if project is deployed to cloud
-        # Placed before lock so user doesn't wait for lock if they'll cancel.
-        if not yes:
-            cloud_cfg = ConfigLoader(project_root).load_cloud_config()
-            if cloud_cfg and cloud_cfg.droplet_ip:
-                target = cloud_cfg.domain or cloud_cfg.droplet_ip
-                console.print(f"[yellow]  This project is deployed to {target}.[/yellow]")
-                console.print(
-                    "[yellow]   `dango sync` syncs data LOCALLY, not on your cloud server.[/yellow]"
-                )
-                console.print("[yellow]   Use `dango remote sync` for cloud.[/yellow]")
-                if not safe_confirm("Continue?", default=False):
-                    raise click.Abort()
-                console.print()
+        # Informational note if project is also deployed to cloud
+        cloud_cfg = ConfigLoader(project_root).load_cloud_config()
+        if cloud_cfg and cloud_cfg.droplet_ip:
+            console.print("  \u2139 Syncing locally. Use `dango remote push` to update cloud.")
+            console.print()
 
         # --- Validate option conflicts (before lock — fast failures) ---
         if backfill and (since or until):

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -168,7 +168,8 @@ class SourceWizard:
                     # NOW we have source_name, so we can save instance-specific credentials
                     oauth_result = self._handle_oauth_setup(source_type, source_name, metadata)
                     if oauth_result == "back":
-                        # User wants to go back - return to name prompt
+                        # User chose "Back to source selection"
+                        state = "source"
                         continue
                     elif oauth_result == "cancel":
                         return False
@@ -744,11 +745,17 @@ class SourceWizard:
             if action == "Cancel source setup":
                 return "cancel"
             elif action == "Re-enter credentials and retry":
-                # Clear cached .env credentials so Google provider re-prompts
+                # Clear cached credentials from both os.environ AND .env file
                 import os
+
+                from dotenv import unset_key
 
                 os.environ.pop("GOOGLE_CLIENT_ID", None)
                 os.environ.pop("GOOGLE_CLIENT_SECRET", None)
+                env_file = self.project_root / ".env"
+                if env_file.exists():
+                    unset_key(str(env_file), "GOOGLE_CLIENT_ID")
+                    unset_key(str(env_file), "GOOGLE_CLIENT_SECRET")
                 console.print("\n[cyan]Re-entering credentials...[/cyan]\n")
                 continue
             else:  # Retry
@@ -1250,6 +1257,29 @@ def {module_name}_resource(api_key: str):
                     break
             if headers_dict:
                 params["headers"] = headers_dict
+
+        # 3c. Credential validation — test base URL with saved credentials
+        if auth_type != "none":
+            console.print("\n[dim]Testing API credentials...[/dim]")
+            status_code, _body, error = self._test_rest_api_endpoint(
+                base_url=base_url,
+                path="/",
+                auth_type=auth_type,
+                params_dict=params,
+                source_headers=params.get("headers"),
+            )
+            if error:
+                console.print(f"  [yellow]\u26a0 Credential test failed: {error}[/yellow]")
+                if not Confirm.ask("Continue anyway?", default=True):
+                    return None
+            elif status_code is not None and status_code >= 400:
+                console.print(
+                    f"  [yellow]\u26a0 Credential test returned HTTP {status_code}[/yellow]"
+                )
+                if not Confirm.ask("Continue anyway?", default=True):
+                    return None
+            elif status_code is not None:
+                console.print(f"  [green]\u2713 API responded (HTTP {status_code})[/green]")
 
         # 4. Endpoint collection
         console.print("\n[bold]API Endpoints[/bold]")

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -1259,6 +1259,8 @@ def {module_name}_resource(api_key: str):
                 params["headers"] = headers_dict
 
         # 3c. Credential validation — test base URL with saved credentials
+        # Only flag auth failures (401/403) or connection errors. Other status
+        # codes (404, 200, etc.) just mean the API is reachable.
         if auth_type != "none":
             console.print("\n[dim]Testing API credentials...[/dim]")
             status_code, _body, error = self._test_rest_api_endpoint(
@@ -1269,15 +1271,15 @@ def {module_name}_resource(api_key: str):
                 source_headers=params.get("headers"),
             )
             if error:
-                console.print(f"  [yellow]\u26a0 Credential test failed: {error}[/yellow]")
-                if not Confirm.ask("Continue anyway?", default=True):
-                    return None
-            elif status_code is not None and status_code >= 400:
+                console.print(f"  [yellow]\u26a0 Could not reach API: {error}[/yellow]")
+                console.print("  [dim]The API may be temporarily down.[/dim]")
+            elif status_code is not None and status_code in (401, 403):
                 console.print(
-                    f"  [yellow]\u26a0 Credential test returned HTTP {status_code}[/yellow]"
+                    f"  [yellow]\u26a0 Authentication failed (HTTP {status_code})[/yellow]"
                 )
-                if not Confirm.ask("Continue anyway?", default=True):
-                    return None
+                if Confirm.ask("Re-enter credentials?", default=True):
+                    # Re-prompt for the auth credential(s) that were just saved
+                    self._reenter_rest_credentials(auth_type, params, source_name)
             elif status_code is not None:
                 console.print(f"  [green]\u2713 API responded (HTTP {status_code})[/green]")
 
@@ -1493,6 +1495,40 @@ def {module_name}_resource(api_key: str):
 
         console.print(f"  [green]✓[/green] Saved {env_var_name} to .env")
         return value
+
+    def _reenter_rest_credentials(
+        self,
+        auth_type: str,
+        params: dict[str, Any],
+        source_name: str,
+    ) -> None:
+        """Re-prompt for REST API credentials after a failed auth test."""
+        if auth_type == "bearer":
+            env_var = params.get("auth_token_env", "")
+            if env_var:
+                self._prompt_and_save_credential(env_var, "Bearer token value")
+        elif auth_type == "api_key":
+            env_var = params.get("auth_token_env", "")
+            if env_var:
+                self._prompt_and_save_credential(env_var, "API key value")
+        elif auth_type == "basic":
+            u_env = params.get("basic_username_env", "")
+            p_env = params.get("basic_password_env", "")
+            if u_env:
+                self._prompt_and_save_credential(u_env, "Username", is_secret=False)
+            if p_env:
+                self._prompt_and_save_credential(p_env, "Password")
+        elif auth_type == "oauth2_client_credentials":
+            id_env = params.get("client_id_env", "")
+            secret_env = params.get("client_secret_env", "")
+            if id_env:
+                self._prompt_and_save_credential(id_env, "Client ID", is_secret=False)
+            if secret_env:
+                self._prompt_and_save_credential(secret_env, "Client secret")
+        elif auth_type == "custom_header":
+            env_var = params.get("auth_token_env", "")
+            if env_var:
+                self._prompt_and_save_credential(env_var, "Token value")
 
     def _test_rest_api_endpoint(
         self,

--- a/dango/config/helpers.py
+++ b/dango/config/helpers.py
@@ -84,14 +84,38 @@ def is_cloud_mode(project_root: Path) -> bool:
     Returns True if the ``DANGO_CLOUD_MODE`` environment variable is set to
     ``"true"`` (used on the server where ``cloud.yml`` does not exist), or if
     ``.dango/cloud.yml`` exists locally and contains a ``droplet_ip``.
-    """
-    import os
 
-    if os.environ.get("DANGO_CLOUD_MODE") == "true":
-        return True
+    .. note::
+
+       This conflates two questions: "has this project been deployed?" and
+       "am I running on the cloud server?". Prefer :func:`has_cloud_deployment`
+       or :func:`is_running_on_cloud` when you need to distinguish.
+    """
+    return is_running_on_cloud() or has_cloud_deployment(project_root)
+
+
+def has_cloud_deployment(project_root: Path) -> bool:
+    """Check if this project has been deployed to a cloud server.
+
+    Returns True if ``.dango/cloud.yml`` exists and contains a ``droplet_ip``.
+    This does NOT mean the current process is running on the cloud — it may be
+    running locally on a machine that has deployed to cloud.
+    """
     loader = ConfigLoader(project_root)
     cloud_cfg: CloudConfig | None = loader.load_cloud_config()
     return cloud_cfg is not None and cloud_cfg.droplet_ip is not None
+
+
+def is_running_on_cloud() -> bool:
+    """Check if the current process is running on a cloud server.
+
+    Returns True only if the ``DANGO_CLOUD_MODE`` environment variable is
+    set to ``"true"``. This env var is set by the systemd unit on cloud
+    servers.
+    """
+    import os
+
+    return os.environ.get("DANGO_CLOUD_MODE") == "true"
 
 
 def get_cloud_origin(project_root: Path) -> str | None:

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -27,11 +27,11 @@ _IDLE_TIMEOUT_CLOUD = 3600  # 1 hour
 _IDLE_TIMEOUT = _IDLE_TIMEOUT_LOCAL  # backward compat for smoke test
 
 
-def _get_idle_timeout(project_root: Path) -> int:
+def _get_idle_timeout(project_root: Path) -> int:  # noqa: ARG001
     """Return the idle timeout in seconds based on deployment mode."""
-    from dango.config.helpers import is_cloud_mode
+    from dango.config.helpers import is_running_on_cloud
 
-    if is_cloud_mode(project_root):
+    if is_running_on_cloud():
         return _IDLE_TIMEOUT_CLOUD
     return _IDLE_TIMEOUT_LOCAL
 
@@ -152,9 +152,9 @@ def start_marimo(
         ]
 
         # Add base-url for cloud proxy so SPA assets use correct prefix
-        from dango.config.helpers import is_cloud_mode
+        from dango.config.helpers import is_running_on_cloud
 
-        if is_cloud_mode(project_root):
+        if is_running_on_cloud():
             cmd.extend(["--base-url", "/notebooks/marimo"])
 
         cmd.append(str(notebooks_dir))

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -132,7 +132,9 @@ async def get_platform_health() -> dict[str, Any]:
     warnings: list[str] = []
 
     project_root = Path(get_project_root())
-    is_cloud = (project_root / ".dango" / "cloud.yml").exists()
+    from dango.config.helpers import is_running_on_cloud
+
+    is_cloud = is_running_on_cloud()
 
     if disk["status"] == "critical":
         critical_issues.append("Critical disk space")
@@ -264,23 +266,11 @@ def _get_scheduler_status() -> dict[str, Any]:
 async def _get_cloud_health_data() -> dict[str, Any] | None:
     """Collect cloud-specific health data if running on a cloud server.
 
-    Returns None if not a cloud deployment.
+    Returns None if not running on a cloud server (i.e. DANGO_CLOUD_MODE != true).
     """
-    project_root = get_project_root()
-    cloud_yml = Path(project_root) / ".dango" / "cloud.yml"
+    from dango.config.helpers import is_running_on_cloud
 
-    if not cloud_yml.exists():
-        return None
-
-    # Check if it has a droplet_ip (actual deployment vs empty config)
-    try:
-        from dango.config.loader import ConfigLoader
-
-        loader = ConfigLoader(project_root)
-        cloud_cfg = loader.load_cloud_config()
-        if cloud_cfg is None or cloud_cfg.droplet_ip is None:
-            return None
-    except Exception:  # noqa: BLE001
+    if not is_running_on_cloud():
         return None
 
     # Collect local resource usage in a thread to avoid blocking the event loop

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -405,9 +405,8 @@ async def lock_notebook(
     port = status.get("port") or _DEFAULT_MARIMO_PORT  # type: ignore[assignment]
 
     # BUG-241: Cloud mode routes through FastAPI notebook proxy (auth-protected).
-    # TODO(R12-M): Marimo needs --base-url /notebooks/marimo for subpath
-    # proxying to work correctly (asset paths, WebSocket URL). Add the flag
-    # in manager.py start_marimo() when is_cloud_mode(). Verify on cloud VM.
+    # --base-url /notebooks/marimo is set in manager.py start_marimo() when
+    # is_running_on_cloud(). TODO(R12-M): Verify on cloud VM.
     from dango.config.helpers import is_running_on_cloud
 
     if is_running_on_cloud():

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -408,9 +408,9 @@ async def lock_notebook(
     # TODO(R12-M): Marimo needs --base-url /notebooks/marimo for subpath
     # proxying to work correctly (asset paths, WebSocket URL). Add the flag
     # in manager.py start_marimo() when is_cloud_mode(). Verify on cloud VM.
-    from dango.config.helpers import is_cloud_mode
+    from dango.config.helpers import is_running_on_cloud
 
-    if is_cloud_mode(project_root):
+    if is_running_on_cloud():
         marimo_url = f"/notebooks/marimo/?file={name}.py"
     else:
         marimo_url = f"http://localhost:{port}/?file={name}.py"

--- a/tests/unit/test_cli_start_guardrails.py
+++ b/tests/unit/test_cli_start_guardrails.py
@@ -88,24 +88,8 @@ class TestStartGuardRails:
         plain = _ANSI_RE.sub("", result.output)
         assert "cloned project" not in plain.lower()
 
-    def test_cloud_warning_shown_and_cancelled(self, tmp_path: Path) -> None:
-        """Cloud warning is shown and start aborts when user says 'n'."""
-        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
-        mock_loader = _make_config_loader(cloud_config=cloud_cfg)
-        runner = CliRunner()
-        with (
-            patch("dango.cli.utils.require_project_context", return_value=tmp_path),
-            patch("dango.config.ConfigLoader", mock_loader),
-        ):
-            result = runner.invoke(start, [], obj={"project_root": str(tmp_path)}, input="n\n")
-
-        plain = _ANSI_RE.sub("", result.output)
-        assert "deployed to 1.2.3.4" in plain
-        assert "SEPARATE instance" in plain
-        assert result.exit_code != 0
-
-    def test_cloud_warning_skipped_with_yes(self, tmp_path: Path) -> None:
-        """Cloud warning is skipped with --yes flag."""
+    def test_cloud_info_shown_as_note(self, tmp_path: Path) -> None:
+        """Cloud deployment shown as informational note (no blocking prompt)."""
         cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
         mock_loader = _make_config_loader(cloud_config=cloud_cfg)
         runner = CliRunner()
@@ -114,7 +98,8 @@ class TestStartGuardRails:
             patch("dango.config.ConfigLoader", mock_loader),
             patch("dango.platform.common.startup.check_duckdb_version_alignment"),
         ):
-            result = runner.invoke(start, ["--yes"], obj={"project_root": str(tmp_path)})
+            result = runner.invoke(start, [], obj={"project_root": str(tmp_path)})
 
         plain = _ANSI_RE.sub("", result.output)
-        assert "deployed to" not in plain
+        assert "deployed to 1.2.3.4" in plain
+        assert "independent" in plain.lower()

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -271,7 +271,7 @@ class TestSyncGuardRails:
         result = self._invoke(["--dry-run"], cloud_config=cloud_cfg)
         plain = _ANSI_RE.sub("", result.output)
         assert "Syncing locally" in plain
-        assert "dango remote push" in plain
+        assert "dango remote sync" in plain
         assert result.exit_code == 0
 
     def test_cloud_info_not_shown_without_cloud(self) -> None:

--- a/tests/unit/test_cli_sync.py
+++ b/tests/unit/test_cli_sync.py
@@ -265,35 +265,20 @@ class TestSyncGuardRails:
             for p in patches:
                 p.stop()
 
-    def test_cloud_warning_shown_and_cancelled(self) -> None:
-        """Cloud warning is shown and sync aborts when user says 'n'."""
+    def test_cloud_info_shown_as_note(self) -> None:
+        """Cloud deployment shown as informational note (no blocking prompt)."""
         cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
-        result = self._invoke_with_input(["--dry-run"], input_text="n\n", cloud_config=cloud_cfg)
+        result = self._invoke(["--dry-run"], cloud_config=cloud_cfg)
         plain = _ANSI_RE.sub("", result.output)
-        assert "deployed to 1.2.3.4" in plain
-        assert "dango remote sync" in plain
-        assert result.exit_code != 0
-
-    def test_cloud_warning_shows_domain(self) -> None:
-        """Cloud warning shows domain when configured."""
-        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4", domain="data.example.com")
-        result = self._invoke_with_input(["--dry-run"], input_text="n\n", cloud_config=cloud_cfg)
-        plain = _ANSI_RE.sub("", result.output)
-        assert "deployed to data.example.com" in plain
-
-    def test_cloud_warning_skipped_with_yes(self) -> None:
-        """Cloud warning is skipped with --yes flag."""
-        cloud_cfg = _make_cloud_config(droplet_ip="1.2.3.4")
-        result = self._invoke(["--dry-run", "--yes"], cloud_config=cloud_cfg)
-        plain = _ANSI_RE.sub("", result.output)
-        assert "deployed to" not in plain
+        assert "Syncing locally" in plain
+        assert "dango remote push" in plain
         assert result.exit_code == 0
 
-    def test_cloud_warning_not_shown_without_cloud(self) -> None:
-        """No cloud warning when project is not deployed."""
+    def test_cloud_info_not_shown_without_cloud(self) -> None:
+        """No cloud note when project is not deployed."""
         result = self._invoke(["--dry-run"], cloud_config=None)
         plain = _ANSI_RE.sub("", result.output)
-        assert "deployed to" not in plain
+        assert "Syncing locally" not in plain
         assert result.exit_code == 0
 
     def test_first_sync_shown_when_no_warehouse(self) -> None:

--- a/tests/unit/test_notebook_manager.py
+++ b/tests/unit/test_notebook_manager.py
@@ -301,15 +301,15 @@ class TestStopIdleChecker:
 class TestGetIdleTimeout:
     """Tests for _get_idle_timeout() deployment mode logic."""
 
-    @patch("dango.config.helpers.is_cloud_mode", return_value=False)
+    @patch("dango.config.helpers.is_running_on_cloud", return_value=False)
     def test_local_mode_returns_7200(self, mock_cloud: MagicMock) -> None:
         from dango.notebooks.manager import _get_idle_timeout
 
         result = _get_idle_timeout(Path("/fake"))
         assert result == 7200
-        mock_cloud.assert_called_once_with(Path("/fake"))
+        mock_cloud.assert_called_once()
 
-    @patch("dango.config.helpers.is_cloud_mode", return_value=True)
+    @patch("dango.config.helpers.is_running_on_cloud", return_value=True)
     def test_cloud_mode_returns_3600(self, mock_cloud: MagicMock) -> None:
         from dango.notebooks.manager import _get_idle_timeout
 
@@ -324,7 +324,7 @@ class TestStartMarimoCloudBaseUrl:
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=3600)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
-    @patch("dango.config.helpers.is_cloud_mode", return_value=True)
+    @patch("dango.config.helpers.is_running_on_cloud", return_value=True)
     def test_cloud_mode_adds_base_url(
         self,
         mock_cloud: MagicMock,
@@ -352,7 +352,7 @@ class TestStartMarimoCloudBaseUrl:
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
-    @patch("dango.config.helpers.is_cloud_mode", return_value=False)
+    @patch("dango.config.helpers.is_running_on_cloud", return_value=False)
     def test_local_mode_no_base_url(
         self,
         mock_cloud: MagicMock,

--- a/tests/unit/test_web_health.py
+++ b/tests/unit/test_web_health.py
@@ -163,13 +163,10 @@ class TestDiskWarningDeduplication:
     ) -> None:
         """Cloud deployment → 80% message suggests resizing."""
         mock_data.return_value = _base_health_data(disk_status="warning", used_pct=85)
-        # Create cloud.yml to simulate cloud deployment
-        (tmp_path / ".dango").mkdir(parents=True, exist_ok=True)
-        (tmp_path / ".dango" / "cloud.yml").write_text("droplet_ip: 1.2.3.4\n")
         app = _make_app(tmp_path)
         client = TestClient(app)
 
-        with patch("dango.web.routes.health.get_project_root", return_value=tmp_path):
+        with patch.dict("os.environ", {"DANGO_CLOUD_MODE": "true"}):
             resp = client.get("/api/health/platform")
         body = resp.json()
 


### PR DESCRIPTION
## Summary

- **Stale PID detection:** `dango start` checks if `.dango/web.pid` references a dead process, prints "Server was stopped. Restarting..." and cleans up the stale file
- **Remove blocking cloud prompts:** `dango start` and `dango sync` replace Confirm dialogs with one-line informational notes when a cloud deployment exists — no more friction on restart
- **Split cloud mode detection:** New `has_cloud_deployment()` (cloud.yml exists) and `is_running_on_cloud()` (DANGO_CLOUD_MODE env var) replace the conflated `is_cloud_mode()`. Health page backup/resource/deployment sections now only show on cloud servers, not locally after deploy
- **Fix OAuth "back" routing:** `_handle_oauth_setup` returning "back" now correctly routes to source selection, not name prompt
- **Fix Google OAuth .env caching:** "Re-enter credentials" calls `unset_key()` to remove stale values from `.env`, not just `os.environ`
- **REST API credential validation:** After saving credentials for REST API sources, tests the base URL with saved auth. Warns on failure but doesn't block (API may be temporarily down)

## Test plan

- [x] `pytest -x` — all 3696 tests pass
- [ ] Manual: `dango start` with stale PID file
- [ ] Manual: `dango start` / `dango sync` with cloud.yml present
- [ ] Manual: `dango source add` REST API source with bad credentials
- [ ] Manual: `dango source add` Google source → re-enter credentials flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)