### PR TITLE
fix: geo seed auto-provisioning, GA4 date cast, staging schema cleanup

### DIFF
--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2389,6 +2389,31 @@ def run_sync(
 
     console.print(f"{'=' * 60}\n")
 
+    # Clean up empty dlt staging schemas after successful sync
+    if success_sources:
+        try:
+            import duckdb as _duckdb
+
+            _conn = _duckdb.connect(str(project_root / "data" / "warehouse.duckdb"))
+            try:
+                _schemas = _conn.execute(
+                    "SELECT schema_name FROM information_schema.schemata "
+                    "WHERE schema_name LIKE '%\\_staging' ESCAPE '\\'"
+                ).fetchall()
+                _dropped = []
+                for (schema_name_val,) in _schemas:
+                    base_name = schema_name_val.removesuffix("_staging")
+                    source_name = base_name.removeprefix("raw_")
+                    if source_name in success_sources or base_name in success_sources:
+                        _conn.execute(f'DROP SCHEMA IF EXISTS "{schema_name_val}" CASCADE')
+                        _dropped.append(schema_name_val)
+                if _dropped:
+                    console.print(f"[dim]🧹 Cleaned up {len(_dropped)} staging schema(s)[/dim]")
+            finally:
+                _conn.close()
+        except Exception:
+            pass  # Don't fail sync for cleanup errors
+
     # Initialize transform tracking (used in summary dict below)
     transform_status = "skipped"
     transform_error_msg: str | None = None

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2392,25 +2392,25 @@ def run_sync(
     # Clean up empty dlt staging schemas after successful sync
     if success_sources:
         try:
-            import duckdb as _duckdb
+            import duckdb
 
-            _conn = _duckdb.connect(str(project_root / "data" / "warehouse.duckdb"))
+            conn = duckdb.connect(str(project_root / "data" / "warehouse.duckdb"))
             try:
-                _schemas = _conn.execute(
+                schemas = conn.execute(
                     "SELECT schema_name FROM information_schema.schemata "
                     "WHERE schema_name LIKE '%\\_staging' ESCAPE '\\'"
                 ).fetchall()
-                _dropped = []
-                for (schema_name_val,) in _schemas:
+                dropped = []
+                for (schema_name_val,) in schemas:
                     base_name = schema_name_val.removesuffix("_staging")
                     source_name = base_name.removeprefix("raw_")
                     if source_name in success_sources or base_name in success_sources:
-                        _conn.execute(f'DROP SCHEMA IF EXISTS "{schema_name_val}" CASCADE')
-                        _dropped.append(schema_name_val)
-                if _dropped:
-                    console.print(f"[dim]🧹 Cleaned up {len(_dropped)} staging schema(s)[/dim]")
+                        conn.execute(f'DROP SCHEMA IF EXISTS "{schema_name_val}" CASCADE')
+                        dropped.append(schema_name_val)
+                if dropped:
+                    console.print(f"[dim]🧹 Cleaned up {len(dropped)} staging schema(s)[/dim]")
             finally:
-                _conn.close()
+                conn.close()
         except Exception:
             pass  # Don't fail sync for cleanup errors
 

--- a/dango/templates/dbt/staging_model.sql.j2
+++ b/dango/templates/dbt/staging_model.sql.j2
@@ -28,4 +28,8 @@
     schema='staging'
 {{ ") }}" }}
 
+{% if date_cast_columns %}
+SELECT * REPLACE ({% for col in date_cast_columns %}CAST({{ col }} AS DATE) AS {{ col }}{% if not loop.last %}, {% endif %}{% endfor %}) FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
+{% else %}
 SELECT * FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
+{% endif %}

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -485,7 +485,13 @@ class DbtModelGenerator:
 
                 # Auto-provision geo_targets seed for Google Ads sources
                 if source.type.value == "google_ads":
-                    self._provision_geo_targets(source.name)
+                    geo_provisioned = self._provision_geo_targets(source.name)
+                    if geo_provisioned:
+                        import logging
+
+                        logging.getLogger(__name__).info(
+                            "geo_targets_provisioned: %s", ", ".join(geo_provisioned)
+                        )
 
                 # Try to get endpoints from config, fall back to DB discovery
                 endpoints = self._get_source_endpoints(source)

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -278,6 +278,40 @@ class DbtModelGenerator:
         except Exception:
             return []
 
+    def _provision_geo_targets(self, source_name: str) -> list[str]:
+        """Provision geo_targets seed CSV and staging join model for Google Ads.
+
+        Copies the seed file and staging model template if they don't already exist.
+        This runs on every sync so existing projects get the seed retroactively.
+
+        Args:
+            source_name: Name of the Google Ads source
+
+        Returns:
+            List of provisioned file names
+        """
+        provisioned: list[str] = []
+
+        # 1. Copy geo_targets.csv to dbt/seeds/
+        seeds_dir = self.project_root / "dbt" / "seeds"
+        seed_dest = seeds_dir / "geo_targets.csv"
+        if not seed_dest.exists():
+            seeds_dir.mkdir(parents=True, exist_ok=True)
+            seed_src = self.templates_dir / "seeds" / "geo_targets.csv"
+            seed_dest.write_text(seed_src.read_text(encoding="utf-8"), encoding="utf-8")
+            provisioned.append("geo_targets.csv")
+
+        # 2. Create staging join model from template
+        model_dest = self.staging_dir / f"stg_{source_name}__geo_names.sql"
+        if not model_dest.exists():
+            self.staging_dir.mkdir(parents=True, exist_ok=True)
+            template = (self.templates_dir / "stg_geo_names.sql").read_text(encoding="utf-8")
+            model_sql = template.replace("__SOURCE_NAME__", source_name)
+            model_dest.write_text(model_sql, encoding="utf-8")
+            provisioned.append(f"stg_{source_name}__geo_names.sql")
+
+        return provisioned
+
     def generate_staging_model(
         self,
         source: DataSource,
@@ -285,6 +319,7 @@ class DbtModelGenerator:
         schema_name: str = "raw",
         dedup_strategy: str | None = None,
         dedup_columns: list[str] | None = None,
+        date_cast_columns: list[str] | None = None,
     ) -> str:
         """
         Generate staging model SQL for a data source
@@ -314,6 +349,7 @@ class DbtModelGenerator:
             "table_name": table_name,
             "dedup_strategy": dedup_strategy,
             "dedup_columns": dedup_columns or [],
+            "date_cast_columns": date_cast_columns or [],
             "generated_at": datetime.now().isoformat(),
         }
 
@@ -447,6 +483,10 @@ class DbtModelGenerator:
                 # Always use raw_{source_name} schema (industry best practice)
                 schema_name = f"raw_{source.name}"
 
+                # Auto-provision geo_targets seed for Google Ads sources
+                if source.type.value == "google_ads":
+                    self._provision_geo_targets(source.name)
+
                 # Try to get endpoints from config, fall back to DB discovery
                 endpoints = self._get_source_endpoints(source)
                 if not endpoints:
@@ -523,6 +563,13 @@ class DbtModelGenerator:
                         source, staging_columns
                     )
 
+                    # Detect GA4 date columns that need TIMESTAMPTZ → DATE cast
+                    date_cast_columns: list[str] = []
+                    if source.type.value == "google_analytics":
+                        for col in staging_columns:
+                            if col["name"] == "date" and "TIMESTAMP" in col["type"].upper():
+                                date_cast_columns.append(col["name"])
+
                     # Generate staging model SQL
                     model_sql = self.generate_staging_model(
                         source=source,
@@ -530,6 +577,7 @@ class DbtModelGenerator:
                         schema_name=schema_name,
                         dedup_strategy=dedup_strategy,
                         dedup_columns=dedup_columns,
+                        date_cast_columns=date_cast_columns,
                     )
 
                     # Write model file

--- a/tests/unit/test_data_fixes.py
+++ b/tests/unit/test_data_fixes.py
@@ -112,6 +112,28 @@ class TestGeoTargetsProvisioning:
             gen.generate_all_models([source])
             mock_provision.assert_called_once_with("my_ads")
 
+    def test_geo_targets_end_to_end_via_generate_all_models(self, tmp_path: Path):
+        """generate_all_models creates geo seed files for google_ads (no mocking)."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_ads", "google_ads")
+
+        # No tables in DB — generate_all_models will skip model generation
+        # but should still provision geo_targets
+        with patch.object(gen, "_discover_tables_from_db", return_value=[]):
+            gen.generate_all_models([source])
+
+        seed_file = project_root / "dbt" / "seeds" / "geo_targets.csv"
+        model_file = project_root / "dbt" / "models" / "staging" / "stg_my_ads__geo_names.sql"
+
+        assert seed_file.exists()
+        assert model_file.exists()
+        assert "my_ads" in model_file.read_text()
+        assert "__SOURCE_NAME__" not in model_file.read_text()
+
 
 # ---------------------------------------------------------------------------
 # Fix 2: GA4 date column cast (P7-1)

--- a/tests/unit/test_data_fixes.py
+++ b/tests/unit/test_data_fixes.py
@@ -1,0 +1,330 @@
+"""tests/unit/test_data_fixes.py
+
+Tests for P3-1 (geo seed provisioning), P7-1 (GA4 date cast), P7-3 (staging schema cleanup).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.config.models import DataSource, SourceType
+from dango.transformation.generator import DbtModelGenerator
+
+
+def _make_source(name: str, source_type: str) -> DataSource:
+    """Create a minimal DataSource for testing."""
+    return DataSource(name=name, type=SourceType(source_type))
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: Geo seed auto-provisioning (P3-1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGeoTargetsProvisioning:
+    def test_geo_targets_copied_when_missing(self, tmp_path: Path):
+        """Google Ads source + no seed file -> seed + model created."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+
+        provisioned = gen._provision_geo_targets("my_google_ads")
+
+        # Seed file should be created
+        seed_file = project_root / "dbt" / "seeds" / "geo_targets.csv"
+        assert seed_file.exists()
+        assert "geo_targets.csv" in provisioned
+
+        # Staging model should be created
+        model_file = (
+            project_root / "dbt" / "models" / "staging" / "stg_my_google_ads__geo_names.sql"
+        )
+        assert model_file.exists()
+        assert "stg_my_google_ads__geo_names.sql" in provisioned
+
+        # Model should reference the correct source name
+        content = model_file.read_text()
+        assert "my_google_ads" in content
+        assert "__SOURCE_NAME__" not in content
+
+    def test_geo_targets_not_copied_when_exists(self, tmp_path: Path):
+        """Google Ads source + seed already exists -> no overwrite."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        # Pre-create seed with custom content
+        seeds_dir = project_root / "dbt" / "seeds"
+        seeds_dir.mkdir(parents=True)
+        seed_file = seeds_dir / "geo_targets.csv"
+        seed_file.write_text("custom_content")
+
+        # Pre-create model
+        staging_dir = project_root / "dbt" / "models" / "staging"
+        staging_dir.mkdir(parents=True)
+        model_file = staging_dir / "stg_my_ads__geo_names.sql"
+        model_file.write_text("custom_model")
+
+        gen = DbtModelGenerator(project_root)
+        provisioned = gen._provision_geo_targets("my_ads")
+
+        # Nothing should be provisioned
+        assert provisioned == []
+
+        # Original content preserved
+        assert seed_file.read_text() == "custom_content"
+        assert model_file.read_text() == "custom_model"
+
+    def test_geo_targets_skipped_for_non_google_ads(self, tmp_path: Path):
+        """Non-Google-Ads source -> no geo seed provisioning."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_stripe", "stripe")
+
+        # Mock DuckDB to return no tables (so generate_all_models skips gracefully)
+        with patch.object(gen, "_discover_tables_from_db", return_value=[]):
+            gen.generate_all_models([source])
+
+        # No seed file should exist
+        seed_file = project_root / "dbt" / "seeds" / "geo_targets.csv"
+        assert not seed_file.exists()
+
+    def test_geo_targets_called_in_generate_all_models(self, tmp_path: Path):
+        """generate_all_models calls _provision_geo_targets for google_ads sources."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_ads", "google_ads")
+
+        with (
+            patch.object(gen, "_provision_geo_targets") as mock_provision,
+            patch.object(gen, "_discover_tables_from_db", return_value=[]),
+        ):
+            gen.generate_all_models([source])
+            mock_provision.assert_called_once_with("my_ads")
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: GA4 date column cast (P7-1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGA4DateCast:
+    def test_ga4_date_column_cast(self, tmp_path: Path):
+        """GA4 source with TIMESTAMP date column -> SQL contains REPLACE cast."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_ga4", "google_analytics")
+
+        sql = gen.generate_staging_model(
+            source=source,
+            table_name="sessions",
+            schema_name="raw_my_ga4",
+            date_cast_columns=["date"],
+        )
+
+        assert "REPLACE" in sql
+        assert "CAST(date AS DATE) AS date" in sql
+        assert "source('my_ga4', 'sessions')" in sql
+
+    def test_non_ga4_no_date_cast(self, tmp_path: Path):
+        """Non-GA4 source -> plain SELECT * with no REPLACE."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_stripe", "stripe")
+
+        sql = gen.generate_staging_model(
+            source=source,
+            table_name="charges",
+            schema_name="raw_my_stripe",
+        )
+
+        assert "REPLACE" not in sql
+        assert "SELECT *" in sql
+        assert "source('my_stripe', 'charges')" in sql
+
+    def test_ga4_no_cast_when_already_date(self, tmp_path: Path):
+        """GA4 source where date column is already DATE -> no REPLACE clause."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_ga4", "google_analytics")
+
+        # Empty date_cast_columns means the column was already DATE type
+        sql = gen.generate_staging_model(
+            source=source,
+            table_name="sessions",
+            schema_name="raw_my_ga4",
+            date_cast_columns=[],
+        )
+
+        assert "REPLACE" not in sql
+        assert "SELECT *" in sql
+
+    def test_ga4_date_detection_in_generate_all_models(self, tmp_path: Path):
+        """generate_all_models detects TIMESTAMP date columns for GA4 sources."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_ga4", "google_analytics")
+
+        mock_columns = [
+            {
+                "name": "date",
+                "type": "TIMESTAMP WITH TIME ZONE",
+                "nullable": True,
+                "tests": [],
+                "description": "date column",
+            },
+            {
+                "name": "sessions",
+                "type": "BIGINT",
+                "nullable": True,
+                "tests": [],
+                "description": "sessions column",
+            },
+        ]
+
+        with (
+            patch.object(gen, "_discover_tables_from_db", return_value=["sessions"]),
+            patch.object(gen, "get_table_schema", return_value=mock_columns),
+            patch.object(gen, "generate_staging_model", return_value="-- mock") as mock_gen,
+        ):
+            gen.generate_all_models([source], generate_schema_yml=False)
+
+            mock_gen.assert_called_once()
+            assert mock_gen.call_args.kwargs.get("date_cast_columns") == ["date"]
+
+    def test_ga4_no_detection_when_date_is_date_type(self, tmp_path: Path):
+        """generate_all_models does NOT add date_cast_columns when type is already DATE."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / "data").mkdir()
+
+        gen = DbtModelGenerator(project_root)
+        source = _make_source("my_ga4", "google_analytics")
+
+        mock_columns = [
+            {
+                "name": "date",
+                "type": "DATE",
+                "nullable": True,
+                "tests": [],
+                "description": "date column",
+            },
+            {
+                "name": "sessions",
+                "type": "BIGINT",
+                "nullable": True,
+                "tests": [],
+                "description": "sessions column",
+            },
+        ]
+
+        with (
+            patch.object(gen, "_discover_tables_from_db", return_value=["sessions"]),
+            patch.object(gen, "get_table_schema", return_value=mock_columns),
+            patch.object(gen, "generate_staging_model", return_value="-- mock") as mock_gen,
+        ):
+            gen.generate_all_models([source], generate_schema_yml=False)
+
+            mock_gen.assert_called_once()
+            assert mock_gen.call_args.kwargs.get("date_cast_columns") == []
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: Staging schema cleanup (P7-3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStagingSchemaCleanup:
+    """Test staging schema cleanup in run_sync.
+
+    Uses skip_dbt=True to minimize mocking scope. Model generation and
+    post-sync hooks still run but are mocked.
+    """
+
+    def test_staging_schemas_dropped_after_success(self):
+        """Staging schemas are dropped for successful sources."""
+        from dango.ingestion.dlt_runner import run_sync
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("raw_my_source_staging",),
+        ]
+
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_source.return_value = {"status": "success"}
+
+        mock_generator = MagicMock()
+        mock_generator.generate_all_models.return_value = {
+            "generated": [],
+            "skipped": [],
+            "errors": [],
+        }
+
+        with (
+            patch(
+                "dango.ingestion.dlt_runner.DltPipelineRunner",
+                return_value=mock_runner_instance,
+            ),
+            patch("duckdb.connect", return_value=mock_conn),
+            patch(
+                "dango.transformation.generator.DbtModelGenerator",
+                return_value=mock_generator,
+            ),
+            patch("dango.utils.post_sync.dispatch_post_sync_hooks", return_value=None),
+        ):
+            source = _make_source("my_source", "stripe")
+            run_sync(Path("/fake/project"), [source], skip_dbt=True)
+
+            # Verify staging schema was dropped
+            drop_calls = [
+                call for call in mock_conn.execute.call_args_list if "DROP SCHEMA" in str(call)
+            ]
+            assert len(drop_calls) == 1
+            assert "raw_my_source_staging" in str(drop_calls[0])
+
+    def test_staging_schemas_not_dropped_on_failure(self):
+        """No staging schemas dropped when all sources fail."""
+        from dango.ingestion.dlt_runner import run_sync
+
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.run_source.return_value = {
+            "status": "error",
+            "error": "Connection failed",
+        }
+
+        with (
+            patch(
+                "dango.ingestion.dlt_runner.DltPipelineRunner",
+                return_value=mock_runner_instance,
+            ),
+            patch("duckdb.connect") as mock_connect,
+        ):
+            source = _make_source("my_source", "stripe")
+            run_sync(Path("/fake/project"), [source], skip_dbt=True)
+
+            # duckdb.connect should NOT have been called (cleanup block skipped)
+            mock_connect.assert_not_called()


