### PR TITLE
fix: wire up structured logging + add version to all log schemas (S2)

### DIFF
--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -16,6 +16,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import dango
 from dango.logging import get_logger
 
 _logger = get_logger("dango.auth.audit")
@@ -143,6 +144,7 @@ def log_auth_event(
     entry: dict[str, Any] = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "event": event_type.value,
+        "dango_version": dango.__version__,
     }
     if user_id is not None:
         entry["user_id"] = user_id

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -55,6 +55,10 @@ def cli(ctx: click.Context) -> None:
     """
     ctx.ensure_object(dict)
 
+    from dango.logging import configure_logging
+
+    configure_logging()
+
     # Warn if the dango binary doesn't match the active venv
     import os
     import sys

--- a/dango/logging.py
+++ b/dango/logging.py
@@ -36,6 +36,8 @@ from structlog.contextvars import (
     unbind_contextvars,
 )
 
+import dango
+
 __all__ = [
     "configure_logging",
     "get_logger",
@@ -145,7 +147,11 @@ def configure_logging(
 
     # Resolve log directory
     if log_dir is None:
-        log_dir = Path.cwd() / ".dango" / "logs"
+        project_root_env = os.environ.get("DANGO_PROJECT_ROOT")
+        if project_root_env:
+            log_dir = Path(project_root_env) / ".dango" / "logs"
+        else:
+            log_dir = Path.cwd() / ".dango" / "logs"
 
     # --- Build handlers ---
     handlers: dict[str, dict] = {}
@@ -209,6 +215,9 @@ def configure_logging(
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=False,
     )
+
+    # Bind version at process start — static for the lifetime of the process.
+    bind_contextvars(dango_version=dango.__version__)
 
     if not file_handler_ok:
         logger = get_logger("dango.logging")

--- a/dango/platform/local/watcher_runner.py
+++ b/dango/platform/local/watcher_runner.py
@@ -177,6 +177,10 @@ def run_validate_command(project_root: Path) -> bool:
 def main() -> None:
     """Main entry point for watcher runner"""
 
+    from dango.logging import configure_logging
+
+    configure_logging()
+
     # Get project root from command line argument
     if len(sys.argv) < 2:
         print("Usage: watcher_runner.py <project_root>")

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -458,6 +458,10 @@ def _trigger_metabase_schema_scan(project_root: Path) -> None:
 
 
 if __name__ == "__main__":
+    from dango.logging import configure_logging
+
+    configure_logging()
+
     if len(sys.argv) < 2:
         print(
             "Usage: python -m dango.platform.scheduling.sync_trigger '<json>'",

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+import dango
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
@@ -147,8 +148,11 @@ def launch_sync_subprocess(
 
     ensure_std_fds()
 
-    log_handle = open(log_path, "w")  # noqa: SIM115
+    log_handle = None
     try:
+        log_handle = open(log_path, "w")  # noqa: SIM115
+
+        log_handle.write(f"# dango_version={dango.__version__}\n")
         process = subprocess.Popen(
             [sys.executable, "-m", "dango.platform.scheduling.sync_trigger", json_args],
             cwd=str(project_root),
@@ -157,7 +161,8 @@ def launch_sync_subprocess(
             stderr=subprocess.STDOUT,
         )
     except Exception:
-        log_handle.close()
+        if log_handle is not None:
+            log_handle.close()
         log_path.unlink(missing_ok=True)
         raise
     # Close the handle in the parent process — the child has its own fd copy

--- a/dango/utils/activity_log.py
+++ b/dango/utils/activity_log.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
+import dango
+
 LogLevel = Literal["info", "success", "warning", "error"]
 LogCategory = Literal["core", "auxiliary"]
 
@@ -48,6 +50,7 @@ def log_activity(
         "source": source,
         "message": message.strip(),  # Remove leading/trailing whitespace
         "category": category,
+        "dango_version": dango.__version__,
     }
 
     log_file = get_activity_log_file(project_root)

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -71,6 +71,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             app.state.project_root = project_root
         else:
             raise RuntimeError(_PROJECT_ROOT_ERROR)
+
+    from dango.logging import configure_logging
+
+    configure_logging(log_dir=project_root / ".dango" / "logs")
     logger.info("api_starting", project_root=str(project_root))
 
     # Write auth.yml if missing (migration path for pre-075d projects)
@@ -298,7 +302,7 @@ def create_app(project_root: Path | None = None) -> FastAPI:
     application = FastAPI(
         title="Dango API",
         description="API for managing and monitoring Dango data pipelines",
-        version="0.1.0",
+        version=dango.__version__,
         docs_url=None,  # Disable default docs, we'll create custom ones with navbar
         redoc_url=None,  # Disable default redoc
         lifespan=lifespan,

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+import dango
+
 
 class TableInfo(BaseModel):
     """Table information for multi-resource sources."""
@@ -44,7 +46,7 @@ class ServiceHealth(BaseModel):
     """Service health check response."""
 
     status: str
-    dango_version: str = "0.1.0"
+    dango_version: str = dango.__version__
     services: dict[str, str]
     uptime: str
 

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -12,6 +12,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from starlette.responses import JSONResponse
 
+import dango
 from dango.oauth.storage import OAuthStorage
 from dango.web.helpers import (
     check_service_status_async,
@@ -49,7 +50,7 @@ async def get_status() -> ServiceHealth:
 
     return ServiceHealth(
         status="healthy",
-        dango_version="0.1.0",
+        dango_version=dango.__version__,
         services={
             "api": "running",
             "duckdb": duckdb_status,

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -262,7 +262,12 @@ async def query_redirect(request: Request) -> HTMLResponse:
 @router.get("/api")
 async def api_info() -> dict[str, str]:
     """API information endpoint."""
-    return {"message": "Dango API", "version": "0.1.0", "docs": "/api/docs", "websocket": "/ws"}
+    return {
+        "message": "Dango API",
+        "version": dango.__version__,
+        "docs": "/api/docs",
+        "websocket": "/ws",
+    }
 
 
 @router.get("/api/docs", include_in_schema=False)


### PR DESCRIPTION
## Summary
- Wires up `configure_logging()` at 4 entry points: CLI (`cli()`), web (`lifespan()`), sync subprocess (`sync_trigger.py __main__`), and file watcher (`watcher_runner.main()`)
- Fixes `log_dir` default to check `DANGO_PROJECT_ROOT` env var before falling back to CWD
- Adds `dango_version` to all log schemas: structlog context, activity log, audit log, and sync log file header
- Fixes 4 stale `"0.1.0"` hardcodes in `web/app.py`, `web/models.py`, `web/routes/health.py`, `web/routes/ui.py`

## Verification
- `pytest tests/unit/ -x -q`: **3762 pass, 0 fail, 7 skipped**
- `pytest tests/unit/test_logging.py tests/unit/test_auth_audit.py tests/unit/test_activity_logging_gaps.py`: **59 pass**
- `pytest tests/unit/test_web_imports.py`: **16 pass**
- No remaining `"0.1.0"` hardcodes in the dango package (grep verified)
- Ruff: clean on all 11 modified files

### Live verification (coordinating chat):
1. `dango start` → `.dango/logs/dango.log` includes `dango_version` in structured JSON
2. `.dango/logs/activity.jsonl` entries include `dango_version`
3. `.dango/logs/audit.jsonl` entries include `dango_version`
4. Trigger a sync → `.dango/logs/sync_*.log` starts with `# dango_version=1.0.4`
5. `GET /api/status` → `dango_version` is `"1.0.4"` (not `"0.1.0"`)
6. `GET /api` → `version` is `"1.0.4"` (not `"0.1.0"`)
7. `GET /api/docs` → OpenAPI spec shows correct version
8. `dango --version` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)