### PR TITLE
Fix 10 web UI bugs: display, filtering, activity logging

### DIFF
--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -340,7 +340,12 @@ def dispatch_post_sync_hooks(
     if not sources:
         return {"failed_hooks": []}
 
+    from dango.utils.activity_log import log_activity
+
     logger.info("post_sync_hooks_start", sources=sources)
+    log_activity(
+        project_root, "info", "post_sync", f"Post-sync hooks starting for {', '.join(sources)}"
+    )
 
     failed_hooks: list[str] = []
     for hook_name, hook_fn in [
@@ -363,6 +368,12 @@ def dispatch_post_sync_hooks(
             logger.warning("post_sync_hook_failed", hook="sync_notification", exc_info=True)
             failed_hooks.append("sync_notification")
 
+    log_activity(
+        project_root,
+        "success" if not failed_hooks else "warning",
+        "post_sync",
+        f"Post-sync hooks completed{' with failures: ' + ', '.join(failed_hooks) if failed_hooks else ''}",
+    )
     logger.info("post_sync_hooks_complete", sources=sources)
     return {"failed_hooks": failed_hooks}
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -169,6 +169,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.debug("sync_status_watcher_start_failed", exc_info=True)
         app.state.sync_watcher_task = None
 
+    try:
+        from dango.utils.activity_log import log_activity
+
+        log_activity(project_root, "info", "system", "Dango server starting")
+    except Exception:
+        logger.debug("startup_activity_log_failed", exc_info=True)
+
     yield
 
     # Shutdown
@@ -190,6 +197,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             await asyncio.to_thread(sched.shutdown, True)
         except Exception:
             logger.error("scheduler_shutdown_failed", exc_info=True)
+
+    try:
+        from dango.utils.activity_log import log_activity
+
+        log_activity(project_root, "info", "system", "Dango server shutting down")
+    except Exception:
+        pass
 
     logger.info("api_shutting_down")
 

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -385,6 +385,7 @@ def _build_catalog_models(
         cols_documented = sum(1 for c in columns.values() if c.get("description"))
         tests = test_map.get(uid, [])
         tests_passing = sum(1 for t in tests if t["status"] == "pass")
+        tests_warning = sum(1 for t in tests if t["status"] == "warn")
         tests_failing = sum(1 for t in tests if t["status"] in ("fail", "error"))
 
         models.append(
@@ -397,6 +398,7 @@ def _build_catalog_models(
                 "description": node.get("description", ""),
                 "test_count": len(tests),
                 "tests_passing": tests_passing,
+                "tests_warning": tests_warning,
                 "tests_failing": tests_failing,
                 "columns_total": len(columns),
                 "columns_documented": cols_documented,
@@ -414,6 +416,7 @@ def _build_catalog_models(
         cols_documented = sum(1 for c in columns.values() if c.get("description"))
         tests = test_map.get(uid, [])
         tests_passing = sum(1 for t in tests if t["status"] == "pass")
+        tests_warning = sum(1 for t in tests if t["status"] == "warn")
         tests_failing = sum(1 for t in tests if t["status"] in ("fail", "error"))
 
         sources.append(
@@ -426,6 +429,7 @@ def _build_catalog_models(
                 "source_name": src.get("source_name", ""),
                 "test_count": len(tests),
                 "tests_passing": tests_passing,
+                "tests_warning": tests_warning,
                 "tests_failing": tests_failing,
                 "columns_total": len(columns),
                 "columns_documented": cols_documented,
@@ -867,32 +871,11 @@ async def list_catalog_models(
     else:
         result = await asyncio.to_thread(_build_catalog_models, manifest, run_results)
 
-    # BUG-132: Discover raw tables without dbt staging models
     project_root = get_project_root()
     db_path = project_root / "data" / "warehouse.duckdb"
     source_stats: dict[str, dict[str, int]] = {}
     if db_path.exists():
-        raw_tables, source_stats = await asyncio.gather(
-            asyncio.to_thread(_get_raw_tables_from_duckdb, db_path),
-            asyncio.to_thread(_get_source_summary_stats, db_path),
-        )
-        known_names = {s["name"] for s in result["sources"]}
-        for rt in raw_tables:
-            if rt["table"] not in known_names:
-                result["sources"].append(
-                    {
-                        "unique_id": f"raw.{rt['schema']}.{rt['table']}",
-                        "name": rt["table"],
-                        "type": "source",
-                        "schema": rt["schema"],
-                        "description": "",
-                        "source_name": rt["source_name"],
-                        "test_count": 0,
-                        "columns_total": 0,
-                        "columns_documented": 0,
-                    }
-                )
-        result["sources"].sort(key=lambda s: s["name"].lower())
+        source_stats = await asyncio.to_thread(_get_source_summary_stats, db_path)
 
     # BUG-128: Overview summary with source freshness
     sources_config = await asyncio.to_thread(load_sources_config)

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -252,6 +252,9 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
             }
         )
     except Exception as e:
+        log_activity(
+            project_root, "error", f"dbt:{model_name}", f"Model '{model_name}' failed: {e!s:.200}"
+        )
         logger.error(f"Error running dbt model {model_name}: {e}")
         await ws_manager.broadcast(
             {

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -120,8 +120,15 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
+        from dango.utils.activity_log import log_activity
+
+        log_activity(project_root, "warning", f"dbt:{model_name}", "dbt lock unavailable")
         logger.warning(f"Could not acquire dbt lock for {model_name}: {e}")
         return
+
+    from dango.utils.activity_log import log_activity
+
+    log_activity(project_root, "info", f"dbt:{model_name}", f"dbt run started: {model_name}")
 
     # Get dbt executable path (from venv or system PATH)
     python_bin_dir = Path(sys.executable).parent
@@ -181,6 +188,12 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
             update_model_status(project_root)
 
             # Success
+            log_activity(
+                project_root,
+                "success",
+                f"dbt:{model_name}",
+                f"Model '{model_name}' completed in {duration:.1f}s",
+            )
             await ws_manager.broadcast(
                 {
                     "event": "dbt_run_completed",
@@ -208,6 +221,12 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
         else:
             # Failed
             error_msg = result.stderr or result.stdout or "Unknown error"
+            log_activity(
+                project_root,
+                "error",
+                f"dbt:{model_name}",
+                f"Model '{model_name}' failed: {error_msg[:200]}",
+            )
             await ws_manager.broadcast(
                 {
                     "event": "dbt_run_failed",
@@ -218,6 +237,12 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
             )
 
     except subprocess.TimeoutExpired:
+        log_activity(
+            project_root,
+            "error",
+            f"dbt:{model_name}",
+            f"Model '{model_name}' timed out after 5 minutes",
+        )
         await ws_manager.broadcast(
             {
                 "event": "dbt_run_failed",

--- a/dango/web/static/css/catalog.css
+++ b/dango/web/static/css/catalog.css
@@ -130,6 +130,7 @@
 
 /* Test status indicators */
 .test-pass { color: #059669; }
+.test-warn { color: #d97706; }
 .test-fail { color: #dc2626; }
 
 /* Instant tooltip — replaces native title (which has ~2s delay).

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1320,7 +1320,7 @@ function renderRowCount(source) {
 
     // If no tables breakdown or single table, show simple count
     if (!source.tables || source.tables.length <= 1) {
-        return source.row_count.toLocaleString();
+        return `${source.row_count.toLocaleString()} rows`;
     }
 
     // Multi-resource source: show breakdown with clean bullets (no monospace needed)
@@ -2052,7 +2052,7 @@ async function openSourceDetail(sourceName) {
                 `;
             } else {
                 // Single resource or no breakdown: show simple count
-                detailRowCountElement.textContent = details.row_count.toLocaleString();
+                detailRowCountElement.textContent = details.row_count.toLocaleString() + ' rows';
             }
         }
 

--- a/dango/web/static/js/logs.js
+++ b/dango/web/static/js/logs.js
@@ -239,8 +239,10 @@ async function loadSources() {
 // ============================================================================
 
 function setupFilterListeners() {
-    // Real-time search filter
     document.getElementById('filter-search')?.addEventListener('input', applyFilters);
+    document.getElementById('filter-level')?.addEventListener('change', applyFilters);
+    document.getElementById('filter-source')?.addEventListener('change', applyFilters);
+    document.getElementById('filter-time')?.addEventListener('change', applyFilters);
 }
 
 function applyFilters() {

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -184,19 +184,21 @@
                                         <template x-for="item in filteredItems" :key="item.unique_id">
                                             <tr class="hover:bg-gray-50 cursor-pointer" @click="openModel(item.name)">
                                                 <td class="px-6 py-4 whitespace-nowrap">
-                                                    <a :href="'/catalog?model=' + encodeURIComponent(item.name)" @click.prevent class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="item.name"></a>
+                                                    <a :href="'/catalog?model=' + encodeURIComponent(item.name)" @click.prevent class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="item.schema ? item.schema + '.' + item.name : item.name"></a>
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     <span class="model-badge" :class="'model-badge-' + item.type" x-text="item.type"></span>
                                                 </td>
                                                 <td class="px-6 py-4 hidden sm:table-cell">
-                                                    <div class="desc-truncate text-sm text-gray-500" x-text="item.description || '--'"></div>
+                                                    <div class="desc-truncate text-sm text-gray-500" :title="item.description" x-text="item.description || '--'"></div>
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap text-sm hidden md:table-cell">
                                                     <template x-if="item.test_count > 0">
                                                         <span>
                                                             <span x-show="item.tests_passing > 0" class="test-pass" x-text="item.tests_passing + ' pass'"></span>
-                                                            <span x-show="item.tests_passing > 0 && item.tests_failing > 0"> / </span>
+                                                            <span x-show="item.tests_passing > 0 && (item.tests_warning > 0 || item.tests_failing > 0)"> / </span>
+                                                            <span x-show="item.tests_warning > 0" class="test-warn" x-text="item.tests_warning + ' warn'"></span>
+                                                            <span x-show="item.tests_warning > 0 && item.tests_failing > 0"> / </span>
                                                             <span x-show="item.tests_failing > 0" class="test-fail" x-text="item.tests_failing + ' fail'"></span>
                                                         </span>
                                                     </template>
@@ -206,7 +208,7 @@
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="getItemFreshness(item)"></td>
                                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell"
-                                                    x-text="item.columns_total > 0 ? item.columns_documented + '/' + item.columns_total : '--'"></td>
+                                                    x-text="item.columns_total > 0 ? item.columns_documented + '/' + item.columns_total : 'No metadata'"></td>
                                                 <td class="px-6 py-4 whitespace-nowrap hidden lg:table-cell">
                                                     <template x-if="item.tags && item.tags.length > 0">
                                                         <div>

--- a/dango/web/templates/logs.html
+++ b/dango/web/templates/logs.html
@@ -65,9 +65,6 @@
                 </div>
 
                 <div class="mt-4 flex items-center justify-between">
-                    <button onclick="applyFilters()" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">
-                        Apply Filters
-                    </button>
                     <button onclick="clearFilters()" class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors">
                         Clear Filters
                     </button>

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -61,9 +61,12 @@
                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 animate-pulse">running</span>
                                 </template>
                                 <template x-if="!runningJobs[sched.name] && sched.last_run">
-                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
-                                          :class="statusBadge(sched.last_run.status)"
-                                          x-text="sched.last_run.status"></span>
+                                    <span>
+                                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
+                                              :class="statusBadge(sched.last_run.status)"
+                                              x-text="sched.last_run.status"></span>
+                                        <span class="text-xs text-gray-400 ml-1" x-text="'· ' + timeAgo(sched.last_run.started_at)"></span>
+                                    </span>
                                 </template>
                                 <template x-if="!runningJobs[sched.name] && !sched.last_run">
                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-500">Not yet run</span>

--- a/dango/web/templates/secrets.html
+++ b/dango/web/templates/secrets.html
@@ -111,7 +111,7 @@
             </div>
 
             <!-- Available sources to connect -->
-            <template x-if="isLocalhost">
+            <template x-if="isLocalhost && oauthCredentials.length === 0">
                 <div class="bg-white shadow rounded-lg p-4">
                     <p class="text-sm text-gray-500">OAuth connections require a domain with HTTPS. Use <code class="bg-gray-100 px-1 rounded">dango oauth setup</code> for local OAuth.</p>
                 </div>

--- a/dango/web/templates/secrets.html
+++ b/dango/web/templates/secrets.html
@@ -116,6 +116,11 @@
                     <p class="text-sm text-gray-500">OAuth connections require a domain with HTTPS. Use <code class="bg-gray-100 px-1 rounded">dango oauth setup</code> for local OAuth.</p>
                 </div>
             </template>
+            <template x-if="isLocalhost && oauthCredentials.length > 0">
+                <div class="bg-white shadow rounded-lg p-4">
+                    <p class="text-sm text-gray-500">To add more OAuth connections, use <code class="bg-gray-100 px-1 rounded">dango oauth setup</code>.</p>
+                </div>
+            </template>
             <template x-if="!isLocalhost">
                 <div class="bg-white shadow rounded-lg p-4">
                     <p class="text-sm text-gray-500 mb-3">Connect a data source via OAuth:</p>

--- a/tests/unit/test_catalog_models.py
+++ b/tests/unit/test_catalog_models.py
@@ -818,19 +818,17 @@ class TestRawTableDiscovery:
 
     @patch("dango.web.routes.catalog._get_source_summary_stats")
     @patch("dango.web.routes.catalog.get_project_root")
-    @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
     @patch("dango.web.routes.catalog._get_run_results")
     @patch("dango.web.routes.catalog.get_dbt_manifest")
-    def test_raw_tables_appended_to_sources(
+    def test_raw_tables_not_appended_to_sources(
         self,
         mock_manifest: MagicMock,
         mock_run_results: MagicMock,
-        mock_raw_tables: MagicMock,
         mock_root: MagicMock,
         mock_source_stats: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Unmodeled raw tables appear in sources list (BUG-132)."""
+        """Raw tables are NOT injected into catalog list (raw table discovery removed)."""
         client, project_root = _setup_client(tmp_path)
         db_dir = tmp_path / "data"
         db_dir.mkdir()
@@ -847,29 +845,22 @@ class TestRawTableDiscovery:
             },
         )
         mock_run_results.return_value = None
-        mock_raw_tables.return_value = [
-            {"schema": "raw_shop", "table": "orders", "source_name": "shop"},
-            {"schema": "raw_shop", "table": "order_items", "source_name": "shop"},
-        ]
 
         resp = client.get("/api/catalog/models")
         data = resp.json()
 
         source_names = [s["name"] for s in data["sources"]]
         assert "orders" in source_names  # from manifest
-        assert "order_items" in source_names  # from raw tables
-        assert source_names.count("orders") == 1  # no duplicate
+        assert len(source_names) == 1  # no raw tables injected
 
     @patch("dango.web.routes.catalog._get_source_summary_stats")
     @patch("dango.web.routes.catalog.get_project_root")
-    @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
     @patch("dango.web.routes.catalog._get_run_results")
     @patch("dango.web.routes.catalog.get_dbt_manifest")
     def test_overview_included_in_response(
         self,
         mock_manifest: MagicMock,
         mock_run_results: MagicMock,
-        mock_raw_tables: MagicMock,
         mock_root: MagicMock,
         mock_source_stats: MagicMock,
         tmp_path: Path,
@@ -897,7 +888,6 @@ class TestRawTableDiscovery:
             },
         )
         mock_run_results.return_value = None
-        mock_raw_tables.return_value = []
 
         resp = client.get("/api/catalog/models")
         data = resp.json()
@@ -941,14 +931,12 @@ class TestSourcesDetail:
     @patch("dango.web.helpers.get_project_root")
     @patch("dango.web.routes.catalog._get_source_summary_stats")
     @patch("dango.web.routes.catalog.get_project_root")
-    @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
     @patch("dango.web.routes.catalog._get_run_results")
     @patch("dango.web.routes.catalog.get_dbt_manifest")
     def test_sources_detail_in_overview(
         self,
         mock_manifest: MagicMock,
         mock_run_results: MagicMock,
-        mock_raw_tables: MagicMock,
         mock_root: MagicMock,
         mock_source_stats: MagicMock,
         mock_helpers_root: MagicMock,
@@ -971,7 +959,6 @@ class TestSourcesDetail:
 
         mock_manifest.return_value = _make_manifest()
         mock_run_results.return_value = None
-        mock_raw_tables.return_value = []
         mock_source_stats.return_value = {
             "shop": {"table_count": 5, "estimated_row_total": 12000},
             "crm": {"table_count": 3, "estimated_row_total": 800},
@@ -994,14 +981,12 @@ class TestSourcesDetail:
     @patch("dango.web.helpers.get_project_root")
     @patch("dango.web.routes.catalog._get_source_summary_stats")
     @patch("dango.web.routes.catalog.get_project_root")
-    @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
     @patch("dango.web.routes.catalog._get_run_results")
     @patch("dango.web.routes.catalog.get_dbt_manifest")
     def test_sources_detail_missing_source_in_duckdb(
         self,
         mock_manifest: MagicMock,
         mock_run_results: MagicMock,
-        mock_raw_tables: MagicMock,
         mock_root: MagicMock,
         mock_source_stats: MagicMock,
         mock_helpers_root: MagicMock,
@@ -1024,7 +1009,6 @@ class TestSourcesDetail:
 
         mock_manifest.return_value = _make_manifest()
         mock_run_results.return_value = None
-        mock_raw_tables.return_value = []
         mock_source_stats.return_value = {
             "shop": {"table_count": 3, "estimated_row_total": 500},
             # new_source is NOT in DuckDB yet


### PR DESCRIPTION
## Summary

Fix Round 3 — Session F: 10 web UI bugs affecting display quality, filtering UX, and activity log completeness.

- **Bug 1:** Sources page row count shows bare number — added "rows" suffix
- **Bug 2:** Catalog table names lack schema prefix — added `schema.name` display
- **Bug 3:** Catalog test warn count missing — added `tests_warning` to API + template + CSS
- **Bug 4:** Catalog descriptions truncated without tooltip — added `:title` attribute
- **Bug 5:** Catalog shows "--" for seed tables — changed to "No metadata"
- **Bug 6:** Raw tables leaking into catalog list — removed raw table injection from list endpoint (detail fallback kept)
- **Bug 7:** Schedules failed status shows no timestamp — added `timeAgo()` display
- **Bug 11:** Logs only show source sync events — added `log_activity()` to dbt runs, server lifecycle, post-sync hooks
- **Bug 12:** Log filters require manual Apply button — added change listeners, removed Apply button
- **Bug 13:** Secrets HTTPS message shown when credentials exist — added `oauthCredentials.length === 0` guard

## Files Changed (12)

| File | Bugs |
|------|------|
| `dango/web/static/js/app.js` | 1 |
| `dango/web/templates/catalog.html` | 2, 3, 4, 5 |
| `dango/web/routes/catalog.py` | 3, 6 |
| `dango/web/static/css/catalog.css` | 3 |
| `dango/web/templates/schedules.html` | 7 |
| `dango/web/routes/dbt.py` | 11 |
| `dango/web/app.py` | 11 |
| `dango/utils/post_sync.py` | 11 |
| `dango/web/static/js/logs.js` | 12 |
| `dango/web/templates/logs.html` | 12 |
| `dango/web/templates/secrets.html` | 13 |
| `tests/unit/test_catalog_models.py` | 6 (test updates) |

## Verification

- `pytest -x`: 3725 passed, 31 skipped, 0 failed
- Pre-commit hooks: all passing
- Bug 6 test updated: `test_raw_tables_appended_to_sources` → `test_raw_tables_not_appended_to_sources`
- Removed unused `_get_raw_tables_from_duckdb` mocks from list endpoint tests
- UI verification needed on beta project before merge

## Test plan

- [ ] Bug 1: Sources page shows "91 rows" not bare "91"
- [ ] Bug 2: Catalog shows `raw_shop.orders` not just `orders`
- [ ] Bug 3: Catalog test column shows "2 pass / 1 warn / 1 fail" format
- [ ] Bug 4: Hover over truncated description shows full text
- [ ] Bug 5: Seed tables show "No metadata" not "--"
- [ ] Bug 6: Raw tables without dbt staging models don't appear in catalog list
- [ ] Bug 7: Failed schedule shows "failed · 2h ago" with timestamp
- [ ] Bug 11: Activity log shows dbt runs, server start/stop, post-sync hooks
- [ ] Bug 12: Changing level/source/time dropdown auto-filters without Apply button
- [ ] Bug 13: HTTPS OAuth message hidden when OAuth credentials already exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)