### PR TITLE
Fix stale/orphan resource cleanup on crash (P0-1, P0-2, P1-1)

### DIFF
--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -233,6 +233,12 @@ def start(ctx: click.Context, yes: bool) -> None:
                 raise click.Abort() from migration_exc
             raise
 
+        # Clean up stale dbt lock from crashed process
+        from dango.platform.common.startup import cleanup_stale_dbt_lock
+
+        if cleanup_stale_dbt_lock(project_root):
+            console.print("[yellow]⚠[/yellow] Removed stale dbt lock from crashed process")
+
         # Ensure all dbt schemas exist (for Metabase visibility)
         ensure_dbt_schemas(project_root)
 
@@ -578,10 +584,14 @@ def start(ctx: click.Context, yes: bool) -> None:
             console.print("[cyan]Starting file watcher...[/cyan]")
             try:
                 from dango.platform.watcher_lifecycle import (
+                    kill_orphan_watchers,
                     start_file_watcher,
                     stop_file_watcher,
                 )
 
+                orphans_killed = kill_orphan_watchers(project_root)
+                if orphans_killed:
+                    console.print(f"[yellow]⚠[/yellow] Killed {orphans_killed} orphaned watcher(s)")
                 stop_file_watcher(project_root)  # Clean up any orphaned watcher
                 watcher_pid = start_file_watcher(project_root)
                 console.print(f"[green]✓[/green] File watcher started (PID {watcher_pid})")
@@ -800,12 +810,19 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
         console.print("[cyan]Stopping services...[/cyan]")
 
         # Stop file watcher
-        from dango.platform.watcher_lifecycle import get_watcher_status, stop_file_watcher
+        from dango.platform.watcher_lifecycle import (
+            get_watcher_status,
+            kill_orphan_watchers,
+            stop_file_watcher,
+        )
 
         watcher_was_running = get_watcher_status(project_root)["running"]
         watcher_stopped = stop_file_watcher(project_root)
         if watcher_was_running and not watcher_stopped:
             console.print("[yellow]⚠[/yellow] Failed to stop file watcher")
+        orphans_killed = kill_orphan_watchers(project_root)
+        if orphans_killed:
+            console.print(f"[yellow]⚠[/yellow] Killed {orphans_killed} orphaned watcher(s)")
 
         # Stop Marimo notebook server
         from dango.notebooks.manager import get_marimo_status, stop_idle_checker, stop_marimo

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -579,19 +579,26 @@ def start(ctx: click.Context, yes: bool) -> None:
             console.print()
             raise click.Abort() from e
 
+        # Kill orphaned watcher processes (non-critical — runs regardless of auto_sync
+        # because orphans from a previous session with auto_sync=true may still exist)
+        try:
+            from dango.platform.watcher_lifecycle import kill_orphan_watchers
+
+            orphans_killed = kill_orphan_watchers(project_root)
+            if orphans_killed:
+                console.print(f"[yellow]⚠[/yellow] Killed {orphans_killed} orphaned watcher(s)")
+        except Exception:
+            logger.debug("orphan_watcher_cleanup_failed", exc_info=True)
+
         # Start file watcher if auto-sync is enabled (non-critical - can continue without it)
         if platform_config.auto_sync:
             console.print("[cyan]Starting file watcher...[/cyan]")
             try:
                 from dango.platform.watcher_lifecycle import (
-                    kill_orphan_watchers,
                     start_file_watcher,
                     stop_file_watcher,
                 )
 
