### PR TITLE
fix: WebSocket sync phase events for post-sync progress (P1-2)

### DIFF
--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2849,6 +2849,11 @@ def run_sync(
 
     # Post-sync hooks (profiling, drift detection, PII scanning, analysis, notifications)
     if success_sources:
+        if progress_callback is not None:
+            progress_callback(
+                "post_sync_started",
+                "Running post-sync hooks (profiling, PII scan, analysis, snapshots)",
+            )
         try:
             from dango.utils.post_sync import dispatch_post_sync_hooks
 
@@ -2874,5 +2879,7 @@ def run_sync(
                     _src_name,
                     {"post_sync_error": "Post-sync hooks failed (see logs)"},
                 )
+        if progress_callback is not None:
+            progress_callback("post_sync_completed", "Post-sync hooks complete")
 
     return summary

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -495,6 +495,8 @@ def _phase_to_event(phase: str) -> str:
         "dbt_started": "dbt_run_all_started",
         "dbt_complete": "dbt_run_all_completed",
         "dbt_failed": "dbt_run_all_failed",
+        "post_sync_started": "post_sync_started",
+        "post_sync_completed": "post_sync_completed",
         "completed": "sync_completed",
         "failed": "sync_failed",
     }

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -37,6 +37,7 @@ let isLoadingSources = false;
 let isLoadingStatus = false;
 // Track active syncs: Map<sourceName, startTimestamp>
 let activeSyncs = new Map();
+let postSyncSources = new Set();  // sources currently in post-sync hook phase
 // Track pending loadSources retry timeout
 let loadSourcesRetryTimeout = null;
 // Track active upload/delete operations to prevent premature loadSources() retries
@@ -80,7 +81,12 @@ function startSyncTimer(sourceName) {
     const timerId = setInterval(() => {
         const elapsed = Math.floor((Date.now() - startTime) / 1000);
         const btn = document.getElementById(`sync-btn-${sourceName}`);
-        if (btn) btn.textContent = `Syncing... ${formatElapsed(elapsed)}`;
+        if (btn) {
+            const isPostSync = postSyncSources.has(sourceName);
+            btn.textContent = isPostSync
+                ? `Processing... ${formatElapsed(elapsed)}`
+                : `Syncing... ${formatElapsed(elapsed)}`;
+        }
     }, 1000);
     syncTimers.set(sourceName, timerId);
 }
