### PR TITLE
fix: UI fixes for source table count, catalog seed labels, and logs filter naming

### DIFF
--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1320,7 +1320,7 @@ function renderRowCount(source) {
 
     // If no tables breakdown or single table, show simple count
     if (!source.tables || source.tables.length <= 1) {
-        return `${source.row_count.toLocaleString()} rows`;
+        return `1 table, ${source.row_count.toLocaleString()} rows`;
     }
 
     // Multi-resource source: show breakdown with clean bullets (no monospace needed)
@@ -2052,7 +2052,7 @@ async function openSourceDetail(sourceName) {
                 `;
             } else {
                 // Single resource or no breakdown: show simple count
-                detailRowCountElement.textContent = details.row_count.toLocaleString() + ' rows';
+                detailRowCountElement.textContent = '1 table, ' + details.row_count.toLocaleString() + ' rows';
             }
         }
 

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -496,7 +496,7 @@
                             </div>
                             <div class="lineage-detail-row">
                                 <span class="lineage-detail-label">Doc coverage</span>
-                                <span class="lineage-detail-value" x-text="selectedNode ? (selectedNode.columns_documented + '/' + selectedNode.columns_total) : ''"></span>
+                                <span class="lineage-detail-value" x-text="selectedNode ? (selectedNode.columns_total > 0 ? selectedNode.columns_documented + '/' + selectedNode.columns_total : 'Seed table') : ''"></span>
                             </div>
                             <div class="mt-4 space-y-2">
                                 <button @click="openModel(selectedNode.name)"

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -208,7 +208,7 @@
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell" x-text="getItemFreshness(item)"></td>
                                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell"
-                                                    x-text="item.columns_total > 0 ? item.columns_documented + '/' + item.columns_total : 'No metadata'"></td>
+                                                    x-text="item.columns_total > 0 ? item.columns_documented + '/' + item.columns_total : 'Seed table'"></td>
                                                 <td class="px-6 py-4 whitespace-nowrap hidden lg:table-cell">
                                                     <template x-if="item.tags && item.tags.length > 0">
                                                         <div>

--- a/dango/web/templates/logs.html
+++ b/dango/web/templates/logs.html
@@ -37,9 +37,9 @@
 
                     <!-- Source Filter -->
                     <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-2">Source</label>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">Origin</label>
                         <select id="filter-source" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
-                            <option value="">All Sources</option>
+                            <option value="">All Origins</option>
                             <!-- Will be populated dynamically -->
                         </select>
                     </div>
@@ -99,7 +99,7 @@
                                     </div>
                                 </th>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Source
+                                    Origin
                                 </th>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Message


### PR DESCRIPTION
## Summary
- **J1/J4:** Single-table sources now show "1 table, N rows" instead of just "N rows" in both the sources table and detail modal
- **J2:** Catalog "Documented" column shows "Seed table" instead of "No metadata" for seed tables (both table view and lineage detail panel)
- **J3:** Logs page filter label renamed from "Source" to "Origin" (label, default option, column header)

## Files Changed
- `dango/web/static/js/app.js` — two edits (renderRowCount + detail modal)
- `dango/web/templates/catalog.html` — two edits (table row + lineage detail panel)
- `dango/web/templates/logs.html` — three edits (label, default option, column header)

## Verification
- `pytest -x`: 3725 passed, 31 skipped
- `grep "No metadata" catalog.html` — 0 matches
- `grep '"Source"' logs.html` — 0 matches (only JS element IDs remain, using `filter-source`)
- All changes are display-only — no API, data model, or logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)