### PR TITLE
fix: protect replace-mode syncs from 0-row data wipe (P1)

### DIFF
--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -624,6 +624,7 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
     help="Allow CSV schema changes (add columns, treat missing as NULL)",
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
+@click.option("--allow-empty-replace", is_flag=True, hidden=True)
 @click.pass_context
 def sync(
     ctx: click.Context,
@@ -637,6 +638,7 @@ def sync(
     dry_run: bool,
     allow_schema_changes: bool,
     yes: bool,
+    allow_empty_replace: bool,
 ) -> None:
     """
     Load data from all sources (or specific source).
@@ -864,6 +866,7 @@ def sync(
                 full_refresh=full_refresh,
                 limit=limit,
                 allow_schema_changes=allow_schema_changes,
+                allow_empty_replace=allow_empty_replace,
             )
         except KeyboardInterrupt:
             console.print("\n[yellow]Sync interrupted — progress saved.[/yellow]")

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -570,9 +570,9 @@ class DltPipelineRunner:
         # Capture pre-refresh row count for empty replace protection
         pre_refresh_rows = self._get_csv_table_rows(source_config.name)
         has_backup = False
+        metadata_backup: list[tuple] = []  # backed-up _dango_file_metadata rows
 
         # Full refresh: backup or drop existing table
-        # Metadata deletion is deferred until after 0-row check (C-2 fix)
         if full_refresh:
             conn = duckdb.connect(str(self.duckdb_path))
             try:
@@ -601,8 +601,14 @@ class DltPipelineRunner:
                     conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
                     console.print("  🔄 Full refresh: dropped existing table")
 
+                # Backup metadata rows before deleting (restored on 0-row rollback)
+                if has_backup:
+                    metadata_backup = conn.execute(
+                        "SELECT * FROM _dango_file_metadata WHERE source_name = ?",
+                        [source_config.name],
+                    ).fetchall()
+
                 # Clear metadata so files are treated as new
-                # (will be restored if 0-row rollback triggers)
                 conn.execute(
                     """
                     DELETE FROM _dango_file_metadata
@@ -635,7 +641,7 @@ class DltPipelineRunner:
             "uses_replace_mode": True,  # CSV sources always do full refresh
         }
 
-        # Empty replace protection: restore backup if 0 rows loaded
+        # Empty replace protection: restore backup table + metadata if 0 rows loaded
         if has_backup and merged["rows_loaded"] == 0:
             conn = duckdb.connect(str(self.duckdb_path))
             try:
@@ -644,6 +650,12 @@ class DltPipelineRunner:
                     f'ALTER TABLE "{target_schema}"."{source_config.name}_pre_refresh_backup" '
                     f'RENAME TO "{source_config.name}"'
                 )
+                # Restore file metadata so next incremental sync resumes correctly
+                if metadata_backup:
+                    conn.executemany(
+                        "INSERT INTO _dango_file_metadata VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        metadata_backup,
+                    )
             finally:
                 conn.close()
             error_msg = (
@@ -710,9 +722,9 @@ class DltPipelineRunner:
         # Capture pre-refresh row count for empty replace protection
         pre_refresh_rows = self._get_csv_table_rows(source_config.name)
         has_backup = False
+        metadata_backup: list[tuple] = []  # backed-up _dango_file_metadata rows
 
         # Full refresh: backup or drop existing table
-        # Metadata deletion is deferred until after 0-row check (C-2 fix)
         if full_refresh:
             conn = duckdb.connect(str(self.duckdb_path))
             try:
@@ -740,6 +752,13 @@ class DltPipelineRunner:
                     # No data to protect — drop normally
                     conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
                     console.print("  🔄 Full refresh: dropped existing table")
+
+                # Backup metadata rows before deleting (restored on 0-row rollback)
+                if has_backup:
+                    metadata_backup = conn.execute(
+                        "SELECT * FROM _dango_file_metadata WHERE source_name = ?",
+                        [source_config.name],
+                    ).fetchall()
 
                 # Clear metadata so files are treated as new
                 conn.execute(
@@ -772,7 +791,7 @@ class DltPipelineRunner:
             "uses_replace_mode": True,  # Local file sources always do full refresh
         }
 
-        # Empty replace protection: restore backup if 0 rows loaded
+        # Empty replace protection: restore backup table + metadata if 0 rows loaded
         if has_backup and merged["rows_loaded"] == 0:
             conn = duckdb.connect(str(self.duckdb_path))
             try:
@@ -781,6 +800,12 @@ class DltPipelineRunner:
                     f'ALTER TABLE "{target_schema}"."{source_config.name}_pre_refresh_backup" '
                     f'RENAME TO "{source_config.name}"'
                 )
