### PR TITLE
Fix 5 health & logic bugs (fix round 3, Session H)

### DIFF
--- a/dango/cli/commands/data.py
+++ b/dango/cli/commands/data.py
@@ -178,12 +178,12 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
         # Connect to database
         conn = duckdb.connect(str(duckdb_path))
 
-        # Get all tables from relevant schemas (without row counts first)
-        # Include: raw, raw_*, staging, intermediate, marts
+        # Get all tables from raw schemas (without row counts first)
+        # Include: raw, raw_*
         tables = conn.execute("""
             SELECT table_schema, table_name
             FROM information_schema.tables
-            WHERE table_schema IN ('raw', 'staging', 'intermediate', 'marts')
+            WHERE table_schema = 'raw'
                OR table_schema LIKE 'raw_%'
             ORDER BY table_schema, table_name
         """).fetchall()
@@ -220,9 +220,9 @@ def db_clean(ctx: click.Context, yes: bool) -> None:
                 schema, table, schema_to_tables, source_to_schema, actual_raw_tables
             ):
                 orphaned_tables.append((schema, table, size))
-            # Note: We do NOT clean intermediate or marts tables
-            # These are custom models created by users with dango model add
-            # and should not be automatically deleted
+            # Note: Only raw schemas are in scope for cleanup.
+            # staging/intermediate/marts contain dbt models and should
+            # not be automatically deleted.
 
         if not orphaned_tables:
             console.print("[green]✅ No orphaned tables found[/green]")

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -657,7 +657,7 @@ def start(ctx: click.Context, yes: bool) -> None:
         console.print("[dim]Waiting for services to be ready...[/dim]")
 
         # Wait for both FastAPI and Metabase to be ready
-        max_wait = 45
+        max_wait = 60
         fastapi_ready = False
         metabase_ready = False
 

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -269,13 +269,11 @@ def get_duckdb_capacity(duckdb_path: Path, project_root: Path) -> dict[str, Any]
 
         # System resources
         disk = shutil.disk_usage(project_root)
-        disk_free_bytes = disk.free
+        disk_total_bytes = disk.total
         ram_bytes = psutil.virtual_memory().total
 
-        # Recommended max: min(4x RAM, 80% of free disk)
-        # Note: DB size uses disk space that reduces disk_free, so the
-        # denominator already accounts for existing DB consumption.
-        recommended_max = min(ram_bytes * 4, int(disk_free_bytes * 0.8))
+        # Recommended max: min(4x RAM, 80% of total disk)
+        recommended_max = min(ram_bytes * 4, int(disk_total_bytes * 0.8))
         # Avoid division by zero
         if recommended_max > 0:
             capacity_pct = min(round((duckdb_size_bytes / recommended_max) * 100, 1), 100.0)

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -987,7 +987,7 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
         if response.status_code != 200:
             return False
 
-        # Wait for sync to complete (poll up to 10 seconds)
+        # Wait for sync to complete (poll up to 30 seconds)
         import time
 
         for _ in range(30):

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -990,7 +990,7 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
         # Wait for sync to complete (poll up to 10 seconds)
         import time
 
-        for _ in range(10):
+        for _ in range(30):
             time.sleep(1)
             db_status = requests.get(
                 f"{metabase_url}/api/database/{database_id}",
@@ -1084,7 +1084,11 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
             logger.warning(f"Error updating table metadata: {e}")
 
         if not tables:
-            logger.warning("sync_metabase_schema_no_tables: database_id=%s", database_id)
+            logger.warning(
+                "sync_metabase_schema: no tables found after sync poll — "
+                "Metabase may still be syncing. database_id=%s",
+                database_id,
+            )
             return False
 
         return True

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -182,7 +182,8 @@ async def get_platform_health() -> dict[str, Any]:
                 try:
                     schemas = conn.execute(
                         "SELECT DISTINCT schema_name FROM information_schema.schemata "
-                        "WHERE schema_name LIKE 'raw_%'"
+                        "WHERE schema_name LIKE 'raw_%' "
+                        "AND schema_name NOT LIKE '%_staging'"
                     ).fetchall()
                 finally:
                     conn.close()

--- a/tests/unit/test_duckdb_capacity.py
+++ b/tests/unit/test_duckdb_capacity.py
@@ -29,7 +29,7 @@ class TestDuckDBCapacity:
         db_file.parent.mkdir(parents=True)
         db_file.write_bytes(b"\x00" * 100)  # 100 bytes
 
-        # RAM=1 GB, disk free=10 GB → recommended_max = min(4GB, 8GB) = 4 GB
+        # RAM=1 GB, disk total=20 GB → recommended_max = min(4GB, 16GB) = 4 GB
         with (
             patch("dango.utils.db_health.shutil.disk_usage") as mock_disk,
             patch("psutil.virtual_memory") as mock_vmem,
@@ -129,7 +129,7 @@ class TestDuckDBCapacity:
         assert result["duckdb_capacity_warning"] is False
 
     def test_recommended_max_uses_minimum(self, tmp_path):
-        """recommended_max = min(RAM*4, disk_free*0.8)."""
+        """recommended_max = min(RAM*4, disk_total*0.8)."""
         db_file = tmp_path / "data" / "warehouse.duckdb"
         db_file.parent.mkdir(parents=True)
         db_file.write_bytes(b"\x00" * 100)
@@ -146,7 +146,7 @@ class TestDuckDBCapacity:
 
         assert result["recommended_max_db_size_bytes"] == 4 * 1024**3
 
-        # Case 2: disk*0.8 < RAM*4 → disk*0.8 wins
+        # Case 2: disk_total*0.8 < RAM*4 → disk_total*0.8 wins
         with (
             patch("dango.utils.db_health.shutil.disk_usage") as mock_disk,
             patch("psutil.virtual_memory") as mock_vmem,
@@ -158,4 +158,4 @@ class TestDuckDBCapacity:
 
             result = get_duckdb_capacity(db_file, tmp_path)
 
-        assert result["recommended_max_db_size_bytes"] == int(2 * 1024**3 * 0.8)
+        assert result["recommended_max_db_size_bytes"] == int(10 * 1024**3 * 0.8)


### PR DESCRIPTION
## Summary
- Bug #8/#27: Exclude dlt `_staging` schemas from orphaned table check (false positive warnings)
- Bug #9: Use total disk instead of free disk for DuckDB capacity formula (circular inflation)
- Bug #10: Increase service readiness timeout from 45s to 60s (false "not ready" warnings)
- Bug #14: Restrict `db clean` to raw schemas only (prevents dropping valid dbt models)
- Bug #15: Increase Metabase sync poll from 10s to 30s (reliability on slower machines)

## Verification
- `pytest -x`: 3725 passed, 31 skipped, 0 failed
- These are logic fixes (SQL queries, timeout values, formulas) — no UI or API testing needed
- Coordinating chat will verify on beta-2: health page, db clean, startup timeout

## Changes

| File | Bug | Change |
|------|-----|--------|
| `dango/web/routes/health.py` | #8/#27 | Add `NOT LIKE '%_staging'` to orphaned schema query |
| `dango/utils/db_health.py` | #9 | `disk.free` → `disk.total` in capacity formula |
| `dango/cli/commands/platform.py` | #10 | `max_wait = 45` → `max_wait = 60` |
| `dango/cli/commands/data.py` | #14 | Remove staging/intermediate/marts from `db clean` query |
| `dango/visualization/metabase.py` | #15 | Poll loop 10→30 iterations, improved warning message |
| `tests/unit/test_duckdb_capacity.py` | #9 | Updated assertions for `disk.total` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)