### PR TITLE
Fix duplicate not_null tests, unblock dango start timeout, bump to 1.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ dango/                          # Python package source
 │   └── formatter.py            # Result categorization + display formatting
 │
 ├── web/                        # Level 2 — FastAPI web server
-│   ├── app.py                  # Entry point (~480 lines) — routers, middleware, admin bootstrap
+│   ├── app.py                  # Entry point (~510 lines) — routers, middleware, admin bootstrap
 │   ├── models.py               # Pydantic request/response DTOs (incl. auth DTOs)
 │   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (893 lines)
 │   ├── middleware/             # Request middleware
@@ -347,6 +347,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/platform.py` | 1075 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 902 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
+| `web/app.py` | 510 | — (background Metabase sync in v1.0.1) |
 | `web/helpers.py` | 893 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 849 | — (module-level job functions) |
@@ -366,7 +367,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `config/models.py` | 620 | — (Pydantic config models) |
 | `cli/commands/deploy.py` | 767 | — (deploy group with DO + BYOS routing, destroy command) |
 | `cli/commands/deploy_wizard.py` | 898 | — (interactive deploy wizard + BYOS) |
-| `transformation/generator.py` | 614 | — |
+| `transformation/generator.py` | 626 | — |
 | `web/routes/catalog.py` | 1351 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
 | `cli/commands/deploy_provision.py` | 1000 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ dango/                          # Python package source
 │
 ├── transformation/             # Level 1 — dbt model generation & execution
 │   ├── __init__.py             # run_dbt_models(), generate_dbt_docs()
-│   └── generator.py            # DbtModelGenerator (613 lines)
+│   └── generator.py            # DbtModelGenerator (626 lines)
 │
 ├── oauth/                      # Level 1 — OAuth flows
 │   ├── __init__.py             # OAuthManager

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ dango/                          # Python package source
 │   └── formatter.py            # Result categorization + display formatting
 │
 ├── web/                        # Level 2 — FastAPI web server
-│   ├── app.py                  # Entry point (~510 lines) — routers, middleware, admin bootstrap
+│   ├── app.py                  # Entry point (~514 lines) — routers, middleware, admin bootstrap
 │   ├── models.py               # Pydantic request/response DTOs (incl. auth DTOs)
 │   ├── helpers.py              # Shared helpers: DuckDB queries, config, logging (893 lines)
 │   ├── middleware/             # Request middleware
@@ -292,7 +292,7 @@ dango/                          # Python package source
 │   ├── data_validation.py      # Data validation utilities
 │   ├── env_file.py             # .env file parsing and serialization
 │   ├── dango_db.py             # SQLite context manager for .dango/dango.db + schema init
-│   ├── post_sync.py            # Post-sync hook dispatcher (~762 lines)
+│   ├── post_sync.py            # Post-sync hook dispatcher (~804 lines)
 │   └── git_info.py             # Git repository info + deployment guardrails
 │
 ├── migrations/                 # Level 0 — Database migration framework
@@ -347,12 +347,12 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/platform.py` | 1075 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 902 | — (split evaluated in DOC-025: exempt, security-critical) |
 | `cli/commands/oauth.py` | 813 | — (renamed from auth.py by TASK-093) |
-| `web/app.py` | 510 | — (background Metabase sync in v1.0.1) |
+| `web/app.py` | 514 | — (background Metabase sync in v1.0.1) |
 | `web/helpers.py` | 893 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
 | `platform/scheduling/jobs.py` | 849 | — (module-level job functions) |
 | `utils/db_health.py` | 654 | — (R5-N5: unified orphan detection from cli/db_helpers.py) |
-| `utils/post_sync.py` | 762 | — (post-sync hooks + sync notification) |
+| `utils/post_sync.py` | 804 | — (post-sync hooks + sync notification) |
 | `config/schedules.py` | 506 | — (R2-D13b: trigger comparison in reload) |
 | `web/routes/schedules.py` | 608 | — (schedule read-only, history, trigger, notifications) |
 | `web/routes/notebooks.py` | 574 | — (notebook management API + heartbeat lock expiry + WS notify) |

--- a/dango/__init__.py
+++ b/dango/__init__.py
@@ -4,7 +4,7 @@ Dango - Open source data platform
 Professional analytics stack built with production-grade tools.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "Dango Team"
 __license__ = "Apache-2.0"
 

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -13,6 +13,16 @@ import jinja2
 from dango.config.models import DataSource
 
 
