### PR TITLE
fix: scope port kill and Docker cleanup to current project (P0-3)

### DIFF
--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -400,8 +400,17 @@ def start(ctx: click.Context, yes: bool) -> None:
 
         # Auto-clean orphaned Docker containers from previous Dango session
         try:
+            from dango.platform.docker import get_compose_project_name
+
+            compose_project = get_compose_project_name(project_root)
             result = subprocess.run(
-                ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
+                [
+                    "docker",
+                    "ps",
+                    "-q",
+                    "--filter",
+                    f"label=com.docker.compose.project={compose_project}",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -410,7 +419,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                 container_ids = [c for c in result.stdout.strip().split("\n") if c]
                 console.print(
                     f"[yellow]⚠[/yellow]  Found {len(container_ids)} orphaned Docker "
-                    "container(s) from a previous session, cleaning up..."
+                    f"container(s) from a previous session of this project, cleaning up..."
                 )
                 from dango.platform import DockerManager
 
@@ -800,7 +809,7 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
     if stop_all:
         # Create a dummy manager just to call the global cleanup method
         manager = DockerManager(Path.cwd())
-        manager.stop_all_dango_containers()
+        manager.stop_all_dango_containers(all_projects=True)
         console.print()
         console.print("[green]✅ Stopped all Dango containers[/green]")
         console.print()

--- a/dango/cli/helpers/process_manager.py
+++ b/dango/cli/helpers/process_manager.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 from pathlib import Path
 
+import psutil
 from rich.console import Console
 
 from dango.utils.process import is_process_running, kill_process
@@ -234,6 +235,7 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
             # Check each process to see if it's a Dango process
             dango_pids = []
             other_pids = []
+            resolved_project_root = project_root.resolve()
 
             for proc_pid_str in pids:
                 try:
@@ -252,7 +254,33 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
 
                         # Check if it's a Dango uvicorn process
                         if "uvicorn" in cmd_line and "dango.web.app" in cmd_line:
-                            dango_pids.append(proc_pid)
+                            # Verify CWD matches current project root to avoid
+                            # killing servers from other Dango projects on the same port.
+                            try:
+                                proc = psutil.Process(proc_pid)
+                                proc_cwd = Path(proc.cwd()).resolve()
+                                if proc_cwd == resolved_project_root:
+                                    dango_pids.append(proc_pid)
+                                else:
+                                    other_pids.append((proc_pid, cmd_line))
+                                    if verbose:
+                                        console.print(
+                                            f"  [dim]Skipping Dango process {proc_pid} "
+                                            f"(belongs to different project: {proc_cwd})[/dim]"
+                                        )
+                            except (
+                                psutil.AccessDenied,
+                                psutil.NoSuchProcess,
+                                psutil.ZombieProcess,
+                                OSError,
+                            ) as e:
+                                # Can't verify CWD → don't kill (conservative)
+                                other_pids.append((proc_pid, cmd_line))
+                                if verbose:
+                                    console.print(
+                                        f"  [yellow]⚠[/yellow] Could not verify CWD for "
+                                        f"PID {proc_pid}: {e}"
+                                    )
                         else:
                             other_pids.append((proc_pid, cmd_line))
                 except (ValueError, Exception):

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -297,27 +297,50 @@ class DockerManager:
         except Exception:
             pass  # Best-effort, never block stop
 
-    def stop_all_dango_containers(self) -> bool:
+    def stop_all_dango_containers(self, all_projects: bool = False) -> bool:
         """
-        Stop ALL Dango containers globally (from any project).
+        Stop Dango containers.
 
-        This is useful when switching between test projects or when
-        containers from a previous project are still running on required ports.
+        By default, stops only containers belonging to this project (determined
+        by the Docker Compose project label).
+
+        Args:
+            all_projects: If True, stop ALL Dango containers globally (from any
+                project), using name-based filtering. This is useful when
+                switching between test projects or cleaning up containers
+                from a previous naming scheme.
 
         Returns:
             True if successful, False otherwise
         """
-        console.print("Stopping all Dango containers (from any project)...")
+        if all_projects:
+            console.print("Stopping all Dango containers (from any project)...")
+        else:
+            console.print(f"Stopping Dango containers for {self.compose_project_name}...")
 
         try:
-            # Find all containers with Dango service names (metabase, dbt-docs)
-            # These are created by docker-compose with predictable naming
-            result = subprocess.run(
-                ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
+            if all_projects:
+                # Find all containers with Dango service names globally
+                result = subprocess.run(
+                    ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            else:
+                # Find containers belonging to this project via compose project label
+                result = subprocess.run(
+                    [
+                        "docker",
+                        "ps",
+                        "-q",
+                        "--filter",
+                        f"label=com.docker.compose.project={self.compose_project_name}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
 
             if result.returncode != 0:
                 console.print("[yellow]⚠[/yellow]  Could not list Docker containers")
@@ -327,7 +350,8 @@ class DockerManager:
             container_ids = [cid for cid in container_ids if cid]  # Filter empty strings
 
             if not container_ids:
-                console.print("[dim]No Dango containers found running[/dim]")
+                scope = "any project" if all_projects else "this project"
+                console.print(f"[dim]No Dango containers found running for {scope}[/dim]")
                 return True
 
             # Stop the containers
@@ -337,7 +361,10 @@ class DockerManager:
             )
 
             if result.returncode == 0:
-                console.print("[green]✓[/green] Stopped all Dango containers")
+                if all_projects:
+                    console.print("[green]✓[/green] Stopped all Dango containers")
+                else:
+                    console.print("[green]✓[/green] Stopped Dango containers for this project")
                 return True
             else:
                 console.print("[yellow]⚠[/yellow]  Some containers may not have stopped")

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -104,6 +104,18 @@ exemptions:
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic. R12-I2 added cloud systemd status check."
     review_by: "v1.1"
 
+  - file: dango/platform/docker.py
+    lines: 508
+    category: exempt
+    reason: "P0-3: Added all_projects parameter and conditional docker ps filtering for project-scoped container cleanup (+26 lines). Marginally over limit."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_process_manager.py
+    lines: 619
+    category: exempt
+    reason: "P0-3: Added 3 new tests for CWD-verified port fallback (cross-project isolation, CWD unreadable, symlink resolution) (+120 lines). Test files are verbose by design."
+    review_by: "v1.1"
+
   - file: dango/cli/commands/oauth.py
     lines: 813
     category: exempt

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -1,0 +1,123 @@
+"""tests/unit/test_docker.py
+
+Tests for dango.platform.docker — Docker Compose lifecycle management.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.platform.docker import DockerManager
+
+
+@pytest.mark.unit
+class TestStopAllDangoContainers:
+    @patch("dango.platform.docker.console")
+    def test_default_stops_containers_for_current_project(self, _mock_console, tmp_path):
+        """Default call (all_projects=False) filters by compose project label."""
+        manager = DockerManager(tmp_path)
+        project_name = manager.compose_project_name
+
+        with patch("subprocess.run") as mock_run:
+            # docker ps returns empty (no containers found)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            manager.stop_all_dango_containers()
+
+        # Verify docker ps was called with project label filter
+        ps_call = mock_run.call_args_list[0]
+        ps_cmd = ps_call[0][0]
+        assert "docker" in ps_cmd[0]
+        assert "ps" in ps_cmd[1]
+        assert "--filter" in ps_cmd
+        assert f"label=com.docker.compose.project={project_name}" in ps_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_all_projects_true_uses_name_filter(self, _mock_console, tmp_path):
+        """all_projects=True uses the global name-based filter (metabase, dbt)."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            manager.stop_all_dango_containers(all_projects=True)
+
+        ps_call = mock_run.call_args_list[0]
+        ps_cmd = ps_call[0][0]
+        # Should filter by name instead of label
+        assert "name=metabase" in ps_cmd
+        assert "name=dbt" in ps_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_stops_found_containers(self, _mock_console, tmp_path):
+        """Found container IDs are passed to docker stop."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            # First call (docker ps) returns container IDs, second (docker stop) succeeds
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="abc123\ndef456\n"),
+                MagicMock(returncode=0, stdout=""),
+            ]
+
+            result = manager.stop_all_dango_containers()
+
+        assert result is True
+
+        # Second call should be docker stop with the container IDs
+        stop_call = mock_run.call_args_list[1]
+        stop_cmd = stop_call[0][0]
+        assert "docker" in stop_cmd[0]
+        assert "stop" in stop_cmd[1]
+        assert "abc123" in stop_cmd
+        assert "def456" in stop_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_no_containers_found(self, _mock_console, tmp_path):
+        """Returns True when no containers match the filter."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            result = manager.stop_all_dango_containers()
+
+        assert result is True
+        # Only docker ps was called, not docker stop
+        assert mock_run.call_count == 1
+
+    @patch("dango.platform.docker.console")
+    def test_docker_ps_failure_returns_false(self, _mock_console, tmp_path):
+        """Non-zero returncode from docker ps returns False."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+
+            result = manager.stop_all_dango_containers()
+
+        assert result is False
+
+    @patch("dango.platform.docker.console")
+    def test_timeout_returns_false(self, _mock_console, tmp_path):
+        """TimeoutExpired from subprocess is caught and returns False."""
+        manager = DockerManager(tmp_path)
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="docker ps", timeout=10),
+        ):
+            result = manager.stop_all_dango_containers()
+
+        assert result is False
+
+    @patch("dango.platform.docker.console")
+    def test_generic_exception_returns_false(self, _mock_console, tmp_path):
+        """Any exception is caught and returns False gracefully."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run", side_effect=RuntimeError("unexpected")):
+            result = manager.stop_all_dango_containers()
+
+        assert result is False

--- a/tests/unit/test_process_manager.py
+++ b/tests/unit/test_process_manager.py
@@ -313,14 +313,20 @@ class TestStopFastapiServer:
 
     # --- Port-based fallback phase ---
 
+    @patch("psutil.Process")
     @patch("dango.cli.helpers.process_manager.kill_process", return_value=True)
     @patch("dango.cli.helpers.process_manager.subprocess.run")
     @patch("dango.cli.helpers.process_manager.console")
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
     def test_no_pid_dango_process_on_port(
-        self, _mock_running, _mock_console, mock_sub_run, mock_kill, tmp_path
+        self, _mock_running, _mock_console, mock_sub_run, mock_kill, mock_psutil, tmp_path
     ):
         self._setup_project(tmp_path)
+
+        # Mock psutil.Process to return CWD matching project root
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = str(tmp_path)
+        mock_psutil.return_value = mock_proc
 
         with patch("dango.config.ConfigLoader") as mock_cl:
             mock_config = MagicMock()
@@ -374,14 +380,20 @@ class TestStopFastapiServer:
 
             assert stop_fastapi_server(tmp_path) is False
 
+    @patch("psutil.Process")
     @patch("dango.cli.helpers.process_manager.kill_process", return_value=False)
     @patch("dango.cli.helpers.process_manager.subprocess.run")
     @patch("dango.cli.helpers.process_manager.console")
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
     def test_dango_pids_found_but_all_kills_fail(
-        self, _mock_running, _mock_console, mock_sub_run, mock_kill, tmp_path
+        self, _mock_running, _mock_console, mock_sub_run, mock_kill, mock_psutil, tmp_path
     ):
         self._setup_project(tmp_path)
+
+        # Mock psutil.Process to return CWD matching project root
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = str(tmp_path)
+        mock_psutil.return_value = mock_proc
 
         with patch("dango.config.ConfigLoader") as mock_cl:
             mock_config = MagicMock()
@@ -460,6 +472,115 @@ class TestStopFastapiServer:
             mock_sub_run.side_effect = subprocess.TimeoutExpired(cmd="lsof", timeout=5)
 
             assert stop_fastapi_server(tmp_path) is False
+
+    @patch("psutil.Process")
+    @patch("dango.cli.helpers.process_manager.subprocess.run")
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
+    def test_dango_process_from_another_project_not_killed(
+        self, _mock_running, mock_console, mock_sub_run, mock_psutil, tmp_path
+    ):
+        """Port fallback finds a Dango process but CWD differs → skip, don't kill."""
+        self._setup_project(tmp_path)
+
+        # Mock psutil.Process so CWD points to a different project
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = "/tmp/other-project"
+        mock_psutil.return_value = mock_proc
+
+        with patch("dango.config.ConfigLoader") as mock_cl:
+            mock_config = MagicMock()
+            mock_config.platform.port = 8080
+            mock_cl.return_value.load_config.return_value = mock_config
+
+            lsof_result = MagicMock(returncode=0, stdout="1234\n")
+            ps_result = MagicMock(
+                returncode=0,
+                stdout="python -m uvicorn dango.web.app:app --host 0.0.0.0 --port 8080",
+            )
+            mock_sub_run.side_effect = [lsof_result, ps_result]
+
+            with patch("dango.cli.helpers.process_manager.kill_process") as mock_kill:
+                result = stop_fastapi_server(tmp_path, verbose=True)
+                assert result is False
+                mock_kill.assert_not_called()
+
+        # Should print a warning about skipping (different project)
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        assert any("different project" in str(c).lower() for c in print_calls)
+
+    @patch("psutil.Process")
+    @patch("dango.cli.helpers.process_manager.subprocess.run")
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
+    def test_dango_process_cwd_unreadable_skips_safely(
+        self, _mock_running, mock_console, mock_sub_run, mock_psutil, tmp_path
+    ):
+        """Port fallback: Dango process found but CWD is unreadable → skip gracefully."""
+        import psutil as psutil_mod
+
+        self._setup_project(tmp_path)
+
+        mock_proc = MagicMock()
+        mock_proc.cwd.side_effect = psutil_mod.AccessDenied()
+        mock_psutil.return_value = mock_proc
+
+        with patch("dango.config.ConfigLoader") as mock_cl:
+            mock_config = MagicMock()
+            mock_config.platform.port = 8080
+            mock_cl.return_value.load_config.return_value = mock_config
+
+            lsof_result = MagicMock(returncode=0, stdout="1234\n")
+            ps_result = MagicMock(
+                returncode=0,
+                stdout="python -m uvicorn dango.web.app:app",
+            )
+            mock_sub_run.side_effect = [lsof_result, ps_result]
+
+            with patch("dango.cli.helpers.process_manager.kill_process") as mock_kill:
+                result = stop_fastapi_server(tmp_path, verbose=True)
+                assert result is False
+                mock_kill.assert_not_called()
+
+        # Should print a warning about being unable to verify CWD
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        assert any("Could not verify CWD" in str(c) for c in print_calls)
+
+    @patch("psutil.Process")
+    @patch("dango.cli.helpers.process_manager.kill_process", return_value=True)
+    @patch("dango.cli.helpers.process_manager.subprocess.run")
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
+    def test_symlinked_project_root_matches_after_resolution(
+        self, _mock_running, _mock_console, mock_sub_run, mock_kill, mock_psutil, tmp_path
+    ):
+        """Port fallback: symlinked project root matches resolved CWD → kills process."""
+        self._setup_project(tmp_path)
+
+        # Create a symlink pointing to tmp_path
+        link_dir = tmp_path / "link-to-project"
+        link_dir.symlink_to(tmp_path, target_is_directory=True)
+
+        # Mock CWD returns the real path (not the symlink)
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = str(tmp_path)
+        mock_psutil.return_value = mock_proc
+
+        with patch("dango.config.ConfigLoader") as mock_cl:
+            mock_config = MagicMock()
+            mock_config.platform.port = 8080
+            mock_cl.return_value.load_config.return_value = mock_config
+
+            lsof_result = MagicMock(returncode=0, stdout="1234\n")
+            ps_result = MagicMock(
+                returncode=0,
+                stdout="python -m uvicorn dango.web.app:app",
+            )
+            mock_sub_run.side_effect = [lsof_result, ps_result]
+
+            result = stop_fastapi_server(link_dir, verbose=True)
+            assert result is True
+            mock_kill.assert_called_once_with(1234, timeout=5)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Fixes two cross-project leaks in cleanup code where `dango stop` on project A could kill project B's server and Docker containers.

### Changes
- **`stop_fastapi_server()` port fallback** now verifies process CWD matches `project_root` before killing uvicorn processes (via `psutil.Process.cwd()`). Cross-project processes are skipped with a warning.
- **`stop_all_dango_containers()`** now filters by `com.docker.compose.project` label by default (`all_projects=False`). `all_projects=True` preserves global name-based filtering for `dango stop --all`.
- **`dango start` orphan check** now scoped to current project's compose label.
- **`dango stop --all`** explicitly passes `all_projects=True`.

### Acceptance criteria
- `dango stop` on project A does NOT kill project B's server on same port ✓
- `dango stop` on project A does NOT stop project B's Docker containers ✓
- `dango stop` still kills its OWN server and containers reliably ✓
- `dango stop --all` still stops ALL dango containers globally ✓
- Server started via symlinked path → resolved correctly ✓
- Port fallback warns when it finds another project's server ✓

## Verification

- `pytest -x`: 44 pass, 0 fail
- CLI cross-project: `dango stop` on project A with project B server on same port → project B NOT killed, warning printed
- CLI own server: `dango stop` kills project A's own server successfully
- CLI Docker scoping: `dango stop` on project A only stops project A's containers
- CLI --all: `dango stop --all` stops all Dango containers globally
- `ruff check`: clean
- `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)