### PR TITLE
fix: remove duplicate _is_marimo_responding call + scope log level to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           cache: pip
       - run: pip install -c constraints.txt -e ".[dev]"
       - name: pytest
+        env:
+          DANGO_LOG_LEVEL: ERROR
         run: pytest --tb=short -q
 
   security:

--- a/dango/notebooks/CLAUDE.md
+++ b/dango/notebooks/CLAUDE.md
@@ -9,7 +9,7 @@ Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking
 | File | Lines | Purpose | Key Exports |
 |------|-------|---------|-------------|
 | `__init__.py` | ~45 | Re-exports public symbols | All public API |
-| `manager.py` | ~330 | Marimo process lifecycle (PID file, start/stop/status) + idle auto-shutdown + cloud base-url | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()`, `start_idle_checker()`, `stop_idle_checker()` |
+| `manager.py` | ~353 | Marimo process lifecycle (PID file, start/stop/status) + idle auto-shutdown + cloud base-url | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()`, `start_idle_checker()`, `stop_idle_checker()` |
 | `snapshot.py` | ~143 | DuckDB snapshot management | `create_snapshot()`, `list_snapshots()`, `cleanup_snapshots()` |
 | `locking.py` | ~285 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `expire_stale_locks()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
 | `proxy.py` | ~186 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -107,16 +107,6 @@ def start_marimo(
         config = loader.load_config()
         port = config.platform.marimo_port
 
-    # After force-unlock, marimo may still be running on the configured port.
-    # Check if the port is already responding before starting a new instance.
-    if _is_marimo_responding(port):
-        logger.debug("Marimo already responding on port %d — reusing existing server", port)
-        # PID file may be missing (e.g., after force-unlock), but we can't
-        # recover it without knowing the PID. The server is reachable, so
-        # return success. stop_marimo() won't find a PID to kill — the
-        # process will exit via its own --timeout or manual kill.
-        return None
-
     notebooks_dir = project_root / "notebooks"
     notebooks_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/unit/test_notebook_manager.py
+++ b/tests/unit/test_notebook_manager.py
@@ -30,7 +30,7 @@ class TestGetMarimoPidFilePath:
 @pytest.mark.unit
 class TestStartMarimo:
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     def test_start_creates_pid_file(
@@ -62,7 +62,7 @@ class TestStartMarimo:
             self._call(tmp_path, port=7805)
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     def test_start_cleans_stale_pid(
@@ -328,7 +328,7 @@ class TestStartMarimoCloudBaseUrl:
     """Tests for --base-url flag when running in cloud mode."""
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=3600)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     @patch("dango.config.helpers.is_running_on_cloud", return_value=True)
@@ -358,7 +358,7 @@ class TestStartMarimoCloudBaseUrl:
         assert cmd[idx + 1] == "/notebooks/marimo"
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     @patch("dango.config.helpers.is_running_on_cloud", return_value=False)
@@ -391,7 +391,7 @@ class TestStartMarimoSnapshotPath:
     """Tests for snapshot_path env var in start_marimo()."""
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=True)
     def test_with_snapshot_path_sets_env_var(
         self,
@@ -425,7 +425,7 @@ class TestStartMarimoSnapshotPath:
             assert env["DANGO_NOTEBOOK_DB_PATH"] == str(snapshot)
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=True)
     def test_without_snapshot_no_env_var(
         self,


### PR DESCRIPTION
## Summary

Two anti-pattern fixes before 1.0.5 release:

**Fix 1:** Remove duplicate `_is_marimo_responding()` call in `start_marimo()`. The early-exit guard was redundant when the PID file exists (the PID check already prevents double-start). When the PID file is missing but marimo is still running (force-unlock edge case), the old code silently returned `None` — leaving an unmanageable orphan process. The new code surfaces the problem with a clear `RuntimeError` pointing to the marimo log file, which is a better outcome.

**Fix 2:** Remove `DANGO_LOG_LEVEL=ERROR` from docs where recommended as default pytest invocation. Kept in `ci.yml` only — CI needs clean output, but local dev should see log output for debugging (prevents silent empty log files in tests that call `configure_logging()`).

## Changes

| File | Change |
|------|--------|
| `dango/notebooks/manager.py` | Delete early-exit guard block (-9 lines) |
| `tests/unit/test_notebook_manager.py` | 6 mocks: `side_effect=[False, True]` → `return_value=True` |
| `.github/workflows/ci.yml` | Add `env: DANGO_LOG_LEVEL: ERROR` to pytest step |
| `dango/notebooks/CLAUDE.md` | Update line count: ~330 → ~353 |
| `CLAUDE.md` (workspace) | `DANGO_LOG_LEVEL=ERROR pytest -x` → `pytest -x` |
| `v1.0.x-planning/PROMPTS.md` | 15 occurrences of same replacement |

## Verification

- `ruff check dango/` — clean
- `ruff format --check dango/` — 216 files already formatted
- `pytest -x` (without `DANGO_LOG_LEVEL=ERROR`) — **3900 passed, 31 skipped, 0 fail**
- `grep -rn "DANGO_LOG_LEVEL=ERROR pytest" CLAUDE.md v1.0.x-planning/PROMPTS.md` — zero results
- `grep -n "_is_marimo_responding" dango/dango/notebooks/manager.py` — definition (line 51) + one call site: poll loop (line 167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)