### PR TITLE
fix: staging models with explicit columns, type casts, _dlt exclusion (P7-2)

### DIFF
--- a/dango/templates/dbt/staging_model.sql.j2
+++ b/dango/templates/dbt/staging_model.sql.j2
@@ -28,8 +28,14 @@
     schema='staging'
 {{ ") }}" }}
 
-{% if date_cast_columns %}
-SELECT * REPLACE ({% for col in date_cast_columns %}CAST({{ col }} AS DATE) AS {{ col }}{% if not loop.last %}, {% endif %}{% endfor %}) FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
-{% else %}
-SELECT * FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
-{% endif %}
+WITH source AS (
+    SELECT * FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
+),
+renamed AS (
+    SELECT
+{% for col in staging_columns %}
+{{ "        " }}{% if col.name in date_cast_columns %}CAST({{ col.quoted_name }} AS DATE) AS {{ col.quoted_name }}{% else %}{{ col.quoted_name }}{% endif %}{% if not loop.last %},{% endif +%}
+{% endfor %}
+    FROM source
+)
+SELECT * FROM renamed

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -3,6 +3,7 @@
 Automatically generates dbt staging models from configured data sources.
 """
 
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,13 @@ def _has_not_null_test(tests: list) -> bool:
         if isinstance(test, dict) and "not_null" in test:
             return True
     return False
+
+
+def _quote_column_name(name: str) -> str:
+    """Double-quote a column name if it contains special characters."""
+    if name and all(c.isalnum() or c == "_" for c in name):
+        return name
+    return f'"{name}"'
 
 
 class DbtModelGenerator:
@@ -320,6 +328,7 @@ class DbtModelGenerator:
         dedup_strategy: str | None = None,
         dedup_columns: list[str] | None = None,
         date_cast_columns: list[str] | None = None,
+        staging_columns: list[dict] | None = None,
     ) -> str:
         """
         Generate staging model SQL for a data source
@@ -330,6 +339,8 @@ class DbtModelGenerator:
             schema_name: Schema name in DuckDB (raw or raw_{source_name})
             dedup_strategy: Deduplication strategy (one of DEDUP_STRATEGIES keys)
             dedup_columns: Columns to use for deduplication
+            date_cast_columns: Columns to CAST from TIMESTAMPTZ to DATE
+            staging_columns: Column definitions with "name" and "type" keys for explicit listing
 
         Returns:
             Generated SQL content
@@ -341,6 +352,16 @@ class DbtModelGenerator:
                 f"Invalid dedup_strategy '{dedup_strategy}'. Must be one of: {valid_strategies}"
             )
 
+        # Prepare columns with quoted names for the template
+        prepared_columns = []
+        for col in staging_columns or []:
+            prepared_columns.append(
+                {
+                    "name": col["name"],
+                    "quoted_name": _quote_column_name(col["name"]),
+                }
+            )
+
         # Template context
         context = {
             "source_name": source.name,
@@ -350,6 +371,7 @@ class DbtModelGenerator:
             "dedup_strategy": dedup_strategy,
             "dedup_columns": dedup_columns or [],
             "date_cast_columns": date_cast_columns or [],
+            "staging_columns": prepared_columns,
             "generated_at": datetime.now().isoformat(),
         }
 
@@ -573,7 +595,10 @@ class DbtModelGenerator:
                     date_cast_columns: list[str] = []
                     if source.type.value == "google_analytics":
                         for col in staging_columns:
-                            if col["name"] == "date" and "TIMESTAMP" in col["type"].upper():
+                            if (
+                                re.search(r"\bdate\b", col["name"].lower())
+                                and "TIMESTAMP" in col["type"].upper()
+                            ):
                                 date_cast_columns.append(col["name"])
 
                     # Generate staging model SQL
@@ -584,6 +609,7 @@ class DbtModelGenerator:
                         dedup_strategy=dedup_strategy,
                         dedup_columns=dedup_columns,
                         date_cast_columns=date_cast_columns,
+                        staging_columns=staging_columns,
                     )
 
                     # Write model file

--- a/tests/unit/test_data_fixes.py
+++ b/tests/unit/test_data_fixes.py
@@ -9,12 +9,36 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dango.config.models import DataSource, SourceType
-from dango.transformation.generator import DbtModelGenerator
+from dango.transformation.generator import DbtModelGenerator, _quote_column_name
 
 
 def _make_source(name: str, source_type: str) -> DataSource:
     """Create a minimal DataSource for testing."""
     return DataSource(name=name, type=SourceType(source_type))
