### PR TITLE
fix: wizard UX bugs (P2-2, P2-4, P2-6, P2-7, P8-3)

### DIFF
--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -179,6 +179,13 @@ class SourceWizard:
                         continue
                     elif oauth_result == "cancel":
                         return False
+                    elif oauth_result == "skipped":
+                        console.print(
+                            "\n[yellow]⚠  No access token obtained — syncs will fail "
+                            "until you complete authentication.[/yellow]"
+                        )
+                        if not click.confirm("Continue setup anyway?", default=False):
+                            raise click.Abort()
 
                     state = "params"
 
@@ -299,50 +306,48 @@ class SourceWizard:
             # Step 9b: Show setup guide + secrets.toml template for
             # sources with credentials in secrets.toml (not .env).
             # Skip for OAuth sources — their credentials are already saved.
+            # Skip for sources without secrets_toml_template (e.g., CSV,
+            # local_files) — their setup_guide is informational, not
+            # credential setup.
             auth_type = metadata.get("auth_type")
-            if (
-                not self.secret_params
-                and metadata.get("setup_guide")
-                and auth_type != AuthType.OAUTH
-            ):
-                console.print("\n[bold]Credential setup required:[/bold]")
-                for line in metadata["setup_guide"]:
-                    console.print(f"  {line}")
+            secrets_template = metadata.get("secrets_toml_template")
+            if not self.secret_params and auth_type != AuthType.OAUTH and secrets_template:
+                if metadata.get("setup_guide"):
+                    console.print("\n[bold]Credential setup required:[/bold]")
+                    for line in metadata["setup_guide"]:
+                        console.print(f"  {line}")
 
-                secrets_template = metadata.get("secrets_toml_template")
-                if secrets_template:
-                    dlt_dir = self.project_root / ".dlt"
-                    secrets_path = dlt_dir / "secrets.toml"
-                    dlt_dir.mkdir(parents=True, exist_ok=True)
-                    try:
-                        existing = secrets_path.read_text() if secrets_path.exists() else ""
-                        section_header = f"[sources.{source_name}."
-                        if section_header not in existing:
-                            # Pre-populate template with wizard-collected params
-                            # (e.g., zendesk subdomain). defaultdict(str) returns ""
-                            # for unknown placeholders — prevents wizard crash from
-                            # registry template typos (caught during manual testing).
-                            from collections import defaultdict
+                dlt_dir = self.project_root / ".dlt"
+                secrets_path = dlt_dir / "secrets.toml"
+                dlt_dir.mkdir(parents=True, exist_ok=True)
+                try:
+                    existing = secrets_path.read_text() if secrets_path.exists() else ""
+                    section_header = f"[sources.{source_name}."
+                    if section_header not in existing:
+                        # Pre-populate template with wizard-collected params
+                        # (e.g., zendesk subdomain). defaultdict(str) returns ""
+                        # for unknown placeholders — prevents wizard crash from
+                        # registry template typos (caught during manual testing).
+                        from collections import defaultdict
 
-                            template_vars = defaultdict(str, source_name=source_name, **params)
-                            template_text = secrets_template.format_map(template_vars)
-                            prefix = existing.rstrip() + "\n\n" if existing.strip() else ""
-                            new_content = prefix + template_text + "\n"
-                            secrets_path.write_text(new_content)
-                            console.print(
-                                "\n[green]✓[/green] Added credential template to "
-                                "[cyan].dlt/secrets.toml[/cyan]"
-                            )
-                            console.print(
-                                "[yellow]Fill in the credential values before syncing.[/yellow]"
-                            )
-                        else:
-                            console.print(
-                                "\n[dim]Credential template already exists in "
-                                ".dlt/secrets.toml[/dim]"
-                            )
-                    except Exception as e:
-                        console.print(f"[yellow]Could not write secrets template: {e}[/yellow]")
+                        template_vars = defaultdict(str, source_name=source_name, **params)
+                        template_text = secrets_template.format_map(template_vars)
+                        prefix = existing.rstrip() + "\n\n" if existing.strip() else ""
+                        new_content = prefix + template_text + "\n"
+                        secrets_path.write_text(new_content)
+                        console.print(
+                            "\n[green]✓[/green] Added credential template to "
+                            "[cyan].dlt/secrets.toml[/cyan]"
+                        )
+                        console.print(
+                            "[yellow]Fill in the credential values before syncing.[/yellow]"
+                        )
+                    else:
+                        console.print(
+                            "\n[dim]Credential template already exists in .dlt/secrets.toml[/dim]"
+                        )
+                except Exception as e:
+                    console.print(f"[yellow]Could not write secrets template: {e}[/yellow]")
 
             # Step 10: Offer automatic analysis metrics
             try:
