### PR TITLE
Unify activity logging as single source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to Dango will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-06-11
+
+### Added
+
+- Activity log category field (`core` vs `auxiliary`) with UI filter dropdown on logs page
+- Subprocess stderr captured to `.dango/logs/sync_*.log` files (was discarded to `/dev/null`)
+- Scheduler now writes start/complete/fail/timeout/cancel events to activity log
+- "Stale" status badge (yellow) on models page when upstream source sync fails
+- Stale sync status files and old sync logs (>7 days) cleaned on server startup
+- SIGTERM signal handler logs shutdown events to activity log for crash diagnostics
+
+### Fixed
+
+- "undefined synced successfully" toast when scheduled sync broadcasts missing source name
+- Phantom toast notifications on server restart from stale sync status files
+- Subprocess crashes now recorded in activity log and sync history (were silent)
+- Source failure now cascades to mark downstream dbt models as stale
+- Stale status does not overwrite error status on models (error is more severe)
+
 ## [1.0.2] - 2026-06-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ dango/                          # Python package source
 │   │   ├── scheduler.py        # SchedulerService (lifecycle, events, cancellation)
 │   │   ├── resilience.py       # Retry, timeout, cancellation
 │   │   ├── history.py          # Execution history tracking
-│   │   ├── jobs.py             # Module-level job functions (849 lines)
+│   │   ├── jobs.py             # Module-level job functions (1034 lines)
 │   │   └── sync_trigger.py     # Server-side manual sync runner
 │   ├── notifications/          # Webhook notifications (TASK-043+)
 │   │   ├── webhook.py          # Event types, config, async sender