@@ -475,6 +481,7 @@ async function handleWebSocketMessage(data) {
 
             // Clean up sync state and refresh
             activeSyncs.delete(source);
+            postSyncSources.delete(source);
             updateSyncCounter();
             loadSources();  // Reload from API to get correct status
             // Fallback: if activeSyncs wasn't set (e.g. upload-triggered sync),
@@ -496,6 +503,7 @@ async function handleWebSocketMessage(data) {
             console.log('❌ [WS] sync_failed - Source:', source);
             stopSyncTimer(source);
             activeSyncs.delete(source);
+            postSyncSources.delete(source);
             updateSyncCounter();  // Update header counter
             addLogEntry('error', message || `Sync failed`, source);
             showToast(`${source} sync failed`, 'error');
@@ -593,6 +601,18 @@ async function handleWebSocketMessage(data) {
             loadDbtModels();
             break;
 
+        case 'post_sync_started':
+            console.log('🟣 [WS] post_sync_started - Source:', source);
+            postSyncSources.add(source);
+            renderSourcesTable();
+            break;
+
+        case 'post_sync_completed':
+            console.log('🟣 [WS] post_sync_completed - Source:', source);
+            postSyncSources.delete(source);
+            renderSourcesTable();
+            break;
+
         case 'dbt_run_failed':
             console.log('❌ [WS] dbt_run_failed - Individual model:', source);
             addLogEntry('error', message, source);
@@ -626,6 +646,7 @@ async function handleWebSocketMessage(data) {
                 // DO clear activeSyncs since the operation failed
                 if (activeSyncs.has(triggeredSource)) {
                     activeSyncs.delete(triggeredSource);
+                    postSyncSources.delete(triggeredSource);
                     stopSyncTimer(triggeredSource);
                     const btn = document.getElementById(`sync-btn-${triggeredSource}`);
                     if (btn) btn.textContent = 'Sync Now';
@@ -679,8 +700,10 @@ function updateSyncCounter() {
 
     // If syncing, show count
     if (count > 0) {
+        const allInPostSync = postSyncSources.size > 0 && postSyncSources.size === count;
+        const prefix = allInPostSync ? 'Processing' : 'Syncing';
         const plural = count === 1 ? 'source' : 'sources';
-        text.textContent = `Syncing ${count} ${plural}...`;
+        text.textContent = `${prefix} ${count} ${plural}...`;
         text.className = 'text-xs sm:text-sm text-blue-600 font-medium animate-pulse-slow';
     } else if (ws && ws.readyState === WebSocket.OPEN) {
         // Connected and not syncing
@@ -1188,12 +1211,15 @@ function renderSourcesTable() {
     tbody.innerHTML = sources.map(source => {
         const isSyncing = activeSyncs.has(source.name);
         const hasFileOps = activeFileOperations.has(source.name);
+        const isPostSync = postSyncSources.has(source.name);
         const isDisabled = isSyncing || hasFileOps;
 
-        console.log(`🎨 [renderSourcesTable] Source "${source.name}": isSyncing=${isSyncing}, hasFileOps=${hasFileOps}, status="${source.status}"`);
+        console.log(`🎨 [renderSourcesTable] Source "${source.name}": isSyncing=${isSyncing}, hasFileOps=${hasFileOps}, isPostSync=${isPostSync}, status="${source.status}"`);
 
         const buttonDisabled = isDisabled ? 'disabled' : '';
-        const buttonText = isSyncing ? 'Syncing...' : (hasFileOps ? 'Processing...' : 'Sync Now');
+        const buttonText = isSyncing
+            ? (isPostSync ? 'Processing...' : 'Syncing...')
+            : (hasFileOps ? 'Processing...' : 'Sync Now');
 
         // For file sources (csv/local_files), clicking the row opens upload modal
         // For other sources, clicking the row opens detail modal
@@ -1351,6 +1377,9 @@ function renderStatusPill(source, isSyncing, hasFileOps) {
         // Distinguish dbt-building from data-loading
         if (dbtRunStartTime !== null) {
             return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800 animate-pulse">🔨 Building models...</span>';
+        }
+        if (postSyncSources.has(source.name)) {
+            return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800 animate-pulse">⚙️ Processing...</span>';
         }
         return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 animate-pulse">⏳ Syncing...</span>';
     }

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -75,11 +75,11 @@
                     <!-- Global sync status indicator -->
                     <div x-show="activeSyncCount > 0" x-cloak
                          class="flex items-center space-x-1.5 px-2 py-1 rounded-md bg-gray-700 text-xs text-gray-200">
-                        <svg class="animate-spin h-3.5 w-3.5 text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <svg class="animate-spin h-3.5 w-3.5" :class="_postSyncSources.size === activeSyncCount ? 'text-purple-400' : 'text-blue-400'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
                         </svg>
-                        <span x-text="'Syncing ' + activeSyncCount + ' source' + (activeSyncCount > 1 ? 's' : '')"></span>
+                        <span x-text="(_postSyncSources.size === activeSyncCount ? 'Processing' : 'Syncing') + ' ' + activeSyncCount + ' source' + (activeSyncCount > 1 ? 's' : '')"></span>
                     </div>
                     {% if request.state.user %}
                     <span class="text-xs text-gray-400 hidden lg:inline mr-2">{{ request.state.user.email }}</span>
@@ -164,6 +164,7 @@
         return {
             activeSyncCount: 0,
             _activeSources: new Set(),
+            _postSyncSources: new Set(),
             _ws: null,
             _reconnectTimer: null,
             init() {
@@ -183,8 +184,13 @@
                         const source = data.source || '';
                         if (data.event === 'sync_started' && source) {
                             this._activeSources.add(source);
+                        } else if (data.event === 'post_sync_started' && source) {
+                            this._postSyncSources.add(source);
+                        } else if (data.event === 'post_sync_completed' && source) {
+                            this._postSyncSources.delete(source);
                         } else if ((data.event === 'sync_completed' || data.event === 'sync_failed') && source) {
                             this._activeSources.delete(source);
+                            this._postSyncSources.delete(source);
                         }
                         this.activeSyncCount = this._activeSources.size;
                     } catch {}

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -743,3 +743,176 @@ class TestBroadcastDbtError:
         call_msg = broadcast_fn.call_args[0][0]
         assert call_msg["event"] == "dbt_run_all_failed"
         assert call_msg["source"] == "dbt (triggered by hubspot)"
+
+
+@pytest.mark.unit
+class TestPhaseToEvent:
+    """Tests for _phase_to_event mapping function."""
+
+    def test_post_sync_phase_mappings(self):
+        """post_sync_started and post_sync_completed map to themselves."""
+        from dango.platform.sync_process import _phase_to_event
+
+        assert _phase_to_event("post_sync_started") == "post_sync_started"
+        assert _phase_to_event("post_sync_completed") == "post_sync_completed"
+
+    def test_existing_mappings_unchanged(self):
+        """Existing phase mappings are not affected."""
+        from dango.platform.sync_process import _phase_to_event
+
+        assert _phase_to_event("starting") == "sync_started"
+        assert _phase_to_event("data_load_complete") == "data_load_complete"
+        assert _phase_to_event("dbt_started") == "dbt_run_all_started"
+        assert _phase_to_event("dbt_complete") == "dbt_run_all_completed"
+        assert _phase_to_event("completed") == "sync_completed"
+        assert _phase_to_event("failed") == "sync_failed"
+
+    def test_unknown_phase_defaults_to_sync_progress(self):
+        """Unknown phases fall back to sync_progress."""
+        from dango.platform.sync_process import _phase_to_event
+
+        assert _phase_to_event("nonexistent_phase") == "sync_progress"
+
+
+@pytest.mark.unit
+class TestBroadcastPostSyncPhases:
+    """Tests for broadcast behavior with post_sync phase events."""
+
+    @pytest.mark.anyio
+    async def test_broadcast_post_sync_started_includes_source(self):
+        """_broadcast_phase_transition for post_sync_started includes source name."""
+        from dango.platform.sync_process import _broadcast_phase_transition
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        status = {"message": "Running post-sync hooks (profiling, PII scan, analysis, snapshots)"}
+        await _broadcast_phase_transition(mock_ws, "hubspot", "post_sync_started", status)
+
+        call_msg = mock_ws.broadcast.call_args[0][0]
+        assert call_msg["event"] == "post_sync_started"
+        assert call_msg["source"] == "hubspot"
+        assert call_msg["message"] == status["message"]
+
+    @pytest.mark.anyio
+    async def test_broadcast_post_sync_completed_includes_source(self):
+        """_broadcast_phase_transition for post_sync_completed includes source name."""
+        from dango.platform.sync_process import _broadcast_phase_transition
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        status = {"message": "Post-sync hooks complete"}
+        await _broadcast_phase_transition(mock_ws, "stripe", "post_sync_completed", status)
+
+        call_msg = mock_ws.broadcast.call_args[0][0]
+        assert call_msg["event"] == "post_sync_completed"
+        assert call_msg["source"] == "stripe"
+        assert call_msg["message"] == status["message"]
+
+
+@pytest.mark.unit
+class TestBlockingPollPostSyncPhases:
+    """Tests for poll_sync_status_blocking with post_sync phase transitions."""
+
+    def test_blocking_poll_post_sync_started(self, tmp_path):
+        """poll_sync_status_blocking broadcasts post_sync_started for new phase."""
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(
+            tmp_path,
+            phase="post_sync_started",
+            sync_id="ps_block",
+            message="Running post-sync hooks",
+        )
+        process = MagicMock()
+        process.poll.return_value = None  # still running
+        broadcast_fn = MagicMock()
+
+        read_count = [0]
+
+        def _side_effect(proj_root, sync_id=None):
+            read_count[0] += 1
+            if read_count[0] == 1:
+                return {
+                    "pid": os.getpid(),
+                    "phase": "post_sync_started",
+                    "message": "Running post-sync hooks",
+                    "sources": ["hubspot"],
+                }
+            # Return completed on next read to terminate
+            return {
+                "pid": os.getpid(),
+                "phase": "completed",
+                "message": "Done",
+                "sources": ["hubspot"],
+            }
+
+        with (
+            patch(f"{_MOD}.read_sync_status", side_effect=_side_effect),
+            patch(f"{_MOD}.time.sleep"),
+        ):
+            success, _ = poll_sync_status_blocking(
+                tmp_path,
+                process,
+                source_name="hubspot",
+                sync_id="ps_block",
+                broadcast_fn=broadcast_fn,
+                poll_interval=0.01,
+            )
+
+        assert success is True
+        # Should have broadcast at least post_sync_started and sync_completed
+        events = [c[0][0]["event"] for c in broadcast_fn.call_args_list]
+        assert "post_sync_started" in events
+        assert "sync_completed" in events
+
+    def test_blocking_poll_post_sync_completed(self, tmp_path):
+        """poll_sync_status_blocking broadcasts post_sync_completed for completed phase."""
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(
+            tmp_path,
+            phase="post_sync_completed",
+            sync_id="ps_comp",
+            message="Post-sync hooks complete",
+        )
+        process = MagicMock()
+        process.poll.return_value = None  # still running
+        broadcast_fn = MagicMock()
+
+        read_count = [0]
+
+        def _side_effect(proj_root, sync_id=None):
+            read_count[0] += 1
+            if read_count[0] == 1:
+                return {
+                    "pid": os.getpid(),
+                    "phase": "post_sync_completed",
+                    "message": "Post-sync hooks complete",
+                    "sources": ["stripe"],
+                }
+            return {
+                "pid": os.getpid(),
+                "phase": "completed",
+                "message": "Done",
+                "sources": ["stripe"],
+            }
+
+        with (
+            patch(f"{_MOD}.read_sync_status", side_effect=_side_effect),
+            patch(f"{_MOD}.time.sleep"),
+        ):
+            success, _ = poll_sync_status_blocking(
+                tmp_path,
+                process,
+                source_name="stripe",
+                sync_id="ps_comp",
+                broadcast_fn=broadcast_fn,
+                poll_interval=0.01,
+            )
+
+        assert success is True
+        events = [c[0][0]["event"] for c in broadcast_fn.call_args_list]
+        assert "post_sync_completed" in events
+        assert "sync_completed" in events


### PR DESCRIPTION
## Summary

Add `post_sync_started` / `post_sync_completed` WebSocket events so the UI shows "Processing..." instead of "Syncing..." during post-sync hooks (profiling, PII scan, analysis, dbt snapshots).

After dbt completes, post-sync hooks run for 60-90 seconds with no UI feedback. Users see "Syncing..." throughout and think the sync is stuck. This change inserts two new status file phases around `dispatch_post_sync_hooks()` so the polling loop can broadcast phase transitions via WebSocket.

## Changes

- **`dlt_runner.py`**: Emit `progress_callback("post_sync_started")` before and `progress_callback("post_sync_completed")` after `dispatch_post_sync_hooks()` (guarded by `if progress_callback is not None` for CLI compatibility)
- **`sync_process.py`**: Add `post_sync_started` / `post_sync_completed` to `_phase_to_event()` mapping
- **`app.js`**: Track `postSyncSources` Set, handle new events, show "Processing..." in button text, status pill, sync counter, and timer
- **`base.html`**: Update `globalSyncIndicator()` Alpine component to track and display post-sync phase
- **Tests**: 7 new tests covering phase-to-event mapping, broadcast payloads, and blocking poll transitions

## Event flow
```
dlt_runner                         sync_process (polls)            app.js (WebSocket)
─────────────────                  ─────────────────────           ─────────────────────
progress_cb("dbt_complete")  →     dbt_run_all_completed     →     source still in activeSyncs,
                                                                    shows "Syncing..."
progress_cb("post_sync_started")→  post_sync_started         →     postSyncSources.add(source),
  [NEW]                                                              shows purple "Processing..."
dispatch_post_sync_hooks() runs
progress_cb("post_sync_completed")→ post_sync_completed      →     postSyncSources.delete(source),
  [NEW]                                                              back to "Syncing..." briefly
_progress("completed")         →    sync_completed           →     activeSyncs.delete(source),
                                                                    all clear
```

## Verification
- `pytest tests/unit/test_sync_process.py -x`: 45 pass (7 new)
- `pytest tests/unit/test_post_sync* -x`: 34 pass (no regressions)
- `pytest tests/unit/ -x`: 3769 pass, 0 fail (no regressions)
- UI: WebSocket message stream verified via browser DevTools — `post_sync_started` fires after `dbt_run_all_completed`, source status changes to "Processing...", `post_sync_completed` fires before `sync_completed`
- Sources page: status pills and buttons work correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)