@@ -734,7 +739,7 @@ class SourceWizard:
                 "\n[dim]You can still configure this source, but you won't be able to sync"
             )
             console.print("until you set up OAuth credentials.[/dim]\n")
-            return None
+            return "skipped"
 
         # "Set up OAuth now" - run OAuth flow with retry
         console.print(
@@ -748,10 +753,21 @@ class SourceWizard:
                 # Verify credentials were actually saved
                 oauth_storage = OAuthStorage(self.project_root)
                 verified_cred = oauth_storage.get(source_type)
-                if verified_cred and not verified_cred.is_expired():
+                # Check for actual auth tokens, not just client credentials
+                has_tokens = verified_cred and (
+                    verified_cred.credentials.get("refresh_token")
+                    or verified_cred.credentials.get("access_token")
+                )
+                if verified_cred and not verified_cred.is_expired() and has_tokens:
                     console.print("\n[green]✅ OAuth credentials configured successfully![/green]")
                     console.print("[dim]  Credentials saved to .dlt/secrets.toml[/dim]\n")
                     return None  # Continue to params
+                elif verified_cred and not has_tokens:
+                    console.print(
+                        "\n[yellow]⚠  Client credentials saved but authorization not completed.[/yellow]"
+                    )
+                    console.print(f"[cyan]Run `dango oauth {source_type}` to complete.[/cyan]")
+                    # Fall through to retry prompt
                 else:
                     console.print(
                         "\n[yellow]⚠️  OAuth flow completed but credentials could not be verified[/yellow]"

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -635,6 +635,7 @@ class SourceWizard:
             None if OAuth setup successful or not needed
             "back" if user wants to go back
             "cancel" if user cancelled
+            "skipped" if user chose to skip OAuth setup
         """
         # Check if this source requires OAuth
         auth_type = metadata.get("auth_type")

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -765,7 +765,7 @@ class SourceWizard:
                     return None  # Continue to params
                 elif verified_cred and not has_tokens:
                     console.print(
-                        "\n[yellow]⚠  Client credentials saved but authorization not completed.[/yellow]"
+                        "\n[yellow]⚠️  Client credentials saved but authorization not completed.[/yellow]"
                     )
                     console.print(f"[cyan]Run `dango oauth {source_type}` to complete.[/cyan]")
                     # Fall through to retry prompt
@@ -774,9 +774,9 @@ class SourceWizard:
                         "\n[yellow]⚠️  OAuth flow completed but credentials could not be verified[/yellow]"
                     )
                     # Fall through to retry prompt
-
-            # OAuth failed or unverified — offer retry / cancel
-            console.print("\n[red]❌ OAuth setup did not complete successfully[/red]")
+            else:
+                # OAuth truly failed (run_oauth_for_source returned False)
+                console.print("\n[red]❌ OAuth setup did not complete successfully[/red]")
 
             # Only offer "re-enter credentials" for Google sources (which cache
             # client_id/secret in env vars). Facebook prompts directly each time.

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -467,9 +467,9 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "optional_params": [
             {
                 "name": "start_date",
-                "type": "string",
+                "type": "date",
                 "prompt": "Start date (YYYY-MM-DD)",
-                "default": "90daysAgo",
+                "default_days_ago": 90,
                 "help": "How far back to load on first sync. Default: 90 days.",
             },
         ],

--- a/tests/unit/test_source_wizard.py
+++ b/tests/unit/test_source_wizard.py
@@ -1,0 +1,235 @@
+"""tests/unit/test_source_wizard.py
+
+Unit tests for source wizard UX bugs (P2-2, P2-4, P2-6, P2-7, P8-3).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.ingestion.sources.registry import SOURCE_REGISTRY
+
+# ---------------------------------------------------------------------------
+# P2-2: Success message requires actual auth tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOAuthSuccessRequiresTokens:
+    """P2-2: Success message should only print when refresh/access token exists."""
+
+    @patch("dango.cli.source_wizard.OAuthStorage")
+    @patch("dango.cli.source_wizard.run_oauth_for_source")
+    @patch("dango.cli.source_wizard.inquirer")
+    def test_no_success_when_only_client_credentials(
+        self, mock_inquirer, mock_run_oauth, mock_storage_cls, tmp_path
+    ):
+        """Credential with only client_id/secret (no tokens) should NOT show success."""
+        from dango.cli.source_wizard import SourceWizard
+
+        # Mock credential with client_id/secret but NO refresh_token
+        mock_cred = MagicMock()
+        mock_cred.is_expired.return_value = False
+        mock_cred.credentials = {"client_id": "xxx", "client_secret": "yyy"}
+
+        # First get() returns None (no existing creds), second returns mock_cred
+        mock_storage_cls.return_value.get.side_effect = [None, mock_cred]
+        mock_run_oauth.return_value = True
+
+        # First inquirer prompt: choose "Set up OAuth now"
+        # Second prompt (retry after warning): cancel
+        mock_inquirer.prompt.side_effect = [
+            {"oauth_action": "Set up OAuth now (recommended)"},
+            None,  # Cancel at retry prompt
+        ]
+        mock_inquirer.List = MagicMock()
+
+        wizard = SourceWizard(tmp_path)
+        metadata = {"auth_type": "oauth", "display_name": "Google Ads"}
+
+        with patch("dango.cli.source_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+
+            wizard._handle_oauth_setup("google_ads", "my_ads", metadata)
+
+        # Should NOT have printed success message
+        success_msgs = [p for p in printed if "configured successfully" in p]
+        assert len(success_msgs) == 0, f"Unexpected success message: {success_msgs}"
+
+        # Should have printed the warning about client credentials
+        warning_msgs = [p for p in printed if "authorization not completed" in p]
+        assert len(warning_msgs) > 0, "Expected warning about incomplete authorization"
+
+    @patch("dango.cli.source_wizard.OAuthStorage")
+    @patch("dango.cli.source_wizard.run_oauth_for_source")
+    @patch("dango.cli.source_wizard.inquirer")
+    def test_success_when_refresh_token_present(
+        self, mock_inquirer, mock_run_oauth, mock_storage_cls, tmp_path
+    ):
+        """Credential with refresh_token should show success."""
+        from dango.cli.source_wizard import SourceWizard
+
+        mock_cred = MagicMock()
+        mock_cred.is_expired.return_value = False
+        mock_cred.credentials = {
+            "client_id": "xxx",
+            "client_secret": "yyy",
+            "refresh_token": "valid_token",
+        }
+
+        # First get() returns None (no existing creds), second returns mock_cred
+        mock_storage_cls.return_value.get.side_effect = [None, mock_cred]
+        mock_run_oauth.return_value = True
+
+        mock_inquirer.prompt.return_value = {"oauth_action": "Set up OAuth now (recommended)"}
+        mock_inquirer.List = MagicMock()
+
+        wizard = SourceWizard(tmp_path)
+        metadata = {"auth_type": "oauth", "display_name": "Google Ads"}
+
+        with patch("dango.cli.source_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+
+            result = wizard._handle_oauth_setup("google_ads", "my_ads", metadata)
+
+        assert result is None  # Continue to params
+        success_msgs = [p for p in printed if "configured successfully" in p]
+        assert len(success_msgs) == 1
+
+
+# ---------------------------------------------------------------------------
+# P2-4/P2-6: Wizard exits on decline after OAuth skip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOAuthSkipHandling:
+    """P2-4/P2-6: 'Skip for now' returns 'skipped', main flow exits on decline."""
+
+    @patch("dango.cli.source_wizard.OAuthStorage")
+    @patch("dango.cli.source_wizard.inquirer")
+    def test_skip_returns_skipped(self, mock_inquirer, mock_storage_cls, tmp_path):
+        """'Skip for now' action should return 'skipped', not None."""
+        from dango.cli.source_wizard import SourceWizard
+
+        mock_storage_cls.return_value.get.return_value = None
+
+        mock_inquirer.prompt.return_value = {
+            "oauth_action": "Skip for now (configure manually later)"
+        }
+        mock_inquirer.List = MagicMock()
+
+        wizard = SourceWizard(tmp_path)
+        metadata = {"auth_type": "oauth", "display_name": "Google Ads"}
+
+        with patch("dango.cli.source_wizard.console"):
+            result = wizard._handle_oauth_setup("google_ads", "my_ads", metadata)
+
+        assert result == "skipped"
+
+    def test_wizard_exits_on_skip_decline(self, tmp_path):
+        """When user declines 'Continue setup anyway?' after skip, wizard exits (returns False)
+        without proceeding to parameter collection."""
+        from dango.cli.source_wizard import SourceWizard
+
+        wizard = SourceWizard(tmp_path)
+        mock_collect = MagicMock()
+
+        with (
+            patch.object(wizard, "_handle_oauth_setup", return_value="skipped"),
+            patch.object(wizard, "_select_source_flat", return_value="google_ads"),
+            patch.object(wizard, "_show_source_info"),
+            patch.object(wizard, "_get_source_name", return_value="my_ads"),
+            patch.object(wizard, "_collect_parameters", mock_collect),
+            patch("dango.cli.source_wizard.click.confirm", return_value=False),
+            patch("dango.cli.source_wizard.console"),
+            patch(
+                "dango.cli.source_wizard.get_source_metadata",
+                return_value={"auth_type": "oauth", "display_name": "Google Ads"},
+            ),
+        ):
+            # click.Abort is caught by run()'s except Exception handler → returns False
+            result = wizard.run()
+            assert result is False
+            # Crucially, parameter collection was never reached
+            mock_collect.assert_not_called()
+
+    def test_wizard_continues_on_skip_confirm(self, tmp_path):
+        """When user confirms 'Continue setup anyway?' after skip, wizard proceeds to params."""
+        from dango.cli.source_wizard import SourceWizard
+
+        wizard = SourceWizard(tmp_path)
+
+        with (
+            patch.object(wizard, "_handle_oauth_setup", return_value="skipped"),
+            patch.object(wizard, "_select_source_flat", return_value="google_ads"),
+            patch.object(wizard, "_show_source_info"),
+            patch.object(wizard, "_get_source_name", return_value="my_ads"),
+            patch.object(wizard, "_collect_parameters", return_value=None),
+            patch("dango.cli.source_wizard.click.confirm", return_value=True),
+            patch("dango.cli.source_wizard.console"),
+            patch(
+                "dango.cli.source_wizard.get_source_metadata",
+                return_value={
+                    "auth_type": "oauth",
+                    "display_name": "Google Ads",
+                    "required_params": [],
+                    "optional_params": [],
+                },
+            ),
+        ):
+            # Should proceed to params state (where _collect_parameters returns
+            # None, ending the wizard — but crucially no click.Abort)
+            result = wizard.run()
+            assert result is False  # _collect_parameters returned None → cancelled
+
+
+# ---------------------------------------------------------------------------
+# P2-7: GA4 start_date uses date type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGA4StartDate:
+    """P2-7: GA4 start_date should use type 'date' with default_days_ago."""
+
+    def test_ga4_start_date_uses_date_type(self):
+        ga4 = SOURCE_REGISTRY["google_analytics"]
+        start_date_param = next(p for p in ga4["optional_params"] if p["name"] == "start_date")
+        assert start_date_param["type"] == "date"
+        assert start_date_param["default_days_ago"] == 90
+        assert "default" not in start_date_param
+
+
+# ---------------------------------------------------------------------------
+# P8-3: No "Credential setup required" without secrets_toml_template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCredentialBlockGating:
+    """P8-3: Sources without secrets_toml_template should not show credential block."""
+
+    def test_no_credential_block_for_csv(self):
+        """CSV has setup_guide but no secrets_toml_template — should not trigger credential block."""
+        csv_meta = SOURCE_REGISTRY["csv"]
+        assert csv_meta.get("setup_guide") is not None, "CSV should have setup_guide"
+        assert csv_meta.get("secrets_toml_template") is None, (
+            "CSV should not have secrets_toml_template"
+        )
+
+    def test_no_credential_block_for_local_files(self):
+        """local_files has setup_guide but no secrets_toml_template."""
+        lf_meta = SOURCE_REGISTRY["local_files"]
+        assert lf_meta.get("setup_guide") is not None
+        assert lf_meta.get("secrets_toml_template") is None
+
+    def test_credential_block_for_salesforce(self):
+        """Salesforce has both setup_guide and secrets_toml_template — should trigger."""
+        sf_meta = SOURCE_REGISTRY["salesforce"]
+        assert sf_meta.get("setup_guide") is not None
+        assert sf_meta.get("secrets_toml_template") is not None

--- a/tests/unit/test_source_wizard.py
+++ b/tests/unit/test_source_wizard.py
@@ -137,14 +137,16 @@ class TestOAuthSkipHandling:
         from dango.cli.source_wizard import SourceWizard
 
         wizard = SourceWizard(tmp_path)
-        mock_collect = MagicMock()
+
+        def _should_not_reach(*args, **kwargs):
+            raise AssertionError("Wizard should not reach parameter collection after skip decline")
 
         with (
             patch.object(wizard, "_handle_oauth_setup", return_value="skipped"),
             patch.object(wizard, "_select_source_flat", return_value="google_ads"),
             patch.object(wizard, "_show_source_info"),
             patch.object(wizard, "_get_source_name", return_value="my_ads"),
-            patch.object(wizard, "_collect_parameters", mock_collect),
+            patch.object(wizard, "_collect_parameters", side_effect=_should_not_reach),
             patch("dango.cli.source_wizard.click.confirm", return_value=False),
             patch("dango.cli.source_wizard.console"),
             patch(
@@ -155,8 +157,6 @@ class TestOAuthSkipHandling:
             # click.Abort is caught by run()'s except Exception handler → returns False
             result = wizard.run()
             assert result is False
-            # Crucially, parameter collection was never reached
-            mock_collect.assert_not_called()
 
     def test_wizard_continues_on_skip_confirm(self, tmp_path):
         """When user confirms 'Continue setup anyway?' after skip, wizard proceeds to params."""
@@ -233,3 +233,38 @@ class TestCredentialBlockGating:
         sf_meta = SOURCE_REGISTRY["salesforce"]
         assert sf_meta.get("setup_guide") is not None
         assert sf_meta.get("secrets_toml_template") is not None
+
+    def test_credential_block_skipped_without_template(self, tmp_path):
+        """Wizard output should NOT contain 'Credential setup required' for sources
+        that have setup_guide but no secrets_toml_template (e.g., local_files)."""
+        from dango.ingestion.sources.registry import AuthType
+
+        metadata = {
+            "auth_type": AuthType.NONE,
+            "setup_guide": ["Step 1: do something", "Step 2: do another thing"],
+            # No secrets_toml_template
+        }
+
+        # Reproduce the gating condition from source_wizard.py Step 9b
+        secret_params = []  # No secret params
+        auth_type = metadata.get("auth_type")
+        secrets_template = metadata.get("secrets_toml_template")
+        would_show = not secret_params and auth_type != AuthType.OAUTH and secrets_template
+        assert not would_show, "Credential block should NOT trigger without secrets_toml_template"
+
+    def test_credential_block_shown_with_template(self, tmp_path):
+        """Wizard output SHOULD contain 'Credential setup required' for sources
+        that have both setup_guide and secrets_toml_template."""
+        from dango.ingestion.sources.registry import AuthType
+
+        metadata = {
+            "auth_type": AuthType.NONE,
+            "setup_guide": ["Step 1: get API key"],
+            "secrets_toml_template": '[sources.{source_name}.credentials]\ntoken = ""\n',
+        }
+
+        secret_params = []
+        auth_type = metadata.get("auth_type")
+        secrets_template = metadata.get("secrets_toml_template")
+        would_show = not secret_params and auth_type != AuthType.OAUTH and secrets_template
+        assert would_show, "Credential block SHOULD trigger with secrets_toml_template"


### PR DESCRIPTION
## Summary

Fixes 5 OAuth wizard UX bugs that cause confusing behavior when OAuth fails or is skipped:

- **P2-2**: Only show OAuth success message when actual auth tokens (refresh_token/access_token) exist, not just client credentials
- **P2-4/P2-6**: Return `"skipped"` from `_handle_oauth_setup()` on "Skip for now", prompt user to confirm before continuing setup (exits cleanly via `click.Abort()` on decline)
- **P2-7**: GA4 `start_date` parameter now uses `type: "date"` with `default_days_ago: 90` (matching all other sources), instead of `type: "string"` with `default: "90daysAgo"`
- **P8-3**: "Credential setup required" block only shown when source has `secrets_toml_template` — CSV/local_files no longer trigger it
- **Bonus**: Red error message only on true OAuth failure, not partial success; emoji consistency

## Files changed

- `dango/cli/source_wizard.py` — P2-2, P2-4, P2-6, P8-3, error messaging
- `dango/ingestion/sources/registry.py` — P2-7
- `tests/unit/test_source_wizard.py` — New: 11 tests covering all 5 bugs

## Verification
- `pytest -x`: 3790 pass, 0 fail, 31 skipped
- `ruff check dango/`: clean
- `ruff format --check dango/`: clean
- Live OAuth wizard testing deferred to coordinating chat (per verification workflow)

Replaces #330 (closed due to CI trigger issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)