### PR TITLE
fix: OAuth port cleanup, catalog link, activity logging, sync indicator (P2-1, P8-1, P4-2, F-5)

### DIFF
--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -73,6 +73,8 @@ class AuditEvent(str, Enum):
     DEPLOYMENT_HISTORY_VIEWED    = "deployment_history_viewed"
     GOVERNANCE_DRIFT_ACCEPTED   = "governance_drift_accepted"
     QUERY_EXECUTED              = "query_executed"
+    CSV_UPLOADED                = "csv_uploaded"
+    CSV_DELETED                 = "csv_deleted"
     # fmt: on
 
 

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -219,6 +219,7 @@ class OAuthManager:
                 else:
                     raise
 
+            server_thread = None
             try:
                 server.timeout = timeout_seconds
 
@@ -266,10 +267,11 @@ class OAuthManager:
                     server.server_close()
                 except Exception:
                     pass
-                try:
-                    server_thread.join(timeout=5)
-                except Exception:
-                    pass
+                if server_thread is not None:
+                    try:
+                        server_thread.join(timeout=5)
+                    except Exception:
+                        pass
 
             answers = inquirer.prompt(
                 [

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -219,43 +219,57 @@ class OAuthManager:
                 else:
                     raise
 
-            server.timeout = timeout_seconds
+            try:
+                server.timeout = timeout_seconds
 
-            server_thread = threading.Thread(target=server.handle_request, daemon=True)
-            server_thread.start()
+                server_thread = threading.Thread(target=server.handle_request, daemon=True)
+                server_thread.start()
 
-            console.print(f"[dim]Callback server listening on port {self.callback_port}[/dim]")
+                console.print(f"[dim]Callback server listening on port {self.callback_port}[/dim]")
 
-            # Open browser for authorization
-            console.print("\n[cyan]Opening browser for authorization...[/cyan]")
-            console.print(f"[dim]If browser doesn't open, visit: {auth_url}[/dim]\n")
+                # Open browser for authorization
+                console.print("\n[cyan]Opening browser for authorization...[/cyan]")
+                console.print(f"[dim]If browser doesn't open, visit: {auth_url}[/dim]\n")
 
-            webbrowser.open(auth_url)
+                webbrowser.open(auth_url)
 
-            # Wait for callback with timeout
-            console.print("[yellow]Waiting for authorization...[/yellow]")
-            console.print("[dim](This window will close automatically once you authorize)[/dim]\n")
+                # Wait for callback with timeout
+                console.print("[yellow]Waiting for authorization...[/yellow]")
+                console.print(
+                    "[dim](This window will close automatically once you authorize)[/dim]\n"
+                )
 
-            start_time = time.time()
-            while time.time() - start_time < timeout_seconds:
-                if OAuthCallbackHandler.oauth_response is not None:
-                    console.print("[green]✓ Authorization received![/green]")
+                start_time = time.time()
+                while time.time() - start_time < timeout_seconds:
+                    if OAuthCallbackHandler.oauth_response is not None:
+                        console.print("[green]✓ Authorization received![/green]")
+                        server.server_close()
+                        return OAuthCallbackHandler.oauth_response
+
+                    if OAuthCallbackHandler.oauth_error is not None:
+                        error = OAuthCallbackHandler.oauth_error
+                        console.print(f"[red]✗ Authorization failed: {error['error']}[/red]")
+                        console.print(f"[red]{error['error_description']}[/red]")
+                        server.server_close()
+                        return None
+
+                    time.sleep(0.5)
+
+                # Timeout — offer retry
+                console.print(
+                    f"\n[red]✗ Authorization timeout after {timeout_seconds} seconds[/red]"
+                )
+                server.server_close()
+                server_thread.join(timeout=2)
+            finally:
+                try:
                     server.server_close()
-                    return OAuthCallbackHandler.oauth_response
-
-                if OAuthCallbackHandler.oauth_error is not None:
-                    error = OAuthCallbackHandler.oauth_error
-                    console.print(f"[red]✗ Authorization failed: {error['error']}[/red]")
-                    console.print(f"[red]{error['error_description']}[/red]")
-                    server.server_close()
-                    return None
-
-                time.sleep(0.5)
-
-            # Timeout — offer retry
-            console.print(f"\n[red]✗ Authorization timeout after {timeout_seconds} seconds[/red]")
-            server.server_close()
-            server_thread.join(timeout=2)
+                except Exception:
+                    pass
+                try:
+                    server_thread.join(timeout=5)
+                except Exception:
+                    pass
 
             answers = inquirer.prompt(
                 [

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -41,7 +41,7 @@ from dango.platform.scheduling.history import (
     get_schedule_history,
     get_scheduler_db_path,
 )
-from dango.web.helpers import get_project_root, load_sources_config
+from dango.web.helpers import append_log_entry, get_project_root, load_sources_config
 from dango.web.models import TriggerRequest
 from dango.web.routes.ui import _render_template
 
@@ -531,6 +531,15 @@ async def trigger_schedule(
         request,
         project_root,
         schedule_name=name,
+    )
+
+    append_log_entry(
+        {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "level": "info",
+            "source": f"schedule:{name}",
+            "message": "Schedule manually triggered",
+        }
     )
 
     return JSONResponse(

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -10,6 +10,7 @@ import time
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import duckdb
 import yaml
@@ -44,7 +45,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["upload"])
 
 
-def _audit(event, user, request, project_root, **extra):
+def _audit(
+    event: AuditEvent,
+    user: User,
+    request: Request,
+    project_root: Path,
+    **extra: Any,
+) -> None:
     log_auth_event(
         event,
         user_id=user.id,
@@ -546,7 +553,8 @@ async def delete_csv_file(
                 "source": source_name,
                 "message": f"Deleted {filename}",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            }
+            },
+            log=False,
         )
 
         # Log activity

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -13,8 +13,18 @@ from pathlib import Path
 
 import duckdb
 import yaml
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, UploadFile
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 
+from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
 from dango.auth.permissions import require_permission
 from dango.validation import sanitize_path_component, validate_source_name
@@ -34,9 +44,21 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["upload"])
 
 
+def _audit(event, user, request, project_root, **extra):
+    log_auth_event(
+        event,
+        user_id=user.id,
+        email=user.email,
+        ip=request.client.host if request.client else None,
+        details=extra,
+        log_dir=project_root / ".dango" / "logs",
+    )
+
+
 @router.post("/api/sources/{source_name}/upload-csv")
 async def upload_csv_to_source(
     source_name: str,
+    request: Request,
     file: UploadFile = File(...),
     background_tasks: BackgroundTasks = None,
     trigger_sync: bool = False,  # Default to false - let frontend control when to sync
@@ -140,6 +162,23 @@ async def upload_csv_to_source(
 
         logger.info(f"Uploaded file for source '{source_name}': {file_path}")
 
+        append_log_entry(
+            {
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "level": "success",
+                "source": source_name,
+                "message": f"CSV uploaded: {safe_filename}",
+            }
+        )
+        _audit(
+            AuditEvent.CSV_UPLOADED,
+            user,
+            request,
+            project_root,
+            source_name=source_name,
+            filename=safe_filename,
+        )
+
         # Broadcast upload event via WebSocket
         await ws_manager.broadcast(
             {
@@ -147,7 +186,8 @@ async def upload_csv_to_source(
                 "source": source_name,
                 "message": f"File {safe_filename} uploaded to {source_name}",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            }
+            },
+            log=False,
         )
 
         # Only trigger sync if explicitly requested (for batch upload optimization)
@@ -337,6 +377,7 @@ async def get_csv_files(source_name: str):
 @router.delete("/api/sources/{source_name}/csv-files")
 async def delete_csv_file(
     source_name: str,
+    request: Request,
     file_path: str = Query(..., description="Full path to file to delete"),
     background_tasks: BackgroundTasks = None,
     user: User = Depends(require_permission("csv.delete")),
@@ -516,6 +557,14 @@ async def delete_csv_file(
                 "source": source_name,
                 "message": f"Deleted file: {filename}",
             }
+        )
+        _audit(
+            AuditEvent.CSV_DELETED,
+            user,
+            request,
+            project_root,
+            source_name=source_name,
+            filename=filename,
         )
 
         # Trigger dbt run for downstream models (in background)

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -52,6 +52,7 @@ def _audit(
     project_root: Path,
     **extra: Any,
 ) -> None:
+    """Log an audit event with standard fields."""
     log_auth_event(
         event,
         user_id=user.id,

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -169,9 +169,14 @@
             init() {
                 this._connect();
             },
+            destroy() {
+                if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+                if (this._ws) this._ws.close();
+            },
             _connect() {
                 const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
                 this._ws = new WebSocket(`${proto}//${location.host}/ws`);
+                this._ws.onerror = () => {};
                 this._ws.onmessage = (e) => {
                     try {
                         const data = JSON.parse(e.data);

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -70,8 +70,17 @@
                     </a>
                 </div>
 
-                <!-- Right side: user email + settings gear + hamburger (mobile) -->
-                <div class="flex items-center space-x-2 ml-auto">
+                <!-- Right side: sync indicator + user email + settings gear + hamburger (mobile) -->
+                <div class="flex items-center space-x-2 ml-auto" x-data="globalSyncIndicator()" x-init="init()">
+                    <!-- Global sync status indicator -->
+                    <div x-show="activeSyncCount > 0" x-cloak
+                         class="flex items-center space-x-1.5 px-2 py-1 rounded-md bg-gray-700 text-xs text-gray-200">
+                        <svg class="animate-spin h-3.5 w-3.5 text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                        </svg>
+                        <span x-text="'Syncing ' + activeSyncCount + ' source' + (activeSyncCount > 1 ? 's' : '')"></span>
+                    </div>
                     {% if request.state.user %}
                     <span class="text-xs text-gray-400 hidden lg:inline mr-2">{{ request.state.user.email }}</span>
                     <span class="text-xs px-1.5 py-0.5 rounded-full hidden lg:inline mr-1
@@ -150,6 +159,38 @@
             </div>
             {% endif %}
         </div>
+    <script>
+    function globalSyncIndicator() {
+        return {
+            activeSyncCount: 0,
+            _activeSources: new Set(),
+            _ws: null,
+            _reconnectTimer: null,
+            init() {
+                this._connect();
+            },
+            _connect() {
+                const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+                this._ws = new WebSocket(`${proto}//${location.host}/ws`);
+                this._ws.onmessage = (e) => {
+                    try {
+                        const data = JSON.parse(e.data);
+                        const source = data.source || '';
+                        if (data.event === 'sync_started' && source) {
+                            this._activeSources.add(source);
+                        } else if ((data.event === 'sync_completed' || data.event === 'sync_failed') && source) {
+                            this._activeSources.delete(source);
+                        }
+                        this.activeSyncCount = this._activeSources.size;
+                    } catch {}
+                };
+                this._ws.onclose = () => {
+                    this._reconnectTimer = setTimeout(() => this._connect(), 3000);
+                };
+            }
+        };
+    }
+    </script>
     </nav>
     {% endblock %}
 

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -268,7 +268,7 @@
                             <span x-show="profilingLoading" x-cloak>Profiling...</span>
                         </button>
                     </template>
-                    <a :href="metabaseQueryUrl()"
+                    <a x-show="metabaseDatabaseId" :href="metabaseQueryUrl()"
                        target="_blank" class="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 text-sm font-medium transition-colors">
                         View in Metabase
                     </a>

--- a/tests/unit/test_activity_logging_gaps.py
+++ b/tests/unit/test_activity_logging_gaps.py
@@ -1,0 +1,195 @@
+"""tests/unit/test_activity_logging_gaps.py
+
+Tests that activity logging (append_log_entry) is called for CSV uploads
+and schedule manual triggers (P4-2).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+from dango.auth.models import Role, User
+
+_UPLOAD_PATCH = "dango.web.routes.upload"
+_SCHED_PATCH = "dango.web.routes.schedules"
+
+
+def _admin_user() -> User:
+    return User(id="admin-id", email="admin@test.com", role=Role.ADMIN, is_active=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — upload app
+# ---------------------------------------------------------------------------
+
+
+def _make_upload_app(tmp_path: Path) -> Any:
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+
+    from dango.exceptions import AuthorizationError
+    from dango.web.routes.upload import router
+
+    app = FastAPI()
+    app.state.project_root = tmp_path
+    app.include_router(router)
+
+    user = _admin_user()
+
+    @app.middleware("http")
+    async def inject_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        return await call_next(request)
+
+    @app.exception_handler(AuthorizationError)
+    async def auth_err(request: Any, exc: AuthorizationError) -> Any:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
+    return app
+
+
+def _setup_csv_source(tmp_path: Path) -> Path:
+    """Create a minimal CSV source config and data directory."""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir(parents=True, exist_ok=True)
+    sources = {
+        "sources": [
+            {"name": "test_csv", "type": "csv", "csv": {"directory": str(tmp_path / "data")}}
+        ]
+    }
+    with open(dango_dir / "sources.yml", "w") as f:
+        yaml.dump(sources, f)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    return data_dir
+
+
+# ---------------------------------------------------------------------------
+# Helpers — schedule app
+# ---------------------------------------------------------------------------
+
+
+def _make_schedule_app(tmp_path: Path, scheduler: Any = None) -> Any:
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+
+    from dango.exceptions import AuthorizationError
+    from dango.web.routes.schedules import router
+
+    app = FastAPI()
+    app.state.project_root = tmp_path
+    if scheduler is not None:
+        app.state.scheduler = scheduler
+    app.include_router(router)
+
+    user = _admin_user()
+
+    @app.middleware("http")
+    async def inject_user(request: Any, call_next: Any) -> Any:
+        request.state.user = user
+        return await call_next(request)
+
+    @app.exception_handler(AuthorizationError)
+    async def auth_err(request: Any, exc: AuthorizationError) -> Any:
+        return JSONResponse(status_code=403, content={"detail": str(exc)})
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Tests — CSV upload activity logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUploadActivityLogging:
+    """CSV upload should call append_log_entry with level=success."""
+
+    def test_upload_logs_activity(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        _setup_csv_source(tmp_path)
+        app = _make_upload_app(tmp_path)
+
+        with (
+            patch(f"{_UPLOAD_PATCH}.get_project_root", return_value=tmp_path),
+            patch(f"{_UPLOAD_PATCH}.append_log_entry") as mock_log,
+            patch(
+                f"{_UPLOAD_PATCH}.ws_manager", new_callable=lambda: MagicMock(broadcast=AsyncMock())
+            ),
+            patch(f"{_UPLOAD_PATCH}.log_auth_event"),
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/sources/test_csv/upload-csv",
+                files={"file": ("test.csv", b"a,b\n1,2\n", "text/csv")},
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        assert mock_log.called
+        log_entry = mock_log.call_args[0][0]
+        assert log_entry["level"] == "success"
+        assert log_entry["source"] == "test_csv"
+        assert "CSV uploaded" in log_entry["message"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — Schedule trigger activity logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScheduleTriggerActivityLogging:
+    """Schedule manual trigger should call append_log_entry."""
+
+    def test_trigger_logs_activity(self, tmp_path: Path) -> None:
+        from fastapi.testclient import TestClient
+
+        # Write schedule config
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir(parents=True, exist_ok=True)
+        schedules = {
+            "schedules": [
+                {
+                    "name": "nightly",
+                    "type": "sync",
+                    "cron": "0 2 * * *",
+                    "sources": ["stripe"],
+                    "enabled": True,
+                }
+            ]
+        }
+        with open(dango_dir / "schedules.yml", "w") as f:
+            yaml.dump(schedules, f)
+
+        scheduler = MagicMock()
+        scheduler.get_jobs.return_value = []
+        mock_job = MagicMock()
+        mock_job.id = "manual:nightly:test"
+        scheduler.add_job.return_value = mock_job
+
+        app = _make_schedule_app(tmp_path, scheduler=scheduler)
+
+        with (
+            patch(f"{_SCHED_PATCH}.get_project_root", return_value=tmp_path),
+            patch(f"{_SCHED_PATCH}.append_log_entry") as mock_log,
+            patch(f"{_SCHED_PATCH}.log_auth_event"),
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/schedules/nightly/trigger",
+                headers={"X-Requested-With": "fetch"},
+            )
+
+        assert resp.status_code == 200
+        assert mock_log.called
+        log_entry = mock_log.call_args[0][0]
+        assert log_entry["level"] == "info"
+        assert log_entry["source"] == "schedule:nightly"
+        assert "manually triggered" in log_entry["message"]

--- a/tests/unit/test_oauth_port_cleanup.py
+++ b/tests/unit/test_oauth_port_cleanup.py
@@ -1,0 +1,72 @@
+"""tests/unit/test_oauth_port_cleanup.py
+
+Tests that OAuth port is properly released on KeyboardInterrupt and timeout.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestOAuthPortCleanup:
+    """Verify server.server_close() is called even on KeyboardInterrupt."""
+
+    @patch("dango.oauth.webbrowser")
+    @patch("dango.oauth.time")
+    @patch("dango.oauth._ReusableTCPServer")
+    def test_keyboard_interrupt_closes_server(self, mock_server_cls, mock_time, mock_wb):
+        """When KeyboardInterrupt occurs during the wait loop, server_close is called."""
+        from dango.oauth import OAuthManager
+
+        mock_server = MagicMock()
+        mock_server_cls.return_value = mock_server
+
+        # Make time.sleep raise KeyboardInterrupt on first call
+        mock_time.sleep.side_effect = KeyboardInterrupt
+        mock_time.time.return_value = 0
+
+        manager = MagicMock(spec=OAuthManager)
+        manager.callback_port = 8080
+        manager.callback_url = "http://localhost:8080/callback"
+
+        with pytest.raises(KeyboardInterrupt):
+            OAuthManager.start_oauth_flow(manager, "test", "http://example.com/auth")
+
+        mock_server.server_close.assert_called()
+
+    @patch("dango.oauth.webbrowser")
+    @patch("dango.oauth.time")
+    @patch("dango.oauth._ReusableTCPServer")
+    def test_timeout_calls_server_close_and_join(self, mock_server_cls, mock_time, mock_wb):
+        """On timeout, both server_close and thread join are called."""
+        from dango.oauth import OAuthCallbackHandler, OAuthManager
+
+        mock_server = MagicMock()
+        mock_server_cls.return_value = mock_server
+
+        # Simulate time progressing past timeout
+        mock_time.time.side_effect = [0, 0, 200]
+        mock_time.sleep.return_value = None
+
+        # Reset handler state
+        OAuthCallbackHandler.oauth_response = None
+        OAuthCallbackHandler.oauth_error = None
+
+        manager = MagicMock(spec=OAuthManager)
+        manager.callback_port = 8080
+        manager.callback_url = "http://localhost:8080/callback"
+
+        # Mock inquirer to return Cancel (inquirer is imported locally inside start_oauth_flow)
+        with patch.dict("sys.modules", {"inquirer": MagicMock()}) as _:
+            import sys
+
+            sys.modules["inquirer"].prompt.return_value = {"timeout_action": "Cancel"}
+            sys.modules["inquirer"].List = MagicMock()
+            result = OAuthManager.start_oauth_flow(
+                manager, "test", "http://example.com/auth", timeout_seconds=60
+            )
+
+        assert result is None
+        # server_close called both in the timeout path AND in finally
+        assert mock_server.server_close.call_count >= 2


### PR DESCRIPTION
## Summary

- **P2-1:** OAuth port not released after Ctrl+C — wrapped callback server in `try/finally` so `server_close()` runs on `KeyboardInterrupt`
- **P8-1:** Catalog "View in Metabase" button shown when Metabase not configured — added `x-show="metabaseDatabaseId"` conditional
- **P4-2:** Missing activity log entries for CSV uploads and schedule manual triggers — added `append_log_entry()` calls + `CSV_UPLOADED`/`CSV_DELETED` audit events with `_audit()` helper
- **F-5:** No sync visibility on Catalog/Schedules/Notebooks pages — added self-contained Alpine.js WebSocket component in nav bar showing active sync count

## Verification

- `ruff check dango/ tests/`: all checks passed
- `ruff format --check dango/ tests/`: 427 files already formatted
- `pytest -x`: 3785 passed, 31 skipped, 0 failed (290s)
- New tests: `test_oauth_port_cleanup.py` (2 tests), `test_activity_logging_gaps.py` (2 tests)

## Manual checks needed

- OAuth: `dango add` → begin OAuth → Ctrl+C → re-run — should work without "port in use"
- Catalog: open catalog detail with/without Metabase — link appears/hidden
- Activity: upload CSV, delete CSV, trigger schedule — check Overview activity log
- Sync indicator: start sync, navigate to Catalog — indicator visible in nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)