+def _has_not_null_test(tests: list) -> bool:
+    """Check if a not_null test already exists in any form (string or dict)."""
+    for test in tests:
+        if test == "not_null":
+            return True
+        if isinstance(test, dict) and "not_null" in test:
+            return True
+    return False
+
+
 class DbtModelGenerator:
     """
     Generates dbt staging models from data sources configuration.
@@ -373,7 +383,7 @@ class DbtModelGenerator:
             return
 
         for col in columns:
-            if col["name"] in zero_null_cols and "not_null" not in col.get("tests", []):
+            if col["name"] in zero_null_cols and not _has_not_null_test(col.get("tests", [])):
                 col.setdefault("tests", []).append("not_null")
 
     def generate_staging_schema_yml(

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -20,7 +20,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~210 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~762 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
+| `post_sync.py` (~804 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -22,6 +22,21 @@ from dango.validation import validate_identifier
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
+# dbt test helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_not_null_test(tests: list) -> bool:
+    """Check if a not_null test already exists in any form (string or dict)."""
+    for test in tests:
+        if test == "not_null":
+            return True
+        if isinstance(test, dict) and "not_null" in test:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Type classification helpers
 # ---------------------------------------------------------------------------
 
@@ -434,7 +449,7 @@ def _enrich_staging_tests(project_root: Path, sources: list[str]) -> None:
                 for col in model.get("columns", []):
                     if col["name"] in zero_null_cols:
                         tests = col.get("tests", [])
-                        if "not_null" not in tests:
+                        if not _has_not_null_test(tests):
                             tests.append("not_null")
                             col["tests"] = tests
                             changed = True

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -55,6 +55,8 @@ logger = get_logger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: startup and shutdown logic."""
+    import asyncio
+
     project_root: Path = app.state.project_root
     logger.info("api_starting", project_root=str(project_root))
 
@@ -89,8 +91,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
                     # Sync newly created admin to Metabase in background
                     # (don't block startup — Metabase may still be starting)
-                    import asyncio
-
                     async def _sync_admin_to_metabase(
                         _db_path: Path, _user_id: int, _project_root: Path
                     ) -> None:
@@ -162,8 +162,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Initialize APScheduler for job scheduling
     try:
-        import asyncio
-
         from dango.platform.scheduling import SchedulerService
 
         scheduler = SchedulerService(project_root)
@@ -193,7 +191,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
     # Shutdown
-    import asyncio
+    mb_task = getattr(app.state, "_metabase_sync_task", None)
+    if mb_task is not None and not mb_task.done():
+        mb_task.cancel()
+        try:
+            await mb_task
+        except asyncio.CancelledError:
+            pass
 
     sync_task = getattr(app.state, "sync_watcher_task", None)
     if sync_task is not None:

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -87,18 +87,32 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     console.print(format_credentials_panel(user.email, password))
                     console.print()
 
-                    # Sync newly created admin to Metabase (if Metabase is running)
-                    try:
-                        from dango.auth.metabase_bridge import (
-                            ensure_metabase_synced,
-                            get_metabase_url,
-                        )
+                    # Sync newly created admin to Metabase in background
+                    # (don't block startup — Metabase may still be starting)
+                    import asyncio
 
