### PR TITLE
ci: add integration branch patterns to CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [v1, main]
   pull_request:
-    branches: [v1, main]
+    branches: [v1, main, 'v1.0.*']
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Add `v1.0.*` glob pattern to `pull_request.branches` in CI workflow
- Without this, PRs targeting integration branches (v1.0.s1, v1.0.s2) have required checks that never run, blocking merges

## Verification
- 1-line change to `.github/workflows/ci.yml`
- No code changes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>