+                # Restore file metadata so next incremental sync resumes correctly
+                if metadata_backup:
+                    conn.executemany(
+                        "INSERT INTO _dango_file_metadata VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        metadata_backup,
+                    )
             finally:
                 conn.close()
             error_msg = (

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -560,6 +560,8 @@ class DltPipelineRunner:
         Returns:
             Load statistics
         """
+        import duckdb
+
         if not source_config.csv:
             raise ValueError(f"CSV config missing for source: {source_config.name}")
 
@@ -569,10 +571,9 @@ class DltPipelineRunner:
         pre_refresh_rows = self._get_csv_table_rows(source_config.name)
         has_backup = False
 
-        # Full refresh: backup or drop existing table and clear metadata
+        # Full refresh: backup or drop existing table
+        # Metadata deletion is deferred until after 0-row check (C-2 fix)
         if full_refresh:
-            import duckdb
-
             conn = duckdb.connect(str(self.duckdb_path))
             try:
                 if (
@@ -580,26 +581,28 @@ class DltPipelineRunner:
                     and pre_refresh_rows > 0
                     and not allow_empty_replace
                 ):
+                    # Drop stale backup if one exists from a previous crash
+                    backup_name = f"{source_config.name}_pre_refresh_backup"
+                    conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{backup_name}"')
                     # Rename to backup instead of dropping — restore if 0 rows loaded
                     try:
                         conn.execute(
                             f'ALTER TABLE "{target_schema}"."{source_config.name}" '
-                            f'RENAME TO "{source_config.name}_pre_refresh_backup"'
+                            f'RENAME TO "{backup_name}"'
                         )
                         has_backup = True
                         console.print("  🔄 Full refresh: existing data backed up")
-                    except Exception:
-                        # Table may not exist — fall through to normal drop
-                        conn.execute(
-                            f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"'
-                        )
-                        console.print("  🔄 Full refresh: dropped existing table")
+                    except duckdb.CatalogException:
+                        # Table does not exist — nothing to protect
+                        has_backup = False
+                        console.print("  🔄 Full refresh: no existing table")
                 else:
                     # No data to protect — drop normally
                     conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
                     console.print("  🔄 Full refresh: dropped existing table")
 
-                # Always clear metadata so files are treated as new
+                # Clear metadata so files are treated as new
+                # (will be restored if 0-row rollback triggers)
                 conn.execute(
                     """
                     DELETE FROM _dango_file_metadata
@@ -634,8 +637,6 @@ class DltPipelineRunner:
 
         # Empty replace protection: restore backup if 0 rows loaded
         if has_backup and merged["rows_loaded"] == 0:
-            import duckdb
-
             conn = duckdb.connect(str(self.duckdb_path))
             try:
                 conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
@@ -648,7 +649,7 @@ class DltPipelineRunner:
             error_msg = (
                 f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
                 f"preserved. To force sync with empty data, use: "
-                f"dango sync --source {source_config.name} --allow-empty-replace"
+                f"dango sync {source_config.name} --allow-empty-replace"
             )
             console.print(f"  [red]❌ {error_msg}[/red]")
             return {
@@ -661,8 +662,6 @@ class DltPipelineRunner:
 
         # Clean up backup table on success
         if has_backup:
-            import duckdb
-
             conn = duckdb.connect(str(self.duckdb_path))
             try:
                 conn.execute(
@@ -701,6 +700,8 @@ class DltPipelineRunner:
         Returns:
             Load statistics
         """
+        import duckdb
+
         if not source_config.local_files:
             raise ValueError(f"local_files config missing for source: {source_config.name}")
 
@@ -710,10 +711,9 @@ class DltPipelineRunner:
         pre_refresh_rows = self._get_csv_table_rows(source_config.name)
         has_backup = False
 
-        # Full refresh: backup or drop existing table and clear metadata
+        # Full refresh: backup or drop existing table
+        # Metadata deletion is deferred until after 0-row check (C-2 fix)
         if full_refresh:
-            import duckdb
-
             conn = duckdb.connect(str(self.duckdb_path))
             try:
                 if (
@@ -721,25 +721,27 @@ class DltPipelineRunner:
                     and pre_refresh_rows > 0
                     and not allow_empty_replace
                 ):
+                    # Drop stale backup if one exists from a previous crash
+                    backup_name = f"{source_config.name}_pre_refresh_backup"
+                    conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{backup_name}"')
                     # Rename to backup instead of dropping — restore if 0 rows loaded
                     try:
                         conn.execute(
                             f'ALTER TABLE "{target_schema}"."{source_config.name}" '
-                            f'RENAME TO "{source_config.name}_pre_refresh_backup"'
+                            f'RENAME TO "{backup_name}"'
                         )
                         has_backup = True
                         console.print("  🔄 Full refresh: existing data backed up")
-                    except Exception:
-                        # Table may not exist — fall through to normal drop
-                        conn.execute(
-                            f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"'
-                        )
-                        console.print("  🔄 Full refresh: dropped existing table")
+                    except duckdb.CatalogException:
+                        # Table does not exist — nothing to protect
+                        has_backup = False
+                        console.print("  🔄 Full refresh: no existing table")
                 else:
                     # No data to protect — drop normally
                     conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
                     console.print("  🔄 Full refresh: dropped existing table")
 
+                # Clear metadata so files are treated as new
                 conn.execute(
                     """
                     DELETE FROM _dango_file_metadata
@@ -772,8 +774,6 @@ class DltPipelineRunner:
 
         # Empty replace protection: restore backup if 0 rows loaded
         if has_backup and merged["rows_loaded"] == 0:
-            import duckdb
-
             conn = duckdb.connect(str(self.duckdb_path))
             try:
                 conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
@@ -786,7 +786,7 @@ class DltPipelineRunner:
             error_msg = (
                 f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
                 f"preserved. To force sync with empty data, use: "
-                f"dango sync --source {source_config.name} --allow-empty-replace"
+                f"dango sync {source_config.name} --allow-empty-replace"
             )
             console.print(f"  [red]❌ {error_msg}[/red]")
             return {
@@ -799,8 +799,6 @@ class DltPipelineRunner:
 
         # Clean up backup table on success
         if has_backup:
-            import duckdb
-
             conn = duckdb.connect(str(self.duckdb_path))
             try:
                 conn.execute(
@@ -913,6 +911,9 @@ class DltPipelineRunner:
                 if custom_sources_dir.exists() and str(custom_sources_dir) in sys.path:
                     sys.path.remove(str(custom_sources_dir))
 
+            # Detect if source uses replace write_disposition
+            uses_replace_mode = self._detect_write_disposition(source)
+
             # Determine dataset name (use custom or default to raw_{source_name})
             dataset_name = config.dataset_name or f"raw_{source_name}"
 
@@ -951,13 +952,13 @@ class DltPipelineRunner:
             stats = self._extract_load_stats(load_info)
             rows_loaded = stats.get("rows_loaded", 0)
 
-            # Empty replace protection: block 0-row full-refresh syncs
+            # Empty replace protection: block 0-row replace-mode syncs
             # that would wipe existing data
             if (
                 rows_loaded == 0
                 and pre_refresh_rows is not None
                 and pre_refresh_rows > 0
-                and full_refresh
+                and (full_refresh or uses_replace_mode)
                 and not allow_empty_replace
             ):
                 # Restore pipeline state so next sync retries correctly
@@ -965,7 +966,7 @@ class DltPipelineRunner:
                 error_msg = (
                     f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
                     f"preserved. To force sync with empty data, use: "
-                    f"dango sync --source {source_name} --allow-empty-replace"
+                    f"dango sync {source_name} --allow-empty-replace"
                 )
                 console.print(f"  [red]❌ {error_msg}[/red]")
                 return {
@@ -973,6 +974,7 @@ class DltPipelineRunner:
                     "source": source_name,
                     "error": error_msg,
                     "rows_loaded": 0,
+                    "uses_replace_mode": uses_replace_mode,
                 }
 
             # Check for data loss on full refresh
@@ -1281,7 +1283,7 @@ class DltPipelineRunner:
                 error_msg = (
                     f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
                     f"preserved. To force sync with empty data, use: "
-                    f"dango sync --source {source_name} --allow-empty-replace"
+                    f"dango sync {source_name} --allow-empty-replace"
                 )
                 console.print(f"  [red]❌ {error_msg}[/red]")
                 return {

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -653,7 +653,10 @@ class DltPipelineRunner:
                 # Restore file metadata so next incremental sync resumes correctly
                 if metadata_backup:
                     conn.executemany(
-                        "INSERT INTO _dango_file_metadata VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        "INSERT INTO _dango_file_metadata "
+                        "(source_name, file_path, file_size, file_mtime, "
+                        "rows_loaded, status, loaded_at, error_message) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                         metadata_backup,
                     )
             finally:
@@ -803,7 +806,10 @@ class DltPipelineRunner:
                 # Restore file metadata so next incremental sync resumes correctly
                 if metadata_backup:
                     conn.executemany(
-                        "INSERT INTO _dango_file_metadata VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        "INSERT INTO _dango_file_metadata "
+                        "(source_name, file_path, file_size, file_mtime, "
+                        "rows_loaded, status, loaded_at, error_message) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                         metadata_backup,
                     )
             finally:

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -173,6 +173,7 @@ class DltPipelineRunner:
         full_refresh: bool = False,
         timeout_minutes: int = 60,
         limit: int | None = None,
+        allow_empty_replace: bool = False,
     ) -> dict[str, Any]:
         """
         Run data pipeline for any source type
@@ -184,6 +185,7 @@ class DltPipelineRunner:
             full_refresh: Drop existing data and reload from scratch
             timeout_minutes: Timeout in minutes (default: 60)
             limit: Max rows to load (dev testing, applies to dlt sources only)
+            allow_empty_replace: If True, allow 0-row syncs to replace existing data
 
         Returns:
             Dictionary with load statistics and status
@@ -340,10 +342,14 @@ class DltPipelineRunner:
         try:
             # CSV: Custom implementation (Phase 1 loader)
             if source_type == SourceType.CSV:
-                result = self._run_csv_source(source_config, full_refresh)
+                result = self._run_csv_source(
+                    source_config, full_refresh, allow_empty_replace=allow_empty_replace
+                )
             # LOCAL_FILES: Unified local file source (CSV, JSON, JSONL, Parquet)
             elif source_type == SourceType.LOCAL_FILES:
-                result = self._run_local_files_source(source_config, full_refresh)
+                result = self._run_local_files_source(
+                    source_config, full_refresh, allow_empty_replace=allow_empty_replace
+                )
             # DLT_NATIVE: Advanced registry bypass
             elif source_type == SourceType.DLT_NATIVE:
                 try:
@@ -353,6 +359,7 @@ class DltPipelineRunner:
                         source_config,
                         full_refresh,
                         limit=limit,
+                        allow_empty_replace=allow_empty_replace,
                     )
                 except SyncTimeoutError as e:
                     error_message = str(e)
@@ -397,6 +404,7 @@ class DltPipelineRunner:
                         end_date,
                         full_refresh,
                         limit=limit,
+                        allow_empty_replace=allow_empty_replace,
                     )
                 except SyncTimeoutError as e:
                     error_message = str(e)
@@ -536,7 +544,10 @@ class DltPipelineRunner:
             }
 
     def _run_csv_source(
-        self, source_config: DataSource, full_refresh: bool = False
+        self,
+        source_config: DataSource,
+        full_refresh: bool = False,
+        allow_empty_replace: bool = False,
     ) -> dict[str, Any]:
         """
         Run CSV source using custom CSV loader
@@ -544,6 +555,7 @@ class DltPipelineRunner:
         Args:
             source_config: Source configuration
             full_refresh: If True, drop existing table and reload
+            allow_empty_replace: If True, allow 0-row syncs to replace existing data
 
         Returns:
             Load statistics
@@ -551,17 +563,43 @@ class DltPipelineRunner:
         if not source_config.csv:
             raise ValueError(f"CSV config missing for source: {source_config.name}")
 
-        # Full refresh: drop existing table and clear metadata
+        target_schema = f"raw_{source_config.name}"
+
+        # Capture pre-refresh row count for empty replace protection
+        pre_refresh_rows = self._get_csv_table_rows(source_config.name)
+        has_backup = False
+
+        # Full refresh: backup or drop existing table and clear metadata
         if full_refresh:
             import duckdb
 
-            target_schema = f"raw_{source_config.name}"
             conn = duckdb.connect(str(self.duckdb_path))
             try:
-                conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
-                console.print("  🔄 Full refresh: dropped existing table")
+                if (
+                    pre_refresh_rows is not None
+                    and pre_refresh_rows > 0
+                    and not allow_empty_replace
+                ):
+                    # Rename to backup instead of dropping — restore if 0 rows loaded
+                    try:
+                        conn.execute(
+                            f'ALTER TABLE "{target_schema}"."{source_config.name}" '
+                            f'RENAME TO "{source_config.name}_pre_refresh_backup"'
+                        )
+                        has_backup = True
+                        console.print("  🔄 Full refresh: existing data backed up")
+                    except Exception:
+                        # Table may not exist — fall through to normal drop
+                        conn.execute(
+                            f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"'
+                        )
+                        console.print("  🔄 Full refresh: dropped existing table")
+                else:
+                    # No data to protect — drop normally
+                    conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
+                    console.print("  🔄 Full refresh: dropped existing table")
 
-                # Also clear metadata for this source so files are treated as new
+                # Always clear metadata so files are treated as new
                 conn.execute(
                     """
                     DELETE FROM _dango_file_metadata
@@ -577,7 +615,6 @@ class DltPipelineRunner:
 
         # Run CSV loader
         # Use raw_{source_name} schema pattern (consistent with all other sources)
-        target_schema = f"raw_{source_config.name}"
         loader = CSVLoader(self.project_root, self.duckdb_path)
         result = loader.load(
             source_name=source_config.name,
@@ -595,6 +632,46 @@ class DltPipelineRunner:
             "uses_replace_mode": True,  # CSV sources always do full refresh
         }
 
+        # Empty replace protection: restore backup if 0 rows loaded
+        if has_backup and merged["rows_loaded"] == 0:
+            import duckdb
+
+            conn = duckdb.connect(str(self.duckdb_path))
+            try:
+                conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
+                conn.execute(
+                    f'ALTER TABLE "{target_schema}"."{source_config.name}_pre_refresh_backup" '
+                    f'RENAME TO "{source_config.name}"'
+                )
+            finally:
+                conn.close()
+            error_msg = (
+                f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
+                f"preserved. To force sync with empty data, use: "
+                f"dango sync --source {source_config.name} --allow-empty-replace"
+            )
+            console.print(f"  [red]❌ {error_msg}[/red]")
+            return {
+                "status": "failed",
+                "source": source_config.name,
+                "error": error_msg,
+                "rows_loaded": 0,
+                "uses_replace_mode": True,
+            }
+
+        # Clean up backup table on success
+        if has_backup:
+            import duckdb
+
+            conn = duckdb.connect(str(self.duckdb_path))
+            try:
+                conn.execute(
+                    f"DROP TABLE IF EXISTS "
+                    f'"{target_schema}"."{source_config.name}_pre_refresh_backup"'
+                )
+            finally:
+                conn.close()
+
         # No files found, no data loaded, no deletions → error
         if (
             merged["status"] == "success"
@@ -608,7 +685,10 @@ class DltPipelineRunner:
         return merged
 
     def _run_local_files_source(
-        self, source_config: DataSource, full_refresh: bool = False
+        self,
+        source_config: DataSource,
+        full_refresh: bool = False,
+        allow_empty_replace: bool = False,
     ) -> dict[str, Any]:
         """
         Run local files source using CSVLoader with multi-format support.
@@ -616,6 +696,7 @@ class DltPipelineRunner:
         Args:
             source_config: Source configuration with local_files config
             full_refresh: If True, drop existing table and reload
+            allow_empty_replace: If True, allow 0-row syncs to replace existing data
 
         Returns:
             Load statistics
@@ -623,15 +704,41 @@ class DltPipelineRunner:
         if not source_config.local_files:
             raise ValueError(f"local_files config missing for source: {source_config.name}")
 
-        # Full refresh: drop existing table and clear metadata
         target_schema = f"raw_{source_config.name}"
+
+        # Capture pre-refresh row count for empty replace protection
+        pre_refresh_rows = self._get_csv_table_rows(source_config.name)
+        has_backup = False
+
+        # Full refresh: backup or drop existing table and clear metadata
         if full_refresh:
             import duckdb
 
             conn = duckdb.connect(str(self.duckdb_path))
             try:
-                conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
-                console.print("  🔄 Full refresh: dropped existing table")
+                if (
+                    pre_refresh_rows is not None
+                    and pre_refresh_rows > 0
+                    and not allow_empty_replace
+                ):
+                    # Rename to backup instead of dropping — restore if 0 rows loaded
+                    try:
+                        conn.execute(
+                            f'ALTER TABLE "{target_schema}"."{source_config.name}" '
+                            f'RENAME TO "{source_config.name}_pre_refresh_backup"'
+                        )
+                        has_backup = True
+                        console.print("  🔄 Full refresh: existing data backed up")
+                    except Exception:
+                        # Table may not exist — fall through to normal drop
+                        conn.execute(
+                            f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"'
+                        )
+                        console.print("  🔄 Full refresh: dropped existing table")
+                else:
+                    # No data to protect — drop normally
+                    conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
+                    console.print("  🔄 Full refresh: dropped existing table")
 
                 conn.execute(
                     """
@@ -645,6 +752,7 @@ class DltPipelineRunner:
                 console.print(f"  ⚠️  Could not drop table/metadata: {e}")
             finally:
                 conn.close()
+
         loader = CSVLoader(self.project_root, self.duckdb_path)
         result = loader.load(
             source_name=source_config.name,
@@ -661,6 +769,46 @@ class DltPipelineRunner:
             "files_processed": result.get("new", 0) + result.get("updated", 0),
             "uses_replace_mode": True,  # Local file sources always do full refresh
         }
+
+        # Empty replace protection: restore backup if 0 rows loaded
+        if has_backup and merged["rows_loaded"] == 0:
+            import duckdb
+
+            conn = duckdb.connect(str(self.duckdb_path))
+            try:
+                conn.execute(f'DROP TABLE IF EXISTS "{target_schema}"."{source_config.name}"')
+                conn.execute(
+                    f'ALTER TABLE "{target_schema}"."{source_config.name}_pre_refresh_backup" '
+                    f'RENAME TO "{source_config.name}"'
+                )
+            finally:
+                conn.close()
+            error_msg = (
+                f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
+                f"preserved. To force sync with empty data, use: "
+                f"dango sync --source {source_config.name} --allow-empty-replace"
+            )
+            console.print(f"  [red]❌ {error_msg}[/red]")
+            return {
+                "status": "failed",
+                "source": source_config.name,
+                "error": error_msg,
+                "rows_loaded": 0,
+                "uses_replace_mode": True,
+            }
+
+        # Clean up backup table on success
+        if has_backup:
+            import duckdb
+
+            conn = duckdb.connect(str(self.duckdb_path))
+            try:
+                conn.execute(
+                    f"DROP TABLE IF EXISTS "
+                    f'"{target_schema}"."{source_config.name}_pre_refresh_backup"'
+                )
+            finally:
+                conn.close()
 
         # No files found, no data loaded, no deletions → error
         if (
@@ -679,6 +827,7 @@ class DltPipelineRunner:
         source_config: DataSource,
         full_refresh: bool = False,
         limit: int | None = None,
+        allow_empty_replace: bool = False,
     ) -> dict[str, Any]:
         """
         Run dlt native source (registry bypass for advanced users)
@@ -781,31 +930,18 @@ class DltPipelineRunner:
         # Backup dlt state BEFORE drop (so backup captures pre-drop state)
         state_backup = self._backup_dlt_state(pipeline_name)
 
-        # Capture pre-refresh row count for data loss detection
-        pre_refresh_rows: int | None = None
-        if full_refresh:
-            pre_refresh_rows = self._get_source_total_rows(source_name)
+        # Always capture pre-refresh row count for empty replace protection
+        pre_refresh_rows = self._get_source_total_rows(source_name)
 
-        # Full refresh: drop pipeline state
+        # Full refresh: drop pipeline state only (NOT schema)
+        # dlt with write_disposition="replace" handles table replacement automatically.
+        # Removing pre-load schema drop preserves data when 0 rows are returned.
         if full_refresh:
             console.print("  🔄 Full refresh: dropping pipeline state")
             try:
                 pipeline.drop()
             except Exception as e:
                 console.print(f"  ⚠️  Could not drop pipeline: {e}")
-
-            # Drop raw schema so dlt recreates with fresh column types
-            try:
-                import duckdb
-
-                conn = duckdb.connect(str(self.duckdb_path))
-                try:
-                    conn.execute(f'DROP SCHEMA IF EXISTS "{dataset_name}" CASCADE')
-                    console.print(f"  🔄 Full refresh: dropped schema {dataset_name}")
-                finally:
-                    conn.close()
-            except Exception as e:
-                console.print(f"  ⚠️  Could not drop schema: {e}")
 
         try:
             # Run pipeline with retry logic
@@ -814,6 +950,30 @@ class DltPipelineRunner:
             # Extract load statistics
             stats = self._extract_load_stats(load_info)
             rows_loaded = stats.get("rows_loaded", 0)
+
+            # Empty replace protection: block 0-row full-refresh syncs
+            # that would wipe existing data
+            if (
+                rows_loaded == 0
+                and pre_refresh_rows is not None
+                and pre_refresh_rows > 0
+                and full_refresh
+                and not allow_empty_replace
+            ):
+                # Restore pipeline state so next sync retries correctly
+                self._restore_dlt_state(state_backup)
+                error_msg = (
+                    f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
+                    f"preserved. To force sync with empty data, use: "
+                    f"dango sync --source {source_name} --allow-empty-replace"
+                )
+                console.print(f"  [red]❌ {error_msg}[/red]")
+                return {
+                    "status": "failed",
+                    "source": source_name,
+                    "error": error_msg,
+                    "rows_loaded": 0,
+                }
 
             # Check for data loss on full refresh
             if full_refresh and pre_refresh_rows is not None and rows_loaded < pre_refresh_rows:
@@ -904,6 +1064,7 @@ class DltPipelineRunner:
         end_date: datetime | None = None,
         full_refresh: bool = False,
         limit: int | None = None,
+        allow_empty_replace: bool = False,
     ) -> dict[str, Any]:
         """
         Run dlt pipeline for any verified source (generic implementation)
@@ -1085,31 +1246,18 @@ class DltPipelineRunner:
         # Backup dlt state BEFORE drop (so backup captures pre-drop state)
         state_backup = self._backup_dlt_state(source_name)
 
-        # Capture pre-refresh row count for data loss detection
-        pre_refresh_rows: int | None = None
-        if full_refresh:
-            pre_refresh_rows = self._get_source_total_rows(source_name)
+        # Always capture pre-refresh row count for empty replace protection
+        pre_refresh_rows = self._get_source_total_rows(source_name)
 
-        # Full refresh: drop pipeline state
+        # Full refresh: drop pipeline state only (NOT schema)
+        # dlt with write_disposition="replace" handles table replacement automatically.
+        # Removing pre-load schema drop preserves data when 0 rows are returned.
         if full_refresh:
             console.print("  🔄 Full refresh: dropping pipeline state")
             try:
                 pipeline.drop()
             except Exception as e:
                 console.print(f"  ⚠️  Could not drop pipeline: {e}")
-
-            # Drop raw schema so dlt recreates with fresh column types
-            try:
-                import duckdb
-
-                conn = duckdb.connect(str(self.duckdb_path))
-                try:
-                    conn.execute(f'DROP SCHEMA IF EXISTS "{dataset_name}" CASCADE')
-                    console.print(f"  🔄 Full refresh: dropped schema {dataset_name}")
-                finally:
-                    conn.close()
-            except Exception as e:
-                console.print(f"  ⚠️  Could not drop schema: {e}")
 
         try:
             # Run pipeline with retry logic
@@ -1118,6 +1266,31 @@ class DltPipelineRunner:
             # Extract load statistics
             stats = self._extract_load_stats(load_info)
             rows_loaded = stats.get("rows_loaded", 0)
+
+            # Empty replace protection: block 0-row replace-mode syncs
+            # that would wipe existing data
+            if (
+                rows_loaded == 0
+                and pre_refresh_rows is not None
+                and pre_refresh_rows > 0
+                and (full_refresh or uses_replace_mode)
+                and not allow_empty_replace
+            ):
+                # Restore pipeline state so next sync retries correctly
+                self._restore_dlt_state(state_backup)
+                error_msg = (
+                    f"Sync returned 0 rows — existing {pre_refresh_rows:,} rows "
+                    f"preserved. To force sync with empty data, use: "
+                    f"dango sync --source {source_name} --allow-empty-replace"
+                )
+                console.print(f"  [red]❌ {error_msg}[/red]")
+                return {
+                    "status": "failed",
+                    "source": source_name,
+                    "error": error_msg,
+                    "rows_loaded": 0,
+                    "uses_replace_mode": uses_replace_mode,
+                }
 
             # Check for row count anomalies
             total_row_count = self._get_source_total_rows(source_name)
@@ -1777,6 +1950,21 @@ class DltPipelineRunner:
         except Exception:
             return None
 
+    def _get_csv_table_rows(self, source_name: str) -> int | None:
+        """Get row count for a CSV/local_files source's single table."""
+        import duckdb
+
+        schema = f"raw_{source_name}"
+        try:
+            conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
+            try:
+                result = conn.execute(f'SELECT COUNT(*) FROM "{schema}"."{source_name}"').fetchone()
+                return result[0] if result else None
+            finally:
+                conn.close()
+        except Exception:
+            return None
+
     def _check_row_count_anomaly(
         self, source_name: str, total_rows: int | None = None
     ) -> dict[str, Any] | None:
@@ -2306,6 +2494,7 @@ def run_sync(
     *,
     skip_sync_notification: bool = False,
     progress_callback: Callable[[str, str], None] | None = None,
+    allow_empty_replace: bool = False,
 ) -> dict[str, Any]:
     """
     Sync multiple sources and return summary
@@ -2324,6 +2513,7 @@ def run_sync(
         progress_callback: Optional callback invoked at sync milestones with
             (phase, message). Phases: ``data_load_complete``, ``dbt_started``,
             ``dbt_complete`` (on success), ``dbt_failed`` (on failure).
+        allow_empty_replace: If True, allow 0-row syncs to replace existing data.
 
     Returns:
         Summary dictionary with success/failed counts
@@ -2342,7 +2532,14 @@ def run_sync(
             skipped_sources.append(source_config.name)
             continue
 
-        result = runner.run_source(source_config, start_date, end_date, full_refresh, limit=limit)
+        result = runner.run_source(
+            source_config,
+            start_date,
+            end_date,
+            full_refresh,
+            limit=limit,
+            allow_empty_replace=allow_empty_replace,
+        )
         results.append(result)
 
         if result.get("status") == "success":

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -103,6 +103,7 @@ def run_manual_sync(
     max_lock_wait: int = 0,
     sync_id: str | None = None,
     record_id: int | None = None,
+    allow_empty_replace: bool = False,
 ) -> dict[str, Any]:
     """Execute a manual sync with execution history tracking.
 
@@ -306,6 +307,7 @@ def run_manual_sync(
             end_date=end_date_obj,
             skip_dbt=skip_dbt,
             progress_callback=_sync_progress_cb,
+            allow_empty_replace=allow_empty_replace,
         )
 
         # Extract rows loaded from sync result
@@ -478,5 +480,6 @@ if __name__ == "__main__":
         max_lock_wait=args.get("max_lock_wait", 0),
         sync_id=args.get("sync_id"),
         record_id=args.get("record_id"),
+        allow_empty_replace=args.get("allow_empty_replace", False),
     )
     print(json.dumps(result))

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -98,6 +98,7 @@ def launch_sync_subprocess(
     source_label: str = "ui",
     max_lock_wait: int = 0,
     record_id: int | None = None,
+    allow_empty_replace: bool = False,
 ) -> tuple[subprocess.Popen, str, Path]:
     """Spawn sync subprocess via sys.executable.
 
@@ -136,6 +137,8 @@ def launch_sync_subprocess(
         args_dict["backfill_days"] = backfill_days
     if record_id is not None:
         args_dict["record_id"] = record_id
+    if allow_empty_replace:
+        args_dict["allow_empty_replace"] = True
 
     json_args = json.dumps(args_dict)
 

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -55,6 +55,7 @@ class SyncRequest(BaseModel):
     full_refresh: bool = False
     start_date: str | None = None
     end_date: str | None = None
+    allow_empty_replace: bool = False
 
 
 class SyncResponse(BaseModel):
@@ -243,3 +244,4 @@ class SyncTriggerRequest(BaseModel):
     sources: list[str]
     full_refresh: bool = False
     backfill: str | None = None  # "7d", "2w", "1m"
+    allow_empty_replace: bool = False

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -77,6 +77,7 @@ async def trigger_sync(source_name: str, sync_request: SyncRequest) -> SyncRespo
             sync_request.full_refresh,
             sync_request.start_date,
             sync_request.end_date,
+            allow_empty_replace=sync_request.allow_empty_replace,
         )
     )
 
@@ -89,7 +90,11 @@ async def trigger_sync(source_name: str, sync_request: SyncRequest) -> SyncRespo
 
 
 async def run_sync_task(
-    source_name: str, full_refresh: bool, start_date: str | None, end_date: str | None
+    source_name: str,
+    full_refresh: bool,
+    start_date: str | None,
+    end_date: str | None,
+    allow_empty_replace: bool = False,
 ) -> None:
     """Run sync task in a subprocess, polling for status and broadcasting updates."""
     from dango.platform.sync_process import (
@@ -137,6 +142,7 @@ async def run_sync_task(
             source_label="ui",
             record_id=record_id,
             max_lock_wait=300,
+            allow_empty_replace=allow_empty_replace,
         )
 
         # Poll until completion (broadcasts WS events + heartbeat internally)
@@ -267,6 +273,7 @@ async def trigger_manual_sync(
             backfill_days,
             job_id,
             db_path,
+            allow_empty_replace=body.allow_empty_replace,
         )
     )
 
@@ -300,6 +307,7 @@ async def _run_manual_sync(
     backfill_days: int | None,
     record_id: int,
     db_path: Any,
+    allow_empty_replace: bool = False,
 ) -> None:
     """Background task that executes a manual sync in a subprocess and records the result."""
     from dango.platform.sync_process import (
@@ -319,6 +327,7 @@ async def _run_manual_sync(
             source_label="manual",
             record_id=record_id,
             max_lock_wait=300,
+            allow_empty_replace=allow_empty_replace,
         )
 
         # Use first source name for WS events (manual sync may have multiple)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -462,6 +462,12 @@ exemptions:
     reason: "R4: push_deploy orchestration + Docker rebuild + requirements.txt install tests. Split from test_deployer.py for file-size compliance."
     review_by: "v1.1"
 
+  - file: tests/unit/test_empty_replace_protection.py
+    lines: 1179
+    category: exempt
+    reason: "41 test cases covering empty replace protection across all source types, CLI, web, scheduler, error messages, and edge cases."
+    review_by: "v1.1"
+
   # --- Scripts ---
   - file: scripts/smoke_test.sh
     lines: 866

--- a/tests/unit/test_empty_replace_protection.py
+++ b/tests/unit/test_empty_replace_protection.py
@@ -1,0 +1,1179 @@
+"""tests/unit/test_empty_replace_protection.py
+
+Unit tests for empty sync protection: replace-mode syncs that return 0 rows
+when previous data existed should fail and preserve existing data.
+
+Covers: core protection, source type coverage, pipeline state, schema interaction,
+CLI flag, web/scheduler, error messages, and edge cases.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_runner(tmp_path: Path):
+    """Create a DltPipelineRunner with mocked internals."""
+    from dango.ingestion.dlt_runner import DltPipelineRunner
+
+    runner = DltPipelineRunner.__new__(DltPipelineRunner)
+    runner.project_root = tmp_path
+    runner.duckdb_path = tmp_path / "data" / "warehouse.duckdb"
+    runner.duckdb_path.parent.mkdir(parents=True, exist_ok=True)
+    runner._current_oauth_warning = None
+    return runner
+
+
+def _make_source_config(name: str = "test_source", source_type: str = "chess"):
+    """Create a minimal DataSource config for testing."""
+    from dango.config.models import DataSource, SourceType
+
+    config = MagicMock(spec=DataSource)
+    config.name = name
+    config.type = SourceType(source_type)
+    config.csv = None
+    config.local_files = None
+    config.dlt_native = None
+    config.generic_config = {}
+    config.enabled = True
+    return config
+
+
+def _make_csv_source_config(name: str = "csv_source"):
+    """Create a CSV DataSource config."""
+    from dango.config.models import DataSource, SourceType
+
+    config = MagicMock(spec=DataSource)
+    config.name = name
+    config.type = SourceType.CSV
+    config.csv = MagicMock()
+    config.local_files = None
+    config.dlt_native = None
+    config.enabled = True
+    return config
+
+
+def _make_local_files_config(name: str = "local_source"):
+    """Create a local_files DataSource config."""
+    from dango.config.models import DataSource, SourceType
+
+    config = MagicMock(spec=DataSource)
+    config.name = name
+    config.type = SourceType.LOCAL_FILES
+    config.csv = None
+    config.local_files = MagicMock()
+    config.dlt_native = None
+    config.enabled = True
+    return config
+
+
+def _make_dlt_native_config(name: str = "native_source"):
+    """Create a dlt_native DataSource config."""
+    from dango.config.models import DataSource, SourceType
+
+    native = MagicMock()
+    native.source_module = "test_module"
+    native.source_function = "test_func"
+    native.function_kwargs = {}
+    native.dataset_name = None
+    native.pipeline_name = None
+
+    config = MagicMock(spec=DataSource)
+    config.name = name
+    config.type = SourceType.DLT_NATIVE
+    config.csv = None
+    config.local_files = None
+    config.dlt_native = native
+    config.enabled = True
+    return config
+
+
+def _mock_load_info(rows: int = 0):
+    """Create a mock LoadInfo with given row count."""
+    info = MagicMock()
+    return info
+
+
+# ============================================================================
+# Core Protection (Tests 1-5)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestCoreProtection:
+    """Core 0-row replace protection for dlt sources."""
+
+    def test_replace_mode_zero_rows_previous_data_fails(self, tmp_path):
+        """Test 1: Replace-mode, 0 rows, had previous data → failed, data preserved."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=5000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert result["rows_loaded"] == 0
+        assert "existing 5,000 rows preserved" in result["error"]
+        assert "--allow-empty-replace" in result["error"]
+        mock_restore.assert_called_once()
+
+    def test_replace_mode_zero_rows_first_sync_succeeds(self, tmp_path):
+        """Test 2: Replace-mode, 0 rows, first sync (no previous data) → success."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=0),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+
+    def test_replace_mode_with_rows_succeeds(self, tmp_path):
+        """Test 3: Replace-mode, >0 rows, had previous data → success."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=5000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 6000}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(6000)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+        assert result["rows_loaded"] == 6000
+
+    def test_replace_mode_first_sync_with_rows_succeeds(self, tmp_path):
+        """Test 4: Replace-mode, >0 rows, first sync → success."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=None),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 100}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(100)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+
+    def test_allow_empty_replace_bypasses_protection(self, tmp_path):
+        """Test 5: Replace-mode, 0 rows, allow_empty_replace=True → success."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=5000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+                allow_empty_replace=True,
+            )
+
+        assert result["status"] == "success"
+        mock_restore.assert_not_called()
+
+
+# ============================================================================
+# Incremental/Merge (Tests 6-8)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestIncrementalMerge:
+    """Incremental/merge modes should not trigger 0-row protection."""
+
+    def test_merge_mode_zero_rows_succeeds(self, tmp_path):
+        """Test 6: Merge mode, 0 rows → success, data untouched."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=5000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=False),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            # Not full_refresh AND not replace mode → no protection
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=False,
+            )
+
+        assert result["status"] == "success"
+
+    def test_append_mode_zero_rows_succeeds(self, tmp_path):
+        """Test 7: Append mode, 0 rows → success, data untouched."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=1000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=False),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=False,
+            )
+
+        assert result["status"] == "success"
+
+    def test_incremental_with_rows_succeeds(self, tmp_path):
+        """Test 8: Incremental, >0 rows → success."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=1000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=False),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 50}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(50)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=False,
+            )
+
+        assert result["status"] == "success"
+        assert result["rows_loaded"] == 50
+
+
+# ============================================================================
+# Source Type Coverage (Tests 9-14)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestSourceTypeCoverage:
+    """Verify protection works across all source types."""
+
+    def test_dlt_source_zero_row_protection(self, tmp_path):
+        """Test 9: dlt source primary path → 0-row protection works."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=1000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert "existing 1,000 rows preserved" in result["error"]
+
+    def test_dlt_native_source_zero_row_protection(self, tmp_path):
+        """Test 10: dlt native source path → 0-row protection works."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=2000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("dango.ingestion.dlt_runner.importlib") as mock_importlib,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_module = MagicMock()
+            mock_module.test_func = MagicMock(return_value=MagicMock())
+            mock_importlib.import_module.return_value = mock_module
+
+            mock_pipeline = MagicMock()
+            mock_dlt.pipeline.return_value = mock_pipeline
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+
+            result = runner._run_dlt_native_source(
+                _make_dlt_native_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert "existing 2,000 rows preserved" in result["error"]
+        mock_restore.assert_called_once()
+
+    def test_csv_source_zero_rows_previous_data_fails(self, tmp_path):
+        """Test 11: CSV source, 0 rows + previous data → fails, old table preserved."""
+        runner = _make_runner(tmp_path)
+
+        mock_conn = MagicMock()
+        with (
+            patch.object(runner, "_get_csv_table_rows", return_value=500),
+            patch("duckdb.connect", return_value=mock_conn),
+            patch("dango.ingestion.dlt_runner.CSVLoader") as mock_loader_cls,
+        ):
+            mock_loader = MagicMock()
+            mock_loader.load.return_value = {
+                "status": "success",
+                "total_rows": 0,
+                "new": 0,
+                "updated": 0,
+            }
+            mock_loader_cls.return_value = mock_loader
+
+            result = runner._run_csv_source(
+                _make_csv_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert "existing 500 rows preserved" in result["error"]
+
+    def test_csv_source_with_rows_succeeds(self, tmp_path):
+        """Test 12: CSV source, >0 rows → succeeds."""
+        runner = _make_runner(tmp_path)
+
+        mock_conn = MagicMock()
+        with (
+            patch.object(runner, "_get_csv_table_rows", return_value=500),
+            patch("duckdb.connect", return_value=mock_conn),
+            patch("dango.ingestion.dlt_runner.CSVLoader") as mock_loader_cls,
+        ):
+            mock_loader = MagicMock()
+            mock_loader.load.return_value = {
+                "status": "success",
+                "total_rows": 600,
+                "new": 5,
+                "updated": 0,
+            }
+            mock_loader_cls.return_value = mock_loader
+
+            result = runner._run_csv_source(
+                _make_csv_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+        assert result["rows_loaded"] == 600
+
+    def test_local_files_zero_rows_previous_data_fails(self, tmp_path):
+        """Test 13: Local files source, 0 rows + previous data → fails."""
+        runner = _make_runner(tmp_path)
+
+        mock_conn = MagicMock()
+        with (
+            patch.object(runner, "_get_csv_table_rows", return_value=300),
+            patch("duckdb.connect", return_value=mock_conn),
+            patch("dango.ingestion.dlt_runner.CSVLoader") as mock_loader_cls,
+        ):
+            mock_loader = MagicMock()
+            mock_loader.load.return_value = {
+                "status": "success",
+                "total_rows": 0,
+                "new": 0,
+                "updated": 0,
+            }
+            mock_loader_cls.return_value = mock_loader
+
+            result = runner._run_local_files_source(
+                _make_local_files_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert "existing 300 rows preserved" in result["error"]
+
+    def test_local_files_with_rows_succeeds(self, tmp_path):
+        """Test 14: Local files source, >0 rows → succeeds."""
+        runner = _make_runner(tmp_path)
+
+        mock_conn = MagicMock()
+        with (
+            patch.object(runner, "_get_csv_table_rows", return_value=300),
+            patch("duckdb.connect", return_value=mock_conn),
+            patch("dango.ingestion.dlt_runner.CSVLoader") as mock_loader_cls,
+        ):
+            mock_loader = MagicMock()
+            mock_loader.load.return_value = {
+                "status": "success",
+                "total_rows": 400,
+                "new": 3,
+                "updated": 1,
+            }
+            mock_loader_cls.return_value = mock_loader
+
+            result = runner._run_local_files_source(
+                _make_local_files_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+        assert result["rows_loaded"] == 400
+
+
+# ============================================================================
+# Pipeline State (Tests 15-16)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestPipelineState:
+    """Verify pipeline state is restored on 0-row failure."""
+
+    def test_dlt_state_restored_on_zero_row_failure(self, tmp_path):
+        """Test 15: After 0-row failure, dlt state restored from backup."""
+        runner = _make_runner(tmp_path)
+        backup_path = Path("/tmp/test_backup")
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=1000),
+            patch.object(runner, "_backup_dlt_state", return_value=backup_path),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        mock_restore.assert_called_once_with(backup_path)
+
+    def test_retry_after_zero_row_failure_succeeds(self, tmp_path):
+        """Test 16: After 0-row failure, retry succeeds normally."""
+        runner = _make_runner(tmp_path)
+
+        # First call: returns 0 rows (fails). Second call: returns rows (succeeds).
+        call_count = [0]
+
+        def mock_extract_stats(load_info):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return {"rows_loaded": 0}
+            return {"rows_loaded": 500}
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=1000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state"),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", side_effect=mock_extract_stats),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info()),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            # First call fails
+            result1 = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+            assert result1["status"] == "failed"
+
+            # Second call succeeds
+            result2 = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+            assert result2["status"] == "success"
+
+
+# ============================================================================
+# Schema Interaction (Tests 17-18)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestSchemaInteraction:
+    """Verify schema handling with empty replace protection."""
+
+    def test_replace_mode_with_rows_schema_updated(self, tmp_path):
+        """Test 17: Replace-mode + schema changes + >0 rows → success."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=1000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(
+                runner,
+                "_extract_load_stats",
+                return_value={"rows_loaded": 1200, "loaded_tables": ["t1", "t2"]},
+            ),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info()),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+        assert result["rows_loaded"] == 1200
+
+    def test_no_pre_schema_drop_in_source_code(self):
+        """Test 18: DROP SCHEMA CASCADE removed from _run_dlt_source."""
+        source = inspect.getsource(
+            __import__(
+                "dango.ingestion.dlt_runner", fromlist=["DltPipelineRunner"]
+            ).DltPipelineRunner._run_dlt_source
+        )
+        assert "DROP SCHEMA" not in source
+
+
+# ============================================================================
+# CLI Flag (Tests 19-21)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestCLIFlag:
+    """Verify --allow-empty-replace CLI flag behavior."""
+
+    def test_allow_empty_replace_flag_passes_through(self, tmp_path):
+        """Test 19: --allow-empty-replace + 0 rows → success (via run_sync)."""
+        from dango.ingestion.dlt_runner import run_sync
+
+        mock_source = _make_source_config()
+
+        with (
+            patch("dango.ingestion.dlt_runner.DltPipelineRunner") as mock_runner_cls,
+            patch("dango.ingestion.dlt_runner.console"),
+        ):
+            mock_runner = MagicMock()
+            mock_runner.run_source.return_value = {
+                "status": "success",
+                "rows_loaded": 0,
+            }
+            mock_runner_cls.return_value = mock_runner
+
+            run_sync(
+                project_root=tmp_path,
+                sources=[mock_source],
+                allow_empty_replace=True,
+            )
+
+            # Verify allow_empty_replace was passed through
+            call_kwargs = mock_runner.run_source.call_args
+            assert call_kwargs[1].get("allow_empty_replace") is True or (
+                len(call_kwargs[0]) > 5 and call_kwargs[0][5] is True
+            )
+
+    def test_without_flag_zero_rows_fails(self, tmp_path):
+        """Test 20: Without flag + 0 rows → fails (via run_sync)."""
+        from dango.ingestion.dlt_runner import run_sync
+
+        mock_source = _make_source_config()
+
+        with (
+            patch("dango.ingestion.dlt_runner.DltPipelineRunner") as mock_runner_cls,
+            patch("dango.ingestion.dlt_runner.console"),
+        ):
+            mock_runner = MagicMock()
+            mock_runner.run_source.return_value = {
+                "status": "failed",
+                "error": "0 rows",
+                "rows_loaded": 0,
+            }
+            mock_runner_cls.return_value = mock_runner
+
+            run_sync(
+                project_root=tmp_path,
+                sources=[mock_source],
+                allow_empty_replace=False,
+            )
+
+            # Verify allow_empty_replace=False was passed
+            call_kwargs = mock_runner.run_source.call_args
+            assert call_kwargs[1].get("allow_empty_replace") is False
+
+    def test_flag_is_hidden(self):
+        """Test 21: --allow-empty-replace is hidden (not in --help)."""
+        from dango.cli.commands.source import sync
+
+        for param in sync.params:
+            if param.name == "allow_empty_replace":
+                assert param.hidden is True, "--allow-empty-replace should be hidden"
+                break
+        else:
+            pytest.fail("--allow-empty-replace param not found on sync command")
+
+
+# ============================================================================
+# Web/Scheduler (Tests 22-24)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestWebScheduler:
+    """Verify web/scheduler threading of allow_empty_replace."""
+
+    def test_sync_request_model_has_field(self):
+        """Test 22: SyncRequest has allow_empty_replace field."""
+        from dango.web.models import SyncRequest
+
+        req = SyncRequest()
+        assert req.allow_empty_replace is False
+
+        req = SyncRequest(allow_empty_replace=True)
+        assert req.allow_empty_replace is True
+
+    def test_sync_trigger_request_has_field(self):
+        """Test 23: SyncTriggerRequest has allow_empty_replace field."""
+        from dango.web.models import SyncTriggerRequest
+
+        req = SyncTriggerRequest(sources=["test"])
+        assert req.allow_empty_replace is False
+
+        req = SyncTriggerRequest(sources=["test"], allow_empty_replace=True)
+        assert req.allow_empty_replace is True
+
+    def test_launch_sync_subprocess_accepts_param(self):
+        """Test 24: launch_sync_subprocess accepts allow_empty_replace."""
+        sig = inspect.signature(
+            __import__(
+                "dango.platform.sync_process", fromlist=["launch_sync_subprocess"]
+            ).launch_sync_subprocess
+        )
+        assert "allow_empty_replace" in sig.parameters
+
+
+# ============================================================================
+# Error Message and Status (Tests 25-28)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestErrorMessageAndStatus:
+    """Verify error messages and sync status recording."""
+
+    def test_error_includes_existing_data_preserved(self, tmp_path):
+        """Test 25: Error message includes 'existing data preserved'."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=3000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert "rows preserved" in result["error"]
+
+    def test_error_includes_allow_empty_replace(self, tmp_path):
+        """Test 26: Error message includes '--allow-empty-replace'."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=100),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert "--allow-empty-replace" in result["error"]
+
+    def test_sync_history_records_failed_status(self, tmp_path):
+        """Test 27: run_source records status='failed' in sync history."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(
+                runner,
+                "run_source",
+                return_value={
+                    "status": "failed",
+                    "error": "Sync returned 0 rows",
+                    "rows_loaded": 0,
+                },
+            ),
+        ):
+            result = runner.run_source(_make_source_config(), full_refresh=True)
+            assert result["status"] == "failed"
+
+    def test_run_source_error_field_mapping(self):
+        """Test 28: run_source extracts error from result.get('error')."""
+        source = inspect.getsource(
+            __import__(
+                "dango.ingestion.dlt_runner", fromlist=["DltPipelineRunner"]
+            ).DltPipelineRunner.run_source
+        )
+        assert 'result.get("error")' in source or "result.get('error')" in source
+
+
+# ============================================================================
+# Edge Cases (Tests 29-31)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestEdgeCases:
+    """Edge cases for empty replace protection."""
+
+    def test_replace_mode_without_full_refresh_protected(self, tmp_path):
+        """Test 29: uses_replace_mode=True without full_refresh → still protected."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=5000),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            # full_refresh=False but uses_replace_mode=True → still protected
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=False,
+            )
+
+        assert result["status"] == "failed"
+        assert "existing 5,000 rows preserved" in result["error"]
+        mock_restore.assert_called_once()
+
+    def test_concurrent_syncs_independent(self, tmp_path):
+        """Test 30: Concurrent syncs — one failure doesn't affect another."""
+        runner = _make_runner(tmp_path)
+
+        # Source A: 0 rows → fails
+        # Source B: 100 rows → succeeds
+        results = []
+        for name, rows_loaded, pre_rows in [
+            ("source_a", 0, 500),
+            ("source_b", 100, 200),
+        ]:
+            with (
+                patch.object(runner, "_get_source_total_rows", return_value=pre_rows),
+                patch.object(runner, "_backup_dlt_state", return_value=Path(f"/tmp/{name}_backup")),
+                patch.object(runner, "_restore_dlt_state"),
+                patch.object(runner, "_cleanup_state_backup"),
+                patch.object(runner, "_build_source_config", return_value={}),
+                patch.object(runner, "_load_dlt_source") as mock_source,
+                patch.object(runner, "_detect_write_disposition", return_value=True),
+                patch.object(runner, "_get_dataset_name", return_value=f"raw_{name}"),
+                patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+                patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+                patch.object(
+                    runner,
+                    "_extract_load_stats",
+                    return_value={"rows_loaded": rows_loaded},
+                ),
+                patch.object(runner, "_check_row_count_anomaly", return_value=None),
+                patch.object(runner, "_run_with_retry", return_value=_mock_load_info()),
+                patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+                patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+                patch("os.getcwd", return_value="/tmp"),
+                patch("os.chdir"),
+            ):
+                mock_meta.return_value = {
+                    "dlt_package": "test",
+                    "dlt_function": "test_func",
+                }
+                mock_dlt.pipeline.return_value = MagicMock()
+                mock_dlt.destinations.duckdb.return_value = MagicMock()
+                mock_source.return_value = MagicMock()
+
+                config = _make_source_config(name=name)
+                result = runner._run_dlt_source(config, full_refresh=True)
+                results.append(result)
+
+        assert results[0]["status"] == "failed"  # source_a: 0 rows
+        assert results[1]["status"] == "success"  # source_b: 100 rows
+
+    def test_anomaly_check_still_works_for_incremental(self, tmp_path):
+        """Test 31: _check_row_count_anomaly still works for incremental sources."""
+        runner = _make_runner(tmp_path)
+
+        # The anomaly check should still detect drops for incremental sources
+        with patch(
+            "dango.utils.sync_history.load_sync_history",
+            return_value=[{"status": "success", "total_row_count": 1000, "rows_processed": 1000}],
+        ):
+            anomaly = runner._check_row_count_anomaly("test_source", total_rows=0)
+
+        assert anomaly is not None
+        assert anomaly["level"] == "error"
+        assert "Zero rows" in anomaly["message"]
+
+
+# ============================================================================
+# Parameter Threading Verification
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestParameterThreading:
+    """Verify allow_empty_replace is threaded through all functions."""
+
+    @pytest.mark.parametrize(
+        "module_path,func_name",
+        [
+            ("dango.ingestion.dlt_runner", "run_sync"),
+            ("dango.platform.sync_process", "launch_sync_subprocess"),
+            ("dango.platform.scheduling.sync_trigger", "run_manual_sync"),
+        ],
+    )
+    def test_function_accepts_allow_empty_replace(self, module_path, func_name):
+        """Verify public functions accept allow_empty_replace parameter."""
+        module = __import__(module_path, fromlist=[func_name])
+        func = getattr(module, func_name)
+        sig = inspect.signature(func)
+        assert "allow_empty_replace" in sig.parameters, (
+            f"{module_path}.{func_name} missing allow_empty_replace parameter"
+        )
+
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "run_source",
+            "_run_dlt_source",
+            "_run_dlt_native_source",
+            "_run_csv_source",
+            "_run_local_files_source",
+        ],
+    )
+    def test_runner_method_accepts_allow_empty_replace(self, method_name):
+        """Verify DltPipelineRunner methods accept allow_empty_replace."""
+        from dango.ingestion.dlt_runner import DltPipelineRunner
+
+        method = getattr(DltPipelineRunner, method_name)
+        sig = inspect.signature(method)
+        assert "allow_empty_replace" in sig.parameters, (
+            f"DltPipelineRunner.{method_name} missing allow_empty_replace parameter"
+        )
+
+
+# ============================================================================
+# DROP SCHEMA Removal Verification
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestDropSchemaRemoval:
+    """Verify DROP SCHEMA CASCADE has been removed from both dlt methods."""
+
+    @pytest.mark.parametrize("method_name", ["_run_dlt_source", "_run_dlt_native_source"])
+    def test_no_drop_schema_cascade(self, method_name):
+        """DROP SCHEMA CASCADE must not appear in dlt sync methods."""
+        from dango.ingestion.dlt_runner import DltPipelineRunner
+
+        source = inspect.getsource(getattr(DltPipelineRunner, method_name))
+        assert "DROP SCHEMA" not in source, (
+            f"{method_name} still contains DROP SCHEMA — must be removed"
+        )

--- a/tests/unit/test_empty_replace_protection.py
+++ b/tests/unit/test_empty_replace_protection.py
@@ -477,6 +477,7 @@ class TestSourceTypeCoverage:
             patch.object(runner, "_get_source_total_rows", return_value=2000),
             patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
             patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
             patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
             patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
             patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
@@ -499,6 +500,40 @@ class TestSourceTypeCoverage:
 
         assert result["status"] == "failed"
         assert "existing 2,000 rows preserved" in result["error"]
+        mock_restore.assert_called_once()
+
+    def test_dlt_native_replace_mode_no_full_refresh_protected(self, tmp_path):
+        """Test 10b: dlt native with uses_replace_mode but no full_refresh → protected."""
+        runner = _make_runner(tmp_path)
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=1500),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("dango.ingestion.dlt_runner.importlib") as mock_importlib,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_module = MagicMock()
+            mock_module.test_func = MagicMock(return_value=MagicMock())
+            mock_importlib.import_module.return_value = mock_module
+
+            mock_pipeline = MagicMock()
+            mock_dlt.pipeline.return_value = mock_pipeline
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+
+            # full_refresh=False but uses_replace_mode=True → still protected
+            result = runner._run_dlt_native_source(
+                _make_dlt_native_config(),
+                full_refresh=False,
+            )
+
+        assert result["status"] == "failed"
+        assert "existing 1,500 rows preserved" in result["error"]
         mock_restore.assert_called_once()
 
     def test_csv_source_zero_rows_previous_data_fails(self, tmp_path):