+
+
+# ---------------------------------------------------------------------------
+# _quote_column_name unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestQuoteColumnName:
+    def test_alphanumeric_unquoted(self):
+        """Column names with only alphanumeric and underscore are not quoted."""
+        assert _quote_column_name("id") == "id"
+        assert _quote_column_name("customer_id") == "customer_id"
+        assert _quote_column_name("_dlt_load_id") == "_dlt_load_id"
+
+    def test_special_chars_quoted(self):
+        """Column names with spaces, hyphens, or other special chars are double-quoted."""
+        assert _quote_column_name("spaces in name") == '"spaces in name"'
+        assert _quote_column_name("column-name") == '"column-name"'
+        assert _quote_column_name("col.name") == '"col.name"'
+
+    def test_empty_string_quoted(self):
+        """Empty column name is quoted (edge case, shouldn't occur in practice)."""
+        assert _quote_column_name("") == '""'
 
 
 # ---------------------------------------------------------------------------
@@ -156,9 +180,13 @@ class TestGA4DateCast:
             table_name="sessions",
             schema_name="raw_my_ga4",
             date_cast_columns=["date"],
+            staging_columns=[
+                {"name": "date", "type": "TIMESTAMP WITH TIME ZONE"},
+                {"name": "sessions", "type": "BIGINT"},
+            ],
         )
 
-        assert "REPLACE" in sql
+        assert "WITH source AS" in sql
         assert "CAST(date AS DATE) AS date" in sql
         assert "source('my_ga4', 'sessions')" in sql
 
@@ -175,10 +203,14 @@ class TestGA4DateCast:
             source=source,
             table_name="charges",
             schema_name="raw_my_stripe",
+            staging_columns=[
+                {"name": "id", "type": "VARCHAR"},
+                {"name": "amount", "type": "BIGINT"},
+            ],
         )
 
-        assert "REPLACE" not in sql
-        assert "SELECT *" in sql
+        assert "WITH source AS" in sql
+        assert "CAST" not in sql
         assert "source('my_stripe', 'charges')" in sql
 
     def test_ga4_no_cast_when_already_date(self, tmp_path: Path):
@@ -196,10 +228,14 @@ class TestGA4DateCast:
             table_name="sessions",
             schema_name="raw_my_ga4",
             date_cast_columns=[],
+            staging_columns=[
+                {"name": "date", "type": "DATE"},
+                {"name": "sessions", "type": "BIGINT"},
+            ],
         )
 
-        assert "REPLACE" not in sql
-        assert "SELECT *" in sql
+        assert "WITH source AS" in sql
+        assert "CAST" not in sql
 
     def test_ga4_date_detection_in_generate_all_models(self, tmp_path: Path):
         """generate_all_models detects TIMESTAMP date columns for GA4 sources."""
@@ -235,7 +271,15 @@ class TestGA4DateCast:
             gen.generate_all_models([source], generate_schema_yml=False)
 
             mock_gen.assert_called_once()
-            assert mock_gen.call_args.kwargs.get("date_cast_columns") == ["date"]
+            call_kwargs = mock_gen.call_args.kwargs
+            assert call_kwargs.get("date_cast_columns") == ["date"]
+            # Verify staging_columns is passed with _dlt_*/_dango_* filtered out
+            staging_cols = call_kwargs.get("staging_columns")
+            assert staging_cols is not None
+            staging_names = [c["name"] for c in staging_cols]
+            assert "_dlt_load_id" not in staging_names
+            assert "_dlt_id" not in staging_names
+            assert "sessions" in staging_names
 
     def test_ga4_no_detection_when_date_is_date_type(self, tmp_path: Path):
         """generate_all_models does NOT add date_cast_columns when type is already DATE."""
@@ -272,6 +316,8 @@ class TestGA4DateCast:
 
             mock_gen.assert_called_once()
             assert mock_gen.call_args.kwargs.get("date_cast_columns") == []
+            # Verify staging_columns is passed even when no date casts needed
+            assert mock_gen.call_args.kwargs.get("staging_columns") is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace SELECT * with explicit column lists from DuckDB introspection
- Exclude _dlt_load_id and _dlt_id from staging output
- CAST TIMESTAMPTZ date columns to DATE for GA4 sources (broadened: any column with "date" in name)
- Double-quote column names with special characters
- Existing model protection preserved (is_auto_generated guard)

## Changes
- `dango/templates/dbt/staging_model.sql.j2` — CTE-based template with explicit column listing
- `dango/transformation/generator.py` — Added `_quote_column_name()`, `staging_columns` param, broadened GA4 date detection
- `tests/unit/test_data_fixes.py` — Updated 3 direct `generate_staging_model()` call assertions

## Verification
- `pytest tests/unit/test_data_fixes.py -v`: 12 pass, 0 fail
- `pytest -m unit -v`: 3695 pass, 7 skipped, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)