@@ -350,7 +350,8 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/app.py` | 514 | — (background Metabase sync in v1.0.1) |
 | `web/helpers.py` | 893 | — (extracted from app.py by TASK-085) |
 | `ingestion/csv_loader.py` | 922 | — |
-| `platform/scheduling/jobs.py` | 849 | — (module-level job functions) |
+| `platform/sync_process.py` | 603 | — (subprocess launch + crash handling) |
+| `platform/scheduling/jobs.py` | 1034 | — (module-level job functions) |
 | `utils/db_health.py` | 654 | — (R5-N5: unified orphan detection from cli/db_helpers.py) |
 | `utils/post_sync.py` | 804 | — (post-sync hooks + sync notification) |
 | `config/schedules.py` | 506 | — (R2-D13b: trigger comparison in reload) |

--- a/dango/__init__.py
+++ b/dango/__init__.py
@@ -4,7 +4,7 @@ Dango - Open source data platform
 Professional analytics stack built with production-grade tools.
 """
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __author__ = "Dango Team"
 __license__ = "Apache-2.0"
 

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,7 +12,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (448 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (245 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (860 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `jobs.py` (1034 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
 | `sync_trigger.py` (330 lines) | Subprocess entrypoint for sync operations — progress writing (incl. dbt phase passthrough via progress_callback), lock acquisition, OAuth validation | `run_manual_sync()`, `_write_status()` |
 
 ## Key Conventions

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -359,9 +359,16 @@ def _run_coalesced_dbt(project_root: Path) -> bool:
         return True
 
     from dango.transformation import generate_dbt_docs, run_dbt_models
+    from dango.utils.activity_log import log_activity as _coalesced_log
 
     select_criteria = " ".join(f"source:{s}+" for s in pending)
     logger.info("coalesced_dbt_run", sources=pending, select=select_criteria)
+    _coalesced_log(
+        project_root,
+        "info",
+        f"dbt:{select_criteria}",
+        f"Coalesced dbt starting for sources: {', '.join(pending)}",
+    )
     dbt_success, _dbt_output = run_dbt_models(project_root, select=select_criteria)
 
     if dbt_success:
@@ -420,6 +427,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         launch_sync_subprocess,
         poll_sync_status_blocking,
     )
+    from dango.utils.activity_log import log_activity
 
     sender = WebhookSender(load_notification_config(project_root))
     source_names = list(sources)
@@ -442,6 +450,13 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
 
         record_id = _try_record_start(project_root, schedule_name, source_names)
 
+        log_activity(
+            project_root,
+            "info",
+            f"schedule:{schedule_name}",
+            f"Scheduled sync starting: {', '.join(source_names)}",
+        )
+
         _broadcast(
             {
                 "event": "sync_started",
@@ -462,7 +477,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             if _scheduler_service is not None and _scheduler_service.is_cancelled(job_id):
                 raise JobCancelledError(f"Sync cancelled between sources for {schedule_name}")
 
-            process, sync_id = launch_sync_subprocess(
+            process, sync_id, log_path = launch_sync_subprocess(
                 project_root,
                 sources=[src.name],
                 full_refresh=full_refresh,
@@ -477,6 +492,8 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 source_name=src.name,
                 sync_id=sync_id,
                 broadcast_fn=_broadcast,
+                log_path=log_path,
+                sources=[src.name],
             )
 
             if not success:
@@ -484,6 +501,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                     _result.get("error", "Unknown error") if _result else "Subprocess failed"
                 )
                 failed_source_errors[src.name] = error_msg
+                log_activity(project_root, "error", src.name, f"Scheduled sync failed: {error_msg}")
                 logger.warning(
                     "scheduled_source_sync_failed",
                     schedule=schedule_name,
@@ -509,6 +527,19 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         if not succeeded_sources:
             combined_error = "; ".join(f"{n}: {e}" for n, e in failed_source_errors.items())
             elapsed = time.monotonic() - t0
+            log_activity(
+                project_root,
+                "error",
+                f"schedule:{schedule_name}",
+                f"All sources failed: {combined_error}",
+            )
+            # Mark downstream dbt models as stale
+            try:
+                from dango.utils.dbt_status import mark_source_models_stale
+
+                mark_source_models_stale(project_root, list(failed_source_errors.keys()))
+            except Exception:  # noqa: BLE001
+                logger.debug("mark_stale_after_all_failed", exc_info=True)
             _try_finish_record(
                 project_root, schedule_name, record_id, "record_failure", error=combined_error
             )
@@ -543,6 +574,13 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
         source_error: str | None = None
         if failed_source_errors:
             source_error = "; ".join(f"{n}: {e}" for n, e in failed_source_errors.items())
+            # Mark downstream dbt models as stale for failed sources
+            try:
+                from dango.utils.dbt_status import mark_source_models_stale
+
+                mark_source_models_stale(project_root, list(failed_source_errors.keys()))
+            except Exception:  # noqa: BLE001
+                logger.debug("mark_stale_after_partial_failure", exc_info=True)
 
         # Run coalesced dbt (waits for coalesce window, merges pending sources)
         transform_error: str | None = None
@@ -612,6 +650,12 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 duration_seconds=round(elapsed, 2),
             )
         else:
+            log_activity(
+                project_root,
+                "success",
+                f"schedule:{schedule_name}",
+                f"Completed: {total_rows} rows ({round(elapsed, 1)}s)",
+            )
             _try_finish_record(project_root, schedule_name, record_id, "record_completion")
             _log_execution_event(
                 schedule_name=schedule_name,
@@ -642,6 +686,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
 
     except JobTimeoutError:
         elapsed = time.monotonic() - t0
+        log_activity(project_root, "error", f"schedule:{schedule_name}", "Sync timed out")
         _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
         _log_execution_event(
             schedule_name=schedule_name,
@@ -671,6 +716,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
 
     except JobCancelledError:
         elapsed = time.monotonic() - t0
+        log_activity(project_root, "warning", f"schedule:{schedule_name}", "Sync cancelled")
         _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")
         _log_execution_event(
             schedule_name=schedule_name,
@@ -701,6 +747,9 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
     except Exception as exc:  # noqa: BLE001
         elapsed = time.monotonic() - t0
         error_msg = str(exc)
+        log_activity(
+            project_root, "error", f"schedule:{schedule_name}", f"Sync failed: {error_msg}"
+        )
         logger.error(
             "scheduled_sync_failed",
             schedule=schedule_name,
@@ -763,6 +812,7 @@ def run_scheduled_dbt(
         WebhookSender,
         load_notification_config,
     )
+    from dango.utils.activity_log import log_activity as _log_activity
     from dango.utils.dbt_lock import DbtLock
 
     sender = WebhookSender(load_notification_config(project_root))
@@ -812,6 +862,14 @@ def run_scheduled_dbt(
 
         record_id = _try_record_start(project_root, schedule_name, source_names=None)
 
+        dbt_label = f"dbt:{dbt_command}" if dbt_command else "dbt:all"
+        _log_activity(
+            project_root,
+            "info",
+            dbt_label,
+            f"Scheduled dbt run starting ({schedule_name})",
+        )
+
         _broadcast(
             {
                 "event": "dbt_started",
@@ -829,6 +887,12 @@ def run_scheduled_dbt(
         dbt_dashboard_url = _build_dashboard_url(project_root)
 
         if success:
+            _log_activity(
+                project_root,
+                "success",
+                dbt_label,
+                f"Scheduled dbt completed ({round(elapsed, 1)}s)",
+            )
             _try_finish_record(project_root, schedule_name, record_id, "record_completion")
             _log_execution_event(
                 schedule_name=schedule_name,
@@ -852,6 +916,12 @@ def run_scheduled_dbt(
                 dashboard_url=dbt_dashboard_url,
             )
         else:
+            _log_activity(
+                project_root,
+                "error",
+                dbt_label,
+                f"Scheduled dbt failed: {output}",
+            )
             _try_finish_record(
                 project_root, schedule_name, record_id, "record_failure", error=output
             )
@@ -880,6 +950,7 @@ def run_scheduled_dbt(
 
     except JobTimeoutError:
         elapsed = time.monotonic() - t0
+        _log_activity(project_root, "error", dbt_label, "Scheduled dbt timed out")
         _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
         _log_execution_event(
             schedule_name=schedule_name,
@@ -906,6 +977,7 @@ def run_scheduled_dbt(
 
     except JobCancelledError:
         elapsed = time.monotonic() - t0
+        _log_activity(project_root, "warning", dbt_label, "Scheduled dbt cancelled")
         _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")
         _log_execution_event(
             schedule_name=schedule_name,
@@ -925,6 +997,7 @@ def run_scheduled_dbt(
     except Exception as exc:  # noqa: BLE001
         elapsed = time.monotonic() - t0
         error_msg = str(exc)
+        _log_activity(project_root, "error", dbt_label, f"Scheduled dbt failed: {error_msg}")
         logger.error(
             "scheduled_dbt_failed",
             schedule=schedule_name,

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -372,6 +372,12 @@ def _run_coalesced_dbt(project_root: Path) -> bool:
     dbt_success, _dbt_output = run_dbt_models(project_root, select=select_criteria)
 
     if dbt_success:
+        log_activity_fn(
+            project_root,
+            "success",
+            f"dbt:{select_criteria}",
+            f"Coalesced dbt completed for sources: {', '.join(pending)}",
+        )
         # Generate docs and refresh Metabase (mirrors run_sync post-dbt steps)
         generate_dbt_docs(project_root)
         try:
@@ -386,6 +392,12 @@ def _run_coalesced_dbt(project_root: Path) -> bool:
         except Exception:
             logger.warning("metabase_refresh_after_coalesced_dbt_failed", exc_info=True)
     else:
+        log_activity_fn(
+            project_root,
+            "error",
+            f"dbt:{select_criteria}",
+            f"Coalesced dbt failed for sources: {', '.join(pending)}",
+        )
         logger.error("coalesced_dbt_run_failed", sources=pending, select=select_criteria)
 
     return dbt_success
@@ -620,6 +632,12 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
             if transform_error and source_error:
                 overall_error = f"{source_error}; {transform_error}"
 
+            log_activity(
+                project_root,
+                "error",
+                f"schedule:{schedule_name}",
+                f"Partial failure: {overall_error}",
+            )
             _try_finish_record(
                 project_root, schedule_name, record_id, "record_failure", error=overall_error
             )

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -359,11 +359,11 @@ def _run_coalesced_dbt(project_root: Path) -> bool:
         return True
 
     from dango.transformation import generate_dbt_docs, run_dbt_models
-    from dango.utils.activity_log import log_activity as _coalesced_log
+    from dango.utils.activity_log import log_activity as log_activity_fn
 
     select_criteria = " ".join(f"source:{s}+" for s in pending)
     logger.info("coalesced_dbt_run", sources=pending, select=select_criteria)
-    _coalesced_log(
+    log_activity_fn(
         project_root,
         "info",
         f"dbt:{select_criteria}",
@@ -812,11 +812,12 @@ def run_scheduled_dbt(
         WebhookSender,
         load_notification_config,
     )
-    from dango.utils.activity_log import log_activity as _log_activity
+    from dango.utils.activity_log import log_activity
     from dango.utils.dbt_lock import DbtLock
 
     sender = WebhookSender(load_notification_config(project_root))
     lock = DbtLock(project_root, source="scheduler", operation=f"dbt:{schedule_name}")
+    dbt_label = f"dbt:{dbt_command}" if dbt_command else "dbt:all"
 
     record_id: int | None = None
 
@@ -862,8 +863,7 @@ def run_scheduled_dbt(
 
         record_id = _try_record_start(project_root, schedule_name, source_names=None)
 
-        dbt_label = f"dbt:{dbt_command}" if dbt_command else "dbt:all"
-        _log_activity(
+        log_activity(
             project_root,
             "info",
             dbt_label,
@@ -887,7 +887,7 @@ def run_scheduled_dbt(
         dbt_dashboard_url = _build_dashboard_url(project_root)
 
         if success:
-            _log_activity(
+            log_activity(
                 project_root,
                 "success",
                 dbt_label,
@@ -916,7 +916,7 @@ def run_scheduled_dbt(
                 dashboard_url=dbt_dashboard_url,
             )
         else:
-            _log_activity(
+            log_activity(
                 project_root,
                 "error",
                 dbt_label,
@@ -950,7 +950,7 @@ def run_scheduled_dbt(
 
     except JobTimeoutError:
         elapsed = time.monotonic() - t0
-        _log_activity(project_root, "error", dbt_label, "Scheduled dbt timed out")
+        log_activity(project_root, "error", dbt_label, "Scheduled dbt timed out")
         _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
         _log_execution_event(
             schedule_name=schedule_name,
@@ -977,7 +977,7 @@ def run_scheduled_dbt(
 
     except JobCancelledError:
         elapsed = time.monotonic() - t0
-        _log_activity(project_root, "warning", dbt_label, "Scheduled dbt cancelled")
+        log_activity(project_root, "warning", dbt_label, "Scheduled dbt cancelled")
         _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")
         _log_execution_event(
             schedule_name=schedule_name,
@@ -997,7 +997,7 @@ def run_scheduled_dbt(
     except Exception as exc:  # noqa: BLE001
         elapsed = time.monotonic() - t0
         error_msg = str(exc)
-        _log_activity(project_root, "error", dbt_label, f"Scheduled dbt failed: {error_msg}")
+        log_activity(project_root, "error", dbt_label, f"Scheduled dbt failed: {error_msg}")
         logger.error(
             "scheduled_dbt_failed",
             schedule=schedule_name,

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -208,7 +208,8 @@ async def poll_sync_status(
                         "timestamp": _ts(),
                     }
                 )
-                _handle_crash(project_root, source_list, None, log_path, error_msg)
+                # Timeout is not a crash — don't call _handle_crash (the caller
+                # has its own timeout handling). Just keep the log for diagnostics.
                 if log_path:
                     _cleanup_sync_log(log_path, keep=True)
                 return False, {"error": error_msg, "phase": "failed"}
@@ -310,7 +311,8 @@ def poll_sync_status_blocking(
                         "timestamp": _ts(),
                     }
                 )
-            _handle_crash(project_root, source_list, None, log_path, error_msg)
+            # Timeout is not a crash — don't call _handle_crash (the caller
+            # has its own timeout handling). Just keep the log for diagnostics.
             if log_path:
                 _cleanup_sync_log(log_path, keep=True)
             return False, {"error": error_msg, "phase": "failed"}

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -209,7 +209,8 @@ async def poll_sync_status(
                     }
                 )
                 _handle_crash(project_root, source_list, None, log_path, error_msg)
-                _cleanup_sync_log(log_path, keep=True) if log_path else None
+                if log_path:
+                    _cleanup_sync_log(log_path, keep=True)
                 return False, {"error": error_msg, "phase": "failed"}
 
             # Check if subprocess has exited
@@ -399,13 +400,30 @@ def _handle_crash(
     Called when a sync subprocess terminates without writing a terminal status.
     """
     from dango.utils.activity_log import log_activity
-    from dango.utils.sync_history import save_sync_history_entry
+    from dango.utils.sync_history import load_sync_history, save_sync_history_entry
 
     log_tail = _read_log_tail(log_path) if log_path else ""
     detail = f"{error_msg}\n{log_tail}".strip() if log_tail else error_msg
 
     for src in sources:
         try:
+            # Skip if the subprocess already wrote a terminal history entry
+            # (e.g., it crashed after recording its own failure in dlt_runner)
+            recent = load_sync_history(project_root, src, limit=1)
+            if recent and recent[0].get("status") in ("failed", "success", "partial"):
+                # Check if this entry is recent (within last 5 minutes)
+                from datetime import datetime, timezone
+
+                entry_ts = recent[0].get("timestamp", "")
+                try:
+                    clean = entry_ts.replace("+00:00", "").replace("Z", "")
+                    ts = datetime.fromisoformat(clean).replace(tzinfo=timezone.utc)
+                    age = (datetime.now(tz=timezone.utc) - ts).total_seconds()
+                    if age < 300:  # 5 minutes
+                        continue  # subprocess already recorded this
+                except (ValueError, TypeError):
+                    pass  # can't parse — write our own entry
+
             save_sync_history_entry(
                 project_root,
                 src,

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -140,12 +140,17 @@ def launch_sync_subprocess(
     json_args = json.dumps(args_dict)
 
     log_handle = open(log_path, "w")  # noqa: SIM115
-    process = subprocess.Popen(
-        [sys.executable, "-m", "dango.platform.scheduling.sync_trigger", json_args],
-        cwd=str(project_root),
-        stdout=log_handle,
-        stderr=subprocess.STDOUT,
-    )
+    try:
+        process = subprocess.Popen(
+            [sys.executable, "-m", "dango.platform.scheduling.sync_trigger", json_args],
+            cwd=str(project_root),
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+        )
+    except Exception:
+        log_handle.close()
+        log_path.unlink(missing_ok=True)
+        raise
     # Close the handle in the parent process — the child has its own fd copy
     log_handle.close()
 
@@ -418,8 +423,12 @@ def _handle_crash(
 
                 entry_ts = recent[0].get("timestamp", "")
                 try:
-                    clean = entry_ts.replace("+00:00", "").replace("Z", "")
-                    ts = datetime.fromisoformat(clean).replace(tzinfo=timezone.utc)
+                    # Normalise common UTC representations for Python 3.10 compat
+                    # (3.11+ handles full ISO 8601 natively)
+                    clean = entry_ts.replace("Z", "+00:00").replace("+0000", "+00:00")
+                    ts = datetime.fromisoformat(clean)
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
                     age = (datetime.now(tz=timezone.utc) - ts).total_seconds()
                     if age < 300:  # 5 minutes
                         continue  # subprocess already recorded this

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -98,11 +98,12 @@ def launch_sync_subprocess(
     source_label: str = "ui",
     max_lock_wait: int = 0,
     record_id: int | None = None,
-) -> tuple[subprocess.Popen, str]:
+) -> tuple[subprocess.Popen, str, Path]:
     """Spawn sync subprocess via sys.executable.
 
-    Returns (Popen handle, sync_id). The sync_id uniquely identifies the
-    status file so concurrent syncs don't clobber each other.
+    Returns (Popen handle, sync_id, log_path). The sync_id uniquely identifies
+    the status file so concurrent syncs don't clobber each other. The log_path
+    captures stdout+stderr so crash output is available for diagnostics.
 
     The subprocess runs ``python -m dango.platform.scheduling.sync_trigger``
     with write_progress=True.
@@ -111,6 +112,11 @@ def launch_sync_subprocess(
 
     # Clean up any stale status file for the default path (legacy)
     cleanup_sync_status(project_root)
+
+    # Capture subprocess output to a log file (was DEVNULL — silent crashes)
+    log_dir = project_root / ".dango" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"sync_{sync_id}.log"
 
     args_dict: dict[str, Any] = {
         "project_root": str(project_root),
@@ -133,12 +139,15 @@ def launch_sync_subprocess(
 
     json_args = json.dumps(args_dict)
 
+    log_handle = open(log_path, "w")  # noqa: SIM115
     process = subprocess.Popen(
         [sys.executable, "-m", "dango.platform.scheduling.sync_trigger", json_args],
         cwd=str(project_root),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
     )
+    # Close the handle in the parent process — the child has its own fd copy
+    log_handle.close()
 
     logger.info(
         "sync_subprocess_launched",
@@ -146,8 +155,9 @@ def launch_sync_subprocess(
         sources=sources,
         source_label=source_label,
         sync_id=sync_id,
+        log_path=str(log_path),
     )
-    return process, sync_id
+    return process, sync_id, log_path
 
 
 async def poll_sync_status(
@@ -158,18 +168,25 @@ async def poll_sync_status(
     poll_interval: float = 2.0,
     heartbeat_interval: float = 30.0,
     max_poll_time: float = 3600.0,
+    log_path: Path | None = None,
+    sources: list[str] | None = None,
 ) -> tuple[bool, dict[str, Any] | None]:
     """Async poll — reads status file, broadcasts WS events on transitions.
 
     Emits heartbeat every ``heartbeat_interval`` seconds. Detects subprocess
     crash via ``process.poll()``. Times out after ``max_poll_time`` seconds.
     Returns (success, result_dict).
+
+    When *log_path* is provided, crash output is read from the file and
+    written to activity log + sync history.  On success the log file is
+    deleted; on failure it is kept for 7 days of diagnostics.
     """
     from dango.web.routes.websocket import ws_manager
 
     if sync_id:
         _locally_polled.add(sync_id)
 
+    source_list = sources or ([source_name] if source_name else [])
     last_phase: str | None = None
     last_heartbeat = time.time()
     start_time = time.time()
@@ -191,6 +208,8 @@ async def poll_sync_status(
                         "timestamp": _ts(),
                     }
                 )
+                _handle_crash(project_root, source_list, None, log_path, error_msg)
+                _cleanup_sync_log(log_path, keep=True) if log_path else None
                 return False, {"error": error_msg, "phase": "failed"}
 
             # Check if subprocess has exited
@@ -211,7 +230,10 @@ async def poll_sync_status(
 
                 # Detect terminal state
                 if current_phase in ("completed", "failed"):
-                    return current_phase == "completed", status
+                    success = current_phase == "completed"
+                    if log_path:
+                        _cleanup_sync_log(log_path, keep=not success)
+                    return success, status
 
             # Heartbeat
             now = time.time()
@@ -232,6 +254,9 @@ async def poll_sync_status(
                 status is None or status.get("phase") not in ("completed", "failed")
             ):
                 error_msg = f"Sync process terminated unexpectedly (exit code {exit_code})"
+                _handle_crash(project_root, source_list, exit_code, log_path, error_msg)
+                if log_path:
+                    _cleanup_sync_log(log_path, keep=True)
                 await ws_manager.broadcast(
                     {
                         "event": "sync_failed",
@@ -254,11 +279,16 @@ def poll_sync_status_blocking(
     broadcast_fn: Callable[[dict[str, Any]], None] | None = None,
     poll_interval: float = 2.0,
     max_poll_time: float = 3600.0,
+    log_path: Path | None = None,
+    sources: list[str] | None = None,
 ) -> tuple[bool, dict[str, Any] | None]:
     """Synchronous version for APScheduler thread pool. Returns (success, result_dict).
 
     Uses time.sleep() for polling. Calls optional broadcast_fn on phase transitions.
+    When *log_path* is provided, crash output is captured and written to
+    activity log + sync history.
     """
+    source_list = sources or ([source_name] if source_name else [])
     last_phase: str | None = None
     start_time = time.time()
 
@@ -279,6 +309,9 @@ def poll_sync_status_blocking(
                         "timestamp": _ts(),
                     }
                 )
+            _handle_crash(project_root, source_list, None, log_path, error_msg)
+            if log_path:
+                _cleanup_sync_log(log_path, keep=True)
             return False, {"error": error_msg, "phase": "failed"}
 
         exit_code = process.poll()
@@ -305,6 +338,8 @@ def poll_sync_status_blocking(
             # Detect terminal state
             if current_phase in ("completed", "failed"):
                 success = current_phase == "completed"
+                if log_path:
+                    _cleanup_sync_log(log_path, keep=not success)
                 return success, status
 
         # Process crashed without writing final status
@@ -312,6 +347,9 @@ def poll_sync_status_blocking(
             status is None or status.get("phase") not in ("completed", "failed")
         ):
             error_msg = f"Sync process terminated unexpectedly (exit code {exit_code})"
+            _handle_crash(project_root, source_list, exit_code, log_path, error_msg)
+            if log_path:
+                _cleanup_sync_log(log_path, keep=True)
             if broadcast_fn is not None:
                 broadcast_fn(
                     {
@@ -322,6 +360,79 @@ def poll_sync_status_blocking(
                     }
                 )
             return False, {"error": error_msg, "phase": "failed"}
+
+
+# ---------------------------------------------------------------------------
+# Crash handling helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_log_tail(log_path: Path, max_lines: int = 50) -> str:
+    """Read the last *max_lines* of a sync log file.  Returns '' on any error."""
+    try:
+        if not log_path.exists():
+            return ""
+        lines = log_path.read_text(errors="replace").splitlines()
+        return "\n".join(lines[-max_lines:])
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _cleanup_sync_log(log_path: Path, *, keep: bool) -> None:
+    """Delete or keep a sync log file depending on outcome."""
+    try:
+        if not keep and log_path.exists():
+            log_path.unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _handle_crash(
+    project_root: Path,
+    sources: list[str],
+    exit_code: int | None,
+    log_path: Path | None,
+    error_msg: str,
+) -> None:
+    """Write crash information to activity log and sync history.
+
+    Called when a sync subprocess terminates without writing a terminal status.
+    """
+    from dango.utils.activity_log import log_activity
+    from dango.utils.sync_history import save_sync_history_entry
+
+    log_tail = _read_log_tail(log_path) if log_path else ""
+    detail = f"{error_msg}\n{log_tail}".strip() if log_tail else error_msg
+
+    for src in sources:
+        try:
+            save_sync_history_entry(
+                project_root,
+                src,
+                {
+                    "timestamp": _ts(),
+                    "status": "failed",
+                    "duration_seconds": 0,
+                    "rows_processed": 0,
+                    "error_message": detail[:2000],  # cap length
+                },
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    try:
+        source_label = ", ".join(sources) if sources else "unknown"
+        log_activity(project_root, "error", source_label, f"Sync crashed: {detail[:1000]}")
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Mark downstream dbt models as stale
+    try:
+        from dango.utils.dbt_status import mark_source_models_stale
+
+        mark_source_models_stale(project_root, sources)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/dango/utils/activity_log.py
+++ b/dango/utils/activity_log.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Literal
 
 LogLevel = Literal["info", "success", "warning", "error"]
+LogCategory = Literal["core", "auxiliary"]
 
 
 def get_activity_log_file(project_root: Path) -> Path:
@@ -19,7 +20,12 @@ def get_activity_log_file(project_root: Path) -> Path:
 
 
 def log_activity(
-    project_root: Path, level: LogLevel, source: str, message: str, timestamp: str | None = None
+    project_root: Path,
+    level: LogLevel,
+    source: str,
+    message: str,
+    timestamp: str | None = None,
+    category: LogCategory = "core",
 ) -> None:
     """
     Write an activity log entry
@@ -30,6 +36,8 @@ def log_activity(
         source: Source name or system component
         message: Log message (will be trimmed of extra whitespace)
         timestamp: ISO timestamp (defaults to now)
+        category: Event category — "core" (syncs, schedules, failures) or
+                  "auxiliary" (queries, notebooks). Defaults to "core".
     """
     if timestamp is None:
         timestamp = datetime.now(tz=timezone.utc).isoformat()
@@ -39,6 +47,7 @@ def log_activity(
         "level": level,
         "source": source,
         "message": message.strip(),  # Remove leading/trailing whitespace
+        "category": category,
     }
 
     log_file = get_activity_log_file(project_root)

--- a/dango/utils/dbt_status.py
+++ b/dango/utils/dbt_status.py
@@ -65,6 +65,57 @@ def update_model_status(project_root: Path) -> None:
         pass
 
 
+def mark_source_models_stale(project_root: Path, failed_sources: list[str]) -> None:
+    """Mark dbt models whose upstream source failed as "stale".
+
+    Loads ``dbt/target/manifest.json`` to discover model→source dependencies.
+    Updates the persistent status file so the UI shows a yellow "stale" badge.
+    Models are automatically cleared back to their real status on the next
+    successful dbt run (``update_model_status()``).
+
+    Silently returns if the manifest doesn't exist or on any error.
+    """
+    if not failed_sources:
+        return
+
+    manifest_path = project_root / "dbt" / "target" / "manifest.json"
+    if not manifest_path.exists():
+        return
+
+    try:
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+
+        persistent_status = _load_persistent_status(project_root)
+
+        # Build a set of source node prefixes to match against
+        # dbt source nodes: "source.{project_name}.{source_name}.{table}"
+        failed_set = set(failed_sources)
+
+        nodes = manifest.get("nodes", {})
+        for node_id, node in nodes.items():
+            if node.get("resource_type") != "model":
+                continue
+            depends_on = node.get("depends_on", {}).get("nodes", [])
+            for dep in depends_on:
+                if not dep.startswith("source."):
+                    continue
+                # source.project_name.source_name.table_name
+                parts = dep.split(".")
+                if len(parts) >= 3 and parts[2] in failed_set:
+                    # Preserve last_run but mark as stale
+                    existing = persistent_status.get(node_id, {})
+                    persistent_status[node_id] = {
+                        "status": "stale",
+                        "last_run": existing.get("last_run"),
+                    }
+                    break  # Only need to mark once per model
+
+        _save_persistent_status(project_root, persistent_status)
+    except Exception:
+        pass
+
+
 def get_model_statuses(project_root: Path) -> dict[str, dict[str, Any]]:
     """
     Get persistent model statuses for UI display

--- a/dango/utils/dbt_status.py
+++ b/dango/utils/dbt_status.py
@@ -115,6 +115,7 @@ def mark_source_models_stale(project_root: Path, failed_sources: list[str]) -> N
 
         _save_persistent_status(project_root, persistent_status)
     except Exception:
+        # Don't fail the caller — stale marking is best-effort
         pass
 
 

--- a/dango/utils/dbt_status.py
+++ b/dango/utils/dbt_status.py
@@ -103,8 +103,10 @@ def mark_source_models_stale(project_root: Path, failed_sources: list[str]) -> N
                 # source.project_name.source_name.table_name
                 parts = dep.split(".")
                 if len(parts) >= 3 and parts[2] in failed_set:
-                    # Preserve last_run but mark as stale
+                    # Don't downgrade "error" to "stale" — error is more severe
                     existing = persistent_status.get(node_id, {})
+                    if existing.get("status") == "error":
+                        break
                     persistent_status[node_id] = {
                         "status": "stale",
                         "last_run": existing.get("last_run"),

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -53,10 +53,12 @@ logger = get_logger(__name__)
 
 
 def _install_sigterm_logger(project_root: Path) -> None:
-    """Install a SIGTERM handler that logs the sender PID before shutdown.
+    """Install a SIGTERM handler that logs the signal before shutdown.
 
-    Helps diagnose unexpected shutdowns — the sender PID is recorded in
-    activity.jsonl so we can identify what killed the server.
+    Records a warning-level entry in activity.jsonl when SIGTERM arrives,
+    then chains to uvicorn's original handler for graceful shutdown.
+    Helps diagnose unexpected shutdowns — the timestamp narrows the window
+    for investigating what sent the signal.
     """
     import signal
 
@@ -78,6 +80,8 @@ def _install_sigterm_logger(project_root: Path) -> None:
         if callable(_original_handler):
             _original_handler(signum, frame)
         elif _original_handler == signal.SIG_DFL:
+            # Restore default and re-send so the process exits normally.
+            # No infinite loop: SIG_DFL is restored before the re-send.
             signal.signal(signal.SIGTERM, signal.SIG_DFL)
             os.kill(os.getpid(), signal.SIGTERM)
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -61,10 +61,11 @@ def _install_sigterm_logger(project_root: Path) -> None:
     for investigating what sent the signal.
     """
     import signal
+    from types import FrameType
 
     _original_handler = signal.getsignal(signal.SIGTERM)
 
-    def _on_sigterm(signum: int, frame: object) -> None:
+    def _on_sigterm(signum: int, frame: FrameType | None) -> None:
         try:
             from dango.utils.activity_log import log_activity
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -171,6 +171,36 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.error("scheduler_startup_failed", exc_info=True)
         app.state.scheduler = None
 
+    # Clean stale sync status files (dead PIDs from prior shutdown)
+    try:
+        from dango.platform.sync_process import cleanup_sync_status
+
+        state_dir = project_root / ".dango" / "state"
+        if state_dir.exists():
+            for path in state_dir.iterdir():
+                if path.name.startswith("sync_status_") and path.name.endswith(".json"):
+                    sync_id = path.name[len("sync_status_") : -len(".json")]
+                    cleanup_sync_status(project_root, sync_id=sync_id)
+    except Exception:
+        logger.debug("stale_sync_status_cleanup_failed", exc_info=True)
+
+    # Clean old sync log files (>7 days)
+    try:
+        import time as _time
+
+        logs_dir = project_root / ".dango" / "logs"
+        if logs_dir.exists():
+            cutoff = _time.time() - 7 * 86400
+            for path in logs_dir.iterdir():
+                if path.name.startswith("sync_") and path.name.endswith(".log"):
+                    try:
+                        if path.stat().st_mtime < cutoff:
+                            path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+    except Exception:
+        logger.debug("old_sync_log_cleanup_failed", exc_info=True)
+
     # Start background sync status watcher (multi-worker support)
     try:
         from dango.platform.sync_process import start_sync_status_watcher

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -52,6 +52,38 @@ from dango.web.middleware import AuthMiddleware, RateLimitMiddleware
 logger = get_logger(__name__)
 
 
+def _install_sigterm_logger(project_root: Path) -> None:
+    """Install a SIGTERM handler that logs the sender PID before shutdown.
+
+    Helps diagnose unexpected shutdowns — the sender PID is recorded in
+    activity.jsonl so we can identify what killed the server.
+    """
+    import signal
+
+    _original_handler = signal.getsignal(signal.SIGTERM)
+
+    def _on_sigterm(signum: int, frame: object) -> None:
+        try:
+            from dango.utils.activity_log import log_activity
+
+            log_activity(
+                project_root,
+                "warning",
+                "system",
+                f"Received SIGTERM (signal {signum}) — server shutting down",
+            )
+        except Exception:
+            pass
+        # Chain to the original handler (uvicorn's graceful shutdown)
+        if callable(_original_handler):
+            _original_handler(signum, frame)
+        elif _original_handler == signal.SIG_DFL:
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    signal.signal(signal.SIGTERM, _on_sigterm)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: startup and shutdown logic."""
@@ -59,6 +91,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     project_root: Path = app.state.project_root
     logger.info("api_starting", project_root=str(project_root))
+
+    # Install SIGTERM logger to diagnose unexpected shutdowns
+    _install_sigterm_logger(project_root)
 
     # Write auth.yml if missing (migration path for pre-075d projects)
     try:

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -561,8 +561,14 @@ def append_log_entry(log_entry: dict[str, Any]):
         logger.error(f"Error appending log entry: {e}")
 
 
-def load_all_logs(limit: int = 1000) -> list[dict[str, Any]]:
-    """Load all logs from the persistent file."""
+def load_all_logs(limit: int = 1000, category: str | None = None) -> list[dict[str, Any]]:
+    """Load all logs from the persistent file.
+
+    Args:
+        limit: Maximum number of entries to return.
+        category: If set, only return entries matching this category.
+                  Entries without a ``category`` field are treated as ``"core"``.
+    """
     logs_file = get_logs_file()
 
     if not logs_file.exists():
@@ -574,9 +580,14 @@ def load_all_logs(limit: int = 1000) -> list[dict[str, Any]]:
             for line in f:
                 if line.strip():
                     try:
-                        logs.append(json.loads(line))
+                        entry = json.loads(line)
                     except json.JSONDecodeError:
                         continue
+                    if category is not None:
+                        entry_cat = entry.get("category", "core")
+                        if entry_cat != category:
+                            continue
+                    logs.append(entry)
 
         # Return most recent logs first, limited to 'limit'
         return logs[-limit:][::-1]

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -556,6 +556,7 @@ def append_log_entry(log_entry: dict[str, Any]):
             source=log_entry.get("source", "system"),
             message=log_entry.get("message", ""),
             timestamp=log_entry.get("timestamp"),
+            category=log_entry.get("category", "core"),
         )
     except Exception as e:
         logger.error(f"Error appending log entry: {e}")

--- a/dango/web/routes/logs.py
+++ b/dango/web/routes/logs.py
@@ -64,18 +64,22 @@ async def get_source_logs(source_name: str, limit: int = 100) -> list[LogEntry]:
 
 
 @router.get("/api/logs")
-async def get_all_logs(limit: int = 1000) -> list[dict[str, object]]:
+async def get_all_logs(limit: int = 1000, category: str | None = None) -> list[dict[str, object]]:
     """Get all activity logs.
 
     Args:
         limit: Maximum number of log entries to return (default 1000)
+        category: Filter by category ("core" or "auxiliary"). None returns all.
 
     Returns:
         List of all log entries
     """
     limit = validate_limit(limit)
+    # Validate category if provided
+    if category is not None and category not in ("core", "auxiliary"):
+        category = None
     try:
-        logs = load_all_logs(limit=limit)
+        logs = load_all_logs(limit=limit, category=category)
         return logs
     except Exception as e:
         logger.error(f"Error fetching logs: {e}")

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -128,7 +128,7 @@ async def run_sync_task(
     sync_id: str | None = None
     try:
         # Launch subprocess (DbtLock acquired inside subprocess)
-        process, sync_id = launch_sync_subprocess(
+        process, sync_id, log_path = launch_sync_subprocess(
             project_root=project_root,
             sources=[source_name],
             full_refresh=full_refresh,
@@ -141,7 +141,12 @@ async def run_sync_task(
 
         # Poll until completion (broadcasts WS events + heartbeat internally)
         success, result = await poll_sync_status(
-            project_root, process, source_name, sync_id=sync_id
+            project_root,
+            process,
+            source_name,
+            sync_id=sync_id,
+            log_path=log_path,
+            sources=[source_name],
         )
 
         # Calculate duration
@@ -306,7 +311,7 @@ async def _run_manual_sync(
     sync_id: str | None = None
     try:
         # Pass record_id so subprocess reuses it (avoids double history records)
-        process, sync_id = launch_sync_subprocess(
+        process, sync_id, log_path = launch_sync_subprocess(
             project_root=project_root,
             sources=source_names,
             full_refresh=full_refresh,
@@ -319,7 +324,12 @@ async def _run_manual_sync(
         # Use first source name for WS events (manual sync may have multiple)
         display_name = source_names[0] if source_names else "manual"
         success, _result = await poll_sync_status(
-            project_root, process, display_name, sync_id=sync_id
+            project_root,
+            process,
+            display_name,
+            sync_id=sync_id,
+            log_path=log_path,
+            sources=source_names,
         )
 
         # Subprocess records its own completion/failure via record_id for normal

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -405,7 +405,8 @@ function connectWebSocket() {
 }
 
 async function handleWebSocketMessage(data) {
-    const { event, source, message, timestamp } = data;
+    const { event, message, timestamp } = data;
+    const source = data.source || 'Unknown';
 
     // 🔍 DIAGNOSTIC: Log ALL incoming WebSocket messages
     console.log('🔔 [WebSocket] Received event:', event, {source, message, timestamp});
@@ -2401,6 +2402,9 @@ function renderDbtModelsTable() {
         } else if (model.status === 'success') {
             // Last run succeeded
             statusBadge = '<span class="px-2 py-1 text-xs rounded-full bg-green-100 text-green-800">✓ Success</span>';
+        } else if (model.status === 'stale') {
+            // Upstream source failed — data may be outdated
+            statusBadge = '<span class="px-2 py-1 text-xs rounded-full bg-yellow-100 text-yellow-800">Stale</span>';
         } else if (model.status === 'error') {
             // Last run failed
             statusBadge = '<span class="px-2 py-1 text-xs rounded-full bg-red-100 text-red-800">✗ Error</span>';

--- a/dango/web/static/js/logs.js
+++ b/dango/web/static/js/logs.js
@@ -206,7 +206,11 @@ async function loadLogs() {
     showLoading();
 
     try {
-        const logs = await apiCall('/api/logs');
+        // Read category filter (defaults to "core" on page load)
+        const categoryEl = document.getElementById('filter-category');
+        const category = categoryEl ? categoryEl.value : '';
+        const url = category ? `/api/logs?category=${encodeURIComponent(category)}` : '/api/logs';
+        const logs = await apiCall(url);
         allLogs = logs || [];
         applyFilters();
     } catch (error) {
@@ -243,6 +247,8 @@ function setupFilterListeners() {
     document.getElementById('filter-level')?.addEventListener('change', applyFilters);
     document.getElementById('filter-source')?.addEventListener('change', applyFilters);
     document.getElementById('filter-time')?.addEventListener('change', applyFilters);
+    // Category changes reload from server (server-side filter)
+    document.getElementById('filter-category')?.addEventListener('change', loadLogs);
 }
 
 function applyFilters() {
@@ -306,6 +312,8 @@ function applyFilters() {
 }
 
 function clearFilters() {
+    const categoryEl = document.getElementById('filter-category');
+    if (categoryEl) categoryEl.value = 'core';
     const levelEl = document.getElementById('filter-level');
     if (levelEl) levelEl.value = '';
     const sourceEl = document.getElementById('filter-source');
@@ -314,7 +322,7 @@ function clearFilters() {
     if (timeEl) timeEl.value = 'all';
     const searchEl = document.getElementById('filter-search');
     if (searchEl) searchEl.value = '';
-    applyFilters();
+    loadLogs();  // Reload from server with default category
 }
 
 function sortLogs(field) {

--- a/dango/web/templates/logs.html
+++ b/dango/web/templates/logs.html
@@ -22,7 +22,17 @@
             <!-- Filters -->
             <div class="bg-white rounded-lg shadow mb-6 p-6">
                 <h2 class="text-lg font-semibold text-gray-900 mb-4">Filters</h2>
-                <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-5 gap-4">
+                    <!-- Category Filter -->
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">Category</label>
+                        <select id="filter-category" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                            <option value="core" selected>Core Events</option>
+                            <option value="">All Events</option>
+                            <option value="auxiliary">Auxiliary</option>
+                        </select>
+                    </div>
+
                     <!-- Log Level Filter -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-2">Log Level</label>

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -272,10 +272,16 @@ exemptions:
     reason: "TASK-090 added CloudConfig, SpacesConfig, DbtOverrides (~40 lines). Config models are data-only with no refactoring path."
     review_by: "v1.1"
 
-  - file: dango/platform/scheduling/jobs.py
-    lines: 849
+  - file: dango/platform/sync_process.py
+    lines: 603
     category: exempt
-    reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. R10-N moved sync to subprocess (removed DbtLock + run_sync, added launch_sync_subprocess + poll). R12-N2 added skip_dbt wiring for SYNC_ONLY schedules. Each job path requires broadcast + notify + record calls — splitting would fragment the job lifecycle."
+    reason: "Subprocess launch + polling + crash handling for process-isolated syncs. Unified logging added crash handlers (_handle_crash, _read_log_tail, _cleanup_sync_log) that write to activity log and sync history on subprocess failures."
+    review_by: "v1.1"
+
+  - file: dango/platform/scheduling/jobs.py
+    lines: 1034
+    category: exempt
+    reason: "TASK-041 + TEST-008: Scheduled sync/dbt job functions with WebSocket broadcast, webhook notification, SQLite history recording, per-source cancellation, and timeout/cancel status tracking. R10-N moved sync to subprocess (removed DbtLock + run_sync, added launch_sync_subprocess + poll). R12-N2 added skip_dbt wiring for SYNC_ONLY schedules. Unified logging added activity log writes at start/complete/fail/timeout/cancel. Each job path requires broadcast + notify + record + log calls — splitting would fragment the job lifecycle."
     review_by: "v1.1"
 
   - file: dango/platform/cloud/digitalocean.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "getdango"
-version = "1.0.2"
+version = "1.0.3"
 description = "Open source data platform built with production-grade tools - dlt, dbt, DuckDB, and Metabase"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/tests/integration/test_sync_notification.py
+++ b/tests/integration/test_sync_notification.py
@@ -87,7 +87,7 @@ class TestSyncFailureNotification:
                 patch(f"{_CFG_MOD}.load_config", return_value=config),
                 patch(
                     f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
-                    return_value=(MagicMock(), "test_id"),
+                    return_value=(MagicMock(), "test_id", tmp_path / "fake.log"),
                 ),
                 patch(
                     f"{_SYNC_PROC_MOD}.poll_sync_status_blocking",

--- a/tests/unit/test_scheduler_gaps.py
+++ b/tests/unit/test_scheduler_gaps.py
@@ -223,7 +223,7 @@ class TestMultiSourceDbtLock:
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
                 f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
-                return_value=(MagicMock(), "test_id"),
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ),
             patch(
                 f"{_SYNC_PROC_MOD}.poll_sync_status_blocking",
@@ -273,7 +273,7 @@ class TestCancellationBetweenSources:
 
         def mock_launch(project_root, sources, **kw):
             launched_sources.append(sources[0])
-            return MagicMock(), "test_id"
+            return MagicMock(), "test_id", MagicMock()
 
         old_svc = jobs_mod._scheduler_service
         try:
@@ -368,7 +368,7 @@ class TestRecordStartWiring:
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
                 f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
-                return_value=(MagicMock(), "test_id"),
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -183,7 +183,8 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
-                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
@@ -209,7 +210,8 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
-                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ),
             patch(
                 f"{_SYNC_PROC_MOD}.poll_sync_status_blocking",
@@ -236,7 +238,8 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
-                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ) as mock_launch,
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
@@ -261,7 +264,8 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
-                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
@@ -309,7 +313,7 @@ class TestRunScheduledSync:
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
                 f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
-                return_value=(MagicMock(), "test_id"),
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
@@ -335,7 +339,8 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
-                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ),
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),
@@ -381,7 +386,8 @@ class TestRunScheduledSync:
             patch(f"{_NOTIF_MOD}.WebhookSender"),
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
-                f"{_SYNC_PROC_MOD}.launch_sync_subprocess", return_value=(MagicMock(), "test_id")
+                f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
+                return_value=(MagicMock(), "test_id", MagicMock()),
             ) as mock_launch,
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", side_effect=_poll_side_effect),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -154,7 +154,7 @@ class TestRunScheduledSync:
             patch(f"{_CFG_MOD}.load_config", return_value=config),
             patch(
                 f"{_SYNC_PROC_MOD}.launch_sync_subprocess",
-                return_value=(mock_process, "test_id"),
+                return_value=(mock_process, "test_id", MagicMock()),
             ) as mock_launch,
             patch(f"{_SYNC_PROC_MOD}.poll_sync_status_blocking", return_value=(True, {})),
             patch(f"{_SYNC_PROC_MOD}.cleanup_sync_status"),

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -134,7 +134,7 @@ class TestLaunchSyncSubprocess:
         mock_process.pid = 12345
         mock_popen.return_value = mock_process
 
-        process, sync_id = launch_sync_subprocess(
+        process, sync_id, log_path = launch_sync_subprocess(
             project_root=tmp_path,
             sources=["hubspot"],
             full_refresh=True,
@@ -143,6 +143,7 @@ class TestLaunchSyncSubprocess:
 
         assert process is mock_process
         assert len(sync_id) == 12  # uuid hex[:12]
+        assert log_path.name == f"sync_{sync_id}.log"
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
         assert cmd[0] == sys.executable
@@ -159,8 +160,8 @@ class TestLaunchSyncSubprocess:
         assert args["sync_id"] == sync_id
 
     @patch("subprocess.Popen")
-    def test_uses_devnull_not_pipe(self, mock_popen, tmp_path):
-        """Stdout/stderr must use DEVNULL to prevent pipe deadlock."""
+    def test_captures_output_to_log_file(self, mock_popen, tmp_path):
+        """Stdout/stderr must be captured to a log file for crash diagnostics."""
         import subprocess
 
         mock_popen.return_value = MagicMock(pid=1)
@@ -168,11 +169,15 @@ class TestLaunchSyncSubprocess:
             "dango.platform.sync_process", fromlist=["launch_sync_subprocess"]
         ).launch_sync_subprocess
 
-        launch(project_root=tmp_path, sources=["src"])
+        _proc, _sid, log_path = launch(project_root=tmp_path, sources=["src"])
 
         call_kwargs = mock_popen.call_args[1]
-        assert call_kwargs["stdout"] == subprocess.DEVNULL
-        assert call_kwargs["stderr"] == subprocess.DEVNULL
+        # stderr should be merged into stdout
+        assert call_kwargs["stderr"] == subprocess.STDOUT
+        # stdout should NOT be DEVNULL (it's a file handle that was opened then closed)
+        assert call_kwargs["stdout"] != subprocess.DEVNULL
+        # Log file path should exist in the logs directory
+        assert log_path.parent == tmp_path / ".dango" / "logs"
 
     @patch("subprocess.Popen")
     def test_includes_optional_params(self, mock_popen, tmp_path):
@@ -180,7 +185,7 @@ class TestLaunchSyncSubprocess:
 
         mock_popen.return_value = MagicMock(pid=1)
 
-        _process, _sync_id = launch_sync_subprocess(
+        _process, _sync_id, _log_path = launch_sync_subprocess(
             project_root=tmp_path,
             sources=["src"],
             start_date="2026-01-01",
@@ -206,8 +211,8 @@ class TestLaunchSyncSubprocess:
 
         mock_popen.return_value = MagicMock(pid=1)
 
-        _, id1 = launch_sync_subprocess(project_root=tmp_path, sources=["src"])
-        _, id2 = launch_sync_subprocess(project_root=tmp_path, sources=["src"])
+        _, id1, _ = launch_sync_subprocess(project_root=tmp_path, sources=["src"])
+        _, id2, _ = launch_sync_subprocess(project_root=tmp_path, sources=["src"])
         assert id1 != id2
 
 

--- a/tests/unit/test_unified_logging.py
+++ b/tests/unit/test_unified_logging.py
@@ -1,0 +1,387 @@
+"""tests/unit/test_unified_logging.py
+
+Tests for unified activity logging: category field, stale model cascade,
+crash handling helpers, category filtering, and SIGTERM handler.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# activity_log.py — category field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestActivityLogCategory:
+    def test_default_category_is_core(self, tmp_path: Path):
+        from dango.utils.activity_log import log_activity
+
+        log_activity(tmp_path, "info", "test", "hello")
+
+        log_file = tmp_path / ".dango" / "logs" / "activity.jsonl"
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["category"] == "core"
+
+    def test_explicit_auxiliary_category(self, tmp_path: Path):
+        from dango.utils.activity_log import log_activity
+
+        log_activity(tmp_path, "info", "query", "SELECT 1", category="auxiliary")
+
+        log_file = tmp_path / ".dango" / "logs" / "activity.jsonl"
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["category"] == "auxiliary"
+
+    def test_old_entries_without_category_treated_as_core(self, tmp_path: Path):
+        """Old entries lacking category field should be treated as core by consumers."""
+        log_dir = tmp_path / ".dango" / "logs"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "activity.jsonl"
+
+        # Write an old-style entry without category
+        old_entry = {
+            "timestamp": "2026-01-01T00:00:00",
+            "level": "info",
+            "source": "test",
+            "message": "old",
+        }
+        log_file.write_text(json.dumps(old_entry) + "\n")
+
+        from dango.web.helpers import load_all_logs
+
+        with patch("dango.web.helpers.get_logs_file", return_value=log_file):
+            # category="core" should include old entries (missing = core)
+            logs = load_all_logs(category="core")
+            assert len(logs) == 1
+
+            # category="auxiliary" should exclude old entries
+            logs = load_all_logs(category="auxiliary")
+            assert len(logs) == 0
+
+
+# ---------------------------------------------------------------------------
+# dbt_status.py — mark_source_models_stale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMarkSourceModelsStale:
+    def _setup_manifest(self, tmp_path: Path, models: dict) -> None:
+        """Write a minimal manifest.json with the given models."""
+        manifest = {"nodes": models}
+        manifest_path = tmp_path / "dbt" / "target" / "manifest.json"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest))
+
+    def _setup_status(self, tmp_path: Path, statuses: dict) -> None:
+        """Write a dbt_model_status.json."""
+        status_path = tmp_path / ".dango" / "dbt_model_status.json"
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        status_path.write_text(json.dumps(statuses))
+
+    def _read_status(self, tmp_path: Path) -> dict:
+        status_path = tmp_path / ".dango" / "dbt_model_status.json"
+        return json.loads(status_path.read_text())
+
+    def test_marks_dependent_model_stale(self, tmp_path: Path):
+        from dango.utils.dbt_status import mark_source_models_stale
+
+        self._setup_manifest(
+            tmp_path,
+            {
+                "model.project.my_model": {
+                    "resource_type": "model",
+                    "depends_on": {"nodes": ["source.project.my_source.table1"]},
+                }
+            },
+        )
+        self._setup_status(
+            tmp_path, {"model.project.my_model": {"status": "success", "last_run": "2026-01-01"}}
+        )
+
+        mark_source_models_stale(tmp_path, ["my_source"])
+
+        result = self._read_status(tmp_path)
+        assert result["model.project.my_model"]["status"] == "stale"
+        assert result["model.project.my_model"]["last_run"] == "2026-01-01"
+
+    def test_does_not_overwrite_error_with_stale(self, tmp_path: Path):
+        from dango.utils.dbt_status import mark_source_models_stale
+
+        self._setup_manifest(
+            tmp_path,
+            {
+                "model.project.my_model": {
+                    "resource_type": "model",
+                    "depends_on": {"nodes": ["source.project.my_source.table1"]},
+                }
+            },
+        )
+        self._setup_status(
+            tmp_path, {"model.project.my_model": {"status": "error", "last_run": "2026-01-01"}}
+        )
+
+        mark_source_models_stale(tmp_path, ["my_source"])
+
+        result = self._read_status(tmp_path)
+        assert result["model.project.my_model"]["status"] == "error"
+
+    def test_skips_unrelated_sources(self, tmp_path: Path):
+        from dango.utils.dbt_status import mark_source_models_stale
+
+        self._setup_manifest(
+            tmp_path,
+            {
+                "model.project.my_model": {
+                    "resource_type": "model",
+                    "depends_on": {"nodes": ["source.project.other_source.table1"]},
+                }
+            },
+        )
+        self._setup_status(
+            tmp_path, {"model.project.my_model": {"status": "success", "last_run": "2026-01-01"}}
+        )
+
+        mark_source_models_stale(tmp_path, ["my_source"])
+
+        result = self._read_status(tmp_path)
+        assert result["model.project.my_model"]["status"] == "success"
+
+    def test_no_manifest_silently_returns(self, tmp_path: Path):
+        from dango.utils.dbt_status import mark_source_models_stale
+
+        # No manifest file — should not raise
+        mark_source_models_stale(tmp_path, ["my_source"])
+
+    def test_empty_failed_sources_returns_early(self, tmp_path: Path):
+        from dango.utils.dbt_status import mark_source_models_stale
+
+        mark_source_models_stale(tmp_path, [])
+
+
+# ---------------------------------------------------------------------------
+# sync_process.py — crash handling helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReadLogTail:
+    def test_reads_last_n_lines(self, tmp_path: Path):
+        from dango.platform.sync_process import _read_log_tail
+
+        log_path = tmp_path / "test.log"
+        log_path.write_text("\n".join(f"line {i}" for i in range(100)))
+
+        result = _read_log_tail(log_path, max_lines=5)
+        lines = result.split("\n")
+        assert len(lines) == 5
+        assert lines[-1] == "line 99"
+
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        from dango.platform.sync_process import _read_log_tail
+
+        result = _read_log_tail(tmp_path / "nonexistent.log")
+        assert result == ""
+
+
+@pytest.mark.unit
+class TestCleanupSyncLog:
+    def test_deletes_on_success(self, tmp_path: Path):
+        from dango.platform.sync_process import _cleanup_sync_log
+
+        log_path = tmp_path / "sync_test.log"
+        log_path.write_text("some output")
+
+        _cleanup_sync_log(log_path, keep=False)
+        assert not log_path.exists()
+
+    def test_keeps_on_failure(self, tmp_path: Path):
+        from dango.platform.sync_process import _cleanup_sync_log
+
+        log_path = tmp_path / "sync_test.log"
+        log_path.write_text("some output")
+
+        _cleanup_sync_log(log_path, keep=True)
+        assert log_path.exists()
+
+
+@pytest.mark.unit
+class TestHandleCrash:
+    def test_writes_sync_history_and_activity_log(self, tmp_path: Path):
+        from dango.platform.sync_process import _handle_crash
+
+        log_path = tmp_path / "sync_test.log"
+        log_path.write_text("Traceback: something broke")
+
+        _handle_crash(tmp_path, ["src1"], 1, log_path, "exit code 1")
+
+        # Check sync history was written
+        history_file = tmp_path / ".dango" / "history" / "src1.json"
+        assert history_file.exists()
+        history = json.loads(history_file.read_text())
+        assert len(history) == 1
+        assert history[0]["status"] == "failed"
+        assert "something broke" in history[0]["error_message"]
+
+        # Check activity log was written
+        activity_file = tmp_path / ".dango" / "logs" / "activity.jsonl"
+        assert activity_file.exists()
+        entry = json.loads(activity_file.read_text().strip().split("\n")[-1])
+        assert entry["level"] == "error"
+        assert "crashed" in entry["message"].lower()
+
+    def test_skips_duplicate_history_entry(self, tmp_path: Path):
+        """If subprocess already wrote a recent failure, don't duplicate."""
+        # Simulate subprocess having already written a failure
+        from datetime import datetime, timezone
+
+        from dango.platform.sync_process import _handle_crash
+        from dango.utils.sync_history import save_sync_history_entry
+
+        save_sync_history_entry(
+            tmp_path,
+            "src1",
+            {
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "status": "failed",
+                "duration_seconds": 5,
+                "rows_processed": 0,
+                "error_message": "subprocess wrote this",
+            },
+        )
+
+        _handle_crash(tmp_path, ["src1"], 1, None, "crash handler")
+
+        history_file = tmp_path / ".dango" / "history" / "src1.json"
+        history = json.loads(history_file.read_text())
+        # Should still be 1 entry (not duplicated)
+        assert len(history) == 1
+        assert history[0]["error_message"] == "subprocess wrote this"
+
+
+# ---------------------------------------------------------------------------
+# web/helpers.py — load_all_logs category filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoadAllLogsCategory:
+    def _write_logs(self, log_file: Path, entries: list[dict]) -> None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_file, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def test_filter_core_only(self, tmp_path: Path):
+        log_file = tmp_path / "activity.jsonl"
+        self._write_logs(
+            log_file,
+            [
+                {
+                    "timestamp": "2026-01-01T00:00:00",
+                    "level": "info",
+                    "source": "sync",
+                    "message": "a",
+                    "category": "core",
+                },
+                {
+                    "timestamp": "2026-01-01T00:00:01",
+                    "level": "info",
+                    "source": "query",
+                    "message": "b",
+                    "category": "auxiliary",
+                },
+            ],
+        )
+
+        from dango.web.helpers import load_all_logs
+
+        with patch("dango.web.helpers.get_logs_file", return_value=log_file):
+            logs = load_all_logs(category="core")
+            assert len(logs) == 1
+            assert logs[0]["source"] == "sync"
+
+    def test_filter_none_returns_all(self, tmp_path: Path):
+        log_file = tmp_path / "activity.jsonl"
+        self._write_logs(
+            log_file,
+            [
+                {
+                    "timestamp": "2026-01-01T00:00:00",
+                    "level": "info",
+                    "source": "sync",
+                    "message": "a",
+                    "category": "core",
+                },
+                {
+                    "timestamp": "2026-01-01T00:00:01",
+                    "level": "info",
+                    "source": "query",
+                    "message": "b",
+                    "category": "auxiliary",
+                },
+            ],
+        )
+
+        from dango.web.helpers import load_all_logs
+
+        with patch("dango.web.helpers.get_logs_file", return_value=log_file):
+            logs = load_all_logs(category=None)
+            assert len(logs) == 2
+
+
+# ---------------------------------------------------------------------------
+# web/app.py — SIGTERM handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSigtermHandler:
+    def test_installs_signal_handler(self, tmp_path: Path):
+        from dango.web.app import _install_sigterm_logger
+
+        original = signal.getsignal(signal.SIGTERM)
+        try:
+            _install_sigterm_logger(tmp_path)
+            current = signal.getsignal(signal.SIGTERM)
+            assert current != original
+            assert callable(current)
+        finally:
+            signal.signal(signal.SIGTERM, original)
+
+    def test_handler_writes_activity_log_and_chains(self, tmp_path: Path):
+        from dango.web.app import _install_sigterm_logger
+
+        original = signal.getsignal(signal.SIGTERM)
+        chain_called = []
+
+        def fake_original(signum, frame):
+            chain_called.append((signum, frame))
+
+        try:
+            # Set a real function as the "original" handler so we can verify chaining
+            signal.signal(signal.SIGTERM, fake_original)
+            _install_sigterm_logger(tmp_path)
+            handler = signal.getsignal(signal.SIGTERM)
+
+            # Call the installed handler directly
+            handler(signal.SIGTERM, None)
+
+            # Verify activity log was written
+            activity_file = tmp_path / ".dango" / "logs" / "activity.jsonl"
+            assert activity_file.exists()
+            entry = json.loads(activity_file.read_text().strip())
+            assert entry["level"] == "warning"
+            assert "SIGTERM" in entry["message"]
+
+            # Verify original handler was chained
+            assert len(chain_called) == 1
+            assert chain_called[0][0] == signal.SIGTERM
+        finally:
+            signal.signal(signal.SIGTERM, original)


### PR DESCRIPTION
## Summary
- Unify activity logging as single source of truth across all system processes
- Capture subprocess stderr to log files (was going to /dev/null)
- Write crash failures to activity log AND sync history (with dedup)
- Scheduler now writes schedule start/complete/fail to activity log
- Mark downstream dbt models as "stale" when source sync fails (does not overwrite "error")
- Clean stale sync status files on server startup (fixes phantom toasts)
- Fix "undefined synced successfully" toast
- Add category field to activity log with UI filtering (core vs auxiliary)
- Add SIGTERM handler to diagnose intermittent unexpected shutdowns
- Version bump: 1.0.2 → 1.0.3

## Verification
- `pytest -x`: 3781 pass, 0 fail, 31 skipped (18 new tests)
- [coordinating chat verifies on beta-1 before merge]

🤖 Generated with [Claude Code](https://claude.com/claude-code)