### PR DESCRIPTION
## Summary

- **Empty replace protection:** Replace-mode syncs that return 0 rows when previous data existed now fail and preserve existing data, instead of silently wiping it
- **Remove pre-load DROP SCHEMA CASCADE** from `_run_dlt_source` and `_run_dlt_native_source` — dlt's `write_disposition="replace"` handles table replacement automatically; removing the schema drop means tables are preserved when 0 rows are returned
- **CSV/local_files:** Use rename-then-swap pattern to backup existing tables before refresh; restore the backup (including file metadata) if 0 rows are loaded
- **Thread `allow_empty_replace`** through the full call chain: CLI → `run_sync` → `run_source` → source methods → web models → sync routes → subprocess → sync trigger
- **Hidden `--allow-empty-replace` CLI flag** for forcing empty syncs when intentional

## Files Changed

| File | Change |
|------|--------|
| `dango/ingestion/dlt_runner.py` | Core logic: remove DROP SCHEMA, add 0-row guard, metadata backup/restore, `_get_csv_table_rows` helper, thread `allow_empty_replace` |
| `dango/cli/commands/source.py` | Add `--allow-empty-replace` hidden CLI flag |
| `dango/web/models.py` | Add `allow_empty_replace` to `SyncRequest` and `SyncTriggerRequest` |
| `dango/web/routes/sync.py` | Thread `allow_empty_replace` through sync routes |
| `dango/platform/sync_process.py` | Add `allow_empty_replace` to `launch_sync_subprocess()` args |
| `dango/platform/scheduling/sync_trigger.py` | Add `allow_empty_replace` to `run_manual_sync()` + `__main__` parsing |
| `tests/unit/test_empty_replace_protection.py` | 42 test cases |
| `docs/file-exemptions.yml` | Add test file exemption |

## Verification

- `pytest tests/unit/test_empty_replace_protection.py -v`: 42 passed
- `pytest -x`: 3823 passed, 31 skipped, 0 failed
- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: all files formatted

## Merge-order dependency

Session 1D (dlt_runner.py changes) must merge first. After 1D merges, rebase this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)