-                orphans_killed = kill_orphan_watchers(project_root)
-                if orphans_killed:
-                    console.print(f"[yellow]⚠[/yellow] Killed {orphans_killed} orphaned watcher(s)")
                 stop_file_watcher(project_root)  # Clean up any orphaned watcher
                 watcher_pid = start_file_watcher(project_root)
                 console.print(f"[green]✓[/green] File watcher started (PID {watcher_pid})")

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -41,6 +41,7 @@ def serve(ctx: click.Context, host: str, port: int | None, workers: int | None) 
     from dango.config import ConfigLoader
     from dango.platform.common.startup import (
         check_duckdb_version_alignment,
+        cleanup_stale_dbt_lock,
         ensure_dbt_schemas,
         ensure_duckdb_driver,
         import_dashboards,
@@ -98,6 +99,10 @@ def serve(ctx: click.Context, host: str, port: int | None, workers: int | None) 
     except Exception as exc:
         print(f"Migration failed: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
+
+    # Clean up stale dbt lock from crashed process
+    if cleanup_stale_dbt_lock(project_root):
+        print("WARNING: Removed stale dbt lock from crashed process", file=sys.stderr)
 
     # BUG-104: Stop leftover containers before DuckDB write operations.
     # Containers from a previous crashed run may hold the DuckDB file lock.

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -58,6 +58,11 @@ def cleanup_stale_dbt_lock(project_root: Path) -> bool:
     Called during startup to proactively clean up locks from crashed processes.
     Returns True if a stale lock was cleaned up, False otherwise.
     Never raises.
+
+    Note: DbtLock._cleanup_stale_lock() has similar logic invoked lazily on
+    acquire().  This function exists separately because startup.py follows the
+    never-display / never-raise contract and cannot instantiate DbtLock (which
+    creates directories as a side effect).
     """
     import json
     import logging
@@ -83,10 +88,8 @@ def cleanup_stale_dbt_lock(project_root: Path) -> bool:
 
         # Process is dead — clean up stale lock files
         lock_file_path = project_root / ".dango" / "state" / "dbt.lock"
-        if lock_file_path.exists():
-            lock_file_path.unlink()
-        if lock_info_path.exists():
-            lock_info_path.unlink()
+        lock_file_path.unlink(missing_ok=True)
+        lock_info_path.unlink(missing_ok=True)
 
         logger.warning(
             "Removed stale dbt lock (PID %d: %s — %s)",

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -52,6 +52,53 @@ def run_pending_migrations(project_root: Path) -> dict[str, Any]:
     return apply_all_pending(project_root)
 
 
+def cleanup_stale_dbt_lock(project_root: Path) -> bool:
+    """Remove stale dbt lock if the holding process is dead.
+
+    Called during startup to proactively clean up locks from crashed processes.
+    Returns True if a stale lock was cleaned up, False otherwise.
+    Never raises.
+    """
+    import json
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        import psutil
+
+        lock_info_path = project_root / ".dango" / "state" / "dbt.lock.json"
+        if not lock_info_path.exists():
+            return False
+
+        with open(lock_info_path) as f:
+            lock_info = json.load(f)
+
+        pid = lock_info.get("pid")
+        if pid is None:
+            return False
+
+        if psutil.pid_exists(pid):
+            return False
+
+        # Process is dead — clean up stale lock files
+        lock_file_path = project_root / ".dango" / "state" / "dbt.lock"
+        if lock_file_path.exists():
+            lock_file_path.unlink()
+        if lock_info_path.exists():
+            lock_info_path.unlink()
+
+        logger.warning(
+            "Removed stale dbt lock (PID %d: %s — %s)",
+            pid,
+            lock_info.get("source", "unknown"),
+            lock_info.get("operation", "unknown"),
+        )
+        return True
+    except Exception:
+        return False
+
+
 def ensure_dbt_schemas(project_root: Path) -> None:
     """
     Create DuckDB schemas required for Metabase visibility.

--- a/dango/platform/local/watcher_lifecycle.py
+++ b/dango/platform/local/watcher_lifecycle.py
@@ -22,6 +22,39 @@ def get_watcher_pid_file_path(project_root: Path) -> Path:
     return project_root / ".dango" / "watcher.pid"
 
 
+def kill_orphan_watchers(project_root: Path) -> int:
+    """Scan for and kill orphaned watcher_runner.py processes for this project.
+
+    Catches orphans that have no PID file (e.g., parent crashed before writing it).
+    Returns count of killed orphans.
+    """
+    import os
+
+    import psutil
+
+    resolved_root = str(project_root.resolve())
+    killed = 0
+    current_pid = os.getpid()
+
+    for proc in psutil.process_iter(["pid", "cmdline"]):
+        try:
+            if proc.pid == current_pid:
+                continue
+            cmdline = proc.info.get("cmdline") or []
+            if not cmdline:
+                continue
+            has_runner = any("watcher_runner.py" in arg for arg in cmdline)
+            has_root = any(resolved_root in arg for arg in cmdline)
+            if has_runner and has_root:
+                logger.warning("Killing orphaned watcher process (PID %d)", proc.pid)
+                kill_process(proc.pid)
+                killed += 1
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+    return killed
+
+
 def start_file_watcher(project_root: Path) -> int | None:
     """
     Start file watcher in background.

--- a/dango/platform/watcher_lifecycle.py
+++ b/dango/platform/watcher_lifecycle.py
@@ -8,6 +8,7 @@ Watcher subprocess lifecycle management (start, stop, status).
 from dango.platform.local.watcher_lifecycle import (
     get_watcher_pid_file_path,
     get_watcher_status,
+    kill_orphan_watchers,
     start_file_watcher,
     stop_file_watcher,
 )
@@ -15,6 +16,7 @@ from dango.platform.local.watcher_lifecycle import (
 __all__ = [
     "get_watcher_pid_file_path",
     "get_watcher_status",
+    "kill_orphan_watchers",
     "start_file_watcher",
     "stop_file_watcher",
 ]

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -119,6 +119,8 @@ class DbtLock:
 
         Returns:
             True if a stale lock was cleaned up, False otherwise
+
+        See also: startup.cleanup_stale_dbt_lock() for the proactive startup variant.
         """
         lock_info = self._read_lock_info()
         if not lock_info:

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -6,6 +6,7 @@ Prevents concurrent dbt runs from UI, CLI, and sync operations to avoid DuckDB l
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 from collections.abc import Generator
@@ -17,6 +18,8 @@ from typing import IO, Any
 import psutil
 
 from dango.exceptions import DbtLockError
+
+logger = logging.getLogger(__name__)
 
 # Platform-specific file locking
 if sys.platform == "win32":
@@ -129,6 +132,12 @@ class DbtLock:
                     self.lock_file_path.unlink()
                 if self.lock_info_path.exists():
                     self.lock_info_path.unlink()
+                logger.warning(
+                    "Removed stale dbt lock (PID %d: %s — %s)",
+                    pid,
+                    lock_info.get("source", "unknown"),
+                    lock_info.get("operation", "unknown"),
+                )
                 return True
             except OSError:
                 pass

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -632,6 +632,11 @@ def setup_metabase(
     metabase_url = metabase_url.rstrip("/")
     project_root / "data" / "warehouse.duckdb"
     credentials_file = project_root / ".dango" / "metabase.yml"
+
+    from dango.platform.docker import get_compose_project_name
+
+    compose_name = get_compose_project_name(project_root)
+
     session = requests.Session()
 
     # Check if already setup
@@ -706,7 +711,7 @@ def setup_metabase(
                     else:
                         summary["errors"].append(
                             "Metabase already initialized but default credentials don't work. "
-                            "Delete Docker volume or metabase.yml to reset."
+                            f"To reset: docker volume rm {compose_name}_metabase-data && dango start"
                         )
                         return summary
 
@@ -750,7 +755,7 @@ def setup_metabase(
                         summary["errors"].append(
                             f"Failed to create admin user: {response.text}\n"
                             "And could not login with default credentials.\n"
-                            "To reset: docker volume rm <project>_metabase_data && dango start"
+                            f"To reset: docker volume rm {compose_name}_metabase-data && dango start"
                         )
                         return summary
                 else:

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -632,17 +632,16 @@ def setup_metabase(
     metabase_url = metabase_url.rstrip("/")
     project_root / "data" / "warehouse.duckdb"
     credentials_file = project_root / ".dango" / "metabase.yml"
-
-    from dango.platform.docker import get_compose_project_name
-
-    compose_name = get_compose_project_name(project_root)
-
     session = requests.Session()
 
     # Check if already setup
     if credentials_file.exists():
         summary["errors"].append("Metabase already configured (credentials file exists)")
         return summary
+
+    from dango.platform.docker import get_compose_project_name
+
+    compose_name = get_compose_project_name(project_root)
 
     # Wait for Metabase to be ready (longer timeout for cloud cold start)
     ready_timeout = 300 if cloud_mode else 60

--- a/tests/unit/test_dbt_lock_stale.py
+++ b/tests/unit/test_dbt_lock_stale.py
@@ -1,0 +1,122 @@
+"""tests/unit/test_dbt_lock_stale.py
+
+Tests for stale dbt lock cleanup (startup helper + DbtLock._cleanup_stale_lock).
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dango.platform.common.startup import cleanup_stale_dbt_lock
+
+# Work around dbt_lock module/function name collision (STANDARDS.md §7)
+# The import statement resolves to the function re-exported by __init__.py,
+# so we must force-import the module first, then grab it from sys.modules.
+importlib.import_module("dango.utils.dbt_lock")
+_dbt_lock_mod = sys.modules["dango.utils.dbt_lock"]
+DbtLock = _dbt_lock_mod.DbtLock
+
+
+def _write_stale_lock(project_root: Path, pid: int) -> None:
+    """Create stale lock files with the given PID."""
+    state_dir = project_root / ".dango" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "dbt.lock").write_text("")
+    (state_dir / "dbt.lock.json").write_text(
+        json.dumps(
+            {
+                "pid": pid,
+                "source": "cli",
+                "operation": "dbt run",
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "hostname": "test",
+            }
+        )
+    )
+
+
+@pytest.mark.unit
+class TestCleanupStaleDbtLock:
+    def test_stale_lock_from_dead_pid_removed(self, tmp_path: Path) -> None:
+        _write_stale_lock(tmp_path, pid=99999)
+        with patch("psutil.pid_exists", return_value=False):
+            result = cleanup_stale_dbt_lock(tmp_path)
+        assert result is True
+        assert not (tmp_path / ".dango" / "state" / "dbt.lock").exists()
+        assert not (tmp_path / ".dango" / "state" / "dbt.lock.json").exists()
+
+    def test_no_lock_files_returns_false(self, tmp_path: Path) -> None:
+        result = cleanup_stale_dbt_lock(tmp_path)
+        assert result is False
+
+    def test_lock_from_running_pid_preserved(self, tmp_path: Path) -> None:
+        _write_stale_lock(tmp_path, pid=12345)
+        with patch("psutil.pid_exists", return_value=True):
+            result = cleanup_stale_dbt_lock(tmp_path)
+        assert result is False
+        assert (tmp_path / ".dango" / "state" / "dbt.lock").exists()
+        assert (tmp_path / ".dango" / "state" / "dbt.lock.json").exists()
+
+    def test_corrupt_json_returns_false(self, tmp_path: Path) -> None:
+        """Corrupt JSON in lock info file should not crash."""
+        state_dir = tmp_path / ".dango" / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "dbt.lock.json").write_text("{invalid json")
+        result = cleanup_stale_dbt_lock(tmp_path)
+        assert result is False
+
+
+@pytest.mark.unit
+class TestDbtLockCleanupStaleIntegration:
+    def test_acquire_succeeds_after_stale_lock_cleanup(self, tmp_path: Path) -> None:
+        """DbtLock.acquire() succeeds when stale lock files exist from a dead process."""
+        _write_stale_lock(tmp_path, pid=99999)
+
+        _mod = sys.modules["dango.utils.dbt_lock"]
+        with patch.object(_mod.DbtLock, "_is_process_running", return_value=False):
+            lock = DbtLock(tmp_path, source="test", operation="test op")
+            acquired = lock.acquire(timeout=0)
+            assert acquired is True
+            lock.release()
+
+    def test_acquire_blocked_by_running_pid(self, tmp_path: Path) -> None:
+        """DbtLock.acquire() raises DbtLockError when lock is held by running process."""
+        from dango.exceptions import DbtLockError as DbtLockErr
+
+        # Create a real lock first
+        holder = DbtLock(tmp_path, source="holder", operation="hold")
+        holder.acquire(timeout=0)
+
+        try:
+            contender = DbtLock(tmp_path, source="contender", operation="contend")
+            with pytest.raises(DbtLockErr, match="Another sync operation"):
+                contender.acquire(timeout=0)
+        finally:
+            holder.release()
+
+
+@pytest.mark.unit
+class TestDbtLockCleanupLogging:
+    def test_cleanup_stale_lock_logs_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """_cleanup_stale_lock() logs a warning when removing stale files."""
+        _write_stale_lock(tmp_path, pid=99999)
+
+        _mod = sys.modules["dango.utils.dbt_lock"]
+        import logging
+
+        with (
+            caplog.at_level(logging.WARNING, logger="dango.utils.dbt_lock"),
+            patch.object(_mod.DbtLock, "_is_process_running", return_value=False),
+        ):
+            lock = DbtLock(tmp_path, source="test", operation="test op")
+            cleaned = lock._cleanup_stale_lock()
+
+        assert cleaned is True
+        assert "Removed stale dbt lock" in caplog.text
+        assert "99999" in caplog.text

--- a/tests/unit/test_metabase_reset.py
+++ b/tests/unit/test_metabase_reset.py
@@ -1,12 +1,91 @@
 """tests/unit/test_metabase_reset.py
 
-Tests for Metabase setup error messages containing correct volume names.
+Unit tests for _reset_metabase_volume() in dango/visualization/metabase.py.
 """
 
+from __future__ import annotations
+
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+@pytest.mark.unit
+class TestResetMetabaseVolume:
+    """Test _reset_metabase_volume helper."""
+
+    @patch("dango.visualization.metabase.subprocess.run")
+    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
+    def test_success(self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path):
+        from dango.visualization.metabase import _reset_metabase_volume
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = _reset_metabase_volume(tmp_path)
+
+        assert result is True
+        assert mock_run.call_count == 4
+
+        # Verify the 4 subprocess calls in order
+        calls = mock_run.call_args_list
+        assert calls[0][0][0] == ["docker", "compose", "stop", "metabase"]
+        assert calls[1][0][0] == ["docker", "compose", "rm", "-f", "metabase"]
+        assert calls[2][0][0] == ["docker", "volume", "rm", "dango-abc12345_metabase-data"]
+        assert calls[3][0][0] == ["docker", "compose", "up", "-d", "metabase"]
+
+    @patch("dango.visualization.metabase.subprocess.run")
+    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
+    def test_volume_rm_failure_returns_false(
+        self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ):
+        from dango.visualization.metabase import _reset_metabase_volume
+
+        def _side_effect(cmd, **kwargs):
+            result = MagicMock(returncode=0)
+            if "volume" in cmd and "rm" in cmd:
+                result.returncode = 1
+                result.stderr = b"volume is in use"
+            return result
+
+        mock_run.side_effect = _side_effect
+
+        result = _reset_metabase_volume(tmp_path)
+
+        assert result is False
+        # Should NOT call docker compose up after failed volume rm
+        assert mock_run.call_count == 3
+
+    @patch("dango.visualization.metabase.subprocess.run")
+    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
+    def test_timeout_returns_false(
+        self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ):
+        from dango.visualization.metabase import _reset_metabase_volume
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=60)
+
+        result = _reset_metabase_volume(tmp_path)
+
+        assert result is False
+
+    @patch("dango.visualization.metabase.subprocess.run")
+    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
+    def test_compose_project_name_used(
+        self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ):
+        from dango.visualization.metabase import _reset_metabase_volume
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        _reset_metabase_volume(tmp_path)
+
+        mock_compose_name.assert_called_once_with(tmp_path)
+        # Verify COMPOSE_PROJECT_NAME is in the env for compose commands
+        for call in mock_run.call_args_list:
+            if "compose" in call[0][0]:
+                assert call[1]["env"]["COMPOSE_PROJECT_NAME"] == "dango-abc12345"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_metabase_reset.py
+++ b/tests/unit/test_metabase_reset.py
@@ -1,11 +1,8 @@
 """tests/unit/test_metabase_reset.py
 
-Unit tests for _reset_metabase_volume() in dango/visualization/metabase.py.
+Tests for Metabase setup error messages containing correct volume names.
 """
 
-from __future__ import annotations
-
-import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -13,76 +10,84 @@ import pytest
 
 
 @pytest.mark.unit
-class TestResetMetabaseVolume:
-    """Test _reset_metabase_volume helper."""
+class TestSetupMetabaseErrorMessages:
+    """Verify error messages include the correct Docker volume name."""
 
-    @patch("dango.visualization.metabase.subprocess.run")
-    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
-    def test_success(self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path):
-        from dango.visualization.metabase import _reset_metabase_volume
+    def test_reset_failed_error_includes_compose_name(self, tmp_path: Path) -> None:
+        """When _reset_metabase_volume returns False, error includes compose name."""
+        credentials_file = tmp_path / ".dango" / "metabase.yml"
+        # Ensure credentials file does NOT exist (triggers setup flow)
+        assert not credentials_file.exists()
 
-        mock_run.return_value = MagicMock(returncode=0)
+        with (
+            patch(
+                "dango.platform.docker.get_compose_project_name",
+                return_value="dango-abc123",
+            ),
+            patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
+            patch("dango.visualization.metabase._reset_metabase_volume", return_value=False),
+        ):
+            import requests
 
-        result = _reset_metabase_volume(tmp_path)
+            mock_session = MagicMock(spec=requests.Session)
+            # First call: session properties — no setup token
+            props_response = MagicMock()
+            props_response.status_code = 200
+            props_response.json.return_value = {"setup-token": None}
 
-        assert result is True
-        assert mock_run.call_count == 4
+            # Second call: login attempt — fails (stale volume)
+            login_response = MagicMock()
+            login_response.status_code = 401
 
-        # Verify the 4 subprocess calls in order
-        calls = mock_run.call_args_list
-        assert calls[0][0][0] == ["docker", "compose", "stop", "metabase"]
-        assert calls[1][0][0] == ["docker", "compose", "rm", "-f", "metabase"]
-        assert calls[2][0][0] == ["docker", "volume", "rm", "dango-abc12345_metabase-data"]
-        assert calls[3][0][0] == ["docker", "compose", "up", "-d", "metabase"]
+            mock_session.get.return_value = props_response
+            mock_session.post.return_value = login_response
 
-    @patch("dango.visualization.metabase.subprocess.run")
-    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
-    def test_volume_rm_failure_returns_false(
-        self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path
-    ):
-        from dango.visualization.metabase import _reset_metabase_volume
+            with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+                from dango.visualization.metabase import setup_metabase
 
-        def _side_effect(cmd, **kwargs):
-            result = MagicMock(returncode=0)
-            if "volume" in cmd and "rm" in cmd:
-                result.returncode = 1
-                result.stderr = b"volume is in use"
-            return result
+                result = setup_metabase(tmp_path, "test-project", "admin@example.com")
 
-        mock_run.side_effect = _side_effect
+        assert not result["success"]
+        error_msg = result["errors"][0]
+        assert "dango-abc123_metabase-data" in error_msg
+        assert "docker volume rm" in error_msg
 
-        result = _reset_metabase_volume(tmp_path)
+    def test_setup_api_failure_error_includes_compose_name(self, tmp_path: Path) -> None:
+        """When setup API returns non-200 and login fails, error includes compose name."""
+        with (
+            patch(
+                "dango.platform.docker.get_compose_project_name",
+                return_value="dango-xyz789",
+            ),
+            patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
+        ):
+            import requests
 
-        assert result is False
-        # Should NOT call docker compose up after failed volume rm
-        assert mock_run.call_count == 3
+            mock_session = MagicMock(spec=requests.Session)
 
-    @patch("dango.visualization.metabase.subprocess.run")
-    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
-    def test_timeout_returns_false(
-        self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path
-    ):
-        from dango.visualization.metabase import _reset_metabase_volume
+            # session properties — has setup token (fresh Metabase)
+            props_response = MagicMock()
+            props_response.status_code = 200
+            props_response.json.return_value = {"setup-token": "tok-123"}
 
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=60)
+            # setup POST — fails with "user exists"
+            setup_response = MagicMock()
+            setup_response.status_code = 400
+            setup_response.text = "first user already exists"
 
-        result = _reset_metabase_volume(tmp_path)
+            # login attempt — also fails
+            login_response = MagicMock()
+            login_response.status_code = 401
 
-        assert result is False
+            mock_session.get.return_value = props_response
+            mock_session.post.side_effect = [setup_response, login_response]
 
-    @patch("dango.visualization.metabase.subprocess.run")
-    @patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc12345")
-    def test_compose_project_name_used(
-        self, mock_compose_name: MagicMock, mock_run: MagicMock, tmp_path: Path
-    ):
-        from dango.visualization.metabase import _reset_metabase_volume
+            with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+                from dango.visualization.metabase import setup_metabase
 
-        mock_run.return_value = MagicMock(returncode=0)
+                result = setup_metabase(tmp_path, "test-project", "admin@example.com")
 
-        _reset_metabase_volume(tmp_path)
-
-        mock_compose_name.assert_called_once_with(tmp_path)
-        # Verify COMPOSE_PROJECT_NAME is in the env for compose commands
-        for call in mock_run.call_args_list:
-            if "compose" in call[0][0]:
-                assert call[1]["env"]["COMPOSE_PROJECT_NAME"] == "dango-abc12345"
+        assert not result["success"]
+        error_msg = result["errors"][0]
+        assert "dango-xyz789_metabase-data" in error_msg
+        assert "docker volume rm" in error_msg

--- a/tests/unit/test_watcher_lifecycle.py
+++ b/tests/unit/test_watcher_lifecycle.py
@@ -1,6 +1,6 @@
 """tests/unit/test_watcher_lifecycle.py
 
-Tests for kill_orphan_watchers in dango.platform.local.watcher_lifecycle.
+Tests for dango.platform.watcher_lifecycle — watcher subprocess lifecycle management.
 """
 
 from pathlib import Path
@@ -9,7 +9,233 @@ from unittest.mock import MagicMock, patch
 import psutil
 import pytest
 
-from dango.platform.local.watcher_lifecycle import kill_orphan_watchers
+from dango.platform.watcher_lifecycle import (
+    get_watcher_pid_file_path,
+    get_watcher_status,
+    kill_orphan_watchers,
+    start_file_watcher,
+    stop_file_watcher,
+)
+
+
+@pytest.mark.unit
+class TestGetWatcherPidFilePath:
+    def test_returns_correct_path(self, tmp_path):
+        result = get_watcher_pid_file_path(tmp_path)
+        assert result == tmp_path / ".dango" / "watcher.pid"
+
+
+@pytest.mark.unit
+class TestStartFileWatcher:
+    def _setup_project(self, tmp_path):
+        """Create .dango dir so PID file operations work."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir(parents=True, exist_ok=True)
+        return dango_dir
+
+    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
+    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
+    def test_successful_start_returns_pid(self, mock_running, mock_popen, mock_sleep, tmp_path):
+        self._setup_project(tmp_path)
+        mock_proc = MagicMock()
+        mock_proc.pid = 5555
+        mock_proc.poll.return_value = None  # Still running
+        mock_popen.return_value = mock_proc
+
+        pid = start_file_watcher(tmp_path)
+
+        assert pid == 5555
+        pid_file = tmp_path / ".dango" / "watcher.pid"
+        assert pid_file.read_text() == "5555"
+
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
+    def test_already_running_raises_runtime_error(self, _mock_running, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text("1234")
+
+        with pytest.raises(RuntimeError, match="already running"):
+            start_file_watcher(tmp_path)
+
+    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
+    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=False)
+    def test_stale_pid_file_cleaned_up(self, mock_running, mock_popen, mock_sleep, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text("9999")
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 7777
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        pid = start_file_watcher(tmp_path)
+        assert pid == 7777
+
+    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
+    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
+    def test_invalid_pid_file_cleaned_up(self, mock_running, mock_popen, mock_sleep, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text("not-a-number")
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 8888
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        pid = start_file_watcher(tmp_path)
+        assert pid == 8888
+
+    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
+    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
+    def test_process_exits_immediately_raises(self, mock_running, mock_popen, mock_sleep, tmp_path):
+        self._setup_project(tmp_path)
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1  # Exited with error
+        mock_popen.return_value = mock_proc
+
+        with pytest.raises(RuntimeError, match="failed to start"):
+            start_file_watcher(tmp_path)
+
+    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
+    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
+    def test_popen_called_with_correct_args(self, mock_running, mock_popen, mock_sleep, tmp_path):
+        self._setup_project(tmp_path)
+        mock_proc = MagicMock()
+        mock_proc.pid = 1111
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        start_file_watcher(tmp_path)
+
+        args = mock_popen.call_args
+        cmd = args[0][0]
+        # cmd[0] is sys.executable, cmd[1] is watcher_runner.py path, cmd[2] is project_root
+        assert cmd[1].endswith("watcher_runner.py")
+        assert cmd[2] == str(tmp_path)
+        assert args[1]["start_new_session"] is True
+
+    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
+    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
+    def test_sleep_called(self, mock_running, mock_popen, mock_sleep, tmp_path):
+        self._setup_project(tmp_path)
+        mock_proc = MagicMock()
+        mock_proc.pid = 2222
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        start_file_watcher(tmp_path)
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
+    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
+    def test_popen_exception_raises_runtime_error(
+        self, mock_running, mock_popen, mock_sleep, tmp_path
+    ):
+        self._setup_project(tmp_path)
+        mock_popen.side_effect = FileNotFoundError("python not found")
+
+        with pytest.raises(RuntimeError, match="Failed to start file watcher"):
+            start_file_watcher(tmp_path)
+
+
+@pytest.mark.unit
+class TestStopFileWatcher:
+    def _setup_project(self, tmp_path):
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir(parents=True, exist_ok=True)
+        return dango_dir
+
+    def test_no_pid_file_returns_false(self, tmp_path):
+        self._setup_project(tmp_path)
+        assert stop_file_watcher(tmp_path) is False
+
+    def test_invalid_pid_content_returns_false(self, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text("garbage")
+
+        assert stop_file_watcher(tmp_path) is False
+        assert not pid_file.exists()
+
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=False)
+    def test_stale_pid_returns_false(self, _mock_running, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text("9999")
+
+        assert stop_file_watcher(tmp_path) is False
+        assert not pid_file.exists()
+
+    @patch("dango.platform.local.watcher_lifecycle.kill_process", return_value=True)
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
+    def test_successful_kill_returns_true(self, _mock_running, mock_kill, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text("4444")
+
+        assert stop_file_watcher(tmp_path) is True
+        mock_kill.assert_called_once_with(4444, timeout=10)
+        assert not pid_file.exists()
+
+    @patch("dango.platform.local.watcher_lifecycle.kill_process", return_value=False)
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
+    def test_kill_fails_returns_false(self, _mock_running, mock_kill, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text("4444")
+
+        assert stop_file_watcher(tmp_path) is False
+        assert not pid_file.exists()  # PID file still cleaned up
+
+
+@pytest.mark.unit
+class TestGetWatcherStatus:
+    def _setup_project(self, tmp_path):
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir(parents=True, exist_ok=True)
+        return dango_dir
+
+    def test_no_pid_file(self, tmp_path):
+        self._setup_project(tmp_path)
+        status = get_watcher_status(tmp_path)
+        assert status["running"] is False
+        assert status["pid"] is None
+        assert status["log_file"] == tmp_path / ".dango" / "watcher.log"
+
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
+    def test_pid_file_with_running_process(self, _mock_running, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        (dango_dir / "watcher.pid").write_text("3333")
+
+        status = get_watcher_status(tmp_path)
+        assert status["running"] is True
+        assert status["pid"] == 3333
+
+    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=False)
+    def test_stale_pid_file(self, _mock_running, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        (dango_dir / "watcher.pid").write_text("9999")
+
+        status = get_watcher_status(tmp_path)
+        assert status["running"] is False
+        assert status["pid"] is None
+
+    def test_invalid_pid_file(self, tmp_path):
+        dango_dir = self._setup_project(tmp_path)
+        (dango_dir / "watcher.pid").write_text("bad")
+
+        status = get_watcher_status(tmp_path)
+        assert status["running"] is False
+        assert status["pid"] is None
 
 
 def _make_proc(pid: int, cmdline: list[str]) -> MagicMock:

--- a/tests/unit/test_watcher_lifecycle.py
+++ b/tests/unit/test_watcher_lifecycle.py
@@ -1,235 +1,108 @@
 """tests/unit/test_watcher_lifecycle.py
 
-Tests for dango.platform.watcher_lifecycle — watcher subprocess lifecycle management.
+Tests for kill_orphan_watchers in dango.platform.local.watcher_lifecycle.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import psutil
 import pytest
 
-from dango.platform.watcher_lifecycle import (
-    get_watcher_pid_file_path,
-    get_watcher_status,
-    start_file_watcher,
-    stop_file_watcher,
-)
+from dango.platform.local.watcher_lifecycle import kill_orphan_watchers
+
+
+def _make_proc(pid: int, cmdline: list[str]) -> MagicMock:
+    """Create a mock process for psutil.process_iter."""
+    proc = MagicMock()
+    proc.pid = pid
+    proc.info = {"pid": pid, "cmdline": cmdline}
+    return proc
 
 
 @pytest.mark.unit
-class TestGetWatcherPidFilePath:
-    def test_returns_correct_path(self, tmp_path):
-        result = get_watcher_pid_file_path(tmp_path)
-        assert result == tmp_path / ".dango" / "watcher.pid"
+class TestKillOrphanWatchers:
+    def test_no_matching_processes_returns_zero(self, tmp_path: Path) -> None:
+        with patch("psutil.process_iter", return_value=[]):
+            assert kill_orphan_watchers(tmp_path) == 0
 
+    def test_matching_process_killed(self, tmp_path: Path) -> None:
+        resolved = str(tmp_path.resolve())
+        proc = _make_proc(12345, ["python3", "watcher_runner.py", resolved])
+        with (
+            patch(
+                "psutil.process_iter",
+                return_value=[proc],
+            ),
+            patch(
+                "dango.platform.local.watcher_lifecycle.kill_process", return_value=True
+            ) as mock_kill,
+            patch("os.getpid", return_value=99999),
+        ):
+            result = kill_orphan_watchers(tmp_path)
+        assert result == 1
+        mock_kill.assert_called_once_with(12345)
 
-@pytest.mark.unit
-class TestStartFileWatcher:
-    def _setup_project(self, tmp_path):
-        """Create .dango dir so PID file operations work."""
-        dango_dir = tmp_path / ".dango"
-        dango_dir.mkdir(parents=True, exist_ok=True)
-        return dango_dir
+    def test_different_project_root_not_killed(self, tmp_path: Path) -> None:
+        other_root = "/some/other/project"
+        proc = _make_proc(12345, ["python3", "watcher_runner.py", other_root])
+        with (
+            patch(
+                "psutil.process_iter",
+                return_value=[proc],
+            ),
+            patch("dango.platform.local.watcher_lifecycle.kill_process") as mock_kill,
+            patch("os.getpid", return_value=99999),
+        ):
+            result = kill_orphan_watchers(tmp_path)
+        assert result == 0
+        mock_kill.assert_not_called()
 
-    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
-    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
-    def test_successful_start_returns_pid(self, mock_running, mock_popen, mock_sleep, tmp_path):
-        self._setup_project(tmp_path)
-        mock_proc = MagicMock()
-        mock_proc.pid = 5555
-        mock_proc.poll.return_value = None  # Still running
-        mock_popen.return_value = mock_proc
+    def test_empty_cmdline_skipped(self, tmp_path: Path) -> None:
+        """Process with empty cmdline is skipped gracefully."""
+        proc = _make_proc(12345, [])
+        with (
+            patch(
+                "psutil.process_iter",
+                return_value=[proc],
+            ),
+            patch("dango.platform.local.watcher_lifecycle.kill_process") as mock_kill,
+            patch("os.getpid", return_value=99999),
+        ):
+            result = kill_orphan_watchers(tmp_path)
+        assert result == 0
+        mock_kill.assert_not_called()
 
-        pid = start_file_watcher(tmp_path)
+    def test_skips_current_process(self, tmp_path: Path) -> None:
+        resolved = str(tmp_path.resolve())
+        proc = _make_proc(99999, ["python3", "watcher_runner.py", resolved])
+        with (
+            patch(
+                "psutil.process_iter",
+                return_value=[proc],
+            ),
+            patch("dango.platform.local.watcher_lifecycle.kill_process") as mock_kill,
+            patch("os.getpid", return_value=99999),
+        ):
+            result = kill_orphan_watchers(tmp_path)
+        assert result == 0
+        mock_kill.assert_not_called()
 
-        assert pid == 5555
-        pid_file = tmp_path / ".dango" / "watcher.pid"
-        assert pid_file.read_text() == "5555"
-
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
-    def test_already_running_raises_runtime_error(self, _mock_running, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        pid_file = dango_dir / "watcher.pid"
-        pid_file.write_text("1234")
-
-        with pytest.raises(RuntimeError, match="already running"):
-            start_file_watcher(tmp_path)
-
-    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
-    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=False)
-    def test_stale_pid_file_cleaned_up(self, mock_running, mock_popen, mock_sleep, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        pid_file = dango_dir / "watcher.pid"
-        pid_file.write_text("9999")
-
-        mock_proc = MagicMock()
-        mock_proc.pid = 7777
-        mock_proc.poll.return_value = None
-        mock_popen.return_value = mock_proc
-
-        pid = start_file_watcher(tmp_path)
-        assert pid == 7777
-
-    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
-    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
-    def test_invalid_pid_file_cleaned_up(self, mock_running, mock_popen, mock_sleep, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        pid_file = dango_dir / "watcher.pid"
-        pid_file.write_text("not-a-number")
-
-        mock_proc = MagicMock()
-        mock_proc.pid = 8888
-        mock_proc.poll.return_value = None
-        mock_popen.return_value = mock_proc
-
-        pid = start_file_watcher(tmp_path)
-        assert pid == 8888
-
-    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
-    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
-    def test_process_exits_immediately_raises(self, mock_running, mock_popen, mock_sleep, tmp_path):
-        self._setup_project(tmp_path)
-        mock_proc = MagicMock()
-        mock_proc.poll.return_value = 1  # Exited with error
-        mock_popen.return_value = mock_proc
-
-        with pytest.raises(RuntimeError, match="failed to start"):
-            start_file_watcher(tmp_path)
-
-    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
-    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
-    def test_popen_called_with_correct_args(self, mock_running, mock_popen, mock_sleep, tmp_path):
-        self._setup_project(tmp_path)
-        mock_proc = MagicMock()
-        mock_proc.pid = 1111
-        mock_proc.poll.return_value = None
-        mock_popen.return_value = mock_proc
-
-        start_file_watcher(tmp_path)
-
-        args = mock_popen.call_args
-        cmd = args[0][0]
-        # cmd[0] is sys.executable, cmd[1] is watcher_runner.py path, cmd[2] is project_root
-        assert cmd[1].endswith("watcher_runner.py")
-        assert cmd[2] == str(tmp_path)
-        assert args[1]["start_new_session"] is True
-
-    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
-    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
-    def test_sleep_called(self, mock_running, mock_popen, mock_sleep, tmp_path):
-        self._setup_project(tmp_path)
-        mock_proc = MagicMock()
-        mock_proc.pid = 2222
-        mock_proc.poll.return_value = None
-        mock_popen.return_value = mock_proc
-
-        start_file_watcher(tmp_path)
-        mock_sleep.assert_called_once_with(1)
-
-    @patch("dango.platform.local.watcher_lifecycle.time.sleep")
-    @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running")
-    def test_popen_exception_raises_runtime_error(
-        self, mock_running, mock_popen, mock_sleep, tmp_path
-    ):
-        self._setup_project(tmp_path)
-        mock_popen.side_effect = FileNotFoundError("python not found")
-
-        with pytest.raises(RuntimeError, match="Failed to start file watcher"):
-            start_file_watcher(tmp_path)
-
-
-@pytest.mark.unit
-class TestStopFileWatcher:
-    def _setup_project(self, tmp_path):
-        dango_dir = tmp_path / ".dango"
-        dango_dir.mkdir(parents=True, exist_ok=True)
-        return dango_dir
-
-    def test_no_pid_file_returns_false(self, tmp_path):
-        self._setup_project(tmp_path)
-        assert stop_file_watcher(tmp_path) is False
-
-    def test_invalid_pid_content_returns_false(self, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        pid_file = dango_dir / "watcher.pid"
-        pid_file.write_text("garbage")
-
-        assert stop_file_watcher(tmp_path) is False
-        assert not pid_file.exists()
-
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=False)
-    def test_stale_pid_returns_false(self, _mock_running, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        pid_file = dango_dir / "watcher.pid"
-        pid_file.write_text("9999")
-
-        assert stop_file_watcher(tmp_path) is False
-        assert not pid_file.exists()
-
-    @patch("dango.platform.local.watcher_lifecycle.kill_process", return_value=True)
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
-    def test_successful_kill_returns_true(self, _mock_running, mock_kill, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        pid_file = dango_dir / "watcher.pid"
-        pid_file.write_text("4444")
-
-        assert stop_file_watcher(tmp_path) is True
-        mock_kill.assert_called_once_with(4444, timeout=10)
-        assert not pid_file.exists()
-
-    @patch("dango.platform.local.watcher_lifecycle.kill_process", return_value=False)
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
-    def test_kill_fails_returns_false(self, _mock_running, mock_kill, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        pid_file = dango_dir / "watcher.pid"
-        pid_file.write_text("4444")
-
-        assert stop_file_watcher(tmp_path) is False
-        assert not pid_file.exists()  # PID file still cleaned up
-
-
-@pytest.mark.unit
-class TestGetWatcherStatus:
-    def _setup_project(self, tmp_path):
-        dango_dir = tmp_path / ".dango"
-        dango_dir.mkdir(parents=True, exist_ok=True)
-        return dango_dir
-
-    def test_no_pid_file(self, tmp_path):
-        self._setup_project(tmp_path)
-        status = get_watcher_status(tmp_path)
-        assert status["running"] is False
-        assert status["pid"] is None
-        assert status["log_file"] == tmp_path / ".dango" / "watcher.log"
-
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
-    def test_pid_file_with_running_process(self, _mock_running, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        (dango_dir / "watcher.pid").write_text("3333")
-
-        status = get_watcher_status(tmp_path)
-        assert status["running"] is True
-        assert status["pid"] == 3333
-
-    @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=False)
-    def test_stale_pid_file(self, _mock_running, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        (dango_dir / "watcher.pid").write_text("9999")
-
-        status = get_watcher_status(tmp_path)
-        assert status["running"] is False
-        assert status["pid"] is None
-
-    def test_invalid_pid_file(self, tmp_path):
-        dango_dir = self._setup_project(tmp_path)
-        (dango_dir / "watcher.pid").write_text("bad")
-
-        status = get_watcher_status(tmp_path)
-        assert status["running"] is False
-        assert status["pid"] is None
+    def test_nosuchprocess_skipped(self, tmp_path: Path) -> None:
+        """NoSuchProcess during iteration is handled gracefully."""
+        proc = MagicMock()
+        proc.pid = 12345
+        type(proc).info = property(
+            lambda self: (_ for _ in ()).throw(psutil.NoSuchProcess(pid=12345))
+        )
+        with (
+            patch(
+                "psutil.process_iter",
+                return_value=[proc],
+            ),
+            patch("dango.platform.local.watcher_lifecycle.kill_process") as mock_kill,
+            patch("os.getpid", return_value=99999),
+        ):
+            result = kill_orphan_watchers(tmp_path)
+        assert result == 0
+        mock_kill.assert_not_called()


### PR DESCRIPTION
## Summary

- **P0-1:** Add `kill_orphan_watchers()` to detect and kill watcher processes that have no PID file (parent crashed before writing it). Called on both `dango start` and `dango stop`.
- **P0-2:** Fix Metabase error messages to show actual Docker volume name (e.g. `dango-abc123_metabase-data`) instead of hardcoded placeholder `<project>_metabase_data`.
- **P1-1:** Add `cleanup_stale_dbt_lock()` startup helper to proactively remove stale dbt lock files from crashed processes. Called during both local and cloud startup. Added warning logging to `DbtLock._cleanup_stale_lock()`.

## Files Changed

| File | Bug | Change |
|------|-----|--------|
| `dango/platform/local/watcher_lifecycle.py` | P0-1 | Add `kill_orphan_watchers()` |
| `dango/platform/watcher_lifecycle.py` | P0-1 | Re-export new function in shim |
| `dango/cli/commands/platform.py` | P0-1, P1-1 | Call orphan cleanup on start/stop; call stale lock cleanup on start |
| `dango/visualization/metabase.py` | P0-2 | Fix error messages with actual volume name |
| `dango/utils/dbt_lock.py` | P1-1 | Add logging to `_cleanup_stale_lock()` |
| `dango/platform/common/startup.py` | P1-1 | Add `cleanup_stale_dbt_lock()` |
| `dango/cli/commands/serve.py` | P1-1 | Call stale lock cleanup on cloud startup |
| `tests/unit/test_watcher_lifecycle.py` | P0-1 | 6 tests for `kill_orphan_watchers` |
| `tests/unit/test_metabase_reset.py` | P0-2 | 2 tests for error message content |
| `tests/unit/test_dbt_lock_stale.py` (new) | P1-1 | 7 tests for stale lock cleanup + logging |

## Verification
- `ruff check dango/`: all passed
- `ruff format --check dango/`: all formatted
- `pytest -x`: 3774 passed, 31 skipped, 0 failed

## Test plan
- [ ] `pytest tests/unit/test_watcher_lifecycle.py -v` — 6 pass
- [ ] `pytest tests/unit/test_metabase_reset.py -v` — 2 pass
- [ ] `pytest tests/unit/test_dbt_lock_stale.py -v` — 7 pass
- [ ] `pytest -x` — full suite green
- [ ] Coordinating chat: verify on beta-1 before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)