### PR TITLE
fix: drift banner Accept prominence, installer help text (P8-2, P6-4)

### DIFF
--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -2784,7 +2784,7 @@ async function renderAttentionBanner() {
         const canManage = window.DANGO_USER_ROLE === 'admin';
         const sourceItems = attentionSources.map(s => {
             const acceptBtn = canManage
-                ? `<button onclick="acceptDrift('${s.source}')" class="ml-2 text-sm text-yellow-700 underline hover:text-yellow-900">Accept</button>`
+                ? `<button onclick="acceptDrift('${s.source}')" class="ml-2 text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded hover:bg-yellow-200 font-medium">Accept</button>`
                 : '';
             return `<span class="font-medium">${escapeHtml(s.source)}</span>: ${escapeHtml(s.reason)}${acceptBtn}`;
         }).join('<br>');
@@ -2800,7 +2800,7 @@ async function renderAttentionBanner() {
                     <div class="ml-3">
                         <h3 class="text-sm font-medium text-yellow-800">Breaking Schema Drift Detected</h3>
                         <div class="mt-2 text-sm text-yellow-700">${sourceItems}</div>
-                        <p class="mt-1 text-xs text-yellow-600">Accept changes to update the schema baseline and clear this warning.</p>
+                        <p class="mt-1 text-xs text-yellow-600">Accept changes to update the schema baseline, or run <code class="bg-yellow-100 px-1 rounded">dango governance accept &lt;source&gt;</code> from the CLI.</p>
                     </div>
                 </div>
             </div>

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -2784,7 +2784,7 @@ async function renderAttentionBanner() {
         const canManage = window.DANGO_USER_ROLE === 'admin';
         const sourceItems = attentionSources.map(s => {
             const acceptBtn = canManage
-                ? `<button onclick="acceptDrift('${s.source}')" class="ml-2 text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded hover:bg-yellow-200 font-medium">Accept</button>`
+                ? `<button onclick="acceptDrift('${escapeHtml(s.source)}')" class="ml-2 text-xs px-3 py-1 bg-yellow-100 text-yellow-800 rounded hover:bg-yellow-200 font-medium">Accept</button>`
                 : '';
             return `<span class="font-medium">${escapeHtml(s.source)}</span>: ${escapeHtml(s.reason)}${acceptBtn}`;
         }).join('<br>');

--- a/install.ps1
+++ b/install.ps1
@@ -510,7 +510,7 @@ function Write-ActivationInstructions {
     Write-Host ""
     Write-Host "Try these commands now:"
     Write-Host "  dango source add" -ForegroundColor Yellow -NoNewline
-    Write-Host "    # Add a data source (CSV or Stripe)"
+    Write-Host "    # Add a data source"
     Write-Host "  dango sync" -ForegroundColor Yellow -NoNewline
     Write-Host "          # Sync data"
     Write-Host "  dango start" -ForegroundColor Yellow -NoNewline
@@ -572,7 +572,7 @@ function Write-GlobalSuccess {
     }
 
     Write-Host "  dango source add" -ForegroundColor Yellow -NoNewline
-    Write-Host "       # Add a data source (CSV or Stripe)"
+    Write-Host "       # Add a data source"
     Write-Host "  dango sync" -ForegroundColor Yellow -NoNewline
     Write-Host "             # Sync data"
     Write-Host "  dango start" -ForegroundColor Yellow -NoNewline

--- a/install.sh
+++ b/install.sh
@@ -542,7 +542,7 @@ print_activation_instructions() {
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo
     echo "Once activated, try these commands:"
-    echo -e "  ${YELLOW}dango source add${NC}    # Add a data source (CSV or Stripe)"
+    echo -e "  ${YELLOW}dango source add${NC}    # Add a data source"
     echo -e "  ${YELLOW}dango sync${NC}          # Sync data"
     echo -e "  ${YELLOW}dango start${NC}         # Start platform (opens http://localhost:8800)"
     echo
@@ -595,7 +595,7 @@ print_global_success() {
         echo -e "  ${YELLOW}cd my-project${NC}"
     fi
 
-    echo -e "  ${YELLOW}dango source add${NC}       # Add a data source (CSV or Stripe)"
+    echo -e "  ${YELLOW}dango source add${NC}       # Add a data source"
     echo -e "  ${YELLOW}dango sync${NC}             # Sync data"
     echo -e "  ${YELLOW}dango start${NC}            # Start platform (opens http://localhost:8800)"
     echo


### PR DESCRIPTION
## Summary
- **P8-2:** Restyle drift banner Accept button from underlined text link (`text-yellow-700 underline`) to pill-shaped button (`bg-yellow-100 text-yellow-800 rounded font-medium`) for better visibility. Add CLI hint mentioning `dango governance accept <source>` to the banner footer. Fix pre-existing escaping gap: `escapeHtml(s.source)` now used in onclick attribute.
- **P6-4:** Remove outdated "(CSV or Stripe)" parenthetical from installer help text in all 4 locations (install.sh x2, install.ps1 x2).
- **P3-2/P3-3:** Confirmed already fixed — `registry.py` already contains all missing GAQL fields.

## Verification
- `ruff check dango/`: pass
- `ruff format --check dango/`: pass
- `pytest -x`: 3781 passed, 31 skipped
- Grep: no remaining "(CSV or Stripe)" in install.sh/install.ps1
- P3-2/P3-3: confirmed already fixed in registry.py (lines 1094-1098, 1144-1147)
- P8-2: Accept button restyled to pill-shaped, CLI hint added to footer, onclick escaping fixed
- P6-4: 4 installer help text occurrences updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)