### PR TITLE
fix: CLI + frontend fixes (FUP-6, FUP-9, FUP-13, FUP-14)

### DIFF
--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -355,7 +355,7 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
 
         # Create table
         table = Table(show_header=True, header_style="bold cyan")
-        table.add_column("Name", style="white", no_wrap=False)
+        table.add_column("Name", style="white", no_wrap=False, min_width=30)
         table.add_column("Type", style="dim")
         table.add_column("Mode", style="dim")
         table.add_column("Status", style="white")
@@ -609,9 +609,6 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 
 @click.command()
 @click.argument("source_name", required=False, default=None)
-@click.option(
-    "--source", "source_option", help="Sync specific source (deprecated, use positional arg)"
-)
 @click.option("--since", help="Start date for incremental loading (YYYY-MM-DD)")
 @click.option("--until", help="End date for incremental loading (YYYY-MM-DD)")
 @click.option("--backfill", help="Backfill duration (e.g. '7d', '2w', '1m')")
@@ -629,7 +626,6 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 def sync(
     ctx: click.Context,
     source_name: str | None,
-    source_option: str | None,
     since: str | None,
     until: str | None,
     backfill: str | None,
@@ -646,7 +642,6 @@ def sync(
     Examples:
       dango sync                               Sync all enabled sources
       dango sync chess                         Sync only 'chess' source
-      dango sync --source orders               Sync only 'orders' (deprecated form)
       dango sync --since 2024-01-01            Override start date
       dango sync --backfill 30d                Backfill last 30 days
       dango sync --limit 1000                  Dev mode: limit rows per source
@@ -668,10 +663,7 @@ def sync(
 
     check_v01x_project()
 
-    # Resolve source: positional arg takes precedence over --source option
-    if source_option and not source_name:
-        console.print("[yellow]Note:[/yellow] --source is deprecated, use: dango sync <name>")
-    source = source_name or source_option
+    source = source_name
 
     console.print("🍡 [bold]Syncing data...[/bold]")
     console.print()

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -180,36 +180,39 @@ function formatRelativeTime(timestamp) {
     const seconds = Math.floor((now - date) / 1000);
     const fullTimestamp = date.toLocaleString();
 
-    // Small negative values (clock skew up to 60s) → "Just now"
+    // Small negative values (clock skew up to 60s) → "just now"
     // Large negative values → show the actual date (something is wrong)
     if (seconds < -60) {
         return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${date.toLocaleDateString()}</span>`;
     }
     if (seconds < 0) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">Just now</span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">just now</span>`;
     }
 
-    // Compact relative time
+    // Unified thresholds (FUP-13)
     if (seconds < 60) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">Just now</span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">just now</span>`;
     }
     const minutes = Math.floor(seconds / 60);
     if (minutes < 60) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${minutes}m ago</span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${minutes} min ago</span>`;
     }
     const hours = Math.floor(minutes / 60);
     if (hours < 24) {
-        const shortDate = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ', ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${hours}h ago <span class="text-gray-400">\u00b7 ${shortDate}</span></span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${hours}h ago</span>`;
     }
     const days = Math.floor(hours / 24);
     if (days < 7) {
-        const shortDate = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ', ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${days}d ago <span class="text-gray-400">\u00b7 ${shortDate}</span></span>`;
+        const dayTime = date.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${dayTime}</span>`;
     }
 
-    // Older than 7 days — show formatted date
-    return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${date.toLocaleDateString()}</span>`;
+    // 7+ days — month + day, add year if not current year
+    const monthDay = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    if (date.getFullYear() !== now.getFullYear()) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${monthDay}, ${date.getFullYear()}</span>`;
+    }
+    return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${monthDay}</span>`;
 }
 
 // Initialize on page load — conditionally based on which page elements exist

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -51,11 +51,7 @@
                                       x-text="sched.type"></span>
                             </td>
                             <td class="px-6 py-4 text-sm text-gray-500 hidden md:table-cell">
-                                <ul class="list-disc list-inside space-y-0.5">
-                                    <template x-for="src in sched.sources.sort()" :key="src">
-                                        <li x-text="src"></li>
-                                    </template>
-                                </ul>
+                                <span x-text="sched.sources.sort().join(' • ')"></span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
                                 x-text="humanCron(sched.cron)"></td>
@@ -435,7 +431,10 @@ function schedulesPage() {
             if (!iso) return '—';
             let ts = String(iso);
             if (!ts.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(ts)) { ts += 'Z'; }
-            const diff = (new Date() - new Date(ts)) / 1000;
+            const date = new Date(ts);
+            if (isNaN(date.getTime())) return '—';
+            const now = new Date();
+            const diff = (now - date) / 1000;
             if (diff < 0) {
                 const absDiff = Math.abs(diff);
                 if (absDiff < 60) return 'in ' + Math.round(absDiff) + 's';
@@ -443,10 +442,23 @@ function schedulesPage() {
                 if (absDiff < 86400) return 'in ' + Math.round(absDiff / 3600) + 'h';
                 return 'in ' + Math.round(absDiff / 86400) + 'd';
             }
-            if (diff < 60) return Math.round(diff) + 's ago';
-            if (diff < 3600) return Math.round(diff / 60) + ' min ago';
-            if (diff < 86400) return Math.round(diff / 3600) + 'h ago';
-            return Math.round(diff / 86400) + 'd ago';
+            // Unified thresholds (FUP-13)
+            const seconds = Math.floor(diff);
+            if (seconds < 60) return 'just now';
+            const minutes = Math.floor(seconds / 60);
+            if (minutes < 60) return minutes + ' min ago';
+            const hours = Math.floor(minutes / 60);
+            if (hours < 24) return hours + 'h ago';
+            const days = Math.floor(hours / 24);
+            if (days < 7) {
+                return date.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+            }
+            // 7+ days — month + day, add year if not current year
+            const monthDay = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+            if (date.getFullYear() !== now.getFullYear()) {
+                return monthDay + ', ' + date.getFullYear();
+            }
+            return monthDay;
         },
         formatDuration(seconds) {
             if (seconds == null) return '—';


### PR DESCRIPTION
## Summary

Four quality-gate fixes from S2 review:

- **FUP-6:** Add `min_width=30` to source list Name column so long names like `investment_desk_prices_latest` display fully
- **FUP-9:** Remove deprecated `--source` flag from `dango sync` — no real users exist, not worth maintaining backwards compatibility
- **FUP-13:** Standardize `timeAgo()` (schedules.html) and `formatRelativeTime()` (app.js) to identical thresholds: just now → X min ago → Xh ago → day name + time (under 7d) → month + day (over 7d)
- **FUP-14:** Replace `<ul>` bullet list with inline `•` separators in schedules page sources column to prevent text wrapping

## Verification

- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: 216 files already formatted
- `DANGO_LOG_LEVEL=ERROR pytest -x`: 1930 passed, 24 skipped, 1 pre-existing failure (`test_writes_json_to_file` — logging test unrelated to changes)
- `pytest tests/unit/test_cli_sync.py -x -q`: 27 passed
- `pytest tests/unit/test_cli_commands.py tests/unit/test_web_imports.py -x -q`: 29 passed
- Git pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)