### PR TITLE
fix: CLI + wizard bugs (R3 Session G)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Dango gives you a complete data stack — ingestion, warehouse, transformations,
 **Prerequisites:** Python 3.10-3.12, [Docker](https://docs.docker.com/desktop/) (for Metabase)
 
 ```bash
+mkdir my-project && cd my-project
 pip install --pre getdango
 dango init
 dango start

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -545,6 +545,7 @@ def run_wizard(project_root: Path) -> WizardConfig:
         Completed ``WizardConfig`` ready for provisioning.
     """
     console.print("\n[bold blue]Dango Cloud Deployment Wizard[/bold blue]\n")
+    console.print("[dim]Press Ctrl+C at any time to cancel[/dim]\n")
 
     # Step 1: Prerequisites
     _step_prereqs(project_root)

--- a/dango/cli/commands/oauth.py
+++ b/dango/cli/commands/oauth.py
@@ -665,6 +665,7 @@ def oauth_setup(ctx: click.Context, provider: str) -> None:
             load_dotenv(env_file)
 
         console.print(f"\n[bold cyan]OAuth Setup Wizard: {provider.title()}[/bold cyan]\n")
+        console.print("[dim]Press Ctrl+C at any time to cancel[/dim]\n")
 
         # Provider-specific configuration
         provider_config = {

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -637,6 +637,8 @@ def schedule_add(ctx: click.Context) -> None:
     schedules = data.setdefault("schedules", [])
     existing_names = {s.get("name") for s in schedules}
 
+    console.print("[dim]Press Ctrl+C at any time to cancel[/dim]\n")
+
     # 1. Name (validate after prompt to avoid per-keystroke flicker)
     console.print(
         "[dim]Format: lowercase, start with letter, only letters/digits/underscores[/dim]"

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -970,26 +970,26 @@ custom_sources/
                     if attempt > 0:
                         console.print(f"    Retry {attempt}/2...")
                         time.sleep(2)  # Wait before retry
-                    response = urllib.request.urlopen(driver_url, timeout=120)
-                    total = int(response.headers.get("Content-Length", 0))
-                    with Progress(
-                        TextColumn("[progress.description]{task.description}"),
-                        BarColumn(),
-                        DownloadColumn(),
-                        TransferSpeedColumn(),
-                        console=console,
-                    ) as progress:
-                        task = progress.add_task(
-                            "Downloading DuckDB driver",
-                            total=total if total > 0 else None,
-                        )
-                        with open(duckdb_driver_path, "wb") as f:
-                            while True:
-                                chunk = response.read(65536)
-                                if not chunk:
-                                    break
-                                f.write(chunk)
-                                progress.advance(task, len(chunk))
+                    with urllib.request.urlopen(driver_url, timeout=120) as response:
+                        total = int(response.headers.get("Content-Length", 0))
+                        with Progress(
+                            TextColumn("[progress.description]{task.description}"),
+                            BarColumn(),
+                            DownloadColumn(),
+                            TransferSpeedColumn(),
+                            console=console,
+                        ) as progress:
+                            task = progress.add_task(
+                                "Downloading DuckDB driver",
+                                total=total if total > 0 else None,
+                            )
+                            with open(duckdb_driver_path, "wb") as f:
+                                while True:
+                                    chunk = response.read(65536)
+                                    if not chunk:
+                                        break
+                                    f.write(chunk)
+                                    progress.advance(task, len(chunk))
                     write_driver_version(plugins_dir, METABASE_DUCKDB_DRIVER_VERSION)
                     console.print(
                         f"[green]✓[/green] Downloaded DuckDB driver ({duckdb_driver_path.stat().st_size // 1024 // 1024}MB)"

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -952,18 +952,44 @@ custom_sources/
                 duckdb_driver_path.unlink()
 
             driver_url = get_duckdb_driver_url()
-            console.print("⏳ Downloading DuckDB driver (70MB, this may take a moment)...")
             driver_downloaded = False
 
             # Retry same URL 3 times (network issues are transient)
             import time
+
+            from rich.progress import (
+                BarColumn,
+                DownloadColumn,
+                Progress,
+                TextColumn,
+                TransferSpeedColumn,
+            )
 
             for attempt in range(3):
                 try:
                     if attempt > 0:
                         console.print(f"    Retry {attempt}/2...")
                         time.sleep(2)  # Wait before retry
-                    urllib.request.urlretrieve(driver_url, duckdb_driver_path)
+                    response = urllib.request.urlopen(driver_url, timeout=120)
+                    total = int(response.headers.get("Content-Length", 0))
+                    with Progress(
+                        TextColumn("[progress.description]{task.description}"),
+                        BarColumn(),
+                        DownloadColumn(),
+                        TransferSpeedColumn(),
+                        console=console,
+                    ) as progress:
+                        task = progress.add_task(
+                            "Downloading DuckDB driver",
+                            total=total if total > 0 else None,
+                        )
+                        with open(duckdb_driver_path, "wb") as f:
+                            while True:
+                                chunk = response.read(65536)
+                                if not chunk:
+                                    break
+                                f.write(chunk)
+                                progress.advance(task, len(chunk))
                     write_driver_version(plugins_dir, METABASE_DUCKDB_DRIVER_VERSION)
                     console.print(
                         f"[green]✓[/green] Downloaded DuckDB driver ({duckdb_driver_path.stat().st_size // 1024 // 1024}MB)"
@@ -971,6 +997,7 @@ custom_sources/
                     driver_downloaded = True
                     break
                 except Exception:
+                    duckdb_driver_path.unlink(missing_ok=True)
                     if attempt == 2:  # Last attempt failed
                         break
                     continue

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -115,19 +115,24 @@ def safe_confirm(
         click.Abort: When *abort* is ``True`` and the answer is no.
     """
     default_str = "yes" if default else "no"
-    try:
-        result = click.prompt(f"{text} (yes/no)", default=default_str, show_default=True)
-    except (click.Abort, EOFError):
-        # Non-interactive context with no input available
-        if not default and abort:
-            raise click.Abort() from None
-        return default
-    answered_yes = str(result).lower().strip() in ("yes", "y")
+    while True:
+        try:
+            result = click.prompt(f"{text} (yes/no)", default=default_str, show_default=True)
+        except (click.Abort, EOFError):
+            # Non-interactive context with no input available
+            if not default and abort:
+                raise click.Abort() from None
+            return default
+        normalised = str(result).lower().strip()
+        if normalised not in ("yes", "y", "no", "n"):
+            click.echo("Please answer yes or no.")
+            continue
+        answered_yes = normalised in ("yes", "y")
 
-    if not answered_yes and abort:
-        raise click.Abort()
+        if not answered_yes and abort:
+            raise click.Abort()
 
-    return answered_yes
+        return answered_yes
 
 
 def confirm(message: str, default: bool = False) -> bool:

--- a/dango/cli/wizard.py
+++ b/dango/cli/wizard.py
@@ -50,9 +50,7 @@ class ProjectWizard:
         project_name = self._ask_project_name()
         organization = self._ask_organization()
 
-        # Try to get creator from git config, otherwise use default
-        # (User can edit .dango/project.yml later if needed)
-        created_by = self._get_git_user() or "Unknown"
+        created_by = "Unknown"
 
         # Use simple defaults for everything else
         from dango import __version__
@@ -103,35 +101,18 @@ class ProjectWizard:
 
     def _ask_organization(self) -> str | None:
         """Ask for organization name (optional)"""
-        console.print("[cyan]Optional - used in UI/Metabase[/cyan]")
-        questions = [inquirer.Text("organization", message="Organization name", default="")]
+        questions = [
+            inquirer.Text(
+                "organization",
+                message="Organization name (optional, used in UI/Metabase)",
+                default="",
+            )
+        ]
         answers = inquirer.prompt(questions)
         if answers is None:
             raise KeyboardInterrupt()
         org = str(answers.get("organization", "")).strip()
         return org if org else None
-
-    def _get_git_user(self) -> str | None:
-        """Get user name and email from git config"""
-        import subprocess
-
-        try:
-            name_result = subprocess.run(
-                ["git", "config", "user.name"], capture_output=True, text=True, timeout=2
-            )
-            email_result = subprocess.run(
-                ["git", "config", "user.email"], capture_output=True, text=True, timeout=2
-            )
-
-            if name_result.returncode == 0 and email_result.returncode == 0:
-                name = name_result.stdout.strip()
-                email = email_result.stdout.strip()
-                if name and email:
-                    return f"{name} <{email}>"
-        except Exception:
-            pass
-
-        return None
 
     def _ask_created_by(self) -> str:
         """Ask for creator info"""
@@ -279,10 +260,6 @@ class ProjectWizard:
         # Show organization if provided
         if self.config.project.organization:
             summary_lines.append(f"[bold]Organization:[/bold] {self.config.project.organization}")
-
-        # Show created_by if not "Unknown"
-        if self.config.project.created_by and self.config.project.created_by != "Unknown":
-            summary_lines.append(f"[bold]Created by:[/bold] {self.config.project.created_by}")
 
         # Show purpose if meaningful
         if self.config.project.purpose and self.config.project.purpose != "Data analytics project":

--- a/dango/cli/wizard.py
+++ b/dango/cli/wizard.py
@@ -114,18 +114,6 @@ class ProjectWizard:
         org = str(answers.get("organization", "")).strip()
         return org if org else None
 
-    def _ask_created_by(self) -> str:
-        """Ask for creator info"""
-        questions = [
-            inquirer.Text(
-                "created_by", message="Your name and email (e.g., 'Jane Doe <jane@company.com>')"
-            )
-        ]
-        answers = inquirer.prompt(questions)
-        if answers is None:
-            raise KeyboardInterrupt()
-        return str(answers["created_by"])
-
     def _ask_purpose(self) -> str:
         """Ask for project purpose"""
         console.print()

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -470,7 +470,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
                 "type": "string",
                 "prompt": "Start date (YYYY-MM-DD)",
                 "default": "90daysAgo",
-                "help": "GA4 accepts relative dates (e.g., '90daysAgo', '30daysAgo') or absolute dates (YYYY-MM-DD). Defaults to 90daysAgo for first sync.",
+                "help": "How far back to load on first sync. Default: 90 days.",
             },
         ],
         # 6 themed queries covering 90-95% of analytics use cases.

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -227,10 +227,6 @@ class OAuthManager:
             console.print(f"[dim]Callback server listening on port {self.callback_port}[/dim]")
 
             # Open browser for authorization
-            console.print(
-                "\n[yellow]Your browser will show 'Google hasn't verified this app' — "
-                "this is normal.\nClick Advanced \u2192 Go to app \u2192 Continue.[/yellow]"
-            )
             console.print("\n[cyan]Opening browser for authorization...[/cyan]")
             console.print(f"[dim]If browser doesn't open, visit: {auth_url}[/dim]\n")
 

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -227,6 +227,10 @@ class OAuthManager:
             console.print(f"[dim]Callback server listening on port {self.callback_port}[/dim]")
 
             # Open browser for authorization
+            console.print(
+                "\n[yellow]Your browser will show 'Google hasn't verified this app' — "
+                "this is normal.\nClick Advanced \u2192 Go to app \u2192 Continue.[/yellow]"
+            )
             console.print("\n[cyan]Opening browser for authorization...[/cyan]")
             console.print(f"[dim]If browser doesn't open, visit: {auth_url}[/dim]\n")
 
@@ -255,6 +259,7 @@ class OAuthManager:
             # Timeout — offer retry
             console.print(f"\n[red]✗ Authorization timeout after {timeout_seconds} seconds[/red]")
             server.server_close()
+            server_thread.join(timeout=2)
 
             answers = inquirer.prompt(
                 [

--- a/dango/oauth/providers.py
+++ b/dango/oauth/providers.py
@@ -214,6 +214,10 @@ class GoogleOAuthProvider(BaseOAuthProvider):
 
             # Start OAuth flow
             console.print("\n[bold]Step 2: Authorize Dango[/bold]")
+            console.print(
+                "\n[yellow]Your browser will show 'Google hasn't verified this app' — "
+                "this is normal.\nClick Advanced \u2192 Go to app \u2192 Continue.[/yellow]"
+            )
             oauth_response = self.oauth_manager.start_oauth_flow("Google", auth_url)
 
             if not oauth_response:

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -87,7 +87,7 @@ def _build_schedule_map() -> dict[str, str]:
             display = _cron_to_display(schedule.cron)
             for src in schedule.sources:
                 per_source[src].append(display)
-        return {src: ", ".join(displays) for src, displays in per_source.items()}
+        return {src: ", ".join(dict.fromkeys(displays)) for src, displays in per_source.items()}
     except Exception:
         return {}
 

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -74,18 +74,20 @@ def _cron_to_display(cron: str) -> str:
 def _build_schedule_map() -> dict[str, str]:
     """Build source_name → schedule display mapping."""
     try:
+        from collections import defaultdict
+
         from dango.config.schedules import load_schedules_config
         from dango.web.helpers import get_project_root
 
         config = load_schedules_config(get_project_root())
-        mapping: dict[str, str] = {}
+        per_source: defaultdict[str, list[str]] = defaultdict(list)
         for schedule in config.schedules:
             if not schedule.enabled:
                 continue
             display = _cron_to_display(schedule.cron)
             for src in schedule.sources:
-                mapping[src] = display
-        return mapping
+                per_source[src].append(display)
+        return {src: ", ".join(displays) for src, displays in per_source.items()}
     except Exception:
         return {}
 


### PR DESCRIPTION
## Summary
- Fix 11 CLI/wizard/init bugs (R3 Session G, bugs 16-26)
- Bug 17: Shorten GA4 start_date help text
- Bug 25: Add `mkdir` step to README Quick Start
- Bug 19: Move org hint into inquirer prompt message
- Bug 22: Remove git identity leak from `created_by`
- Bug 24: Re-prompt on invalid yes/no input instead of aborting
- Bug 26: Add Ctrl+C guidance to deploy/schedule/oauth wizards
- Bug 18: Add unverified app warning before OAuth browser open
- Bug 23: Join server thread on timeout to prevent retry hang
- Bug 16: Accumulate multiple schedules per source in sources page
- Bugs 20+21: Replace `urlretrieve` with streaming download + Rich progress bar

## Verification
- `pytest -x`: 3725 passed, 31 skipped, 0 fail
- Bugs 17, 19, 22, 24, 25: code-level changes verified by reading diffs
- Bugs 18, 20/21, 23, 26: interactive CLI flows — coordinating chat verifies on beta-2
- Bug 16: API response change — coordinating chat verifies on beta-2