### PR TITLE
fix: sync queue — wait instead of failing on lock contention (F-1)

### DIFF
--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -765,6 +765,7 @@ def sync(
                     raise click.Abort()
 
         # Try to acquire lock before running sync (which includes dbt)
+        console.print("\n[bold yellow]⌛ Waiting for lock...[/bold yellow]")
         try:
             lock = DbtLock(
                 project_root=project_root,

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -495,7 +495,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 full_refresh=full_refresh,
                 skip_dbt=True,
                 source_label="scheduler",
-                max_lock_wait=300,
+                max_lock_wait=60,
             )
 
             success, _result = poll_sync_status_blocking(
@@ -841,17 +841,20 @@ def run_scheduled_dbt(
 
     try:
         try:
-            lock.acquire()
+            lock.acquire(timeout=60)
         except DbtLockError:
             elapsed = time.monotonic() - t0
             logger.warning(
-                "scheduler_lock_contention", schedule=schedule_name, dbt_command=dbt_command
+                "scheduler_lock_timeout",
+                schedule=schedule_name,
+                dbt_command=dbt_command,
+                timeout_seconds=60,
             )
             _broadcast(
                 {
                     "event": "job_queued",
                     "schedule": schedule_name,
-                    "message": "Lock contention",
+                    "message": "Lock unavailable after 60s wait",
                     "timestamp": _ts(),
                 }
             )

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -117,7 +117,7 @@ def run_manual_sync(
         write_progress: If True, write progress to .dango/state/sync_status.json.
         source_label: Label for the sync trigger (e.g., "ui", "scheduler", "manual").
         skip_dbt: If True, skip dbt run after data load.
-        max_lock_wait: Max seconds to wait for lock (0 = fail immediately).
+        max_lock_wait: Max seconds to wait for lock (0 = use default of 300s).
         sync_id: Unique identifier for the status file (avoids concurrent clobber).
         record_id: Existing execution history record ID to reuse (avoids double records).
 
@@ -191,7 +191,7 @@ def run_manual_sync(
         # Non-OAuth errors during validation: continue (benefit of the doubt)
         logger.warning("pre_sync_validation_error", error=str(e), exc_info=True)
 
-    # --- Lock acquisition with retry ---
+    # --- Lock acquisition ---
     _progress("lock_waiting", "Waiting for lock")
     lock = None
     try:
@@ -200,27 +200,7 @@ def run_manual_sync(
             source=source_label,
             operation=f"sync:{','.join(sources)}",
         )
-
-        acquired = False
-        wait_start = time.time()
-        while not acquired:
-            try:
-                lock.acquire()
-                acquired = True
-            except DbtLockError as exc:
-                elapsed_wait = time.time() - wait_start
-                if elapsed_wait >= max_lock_wait:
-                    error_msg = f"Lock unavailable: {exc}"
-                    record_failure(db_path, record_id, error_msg)
-                    duration = round(time.time() - start_time, 1)
-                    _progress("failed", error_msg, error=error_msg)
-                    return {
-                        "record_id": record_id,
-                        "status": "failed",
-                        "duration_seconds": duration,
-                        "error": error_msg,
-                    }
-                time.sleep(5)
+        lock.acquire(timeout=max_lock_wait or 300)
     except DbtLockError as exc:
         error_msg = f"Lock unavailable: {exc}"
         record_failure(db_path, record_id, error_msg)

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -493,8 +493,7 @@ def _ts() -> str:
 def _phase_to_event(phase: str) -> str:
     """Map status file phase to a WebSocket event name."""
     mapping = {
-        "starting": "sync_started",
-        "lock_waiting": "sync_progress",
+        "lock_waiting": "sync_queued",
         "data_load": "sync_progress",
         "data_load_complete": "data_load_complete",
         "dbt_started": "dbt_run_all_started",
@@ -519,6 +518,7 @@ async def _broadcast_phase_transition(
     message: dict[str, Any] = {
         "event": event,
         "source": source_name,
+        "phase": phase,
         "message": status.get("message", ""),
         "timestamp": _ts(),
     }

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -146,13 +146,13 @@ class DbtLock:
 
         return False
 
-    def acquire(self, timeout: float = 30) -> bool:
+    def acquire(self, timeout: float = 300) -> bool:
         """
         Acquire the lock.
 
         Args:
             timeout: Maximum time to wait for the lock (0 = don't wait).
-                Retries every 1 second until timeout is reached.
+                Retries every 3 seconds until timeout is reached.
 
         Returns:
             True if lock was acquired
@@ -196,31 +196,19 @@ class DbtLock:
 
                 # Retry if we still have time
                 if time.monotonic() < deadline:
-                    time.sleep(1)
+                    lock_info = self._read_lock_info()
+                    if lock_info:
+                        logger.info(
+                            "Waiting for dbt lock... (held by PID %d)",
+                            lock_info.get("pid", "unknown"),
+                        )
+                    else:
+                        logger.info("Waiting for dbt lock...")
+                    time.sleep(3)
                     continue
 
                 lock_info = self._read_lock_info()
-
-                # Build a helpful error message
-                if lock_info:
-                    source = lock_info.get("source", "unknown")
-                    operation = lock_info.get("operation", "unknown operation")
-                    started_at = lock_info.get("started_at", "unknown time")
-                    pid = lock_info.get("pid", "unknown")
-
-                    message = (
-                        f"Another sync operation is currently running.\n"
-                        f"Source: {source}\n"
-                        f"Operation: {operation}\n"
-                        f"Started at: {started_at}\n"
-                        f"Process ID: {pid}\n"
-                        f"Please wait for it to complete before starting a new operation."
-                    )
-                else:
-                    message = (
-                        "Another sync operation is currently running. "
-                        "Please wait for it to complete before starting a new operation."
-                    )
+                message = "Sync queue timeout. Another sync is still running."
 
                 raise DbtLockError(message, lock_info=lock_info) from None
 

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -72,14 +72,19 @@
 
                 <!-- Right side: sync indicator + user email + settings gear + hamburger (mobile) -->
                 <div class="flex items-center space-x-2 ml-auto" x-data="globalSyncIndicator()" x-init="init()">
-                    <!-- Global sync status indicator -->
-                    <div x-show="activeSyncCount > 0" x-cloak
+                    <!-- Global sync status indicator (queued + active) -->
+                    <div x-show="queuedCount > 0 || activeSyncCount > 0" x-cloak
                          class="flex items-center space-x-1.5 px-2 py-1 rounded-md bg-gray-700 text-xs text-gray-200">
-                        <svg class="animate-spin h-3.5 w-3.5" :class="_postSyncSources.size === activeSyncCount ? 'text-purple-400' : 'text-blue-400'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <!-- Clock icon when queued (not yet syncing) -->
+                        <svg x-show="activeSyncCount === 0 && queuedCount > 0" class="h-3.5 w-3.5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                        </svg>
+                        <!-- Spinner when actively syncing (purple = post-sync, blue = syncing) -->
+                        <svg x-show="activeSyncCount > 0" class="animate-spin h-3.5 w-3.5" :class="_postSyncSources.size === activeSyncCount && activeSyncCount > 0 ? 'text-purple-400' : 'text-blue-400'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
                         </svg>
-                        <span x-text="(_postSyncSources.size === activeSyncCount ? 'Processing' : 'Syncing') + ' ' + activeSyncCount + ' source' + (activeSyncCount > 1 ? 's' : '')"></span>
+                        <span x-text="statusText"></span>
                     </div>
                     {% if request.state.user %}
                     <span class="text-xs text-gray-400 hidden lg:inline mr-2">{{ request.state.user.email }}</span>
@@ -163,8 +168,10 @@
     function globalSyncIndicator() {
         return {
             activeSyncCount: 0,
+            queuedCount: 0,
             _activeSources: new Set(),
             _postSyncSources: new Set(),
+            _queuedSources: new Set(),
             _ws: null,
             _reconnectTimer: null,
             init() {
@@ -174,6 +181,18 @@
                 if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
                 if (this._ws) this._ws.close();
             },
+            get statusText() {
+                if (this.activeSyncCount > 0) {
+                    let verb = this._postSyncSources.size === this.activeSyncCount ? 'Processing' : 'Syncing';
+                    let text = verb + ' ' + this.activeSyncCount;
+                    if (this.queuedCount > 0) text += ' (+' + this.queuedCount + ' queued)';
+                    return text;
+                }
+                if (this.queuedCount > 0) {
+                    return 'Queued ' + this.queuedCount + ' source' + (this.queuedCount > 1 ? 's' : '');
+                }
+                return '';
+            },
             _connect() {
                 const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
                 this._ws = new WebSocket(`${proto}//${location.host}/ws`);
@@ -182,7 +201,14 @@
                     try {
                         const data = JSON.parse(e.data);
                         const source = data.source || '';
-                        if (data.event === 'sync_started' && source) {
+                        if (data.event === 'sync_queued' && source) {
+                            this._activeSources.delete(source);
+                            this._queuedSources.add(source);
+                        } else if (data.event === 'sync_started' && source) {
+                            this._queuedSources.delete(source);
+                            this._activeSources.add(source);
+                        } else if (data.event === 'sync_progress' && source && data.phase === 'data_load' && this._queuedSources.has(source)) {
+                            this._queuedSources.delete(source);
                             this._activeSources.add(source);
                         } else if (data.event === 'post_sync_started' && source) {
                             this._postSyncSources.add(source);
@@ -191,8 +217,10 @@
                         } else if ((data.event === 'sync_completed' || data.event === 'sync_failed') && source) {
                             this._activeSources.delete(source);
                             this._postSyncSources.delete(source);
+                            this._queuedSources.delete(source);
                         }
                         this.activeSyncCount = this._activeSources.size;
+                        this.queuedCount = this._queuedSources.size;
                     } catch {}
                 };
                 this._ws.onclose = () => {

--- a/tests/unit/test_dbt_lock_stale.py
+++ b/tests/unit/test_dbt_lock_stale.py
@@ -93,10 +93,63 @@ class TestDbtLockCleanupStaleIntegration:
 
         try:
             contender = DbtLock(tmp_path, source="contender", operation="contend")
-            with pytest.raises(DbtLockErr, match="Another sync operation"):
+            with pytest.raises(DbtLockErr, match="Sync queue timeout"):
                 contender.acquire(timeout=0)
         finally:
             holder.release()
+
+    def test_acquire_immediate_no_contention(self, tmp_path: Path) -> None:
+        """Lock acquired immediately when no contention."""
+        lock = DbtLock(tmp_path, source="test", operation="test op")
+        acquired = lock.acquire(timeout=0)
+        assert acquired is True
+        lock.release()
+
+    def test_lock_wait_times_out(self, tmp_path: Path) -> None:
+        """Lock wait raises DbtLockError after timeout."""
+        from dango.exceptions import DbtLockError as DbtLockErr
+
+        holder = DbtLock(tmp_path, source="holder", operation="hold")
+        holder.acquire(timeout=0)
+
+        try:
+            contender = DbtLock(tmp_path, source="contender", operation="contend")
+            with pytest.raises(DbtLockErr, match="Sync queue timeout"):
+                contender.acquire(timeout=1)  # short timeout for test speed
+        finally:
+            holder.release()
+
+    def test_lock_wait_succeeds_when_released(self, tmp_path: Path) -> None:
+        """Lock acquired when holder releases within timeout."""
+        import threading
+
+        from dango.exceptions import DbtLockError as DbtLockErr
+
+        holder = DbtLock(tmp_path, source="holder", operation="hold")
+        holder.acquire(timeout=0)
+
+        result = {"acquired": False, "error": None}
+
+        def _contend():
+            try:
+                c = DbtLock(tmp_path, source="contender", operation="contend")
+                c.acquire(timeout=5)
+                result["acquired"] = True
+                c.release()
+            except DbtLockErr as e:
+                result["error"] = e
+
+        t = threading.Thread(target=_contend)
+        t.start()
+
+        import time
+
+        time.sleep(0.1)  # let contender start waiting
+        holder.release()
+        t.join(timeout=6)
+
+        assert result["acquired"] is True
+        assert result["error"] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -173,7 +173,7 @@ class TestRunScheduledSync:
         assert call_kwargs["sources"] == ["src1"]
         assert call_kwargs["skip_dbt"] is True
         assert call_kwargs["source_label"] == "scheduler"
-        assert call_kwargs["max_lock_wait"] == 300
+        assert call_kwargs["max_lock_wait"] == 60
 
     def test_broadcasts_sync_started_and_completed(self, tmp_path):
         config = _make_config_with_sources("src1")
@@ -451,7 +451,7 @@ class TestRunScheduledDbt:
 
             run_scheduled_dbt("nightly", "model_name+", project_root=str(tmp_path))
 
-        mock_lock.acquire.assert_called_once()
+        mock_lock.acquire.assert_called_once_with(timeout=60)
         mock_lock.release.assert_called_once()
 
     def test_broadcasts_dbt_events(self, tmp_path):

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -760,7 +760,7 @@ class TestPhaseToEvent:
         """Existing phase mappings are not affected."""
         from dango.platform.sync_process import _phase_to_event
 
-        assert _phase_to_event("starting") == "sync_started"
+        assert _phase_to_event("lock_waiting") == "sync_queued"
         assert _phase_to_event("data_load_complete") == "data_load_complete"
         assert _phase_to_event("dbt_started") == "dbt_run_all_started"
         assert _phase_to_event("dbt_complete") == "dbt_run_all_completed"
@@ -768,9 +768,10 @@ class TestPhaseToEvent:
         assert _phase_to_event("failed") == "sync_failed"
 
     def test_unknown_phase_defaults_to_sync_progress(self):
-        """Unknown phases fall back to sync_progress."""
+        """Unknown phases (including removed 'starting') fall back to sync_progress."""
         from dango.platform.sync_process import _phase_to_event
 
+        assert _phase_to_event("starting") == "sync_progress"
         assert _phase_to_event("nonexistent_phase") == "sync_progress"
 
 

--- a/tests/unit/test_sync_trigger.py
+++ b/tests/unit/test_sync_trigger.py
@@ -72,7 +72,7 @@ class TestRunManualSync:
         assert result["status"] == "success"
         assert result["record_id"] == 1
         assert "duration_seconds" in result
-        mock_lock_cls.return_value.acquire.assert_called_once()
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=300)
         mock_lock_cls.return_value.release.assert_called_once()
         mock_sync.assert_called_once()
         mock_complete.assert_called_once()
@@ -136,6 +136,7 @@ class TestRunManualSync:
         assert result["status"] == "failed"
         assert "Lock unavailable" in result["error"]
         mock_failure.assert_called_once()
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=300)
 
     @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
     @patch(f"{_PATCH_CONFIG}.load_config")
@@ -378,47 +379,61 @@ class TestRunManualSync:
         assert result["status"] == "success"
         assert result["rows_loaded"] == 150
 
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
+    @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_UTILS}.DbtLock")
-    @patch(f"{_PATCH_HISTORY}.record_failure")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
     @patch(f"{_PATCH_HISTORY}.record_start", return_value=10)
     @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
-    @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_OAUTH}.validate_before_sync")
-    def test_lock_retry_loop(
+    def test_acquire_passes_timeout(
         self,
         mock_oauth,
-        mock_config,
         mock_db_path,
         mock_start,
-        mock_failure,
+        mock_complete,
         mock_lock_cls,
+        mock_config,
+        mock_sync,
         tmp_path,
     ):
-        """With max_lock_wait > 0, should retry before failing."""
-        from dango.exceptions import DbtLockError
+        """Lock acquire() should pass max_lock_wait as timeout."""
         from dango.platform.scheduling.sync_trigger import run_manual_sync
 
         mock_config.return_value = _make_config(["src1"])
 
-        # Fail first 2 attempts, succeed on third
-        attempts = [0]
+        result = run_manual_sync(tmp_path, sources=["src1"], max_lock_wait=30)
 
-        def _side_effect():
-            attempts[0] += 1
-            if attempts[0] < 3:
-                raise DbtLockError("lock held")
-
-        mock_lock_cls.return_value.acquire.side_effect = _side_effect
-
-        with (
-            patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0}),
-            patch(f"{_PATCH_HISTORY}.record_completion"),
-            patch(f"{_PATCH_HISTORY}.time.sleep"),
-        ):
-            result = run_manual_sync(tmp_path, sources=["src1"], max_lock_wait=30)
-
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=30)
         assert result["status"] == "success"
-        assert attempts[0] == 3
+
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=11)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_default_timeout_is_300(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_lock_cls,
+        mock_config,
+        mock_sync,
+        tmp_path,
+    ):
+        """Without max_lock_wait, should use 300s default timeout."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        result = run_manual_sync(tmp_path, sources=["src1"])
+
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=300)
+        assert result["status"] == "success"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Replace immediate "Lock unavailable" failure with 5-minute wait loop in `DbtLock.acquire()` (default timeout 300s, retry every 3s)
- Web UI shows "Queued" status during lock wait via WebSocket `sync_queued` event
- CLI shows "Waiting for lock..." feedback instead of crashing
- Scheduled syncs use shorter 60s timeout to avoid cascading delays
- Simplified `sync_trigger.py` by removing redundant outer retry loop (DbtLock handles it internally)

## Changes
- **`dango/utils/dbt_lock.py`** — Default timeout 30→300s, retry interval 1→3s, add logging during wait, cleaner error message
- **`dango/platform/scheduling/sync_trigger.py`** — Remove outer retry loop; `lock.acquire(timeout=max_lock_wait or 300)` handles it
- **`dango/platform/sync_process.py`** — `lock_waiting` phase maps to `sync_queued` WebSocket event
- **`dango/web/templates/base.html`** — Frontend: clock icon for queued, spinner for syncing, status text shows both states
- **`dango/cli/commands/source.py`** — "Waiting for lock..." message before acquire
- **`dango/platform/scheduling/jobs.py`** — `max_lock_wait=60` for scheduled syncs, `timeout=60` for scheduled dbt

## Verification
- `pytest -x`: 3871 pass, 0 fail, 31 skipped
- Targeted tests: 71 pass (test_dbt_lock_stale, test_sync_jobs, test_sync_trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)