### PR DESCRIPTION
## Summary

- **P3-1**: Add `_provision_geo_targets()` to `DbtModelGenerator` so existing Google Ads projects get `geo_targets.csv` on every sync, not just during `dango source add`
- **P7-1**: Cast GA4 `date` columns from `TIMESTAMP WITH TIME ZONE` to `DATE` in staging models using DuckDB's `SELECT * REPLACE` syntax. Detection runs automatically for `google_analytics` sources
- **P7-3**: Drop empty `raw_*_staging` schemas from DuckDB after successful sync (Metabase already hides them; this removes them from DuckDB too)

## Files changed

- `dango/transformation/generator.py` — new `_provision_geo_targets()` method, `date_cast_columns` parameter in `generate_staging_model()`, detection logic in `generate_all_models()`
- `dango/templates/dbt/staging_model.sql.j2` — conditional `SELECT * REPLACE` for date cast
- `dango/ingestion/dlt_runner.py` — staging schema cleanup block in `run_sync()`
- `tests/unit/test_data_fixes.py` — 11 unit tests covering all three fixes

## Verification

- `ruff check`: all checks passed
- `ruff format --check`: all files formatted
- `pytest -x`: 3792 passed, 31 skipped, 0 failed

## Test plan

- [ ] Verify geo_targets.csv is provisioned on sync for existing Google Ads projects
- [ ] Verify GA4 staging models contain `CAST(date AS DATE)` after sync
- [ ] Verify `raw_*_staging` schemas are dropped from DuckDB after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)