-                        mb_url = await get_metabase_url(project_root)
-                        if mb_url is not None:
-                            await ensure_metabase_synced(db_path, user.id, project_root, mb_url)
-                    except Exception:
-                        logger.debug("metabase_sync_on_admin_create_skipped", exc_info=True)
+                    async def _sync_admin_to_metabase(
+                        _db_path: Path, _user_id: int, _project_root: Path
+                    ) -> None:
+                        try:
+                            from dango.auth.metabase_bridge import (
+                                ensure_metabase_synced,
+                                get_metabase_url,
+                            )
+
+                            mb_url = await get_metabase_url(_project_root)
+                            if mb_url is not None:
+                                await ensure_metabase_synced(
+                                    _db_path, _user_id, _project_root, mb_url
+                                )
+                        except Exception:
+                            logger.debug("metabase_sync_on_admin_create_skipped", exc_info=True)
+
+                    # Store task reference on app.state to prevent GC
+                    task = asyncio.create_task(
+                        _sync_admin_to_metabase(db_path, user.id, project_root)
+                    )
+                    app.state._metabase_sync_task = task
         except Exception:
             logger.warning("first_run_admin_check_failed", exc_info=True)
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -92,7 +92,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     # Sync newly created admin to Metabase in background
                     # (don't block startup — Metabase may still be starting)
                     async def _sync_admin_to_metabase(
-                        _db_path: Path, _user_id: int, _project_root: Path
+                        _db_path: Path, _user_id: str, _project_root: Path
                     ) -> None:
                         try:
                             from dango.auth.metabase_bridge import (

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -10,6 +10,12 @@ schema_version: 1
 limit: 500  # Informational — scripts/check_file_sizes.py owns the enforced threshold
 
 exemptions:
+  - file: dango/web/app.py
+    lines: 510
+    category: exempt
+    reason: "FastAPI entry point + lifespan. Background Metabase sync (v1.0.1) added ~10 lines over 500."
+    review_by: "v1.1"
+
   # --- Post-TASK-085 split results (from web/app.py 3032 → web/routes/) ---
   - file: dango/web/helpers.py
     lines: 893

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -11,9 +11,9 @@ limit: 500  # Informational — scripts/check_file_sizes.py owns the enforced th
 
 exemptions:
   - file: dango/web/app.py
-    lines: 510
+    lines: 514
     category: exempt
-    reason: "FastAPI entry point + lifespan. Background Metabase sync (v1.0.1) added ~10 lines over 500."
+    reason: "FastAPI entry point + lifespan. Background Metabase sync (v1.0.1) added ~14 lines over 500."
     review_by: "v1.1"
 
   # --- Post-TASK-085 split results (from web/app.py 3032 → web/routes/) ---
@@ -365,7 +365,7 @@ exemptions:
   # --- Phase 4 scheduling ---
 
   - file: dango/utils/post_sync.py
-    lines: 762
+    lines: 804
     category: exempt
     reason: "R10-G2: Added _enrich_staging_tests for post-sync dbt test enrichment from profiling data. R12-F added _run_dbt_snapshots hook (+29 lines). M2-final: Added _profile_dbt_models for intermediate/marts schema profiling (+62 lines)."
     review_by: "v1.1"

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -210,7 +210,7 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/transformation/generator.py
-    lines: 614
+    lines: 626
     category: exempt
     reason: "DbtModelGenerator — generates dbt models from source configs. R10-G2 added _enrich_columns_from_profiling for dbt test enrichment."
     review_by: "v1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "getdango"
-version = "1.0.0"
+version = "1.0.1"
 description = "Open source data platform built with production-grade tools - dlt, dbt, DuckDB, and Metabase"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/tests/unit/test_dbt_test_generation.py
+++ b/tests/unit/test_dbt_test_generation.py
@@ -208,6 +208,33 @@ class TestEnrichColumnsFromProfiling:
 
         assert columns[0]["tests"].count("not_null") == 1
 
+    def test_does_not_duplicate_not_null_dict_form(self, tmp_path):
+        """If not_null exists in dict form (with config), don't add a string duplicate."""
+        gen = DbtModelGenerator(tmp_path)
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [("order_id",)]
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        columns = [
+            {
+                "name": "order_id",
+                "tests": [{"not_null": {"config": {"severity": "warn"}}}, "unique"],
+            },
+        ]
+
+        with patch("dango.utils.dango_db.connect", return_value=mock_conn):
+            gen._enrich_columns_from_profiling("shopify", "orders", columns)
+
+        # Should not add a string "not_null" when dict form already exists
+        not_null_count = sum(
+            1
+            for t in columns[0]["tests"]
+            if t == "not_null" or (isinstance(t, dict) and "not_null" in t)
+        )
+        assert not_null_count == 1
+
     def test_handles_db_error_gracefully(self, tmp_path):
         """Database errors should leave columns unchanged."""
         gen = DbtModelGenerator(tmp_path)

--- a/tests/unit/test_post_sync.py
+++ b/tests/unit/test_post_sync.py
@@ -346,3 +346,47 @@ class TestEnsureDefaultMetrics:
         added = mock_add.call_args[0][1]
         assert len(added) == 1
         assert added[0].name == "shared_metric"
+
+
+@pytest.mark.unit
+class TestEnrichStagingTests:
+    """Tests for _enrich_staging_tests not_null dedup logic."""
+
+    def test_does_not_duplicate_not_null_dict_form(self, tmp_path: Path):
+        """If not_null exists in dict form, don't add a plain string duplicate."""
+        from dango.utils.post_sync import _enrich_staging_tests
+
+        # Create staging schema file with dict-form not_null
+        staging_dir = tmp_path / "dbt" / "models" / "staging"
+        staging_dir.mkdir(parents=True)
+        schema_content = """\
+models:
+  - name: stg_shopify__orders
+    columns:
+      - name: order_id
+        tests:
+          - not_null:
+              config:
+                severity: warn
+          - unique
+"""
+        (staging_dir / "stg_shopify.yml").write_text(schema_content)
+
+        # Mock profiling to say order_id has 0% nulls
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [("order_id",)]
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        with patch("dango.utils.post_sync.connect", return_value=mock_conn):
+            _enrich_staging_tests(tmp_path, ["shopify"])
+
+        # Re-read and verify no duplicate
+        import yaml
+
+        data = yaml.safe_load((staging_dir / "stg_shopify.yml").read_text())
+        col_tests = data["models"][0]["columns"][0]["tests"]
+        not_null_count = sum(
+            1 for t in col_tests if t == "not_null" or (isinstance(t, dict) and "not_null" in t)
+        )
+        assert not_null_count == 1


### PR DESCRIPTION
## Summary
- **Generator:** Add `_has_not_null_test()` helper that detects both string (`"not_null"`) and dict (`{"not_null": {...}}`) forms, preventing duplicate not_null tests in generated dbt schema YAML
- **Startup:** Move Metabase admin sync from blocking `await` to `asyncio.create_task()` in FastAPI lifespan, so `/api/status` is reachable immediately and `dango start` no longer times out waiting for Metabase
- **Version:** Bump `1.0.0` → `1.0.1` in `__init__.py` and `pyproject.toml`

## Verification
- `pytest -x`: 3737 passed, 31 skipped
- `python -c "import dango; print(dango.__version__)"` → `1.0.1`
- `grep _has_not_null_test dango/transformation/generator.py` — helper defined and called
- `grep create_task dango/web/app.py` — Metabase sync is background task

## Test plan
- [ ] Coordinating chat: install branch into test project, run `dango start`, confirm no timeout
- [ ] Coordinating chat: run `dango transform generate` on a source with non-nullable columns, verify no duplicate not_null tests in schema YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)