### PR TITLE
Remove beta artifacts, fix CLI UX, bump to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 Dango gives you a complete data stack — ingestion, warehouse, transformations, and dashboards — in a single CLI. It combines [dlt](https://dlthub.com/) for data loading, [DuckDB](https://duckdb.org/) as the analytics database, [dbt](https://www.getdbt.com/) for SQL transformations, and [Metabase](https://www.metabase.com/) for dashboards. One `pip install`, one command to start.
 
-> **Beta Release:** Dango v1 is currently in beta (v1.0.0b7). We'd love your feedback — [report issues](https://github.com/getdango/dango/issues) or [join the discussion](https://github.com/getdango/dango/discussions).
-
 > **Upgrading from v0.1.x?** v1.0.0 is a complete rewrite. Back up your data and run `dango init` to create a new v1 project. See the [migration guide](https://docs.getdango.dev) for details.
 
 ## Quick Start
@@ -19,7 +17,7 @@ Dango gives you a complete data stack — ingestion, warehouse, transformations,
 
 ```bash
 mkdir my-project && cd my-project
-pip install --pre getdango
+pip install getdango
 dango init
 dango start
 ```

--- a/dango/__init__.py
+++ b/dango/__init__.py
@@ -4,7 +4,7 @@ Dango - Open source data platform
 Professional analytics stack built with production-grade tools.
 """
 
-__version__ = "1.0.0b7"
+__version__ = "1.0.0"
 __author__ = "Dango Team"
 __license__ = "Apache-2.0"
 

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -405,7 +405,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install --pre getdango
+      - run: pip install getdango
       - run: dango config validate
       - run: cd dbt && dbt parse --profiles-dir .
       - name: Check for secrets

--- a/dango/cli/oauth.py
+++ b/dango/cli/oauth.py
@@ -352,13 +352,17 @@ class GoogleOAuthHelper(OAuthHelper):
                     "[dim]  Use a manager (MCC) account ID if managing multiple accounts,[/dim]"
                 )
                 console.print("[dim]  or a regular account ID for a single account.[/dim]")
-                dev_token = Prompt.ask("Developer Token (from Google Ads API Center)")
+                dev_token = Prompt.ask(
+                    "Developer Token (from a Manager/MCC account → Tools & Settings → API Center)"
+                )
                 if dev_token:
                     self.save_to_env(
                         "GOOGLE_ADS_DEV_TOKEN", dev_token, "Google Ads Developer Token"
                     )
 
-                customer_id = Prompt.ask("Customer ID (optional, can add later)", default="")
+                customer_id = Prompt.ask(
+                    "Customer ID (10-digit number from top-right of your Google Ads account, no hyphens)"
+                )
                 if customer_id:
                     customer_id = customer_id.replace("-", "")
                     self.save_to_env(

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -11,6 +11,7 @@ import inquirer
 from inquirer import themes
 from rich.console import Console
 from rich.markup import escape
+from rich.panel import Panel
 from rich.prompt import Confirm
 
 from dango.cli.env_helpers import (
@@ -118,9 +119,13 @@ class SourceWizard:
             True if source added successfully, False otherwise
         """
         try:
-            console.print("\n[bold cyan]🍡 Dango Source Wizard[/bold cyan]\n")
+            console.print()
             console.print(
-                "[dim]Press Ctrl+C at any time to abort (nothing saved until the end)[/dim]\n"
+                Panel(
+                    "[bold]Press Ctrl+C at any time to abort (nothing saved until the end)[/bold]",
+                    title="🍡 Dango Source Wizard",
+                    border_style="cyan",
+                )
             )
 
             # State machine for navigation with back button support
@@ -1810,7 +1815,8 @@ def {module_name}_resource(api_key: str):
 
         # Enhance prompt text with default value for optional params
         if not required and default is not None and param_type not in ("secret", "boolean", "bool"):
-            prompt = f"{prompt} (default: {default})"
+            if not (help_text and "default" in help_text.lower()):
+                prompt = f"{prompt} (default: {default})"
 
         # Different prompt types based on parameter type
         if param_type == "secret" or param_name.endswith("_env"):

--- a/dango/oauth/providers.py
+++ b/dango/oauth/providers.py
@@ -215,8 +215,15 @@ class GoogleOAuthProvider(BaseOAuthProvider):
             # Start OAuth flow
             console.print("\n[bold]Step 2: Authorize Dango[/bold]")
             console.print(
-                "\n[yellow]Your browser will show 'Google hasn't verified this app' — "
-                "this is normal.\nClick Advanced \u2192 Go to app \u2192 Continue.[/yellow]"
+                "\n[yellow]If your app is in Testing mode (the default):[/yellow]"
+                "\n[yellow]  Your browser will show 'Google hasn't verified this app'[/yellow]"
+                "\n[yellow]  Click [bold]Advanced[/bold] → [bold]Go to <app name> "
+                "(unsafe)[/bold] → [bold]Continue[/bold][/yellow]"
+            )
+            console.print(
+                "[yellow]If your app is Published:[/yellow]"
+                "\n[yellow]  You'll see a standard Google consent screen — "
+                "click [bold]Allow[/bold][/yellow]"
             )
             oauth_response = self.oauth_manager.start_oauth_flow("Google", auth_url)
 

--- a/install.ps1
+++ b/install.ps1
@@ -327,8 +327,8 @@ function Install-Dango {
     # Upgrade pip silently
     & pip install --upgrade pip --quiet
 
-    # Install getdango from PyPI (--pre includes beta versions)
-    & pip install --pre getdango
+    # Install getdango from PyPI
+    & pip install getdango
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error-Message "Failed to install Dango"
@@ -354,7 +354,7 @@ function Update-Dango {
     & $activateScript
 
     # Upgrade from PyPI
-    & pip install --upgrade --pre getdango --quiet
+    & pip install --upgrade getdango --quiet
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error-Message "Failed to upgrade Dango"
@@ -377,7 +377,7 @@ function Install-DangoGlobal {
     Write-Host ""
 
     # Install from PyPI
-    & $PythonCmd -m pip install --pre --user getdango
+    & $PythonCmd -m pip install --user getdango
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error-Message "Failed to install Dango from PyPI"
@@ -788,7 +788,7 @@ function Main {
                 Write-Host "To create venv manually:"
                 Write-Host "  $($pythonInfo.Command) -m venv venv"
                 Write-Host "  .\venv\Scripts\Activate.ps1"
-                Write-Host "  pip install --pre getdango"
+                Write-Host "  pip install getdango"
                 Write-Host ""
                 exit 0
             }

--- a/install.sh
+++ b/install.sh
@@ -291,7 +291,7 @@ install_dango() {
     source "$venv_path/bin/activate"
     $PYTHON_CMD -m pip install --upgrade pip -q
 
-    if ! $PYTHON_CMD -m pip install --pre getdango; then
+    if ! $PYTHON_CMD -m pip install getdango; then
         print_error "Failed to install Dango"
         echo
         echo "Possible causes:"
@@ -316,7 +316,7 @@ upgrade_dango() {
     print_step "Upgrading Dango..."
 
     source "$venv_path/bin/activate"
-    $PYTHON_CMD -m pip install --upgrade --pre getdango -q
+    $PYTHON_CMD -m pip install --upgrade getdango -q
 
     DANGO_VERSION=$(dango --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9]*' || echo "unknown")
 
@@ -366,7 +366,7 @@ check_conflicts() {
     echo
 
     # Run dry-run to see what will be installed/upgraded
-    dry_run_output=$($PYTHON_CMD -m pip install --dry-run --pre --user getdango 2>&1)
+    dry_run_output=$($PYTHON_CMD -m pip install --dry-run --user getdango 2>&1)
 
     # Check if any packages will be upgraded
     if echo "$dry_run_output" | grep -q "Would upgrade"; then
@@ -402,7 +402,7 @@ install_dango_global() {
     print_step "Installing Dango globally..."
     echo
 
-    if ! $PYTHON_CMD -m pip install --pre --user getdango; then
+    if ! $PYTHON_CMD -m pip install --user getdango; then
         print_error "Failed to install Dango"
         echo
         echo "Possible causes:"
@@ -841,7 +841,7 @@ main() {
                 echo "To create venv manually:"
                 echo "  $PYTHON_CMD -m venv venv"
                 echo "  source venv/bin/activate"
-                echo "  pip install --pre getdango"
+                echo "  pip install getdango"
                 echo
                 exit 0
             fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "getdango"
-version = "1.0.0b7"
+version = "1.0.0"
 description = "Open source data platform built with production-grade tools - dlt, dbt, DuckDB, and Metabase"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/tests/unit/test_cli_init_ci.py
+++ b/tests/unit/test_cli_init_ci.py
@@ -89,7 +89,7 @@ class TestCreateCiWorkflow:
         content = (tmp_path / ".github" / "workflows" / "dango-validate.yml").read_text()
         assert "dango config validate" in content
         assert "dbt parse --profiles-dir ." in content
-        assert "pip install --pre getdango" in content
+        assert "pip install getdango" in content
 
     def test_idempotent_on_existing_directory(self, tmp_path: Path) -> None:
         """Works when .github/workflows/ already exists."""


### PR DESCRIPTION
## Summary

- **I1/I2:** Remove all `--pre` flags from `install.sh` (5 locations) and `install.ps1` (5 locations)
- **I3:** OAuth pre-warning now shows two scenarios (Testing mode vs Published app)
- **I4:** Source wizard skips duplicate `(default: ...)` hint when help text already mentions "default"
- **I5:** Google Ads Customer ID is now required with a descriptive prompt
- **I6:** Google Ads Developer Token prompt improved with MCC account guidance
- **I7:** Verified `data_processing.py:172` — no change needed (verify-only)
- **I8:** Source wizard header replaced with `Panel` box (matching wizard.py style)
- **I9:** Version bumped from `1.0.0b7` to `1.0.0` in `__init__.py`, `pyproject.toml`, `README.md`; beta banner removed from README

## Verification

- `grep -rn "\-\-pre" install.sh install.ps1` → 0 matches
- `python -c "import dango; print(dango.__version__)"` → `1.0.0`
- `pytest -x`: 3725 passed, 31 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)