### PR TITLE
fix: fd 0 clobbering breaks all scheduled syncs after terminal close

### DIFF
--- a/dango/platform/local/watcher_lifecycle.py
+++ b/dango/platform/local/watcher_lifecycle.py
@@ -91,6 +91,11 @@ def start_file_watcher(project_root: Path) -> int | None:
     log_file = project_root / ".dango" / "watcher.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
+    # Prevent fd 0 clobbering: see ensure_std_fds() docstring for details.
+    from dango.utils.process import ensure_std_fds
+
+    ensure_std_fds()
+
     try:
         # Open log file
         log_handle = open(log_file, "w")  # noqa: SIM115

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -142,16 +142,10 @@ def launch_sync_subprocess(
 
     json_args = json.dumps(args_dict)
 
-    # Ensure fds 0-2 are occupied so open() never returns a std fd number.
-    # When the server runs daemonized, fd 0 (stdin) may be closed. If open()
-    # gets fd 0 for the log file, subprocess.Popen's dup2(devnull, 0) clobbers
-    # the log handle before it can be duped to stdout, crashing the child with
-    # "Bad file descriptor" at init_sys_streams.
-    for _fd in range(3):
-        try:
-            os.fstat(_fd)
-        except OSError:
-            os.open(os.devnull, os.O_RDWR)
+    # Prevent fd 0 clobbering: see ensure_std_fds() docstring for details.
+    from dango.utils.process import ensure_std_fds
+
+    ensure_std_fds()
 
     log_handle = open(log_path, "w")  # noqa: SIM115
     try:

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -142,6 +142,17 @@ def launch_sync_subprocess(
 
     json_args = json.dumps(args_dict)
 
+    # Ensure fds 0-2 are occupied so open() never returns a std fd number.
+    # When the server runs daemonized, fd 0 (stdin) may be closed. If open()
+    # gets fd 0 for the log file, subprocess.Popen's dup2(devnull, 0) clobbers
+    # the log handle before it can be duped to stdout, crashing the child with
+    # "Bad file descriptor" at init_sys_streams.
+    for _fd in range(3):
+        try:
+            os.fstat(_fd)
+        except OSError:
+            os.open(os.devnull, os.O_RDWR)
+
     log_handle = open(log_path, "w")  # noqa: SIM115
     try:
         process = subprocess.Popen(

--- a/dango/utils/process.py
+++ b/dango/utils/process.py
@@ -3,7 +3,26 @@
 Generic process utilities shared by platform/ and cli/.
 """
 
+import os
+
 import psutil
+
+
+def ensure_std_fds() -> None:
+    """Ensure file descriptors 0-2 (stdin/stdout/stderr) are open.
+
+    When a process is daemonized (terminal closed), fd 0 may be closed.
+    If open() then gets fd 0 for a log file, subprocess.Popen's
+    dup2(devnull, 0) clobbers the log handle, crashing the child with
+    "Bad file descriptor" at init_sys_streams.
+
+    Call this before opening files that will be passed to subprocess.Popen.
+    """
+    for fd in range(3):
+        try:
+            os.fstat(fd)
+        except OSError:
+            os.open(os.devnull, os.O_RDWR)
 
 
 def is_process_running(pid: int) -> bool:


### PR DESCRIPTION
## Summary

When the dango server runs daemonized (launching terminal closed), fd 0 (stdin) is closed. `launch_sync_subprocess()` calls `open(log_path, "w")` which gets fd 0 as the lowest available fd. Then `subprocess.Popen(stdin=subprocess.DEVNULL)` does `dup2(devnull_fd, 0)` which clobbers the log file handle before it can be duped to stdout. The child Python process crashes with "Bad file descriptor" at `init_sys_streams`.

This caused 126 consecutive scheduled sync failures on beta-1 since Jun 14.

## Fix

Ensure fds 0-2 are occupied before opening the log file by filling any missing standard fds with `/dev/null`.

## Verification
- `ruff check dango/platform/sync_process.py`: passed
- `ruff format --check dango/platform/sync_process.py`: formatted
- `pytest tests/unit/test_sync_process.py -x`: 38 passed
- Manual verification needed on beta-1: restart dango, wait for scheduled sync, confirm success

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>