### PR TITLE
merge: v1.0.s2 → main (S2 — 1.0.5 release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           cache: pip
       - run: pip install -c constraints.txt -e ".[dev]"
       - name: pytest
+        env:
+          DANGO_LOG_LEVEL: ERROR
         run: pytest --tb=short -q
 
   security:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,8 +447,8 @@ git checkout main && git pull && git checkout -b feat/<task-name>
 git push -u origin feat/<task-name>
 gh pr create --base main --title "Description" --body "..."
 
-# Merge — Option A (preferred when merge queue is enabled):
-gh pr merge NUMBER --merge-queue
+# Merge — Option A (merge):
+gh pr merge NUMBER --merge
 
 # Merge — Option B (direct merge via API):
 gh api repos/getdango/dango/pulls/NUMBER/merge -X PUT -f merge_method=merge

--- a/constraints.txt
+++ b/constraints.txt
@@ -13,6 +13,7 @@ dlt==1.24.0
 # Transitive — prevent known breakage
 starlette>=1.0.0
 pydantic-core>=2.20.0
+numpy<2.5               # 2.5.0 type stubs break mypy 1.19.1 on Python 3.12
 #
 # Transitive — CVE floor pins (2026-05-14 audit)
 aiohttp>=3.13.4         # 10 CVEs (CVE-2026-34513 through CVE-2026-22815)

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -16,6 +16,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import dango
 from dango.logging import get_logger
 
 _logger = get_logger("dango.auth.audit")
@@ -143,6 +144,7 @@ def log_auth_event(
     entry: dict[str, Any] = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "event": event_type.value,
+        "dango_version": dango.__version__,
     }
     if user_id is not None:
         entry["user_id"] = user_id

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -400,8 +400,17 @@ def start(ctx: click.Context, yes: bool) -> None:
 
         # Auto-clean orphaned Docker containers from previous Dango session
         try:
+            from dango.platform.docker import get_compose_project_name
+
+            compose_project = get_compose_project_name(project_root)
             result = subprocess.run(
-                ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
+                [
+                    "docker",
+                    "ps",
+                    "-q",
+                    "--filter",
+                    f"label=com.docker.compose.project={compose_project}",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -410,7 +419,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                 container_ids = [c for c in result.stdout.strip().split("\n") if c]
                 console.print(
                     f"[yellow]⚠[/yellow]  Found {len(container_ids)} orphaned Docker "
-                    "container(s) from a previous session, cleaning up..."
+                    f"container(s) from a previous session of this project, cleaning up..."
                 )
                 from dango.platform import DockerManager
 
@@ -800,7 +809,7 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
     if stop_all:
         # Create a dummy manager just to call the global cleanup method
         manager = DockerManager(Path.cwd())
-        manager.stop_all_dango_containers()
+        manager.stop_all_dango_containers(all_projects=True)
         console.print()
         console.print("[green]✅ Stopped all Dango containers[/green]")
         console.print()

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -355,7 +355,7 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
 
         # Create table
         table = Table(show_header=True, header_style="bold cyan")
-        table.add_column("Name", style="white", no_wrap=False)
+        table.add_column("Name", style="white", no_wrap=False, min_width=30)
         table.add_column("Type", style="dim")
         table.add_column("Mode", style="dim")
         table.add_column("Status", style="white")
@@ -609,9 +609,6 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 
 @click.command()
 @click.argument("source_name", required=False, default=None)
-@click.option(
-    "--source", "source_option", help="Sync specific source (deprecated, use positional arg)"
-)
 @click.option("--since", help="Start date for incremental loading (YYYY-MM-DD)")
 @click.option("--until", help="End date for incremental loading (YYYY-MM-DD)")
 @click.option("--backfill", help="Backfill duration (e.g. '7d', '2w', '1m')")
@@ -629,7 +626,6 @@ def source_remove(ctx: click.Context, source_name: str, yes: bool) -> None:
 def sync(
     ctx: click.Context,
     source_name: str | None,
-    source_option: str | None,
     since: str | None,
     until: str | None,
     backfill: str | None,
@@ -646,7 +642,6 @@ def sync(
     Examples:
       dango sync                               Sync all enabled sources
       dango sync chess                         Sync only 'chess' source
-      dango sync --source orders               Sync only 'orders' (deprecated form)
       dango sync --since 2024-01-01            Override start date
       dango sync --backfill 30d                Backfill last 30 days
       dango sync --limit 1000                  Dev mode: limit rows per source
@@ -668,10 +663,7 @@ def sync(
 
     check_v01x_project()
 
-    # Resolve source: positional arg takes precedence over --source option
-    if source_option and not source_name:
-        console.print("[yellow]Note:[/yellow] --source is deprecated, use: dango sync <name>")
-    source = source_name or source_option
+    source = source_name
 
     console.print("🍡 [bold]Syncing data...[/bold]")
     console.print()

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -765,6 +765,7 @@ def sync(
                     raise click.Abort()
 
         # Try to acquire lock before running sync (which includes dbt)
+        console.print("\n[bold yellow]⌛ Waiting for lock...[/bold yellow]")
         try:
             lock = DbtLock(
                 project_root=project_root,

--- a/dango/cli/helpers/process_manager.py
+++ b/dango/cli/helpers/process_manager.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 from pathlib import Path
 
+import psutil
 from rich.console import Console
 
 from dango.utils.process import is_process_running, kill_process
@@ -234,6 +235,7 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
             # Check each process to see if it's a Dango process
             dango_pids = []
             other_pids = []
+            resolved_project_root = project_root.resolve()
 
             for proc_pid_str in pids:
                 try:
@@ -252,7 +254,33 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
 
                         # Check if it's a Dango uvicorn process
                         if "uvicorn" in cmd_line and "dango.web.app" in cmd_line:
-                            dango_pids.append(proc_pid)
+                            # Verify CWD matches current project root to avoid
+                            # killing servers from other Dango projects on the same port.
+                            try:
+                                proc = psutil.Process(proc_pid)
+                                proc_cwd = Path(proc.cwd()).resolve()
+                                if proc_cwd == resolved_project_root:
+                                    dango_pids.append(proc_pid)
+                                else:
+                                    other_pids.append((proc_pid, cmd_line))
+                                    if verbose:
+                                        console.print(
+                                            f"  [dim]Skipping Dango process {proc_pid} "
+                                            f"(belongs to different project: {proc_cwd})[/dim]"
+                                        )
+                            except (
+                                psutil.AccessDenied,
+                                psutil.NoSuchProcess,
+                                psutil.ZombieProcess,
+                                OSError,
+                            ) as e:
+                                # Can't verify CWD → don't kill (conservative)
+                                other_pids.append((proc_pid, cmd_line))
+                                if verbose:
+                                    console.print(
+                                        f"  [yellow]⚠[/yellow] Could not verify CWD for "
+                                        f"PID {proc_pid}: {e}"
+                                    )
                         else:
                             other_pids.append((proc_pid, cmd_line))
                 except (ValueError, Exception):

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -55,6 +55,10 @@ def cli(ctx: click.Context) -> None:
     """
     ctx.ensure_object(dict)
 
+    from dango.logging import configure_logging
+
+    configure_logging()
+
     # Warn if the dango binary doesn't match the active venv
     import os
     import sys

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -162,6 +162,9 @@ def _get_analyzer() -> Any | None:
             nlp_configuration={
                 "nlp_engine_name": "spacy",
                 "models": [{"lang_code": "en", "model_name": _SPACY_MODEL}],
+                "ner_model_configuration": {
+                    "labels_to_ignore": ["CARDINAL", "PRODUCT", "MONEY"],
+                },
             }
         )
         _analyzer = AnalyzerEngine(nlp_engine=provider.create_engine())

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -2849,6 +2849,11 @@ def run_sync(
 
     # Post-sync hooks (profiling, drift detection, PII scanning, analysis, notifications)
     if success_sources:
+        if progress_callback is not None:
+            progress_callback(
+                "post_sync_started",
+                "Running post-sync hooks (profiling, PII scan, analysis, snapshots)",
+            )
         try:
             from dango.utils.post_sync import dispatch_post_sync_hooks
 
@@ -2874,5 +2879,7 @@ def run_sync(
                     _src_name,
                     {"post_sync_error": "Post-sync hooks failed (see logs)"},
                 )
+        if progress_callback is not None:
+            progress_callback("post_sync_completed", "Post-sync hooks complete")
 
     return summary

--- a/dango/logging.py
+++ b/dango/logging.py
@@ -129,6 +129,7 @@ def configure_logging(
     log_level: str | None = None,
     log_dir: Path | None = None,
     json_console: bool = False,
+    console_level: str | None = None,
 ) -> None:
     """Configure structured logging for Dango.
 
@@ -142,8 +143,12 @@ def configure_logging(
             falls back to console-only logging with a warning.
         json_console: If True, console output uses JSON. Otherwise uses
             structlog's ``ConsoleRenderer`` (human-readable, colored when TTY).
+        console_level: Logging level for console output only. Defaults to
+            ``"WARNING"`` so that sync progress lines are not printed to the
+            terminal. The file handler continues to use *log_level*.
     """
     level = _resolve_log_level(log_level)
+    resolved_console_level = _resolve_log_level(console_level or "WARNING")
 
     # Resolve log directory
     if log_dir is None:
@@ -170,7 +175,7 @@ def configure_logging(
         "class": "logging.StreamHandler",
         "formatter": console_formatter,
         "stream": "ext://sys.stderr",
-        "level": level,
+        "level": resolved_console_level,
     }
 
     # --- stdlib logging config ---

--- a/dango/logging.py
+++ b/dango/logging.py
@@ -36,6 +36,8 @@ from structlog.contextvars import (
     unbind_contextvars,
 )
 
+import dango
+
 __all__ = [
     "configure_logging",
     "get_logger",
@@ -145,7 +147,11 @@ def configure_logging(
 
     # Resolve log directory
     if log_dir is None:
-        log_dir = Path.cwd() / ".dango" / "logs"
+        project_root_env = os.environ.get("DANGO_PROJECT_ROOT")
+        if project_root_env:
+            log_dir = Path(project_root_env) / ".dango" / "logs"
+        else:
+            log_dir = Path.cwd() / ".dango" / "logs"
 
     # --- Build handlers ---
     handlers: dict[str, dict] = {}
@@ -209,6 +215,9 @@ def configure_logging(
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=False,
     )
+
+    # Bind version at process start — static for the lifetime of the process.
+    bind_contextvars(dango_version=dango.__version__)
 
     if not file_handler_ok:
         logger = get_logger("dango.logging")

--- a/dango/notebooks/CLAUDE.md
+++ b/dango/notebooks/CLAUDE.md
@@ -9,7 +9,7 @@ Marimo notebook server lifecycle, DuckDB read-only snapshots, file-level locking
 | File | Lines | Purpose | Key Exports |
 |------|-------|---------|-------------|
 | `__init__.py` | ~45 | Re-exports public symbols | All public API |
-| `manager.py` | ~330 | Marimo process lifecycle (PID file, start/stop/status) + idle auto-shutdown + cloud base-url | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()`, `start_idle_checker()`, `stop_idle_checker()` |
+| `manager.py` | ~353 | Marimo process lifecycle (PID file, start/stop/status) + idle auto-shutdown + cloud base-url | `get_marimo_pid_file_path()`, `start_marimo()`, `stop_marimo()`, `get_marimo_status()`, `start_idle_checker()`, `stop_idle_checker()` |
 | `snapshot.py` | ~143 | DuckDB snapshot management | `create_snapshot()`, `list_snapshots()`, `cleanup_snapshots()` |
 | `locking.py` | ~285 | File-level notebook locking via `notebook_locks` table | `acquire_lock()`, `release_lock()`, `refresh_lock()`, `force_release_lock()`, `expire_stale_locks()`, `is_locked()`, `get_lock_info()`, `copy_locked_notebook()` |
 | `proxy.py` | ~186 | HTTP + WebSocket reverse proxy to Marimo | `proxy_to_marimo()`, `proxy_websocket_to_marimo()` |

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -107,16 +107,6 @@ def start_marimo(
         config = loader.load_config()
         port = config.platform.marimo_port
 
-    # After force-unlock, marimo may still be running on the configured port.
-    # Check if the port is already responding before starting a new instance.
-    if _is_marimo_responding(port):
-        logger.debug("Marimo already responding on port %d — reusing existing server", port)
-        # PID file may be missing (e.g., after force-unlock), but we can't
-        # recover it without knowing the PID. The server is reachable, so
-        # return success. stop_marimo() won't find a PID to kill — the
-        # process will exit via its own --timeout or manual kill.
-        return None
-
     notebooks_dir = project_root / "notebooks"
     notebooks_dir.mkdir(parents=True, exist_ok=True)
 

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -167,23 +167,15 @@ def start_marimo(
             env=env,
         )
 
-        # Wait for Marimo to start responding (up to 10 seconds).
-        # 1 second is often insufficient on cold start.
-        started = False
-        for _attempt in range(10):
+        # Wait for Marimo to start responding (poll until ready or dead).
+        # Previously used a fixed 10-attempt loop which redirected to an
+        # unready server if marimo was slow to boot (FUP-15).
+        while True:
             time.sleep(1)
             if proc.poll() is not None:
                 raise RuntimeError(f"Marimo failed to start. Check logs at {log_file}")
             if _is_marimo_responding(port, timeout=1.0):
-                started = True
                 break
-
-        if not started:
-            logger.warning(
-                "Marimo process running (PID %d) but not yet responding on port %d",
-                proc.pid,
-                port,
-            )
 
         pid_file.write_text(str(proc.pid))
 

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -256,10 +256,45 @@ class OAuthManager:
 
                     time.sleep(0.5)
 
-                # Timeout — offer retry
+                # Timeout — offer retry with troubleshooting guidance
                 console.print(
-                    f"\n[red]✗ Authorization timeout after {timeout_seconds} seconds[/red]"
+                    f"\n[red]✗ Authorization timed out after {timeout_seconds} seconds[/red]"
                 )
+                console.print(
+                    "\n[yellow]  This usually means your OAuth credentials are incorrect or you did not[/yellow]"
+                )
+                console.print("[yellow]  complete the authorization in the browser.[/yellow]")
+                if provider_name.lower() == "google":
+                    console.print(
+                        "\n[yellow]  Check the following in Google Cloud Console:[/yellow]"
+                    )
+                    console.print(
+                        "[yellow]  1. Your Client ID and Client Secret are correct[/yellow]"
+                    )
+                    console.print(
+                        f"[yellow]  2. The redirect URI [cyan]{self.callback_url}[/cyan] is listed in[/yellow]"
+                    )
+                    console.print(
+                        "[yellow]     Authorized redirect URIs (APIs & Services > Credentials)[/yellow]"
+                    )
+                    console.print(
+                        "[yellow]  3. The required API is enabled (APIs & Services > Library)[/yellow]"
+                    )
+                    console.print(
+                        "[yellow]  4. Your email is added as a Test User (OAuth consent screen)[/yellow]"
+                    )
+                    console.print("[yellow]     if the app is in Testing mode[/yellow]")
+                    console.print(
+                        "\n[yellow]  Link: https://console.cloud.google.com/apis/credentials[/yellow]"
+                    )
+                else:
+                    console.print(
+                        "\n[yellow]  Check that your OAuth credentials are correct and that the[/yellow]"
+                    )
+                    console.print(
+                        f"[yellow]  redirect URI [cyan]{self.callback_url}[/cyan] is configured in your[/yellow]"
+                    )
+                    console.print("[yellow]  provider's developer console.[/yellow]")
                 server.server_close()
                 server_thread.join(timeout=2)
             finally:

--- a/dango/oauth/providers.py
+++ b/dango/oauth/providers.py
@@ -134,113 +134,148 @@ class GoogleOAuthProvider(BaseOAuthProvider):
                         elif line.startswith("GOOGLE_CLIENT_SECRET="):
                             client_secret = line.split("=", 1)[1].strip().strip('"').strip("'")
 
-            if client_id and client_secret:
-                # Credentials found in .env
-                console.print("[green]✓ Found OAuth credentials in .env[/green]")
-                console.print(f"[dim]  Client ID: {client_id[:20]}...{client_id[-10:]}[/dim]\n")
-            else:
-                # Show setup instructions only if credentials not found
-                api_name = self.API_NAMES.get(service, "the required API")
-                instructions = [
-                    "[bold]Prerequisites:[/bold]",
-                    "1. Create a Google Cloud Project at https://console.cloud.google.com/",
-                    "",
-                    "2. Configure the OAuth consent screen:",
-                    "   • Go to APIs & Services > OAuth consent screen",
-                    "   • Select [yellow]External[/yellow] user type > Create",
-                    "   • Fill in App name, User support email, Developer email",
-                    "   • Click through Scopes (no changes needed)",
-                    "   • Add your Google account email as a Test User",
-                    "   • Save and return to dashboard",
-                    "",
-                    f"3. Enable the [bold]{api_name}[/bold]:",
-                    "   • Go to APIs & Services > Library",
-                    f'   • Search for "{api_name}" and click Enable',
-                    "",
-                    "4. Create OAuth 2.0 credentials:",
-                    "   • Go to APIs & Services > Credentials",
-                    "   • Create Credentials > OAuth client ID",
-                    "   • Application type: [yellow]Web application[/yellow]",
-                    f"   • Add Authorized redirect URI: {self.oauth_manager.callback_url}",
-                    "   • Copy the Client ID and Client Secret",
-                    "",
-                    "[yellow]⚠  Testing mode:[/yellow] Tokens expire after 7 days.",
-                    "   To get permanent tokens, publish your app:",
-                    "   OAuth consent screen > Publishing status > [bold]Publish App[/bold]",
-                    "",
-                    "[dim]Tip: Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to .env to skip this step[/dim]",
-                ]
-
-                console.print(
-                    Panel("\n".join(instructions), title="Setup Instructions", border_style="cyan")
-                )
-
-                # Get OAuth client credentials
-                console.print("\n[bold]Enter OAuth Client Credentials:[/bold]")
-                client_id = _clean_pasted_input(Prompt.ask("Client ID"))
-                client_secret = _clean_pasted_input(Prompt.ask("Client Secret", password=True))
-
-                # Save to .env for future Google services (shared credentials)
+            while True:
                 if client_id and client_secret:
-                    from dotenv import set_key
+                    # Credentials found in .env
+                    console.print("[green]✓ Found OAuth credentials in .env[/green]")
+                    console.print(f"[dim]  Client ID: {client_id[:20]}...{client_id[-10:]}[/dim]\n")
+                    # Check if actual Google tokens exist - without tokens, .env creds
+                    # may be stale from a previous failed OAuth flow (P2-3 guard).
+                    has_any_google_token = any(
+                        self.oauth_storage.exists(svc)
+                        for svc in ["google_ads", "google_analytics", "google_sheets"]
+                    )
+                    if not has_any_google_token:
+                        console.print(
+                            "\n[yellow]⚠️  OAuth credentials found in .env but no Google tokens exist.[/yellow]"
+                        )
+                        console.print(
+                            "   [yellow]This can happen if a previous OAuth flow failed to complete.[/yellow]"
+                        )
+                        console.print(
+                            "   [yellow]Check your credentials at: https://console.cloud.google.com/apis/credentials[/yellow]"
+                        )
+                        if Confirm.ask("\n[cyan]Re-enter credentials?[/cyan]", default=False):
+                            from dotenv import unset_key
 
-                    if not env_file.exists():
-                        env_file.touch()
-                    set_key(str(env_file), "GOOGLE_CLIENT_ID", client_id)
-                    set_key(str(env_file), "GOOGLE_CLIENT_SECRET", client_secret)
-                    console.print("[dim]Saved credentials to .env for future use[/dim]")
+                            client_id = ""
+                            client_secret = ""
+                            os.environ.pop("GOOGLE_CLIENT_ID", None)
+                            os.environ.pop("GOOGLE_CLIENT_SECRET", None)
+                            if env_file.exists():
+                                unset_key(str(env_file), "GOOGLE_CLIENT_ID")
+                                unset_key(str(env_file), "GOOGLE_CLIENT_SECRET")
+                            continue
+                else:
+                    # Show setup instructions only if credentials not found
+                    api_name = self.API_NAMES.get(service, "the required API")
+                    instructions = [
+                        "[bold]Prerequisites:[/bold]",
+                        "1. Create a Google Cloud Project at https://console.cloud.google.com/",
+                        "",
+                        "2. Configure the OAuth consent screen:",
+                        "   • Go to APIs & Services > OAuth consent screen",
+                        "   • Select [yellow]External[/yellow] user type > Create",
+                        "   • Fill in App name, User support email, Developer email",
+                        "   • Click through Scopes (no changes needed)",
+                        "   • Add your Google account email as a Test User",
+                        "   • Save and return to dashboard",
+                        "",
+                        f"3. Enable the [bold]{api_name}[/bold]:",
+                        "   • Go to APIs & Services > Library",
+                        f'   • Search for "{api_name}" and click Enable',
+                        "",
+                        "4. Create OAuth 2.0 credentials:",
+                        "   • Go to APIs & Services > Credentials",
+                        "   • Create Credentials > OAuth client ID",
+                        "   • Application type: [yellow]Web application[/yellow]",
+                        f"   • Add Authorized redirect URI: {self.oauth_manager.callback_url}",
+                        "   • Copy the Client ID and Client Secret",
+                        "",
+                        "[yellow]⚠  Testing mode:[/yellow] Tokens expire after 7 days.",
+                        "   To get permanent tokens, publish your app:",
+                        "   OAuth consent screen > Publishing status > [bold]Publish App[/bold]",
+                        "",
+                        "[dim]Tip: Add GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to .env to skip this step[/dim]",
+                    ]
 
-            if not client_id or not client_secret:
-                console.print("[red]✗ Client ID and Secret are required[/red]")
-                return False
+                    console.print(
+                        Panel(
+                            "\n".join(instructions), title="Setup Instructions", border_style="cyan"
+                        )
+                    )
 
-            # Build authorization URL
-            # Combine base scopes (userinfo) with service-specific scopes
-            service_scopes = self.SCOPES.get(service, self.SCOPES["google_ads"])
-            all_scopes = self.BASE_SCOPES + service_scopes
-            state = self.oauth_manager.generate_state()
+                    # Get OAuth client credentials
+                    console.print("\n[bold]Enter OAuth Client Credentials:[/bold]")
+                    client_id = _clean_pasted_input(Prompt.ask("Client ID"))
+                    client_secret = _clean_pasted_input(Prompt.ask("Client Secret", password=True))
 
-            auth_params = {
-                "client_id": client_id,
-                "redirect_uri": self.oauth_manager.callback_url,
-                "response_type": "code",
-                "scope": " ".join(all_scopes),
-                "access_type": "offline",  # Request refresh token
-                "prompt": "consent",  # Force consent screen to get refresh token
-                "state": state,
-            }
+                if not client_id or not client_secret:
+                    console.print("[red]✗ Client ID and Secret are required[/red]")
+                    return None
 
-            auth_url = f"{self.AUTH_URL}?{urlencode(auth_params)}"
+                # Build authorization URL
+                # Combine base scopes (userinfo) with service-specific scopes
+                service_scopes = self.SCOPES.get(service, self.SCOPES["google_ads"])
+                all_scopes = self.BASE_SCOPES + service_scopes
+                state = self.oauth_manager.generate_state()
 
-            # Start OAuth flow
-            console.print("\n[bold]Step 2: Authorize Dango[/bold]")
-            console.print(
-                "\n[yellow]If your app is in Testing mode (the default):[/yellow]"
-                "\n[yellow]  Your browser will show 'Google hasn't verified this app'[/yellow]"
-                "\n[yellow]  Click [bold]Advanced[/bold] → [bold]Go to <app name> "
-                "(unsafe)[/bold] → [bold]Continue[/bold][/yellow]"
-            )
-            console.print(
-                "[yellow]If your app is Published:[/yellow]"
-                "\n[yellow]  You'll see a standard Google consent screen — "
-                "click [bold]Allow[/bold][/yellow]"
-            )
-            oauth_response = self.oauth_manager.start_oauth_flow("Google", auth_url)
+                auth_params = {
+                    "client_id": client_id,
+                    "redirect_uri": self.oauth_manager.callback_url,
+                    "response_type": "code",
+                    "scope": " ".join(all_scopes),
+                    "access_type": "offline",  # Request refresh token
+                    "prompt": "consent",  # Force consent screen to get refresh token
+                    "state": state,
+                }
 
-            if not oauth_response:
-                console.print("[red]✗ OAuth flow failed or timed out[/red]")
-                return False
+                auth_url = f"{self.AUTH_URL}?{urlencode(auth_params)}"
 
-            # Handle re-enter credentials sentinel from start_oauth_flow().
-            # Returning False causes the source wizard's retry loop to call
-            # run_oauth_for_source() again, which re-prompts for credentials.
-            if "action" in oauth_response:
-                return False
+                # Start OAuth flow
+                console.print("\n[bold]Step 2: Authorize Dango[/bold]")
+                console.print(
+                    "\n[yellow]If your app is in Testing mode (the default):[/yellow]"
+                    "\n[yellow]  Your browser will show 'Google hasn't verified this app'[/yellow]"
+                    "\n[yellow]  Click [bold]Advanced[/bold] → [bold]Go to <app name> "
+                    "(unsafe)[/bold] → [bold]Continue[/bold][/yellow]"
+                )
+                console.print(
+                    "[yellow]If your app is Published:[/yellow]"
+                    "\n[yellow]  You'll see a standard Google consent screen — "
+                    "click [bold]Allow[/bold][/yellow]"
+                )
+                oauth_response = self.oauth_manager.start_oauth_flow("Google", auth_url)
+
+                if not oauth_response:
+                    console.print("[red]✗ OAuth flow failed or timed out[/red]")
+                    return None
+
+                # Handle re-enter credentials sentinel from start_oauth_flow().
+                # Clear cached credentials and loop back to the credential prompt
+                # so the user can re-enter immediately without a second prompt.
+                if "action" in oauth_response:
+                    from dotenv import unset_key
+
+                    os.environ.pop("GOOGLE_CLIENT_ID", None)
+                    os.environ.pop("GOOGLE_CLIENT_SECRET", None)
+                    if env_file.exists():
+                        unset_key(str(env_file), "GOOGLE_CLIENT_ID")
+                        unset_key(str(env_file), "GOOGLE_CLIENT_SECRET")
+                    console.print(
+                        "\n[yellow]Cleared cached credentials. Please enter new OAuth credentials.[/yellow]\n"
+                    )
+                    client_id = ""
+                    client_secret = ""
+                    continue
+
+                # Exit loop on successful OAuth callback (has code, not sentinel)
+                break
 
             # Verify state parameter
             if oauth_response.get("state") != state:
                 console.print("[red]✗ Invalid state parameter (possible CSRF attack)[/red]")
-                return False
+                return None
 
             # Exchange authorization code for tokens
             console.print("\n[cyan]Exchanging authorization code for tokens...[/cyan]")
@@ -253,6 +288,18 @@ class GoogleOAuthProvider(BaseOAuthProvider):
             if not tokens:
                 console.print("[red]✗ Token exchange failed[/red]")
                 return None
+
+            # Save OAuth client credentials to .env only after token exchange succeeds.
+            # Token exchange validates the client_id/secret against Google's endpoint.
+            # If invalid, we never reach this point and bad credentials are not persisted.
+            if client_id and client_secret:
+                from dotenv import set_key
+
+                if not env_file.exists():
+                    env_file.touch()
+                set_key(str(env_file), "GOOGLE_CLIENT_ID", client_id)
+                set_key(str(env_file), "GOOGLE_CLIENT_SECRET", client_secret)
+                console.print("[dim]Saved credentials to .env for future use[/dim]")
 
             # Fetch user info to get email (identifier)
             console.print("\n[cyan]Fetching user info...[/cyan]")

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -297,27 +297,50 @@ class DockerManager:
         except Exception:
             pass  # Best-effort, never block stop
 
-    def stop_all_dango_containers(self) -> bool:
+    def stop_all_dango_containers(self, all_projects: bool = False) -> bool:
         """
-        Stop ALL Dango containers globally (from any project).
+        Stop Dango containers.
 
-        This is useful when switching between test projects or when
-        containers from a previous project are still running on required ports.
+        By default, stops only containers belonging to this project (determined
+        by the Docker Compose project label).
+
+        Args:
+            all_projects: If True, stop ALL Dango containers globally (from any
+                project), using name-based filtering. This is useful when
+                switching between test projects or cleaning up containers
+                from a previous naming scheme.
 
         Returns:
             True if successful, False otherwise
         """
-        console.print("Stopping all Dango containers (from any project)...")
+        if all_projects:
+            console.print("Stopping all Dango containers (from any project)...")
+        else:
+            console.print(f"Stopping Dango containers for {self.compose_project_name}...")
 
         try:
-            # Find all containers with Dango service names (metabase, dbt-docs)
-            # These are created by docker-compose with predictable naming
-            result = subprocess.run(
-                ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
+            if all_projects:
+                # Find all containers with Dango service names globally
+                result = subprocess.run(
+                    ["docker", "ps", "-q", "--filter", "name=metabase", "--filter", "name=dbt"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            else:
+                # Find containers belonging to this project via compose project label
+                result = subprocess.run(
+                    [
+                        "docker",
+                        "ps",
+                        "-q",
+                        "--filter",
+                        f"label=com.docker.compose.project={self.compose_project_name}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
 
             if result.returncode != 0:
                 console.print("[yellow]⚠[/yellow]  Could not list Docker containers")
@@ -327,7 +350,8 @@ class DockerManager:
             container_ids = [cid for cid in container_ids if cid]  # Filter empty strings
 
             if not container_ids:
-                console.print("[dim]No Dango containers found running[/dim]")
+                scope = "any project" if all_projects else "this project"
+                console.print(f"[dim]No Dango containers found running for {scope}[/dim]")
                 return True
 
             # Stop the containers
@@ -337,7 +361,10 @@ class DockerManager:
             )
 
             if result.returncode == 0:
-                console.print("[green]✓[/green] Stopped all Dango containers")
+                if all_projects:
+                    console.print("[green]✓[/green] Stopped all Dango containers")
+                else:
+                    console.print("[green]✓[/green] Stopped Dango containers for this project")
                 return True
             else:
                 console.print("[yellow]⚠[/yellow]  Some containers may not have stopped")

--- a/dango/platform/local/watcher_runner.py
+++ b/dango/platform/local/watcher_runner.py
@@ -177,6 +177,10 @@ def run_validate_command(project_root: Path) -> bool:
 def main() -> None:
     """Main entry point for watcher runner"""
 
+    from dango.logging import configure_logging
+
+    configure_logging()
+
     # Get project root from command line argument
     if len(sys.argv) < 2:
         print("Usage: watcher_runner.py <project_root>")

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -495,7 +495,7 @@ def run_scheduled_sync(schedule_name: str, sources: list[str], **kwargs: Any) ->
                 full_refresh=full_refresh,
                 skip_dbt=True,
                 source_label="scheduler",
-                max_lock_wait=300,
+                max_lock_wait=60,
             )
 
             success, _result = poll_sync_status_blocking(
@@ -841,17 +841,20 @@ def run_scheduled_dbt(
 
     try:
         try:
-            lock.acquire()
+            lock.acquire(timeout=60)
         except DbtLockError:
             elapsed = time.monotonic() - t0
             logger.warning(
-                "scheduler_lock_contention", schedule=schedule_name, dbt_command=dbt_command
+                "scheduler_lock_timeout",
+                schedule=schedule_name,
+                dbt_command=dbt_command,
+                timeout_seconds=60,
             )
             _broadcast(
                 {
                     "event": "job_queued",
                     "schedule": schedule_name,
-                    "message": "Lock contention",
+                    "message": "Lock unavailable after 60s wait",
                     "timestamp": _ts(),
                 }
             )

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -117,7 +117,7 @@ def run_manual_sync(
         write_progress: If True, write progress to .dango/state/sync_status.json.
         source_label: Label for the sync trigger (e.g., "ui", "scheduler", "manual").
         skip_dbt: If True, skip dbt run after data load.
-        max_lock_wait: Max seconds to wait for lock (0 = fail immediately).
+        max_lock_wait: Max seconds to wait for lock (0 = use default of 300s).
         sync_id: Unique identifier for the status file (avoids concurrent clobber).
         record_id: Existing execution history record ID to reuse (avoids double records).
 
@@ -191,7 +191,7 @@ def run_manual_sync(
         # Non-OAuth errors during validation: continue (benefit of the doubt)
         logger.warning("pre_sync_validation_error", error=str(e), exc_info=True)
 
-    # --- Lock acquisition with retry ---
+    # --- Lock acquisition ---
     _progress("lock_waiting", "Waiting for lock")
     lock = None
     try:
@@ -200,27 +200,7 @@ def run_manual_sync(
             source=source_label,
             operation=f"sync:{','.join(sources)}",
         )
-
-        acquired = False
-        wait_start = time.time()
-        while not acquired:
-            try:
-                lock.acquire()
-                acquired = True
-            except DbtLockError as exc:
-                elapsed_wait = time.time() - wait_start
-                if elapsed_wait >= max_lock_wait:
-                    error_msg = f"Lock unavailable: {exc}"
-                    record_failure(db_path, record_id, error_msg)
-                    duration = round(time.time() - start_time, 1)
-                    _progress("failed", error_msg, error=error_msg)
-                    return {
-                        "record_id": record_id,
-                        "status": "failed",
-                        "duration_seconds": duration,
-                        "error": error_msg,
-                    }
-                time.sleep(5)
+        lock.acquire(timeout=max_lock_wait or 300)
     except DbtLockError as exc:
         error_msg = f"Lock unavailable: {exc}"
         record_failure(db_path, record_id, error_msg)

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -458,6 +458,10 @@ def _trigger_metabase_schema_scan(project_root: Path) -> None:
 
 
 if __name__ == "__main__":
+    from dango.logging import configure_logging
+
+    configure_logging()
+
     if len(sys.argv) < 2:
         print(
             "Usage: python -m dango.platform.scheduling.sync_trigger '<json>'",

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -493,8 +493,7 @@ def _ts() -> str:
 def _phase_to_event(phase: str) -> str:
     """Map status file phase to a WebSocket event name."""
     mapping = {
-        "starting": "sync_started",
-        "lock_waiting": "sync_progress",
+        "lock_waiting": "sync_queued",
         "data_load": "sync_progress",
         "data_load_complete": "data_load_complete",
         "dbt_started": "dbt_run_all_started",
@@ -519,6 +518,7 @@ async def _broadcast_phase_transition(
     message: dict[str, Any] = {
         "event": event,
         "source": source_name,
+        "phase": phase,
         "message": status.get("message", ""),
         "timestamp": _ts(),
     }

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -118,7 +119,10 @@ def launch_sync_subprocess(
     # Capture subprocess output to a log file (was DEVNULL — silent crashes)
     log_dir = project_root / ".dango" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_path = log_dir / f"sync_{sync_id}.log"
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    source_tag = sources[0].replace("/", "_") if sources else "unknown"
+    log_path = log_dir / f"sync_{source_tag}_{ts}.log"
 
     args_dict: dict[str, Any] = {
         "project_root": str(project_root),
@@ -433,7 +437,6 @@ def _handle_crash(
             recent = load_sync_history(project_root, src, limit=1)
             if recent and recent[0].get("status") in ("failed", "success", "partial"):
                 # Check if this entry is recent (within last 5 minutes)
-                from datetime import datetime, timezone
 
                 entry_ts = recent[0].get("timestamp", "")
                 try:
@@ -485,8 +488,6 @@ def _handle_crash(
 
 def _ts() -> str:
     """UTC ISO timestamp."""
-    from datetime import datetime, timezone
-
     return datetime.now(tz=timezone.utc).isoformat()
 
 

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -495,6 +495,8 @@ def _phase_to_event(phase: str) -> str:
         "dbt_started": "dbt_run_all_started",
         "dbt_complete": "dbt_run_all_completed",
         "dbt_failed": "dbt_run_all_failed",
+        "post_sync_started": "post_sync_started",
+        "post_sync_completed": "post_sync_completed",
         "completed": "sync_completed",
         "failed": "sync_failed",
     }

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+import dango
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
@@ -147,8 +148,11 @@ def launch_sync_subprocess(
 
     ensure_std_fds()
 
-    log_handle = open(log_path, "w")  # noqa: SIM115
+    log_handle = None
     try:
+        log_handle = open(log_path, "w")  # noqa: SIM115
+
+        log_handle.write(f"# dango_version={dango.__version__}\n")
         process = subprocess.Popen(
             [sys.executable, "-m", "dango.platform.scheduling.sync_trigger", json_args],
             cwd=str(project_root),
@@ -157,7 +161,8 @@ def launch_sync_subprocess(
             stderr=subprocess.STDOUT,
         )
     except Exception:
-        log_handle.close()
+        if log_handle is not None:
+            log_handle.close()
         log_path.unlink(missing_ok=True)
         raise
     # Close the handle in the parent process — the child has its own fd copy

--- a/dango/templates/dbt/staging_model.sql.j2
+++ b/dango/templates/dbt/staging_model.sql.j2
@@ -28,8 +28,14 @@
     schema='staging'
 {{ ") }}" }}
 
-{% if date_cast_columns %}
-SELECT * REPLACE ({% for col in date_cast_columns %}CAST({{ col }} AS DATE) AS {{ col }}{% if not loop.last %}, {% endif %}{% endfor %}) FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
-{% else %}
-SELECT * FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
-{% endif %}
+WITH source AS (
+    SELECT * FROM {{ "{{ source('" ~ source_name ~ "', '" ~ table_name ~ "') }}" }}
+),
+renamed AS (
+    SELECT
+{% for col in staging_columns %}
+{{ "        " }}{% if col.name in date_cast_columns %}CAST({{ col.quoted_name }} AS DATE) AS {{ col.quoted_name }}{% else %}{{ col.quoted_name }}{% endif %}{% if not loop.last %},{% endif +%}
+{% endfor %}
+    FROM source
+)
+SELECT * FROM renamed

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -3,6 +3,7 @@
 Automatically generates dbt staging models from configured data sources.
 """
 
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,13 @@ def _has_not_null_test(tests: list) -> bool:
         if isinstance(test, dict) and "not_null" in test:
             return True
     return False
+
+
+def _quote_column_name(name: str) -> str:
+    """Double-quote a column name if it contains special characters."""
+    if name and all(c.isalnum() or c == "_" for c in name):
+        return name
+    return f'"{name}"'
 
 
 class DbtModelGenerator:
@@ -320,6 +328,7 @@ class DbtModelGenerator:
         dedup_strategy: str | None = None,
         dedup_columns: list[str] | None = None,
         date_cast_columns: list[str] | None = None,
+        staging_columns: list[dict] | None = None,
     ) -> str:
         """
         Generate staging model SQL for a data source
@@ -330,6 +339,8 @@ class DbtModelGenerator:
             schema_name: Schema name in DuckDB (raw or raw_{source_name})
             dedup_strategy: Deduplication strategy (one of DEDUP_STRATEGIES keys)
             dedup_columns: Columns to use for deduplication
+            date_cast_columns: Columns to CAST from TIMESTAMPTZ to DATE
+            staging_columns: Column definitions with "name" and "type" keys for explicit listing
 
         Returns:
             Generated SQL content
@@ -341,6 +352,16 @@ class DbtModelGenerator:
                 f"Invalid dedup_strategy '{dedup_strategy}'. Must be one of: {valid_strategies}"
             )
 
+        # Prepare columns with quoted names for the template
+        prepared_columns = []
+        for col in staging_columns or []:
+            prepared_columns.append(
+                {
+                    "name": col["name"],
+                    "quoted_name": _quote_column_name(col["name"]),
+                }
+            )
+
         # Template context
         context = {
             "source_name": source.name,
@@ -350,6 +371,7 @@ class DbtModelGenerator:
             "dedup_strategy": dedup_strategy,
             "dedup_columns": dedup_columns or [],
             "date_cast_columns": date_cast_columns or [],
+            "staging_columns": prepared_columns,
             "generated_at": datetime.now().isoformat(),
         }
 
@@ -573,7 +595,10 @@ class DbtModelGenerator:
                     date_cast_columns: list[str] = []
                     if source.type.value == "google_analytics":
                         for col in staging_columns:
-                            if col["name"] == "date" and "TIMESTAMP" in col["type"].upper():
+                            if (
+                                re.search(r"\bdate\b", col["name"].lower())
+                                and "TIMESTAMP" in col["type"].upper()
+                            ):
                                 date_cast_columns.append(col["name"])
 
                     # Generate staging model SQL
@@ -584,6 +609,7 @@ class DbtModelGenerator:
                         dedup_strategy=dedup_strategy,
                         dedup_columns=dedup_columns,
                         date_cast_columns=date_cast_columns,
+                        staging_columns=staging_columns,
                     )
 
                     # Write model file

--- a/dango/utils/activity_log.py
+++ b/dango/utils/activity_log.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
+import dango
+
 LogLevel = Literal["info", "success", "warning", "error"]
 LogCategory = Literal["core", "auxiliary"]
 
@@ -48,6 +50,7 @@ def log_activity(
         "source": source,
         "message": message.strip(),  # Remove leading/trailing whitespace
         "category": category,
+        "dango_version": dango.__version__,
     }
 
     log_file = get_activity_log_file(project_root)

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -146,13 +146,13 @@ class DbtLock:
 
         return False
 
-    def acquire(self, timeout: float = 30) -> bool:
+    def acquire(self, timeout: float = 300) -> bool:
         """
         Acquire the lock.
 
         Args:
             timeout: Maximum time to wait for the lock (0 = don't wait).
-                Retries every 1 second until timeout is reached.
+                Retries every 3 seconds until timeout is reached.
 
         Returns:
             True if lock was acquired
@@ -196,31 +196,19 @@ class DbtLock:
 
                 # Retry if we still have time
                 if time.monotonic() < deadline:
-                    time.sleep(1)
+                    lock_info = self._read_lock_info()
+                    if lock_info:
+                        logger.info(
+                            "Waiting for dbt lock... (held by PID %d)",
+                            lock_info.get("pid", "unknown"),
+                        )
+                    else:
+                        logger.info("Waiting for dbt lock...")
+                    time.sleep(3)
                     continue
 
                 lock_info = self._read_lock_info()
-
-                # Build a helpful error message
-                if lock_info:
-                    source = lock_info.get("source", "unknown")
-                    operation = lock_info.get("operation", "unknown operation")
-                    started_at = lock_info.get("started_at", "unknown time")
-                    pid = lock_info.get("pid", "unknown")
-
-                    message = (
-                        f"Another sync operation is currently running.\n"
-                        f"Source: {source}\n"
-                        f"Operation: {operation}\n"
-                        f"Started at: {started_at}\n"
-                        f"Process ID: {pid}\n"
-                        f"Please wait for it to complete before starting a new operation."
-                    )
-                else:
-                    message = (
-                        "Another sync operation is currently running. "
-                        "Please wait for it to complete before starting a new operation."
-                    )
+                message = "Sync queue timeout. Another sync is still running."
 
                 raise DbtLockError(message, lock_info=lock_info) from None
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -71,6 +71,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             app.state.project_root = project_root
         else:
             raise RuntimeError(_PROJECT_ROOT_ERROR)
+
+    from dango.logging import configure_logging
+
+    configure_logging(log_dir=project_root / ".dango" / "logs")
     logger.info("api_starting", project_root=str(project_root))
 
     # Write auth.yml if missing (migration path for pre-075d projects)
@@ -298,7 +302,7 @@ def create_app(project_root: Path | None = None) -> FastAPI:
     application = FastAPI(
         title="Dango API",
         description="API for managing and monitoring Dango data pipelines",
-        version="0.1.0",
+        version=dango.__version__,
         docs_url=None,  # Disable default docs, we'll create custom ones with navbar
         redoc_url=None,  # Disable default redoc
         lifespan=lifespan,

--- a/dango/web/models.py
+++ b/dango/web/models.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+import dango
+
 
 class TableInfo(BaseModel):
     """Table information for multi-resource sources."""
@@ -44,7 +46,7 @@ class ServiceHealth(BaseModel):
     """Service health check response."""
 
     status: str
-    dango_version: str = "0.1.0"
+    dango_version: str = dango.__version__
     services: dict[str, str]
     uptime: str
 

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -12,6 +12,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from starlette.responses import JSONResponse
 
+import dango
 from dango.oauth.storage import OAuthStorage
 from dango.web.helpers import (
     check_service_status_async,
@@ -49,7 +50,7 @@ async def get_status() -> ServiceHealth:
 
     return ServiceHealth(
         status="healthy",
-        dango_version="0.1.0",
+        dango_version=dango.__version__,
         services={
             "api": "running",
             "duckdb": duckdb_status,

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -262,7 +262,12 @@ async def query_redirect(request: Request) -> HTMLResponse:
 @router.get("/api")
 async def api_info() -> dict[str, str]:
     """API information endpoint."""
-    return {"message": "Dango API", "version": "0.1.0", "docs": "/api/docs", "websocket": "/ws"}
+    return {
+        "message": "Dango API",
+        "version": dango.__version__,
+        "docs": "/api/docs",
+        "websocket": "/ws",
+    }
 
 
 @router.get("/api/docs", include_in_schema=False)

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -37,6 +37,7 @@ let isLoadingSources = false;
 let isLoadingStatus = false;
 // Track active syncs: Map<sourceName, startTimestamp>
 let activeSyncs = new Map();
+let postSyncSources = new Set();  // sources currently in post-sync hook phase
 // Track pending loadSources retry timeout
 let loadSourcesRetryTimeout = null;
 // Track active upload/delete operations to prevent premature loadSources() retries
@@ -80,7 +81,12 @@ function startSyncTimer(sourceName) {
     const timerId = setInterval(() => {
         const elapsed = Math.floor((Date.now() - startTime) / 1000);
         const btn = document.getElementById(`sync-btn-${sourceName}`);
-        if (btn) btn.textContent = `Syncing... ${formatElapsed(elapsed)}`;
+        if (btn) {
+            const isPostSync = postSyncSources.has(sourceName);
+            btn.textContent = isPostSync
+                ? `Processing... ${formatElapsed(elapsed)}`
+                : `Syncing... ${formatElapsed(elapsed)}`;
+        }
     }, 1000);
     syncTimers.set(sourceName, timerId);
 }
@@ -475,6 +481,7 @@ async function handleWebSocketMessage(data) {
 
             // Clean up sync state and refresh
             activeSyncs.delete(source);
+            postSyncSources.delete(source);
             updateSyncCounter();
             loadSources();  // Reload from API to get correct status
             // Fallback: if activeSyncs wasn't set (e.g. upload-triggered sync),
@@ -496,6 +503,7 @@ async function handleWebSocketMessage(data) {
             console.log('❌ [WS] sync_failed - Source:', source);
             stopSyncTimer(source);
             activeSyncs.delete(source);
+            postSyncSources.delete(source);
             updateSyncCounter();  // Update header counter
             addLogEntry('error', message || `Sync failed`, source);
             showToast(`${source} sync failed`, 'error');
@@ -593,6 +601,18 @@ async function handleWebSocketMessage(data) {
             loadDbtModels();
             break;
 
+        case 'post_sync_started':
+            console.log('🟣 [WS] post_sync_started - Source:', source);
+            postSyncSources.add(source);
+            renderSourcesTable();
+            break;
+
+        case 'post_sync_completed':
+            console.log('🟣 [WS] post_sync_completed - Source:', source);
+            postSyncSources.delete(source);
+            renderSourcesTable();
+            break;
+
         case 'dbt_run_failed':
             console.log('❌ [WS] dbt_run_failed - Individual model:', source);
             addLogEntry('error', message, source);
@@ -626,6 +646,7 @@ async function handleWebSocketMessage(data) {
                 // DO clear activeSyncs since the operation failed
                 if (activeSyncs.has(triggeredSource)) {
                     activeSyncs.delete(triggeredSource);
+                    postSyncSources.delete(triggeredSource);
                     stopSyncTimer(triggeredSource);
                     const btn = document.getElementById(`sync-btn-${triggeredSource}`);
                     if (btn) btn.textContent = 'Sync Now';
@@ -679,8 +700,10 @@ function updateSyncCounter() {
 
     // If syncing, show count
     if (count > 0) {
+        const allInPostSync = postSyncSources.size > 0 && postSyncSources.size === count;
+        const prefix = allInPostSync ? 'Processing' : 'Syncing';
         const plural = count === 1 ? 'source' : 'sources';
-        text.textContent = `Syncing ${count} ${plural}...`;
+        text.textContent = `${prefix} ${count} ${plural}...`;
         text.className = 'text-xs sm:text-sm text-blue-600 font-medium animate-pulse-slow';
     } else if (ws && ws.readyState === WebSocket.OPEN) {
         // Connected and not syncing
@@ -1188,12 +1211,15 @@ function renderSourcesTable() {
     tbody.innerHTML = sources.map(source => {
         const isSyncing = activeSyncs.has(source.name);
         const hasFileOps = activeFileOperations.has(source.name);
+        const isPostSync = postSyncSources.has(source.name);
         const isDisabled = isSyncing || hasFileOps;
 
-        console.log(`🎨 [renderSourcesTable] Source "${source.name}": isSyncing=${isSyncing}, hasFileOps=${hasFileOps}, status="${source.status}"`);
+        console.log(`🎨 [renderSourcesTable] Source "${source.name}": isSyncing=${isSyncing}, hasFileOps=${hasFileOps}, isPostSync=${isPostSync}, status="${source.status}"`);
 
         const buttonDisabled = isDisabled ? 'disabled' : '';
-        const buttonText = isSyncing ? 'Syncing...' : (hasFileOps ? 'Processing...' : 'Sync Now');
+        const buttonText = isSyncing
+            ? (isPostSync ? 'Processing...' : 'Syncing...')
+            : (hasFileOps ? 'Processing...' : 'Sync Now');
 
         // For file sources (csv/local_files), clicking the row opens upload modal
         // For other sources, clicking the row opens detail modal
@@ -1351,6 +1377,9 @@ function renderStatusPill(source, isSyncing, hasFileOps) {
         // Distinguish dbt-building from data-loading
         if (dbtRunStartTime !== null) {
             return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800 animate-pulse">🔨 Building models...</span>';
+        }
+        if (postSyncSources.has(source.name)) {
+            return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800 animate-pulse">⚙️ Processing...</span>';
         }
         return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 animate-pulse">⏳ Syncing...</span>';
     }

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -167,52 +167,16 @@ function getTotalFileOperations() {
 function formatRelativeTime(timestamp) {
     if (!timestamp) return 'Never';
 
-    // Server sends UTC timestamps (with +00:00 or Z suffix).
-    // For legacy naive timestamps, append 'Z' so the browser treats them as UTC.
+    const text = timeAgoIso(timestamp);
+    if (text === '\u2014') return 'Invalid date';
+
+    // Build full timestamp for the tooltip
     let ts = String(timestamp);
-    if (!ts.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(ts)) {
-        ts += 'Z';
-    }
+    if (!ts.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(ts)) ts += 'Z';
     const date = new Date(ts);
-    if (isNaN(date.getTime())) return 'Invalid date';
+    const fullTimestamp = isNaN(date.getTime()) ? String(timestamp) : date.toLocaleString();
 
-    const now = new Date();
-    const seconds = Math.floor((now - date) / 1000);
-    const fullTimestamp = date.toLocaleString();
-
-    // Small negative values (clock skew up to 60s) → "just now"
-    // Large negative values → show the actual date (something is wrong)
-    if (seconds < -60) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${date.toLocaleDateString()}</span>`;
-    }
-    if (seconds < 0) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">just now</span>`;
-    }
-
-    // Unified thresholds (FUP-13)
-    if (seconds < 60) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">just now</span>`;
-    }
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${minutes} min ago</span>`;
-    }
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${hours}h ago</span>`;
-    }
-    const days = Math.floor(hours / 24);
-    if (days < 7) {
-        const dayTime = date.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${dayTime}</span>`;
-    }
-
-    // 7+ days — month + day, add year if not current year
-    const monthDay = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-    if (date.getFullYear() !== now.getFullYear()) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${monthDay}, ${date.getFullYear()}</span>`;
-    }
-    return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${monthDay}</span>`;
+    return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${text}</span>`;
 }
 
 // Initialize on page load — conditionally based on which page elements exist

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -180,36 +180,39 @@ function formatRelativeTime(timestamp) {
     const seconds = Math.floor((now - date) / 1000);
     const fullTimestamp = date.toLocaleString();
 
-    // Small negative values (clock skew up to 60s) → "Just now"
+    // Small negative values (clock skew up to 60s) → "just now"
     // Large negative values → show the actual date (something is wrong)
     if (seconds < -60) {
         return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${date.toLocaleDateString()}</span>`;
     }
     if (seconds < 0) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">Just now</span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">just now</span>`;
     }
 
-    // Compact relative time
+    // Unified thresholds (FUP-13)
     if (seconds < 60) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">Just now</span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">just now</span>`;
     }
     const minutes = Math.floor(seconds / 60);
     if (minutes < 60) {
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${minutes}m ago</span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${minutes} min ago</span>`;
     }
     const hours = Math.floor(minutes / 60);
     if (hours < 24) {
-        const shortDate = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ', ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${hours}h ago <span class="text-gray-400">\u00b7 ${shortDate}</span></span>`;
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${hours}h ago</span>`;
     }
     const days = Math.floor(hours / 24);
     if (days < 7) {
-        const shortDate = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ', ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${days}d ago <span class="text-gray-400">\u00b7 ${shortDate}</span></span>`;
+        const dayTime = date.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${dayTime}</span>`;
     }
 
-    // Older than 7 days — show formatted date
-    return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${date.toLocaleDateString()}</span>`;
+    // 7+ days — month + day, add year if not current year
+    const monthDay = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    if (date.getFullYear() !== now.getFullYear()) {
+        return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${monthDay}, ${date.getFullYear()}</span>`;
+    }
+    return `<span data-tooltip="${fullTimestamp}" class="tooltip cursor-help">${monthDay}</span>`;
 }
 
 // Initialize on page load — conditionally based on which page elements exist

--- a/dango/web/static/js/utils.js
+++ b/dango/web/static/js/utils.js
@@ -1,0 +1,41 @@
+// Shared Dango frontend utilities. Loaded in base.html before page scripts.
+
+/**
+ * Format an ISO timestamp for display.
+ * Thresholds: <60s "just now", <1h "X min ago", <24h "Xh ago",
+ * <7d "Mon 15:39", >=7d "Jun 16" (with year if not current).
+ *
+ * @param {string} iso - ISO 8601 timestamp string
+ * @returns {string} formatted relative time string
+ */
+function timeAgoIso(iso) {
+    if (!iso) return '\u2014';  // em dash
+    let ts = String(iso);
+    if (!ts.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(ts)) ts += 'Z';
+    const date = new Date(ts);
+    if (isNaN(date.getTime())) return '\u2014';
+    const now = new Date();
+    const diff = (now - date) / 1000;
+    if (diff < 0) {
+        const absDiff = Math.abs(diff);
+        if (absDiff < 60) return 'in ' + Math.round(absDiff) + 's';
+        if (absDiff < 3600) return 'in ' + Math.round(absDiff / 60) + ' min';
+        if (absDiff < 86400) return 'in ' + Math.round(absDiff / 3600) + 'h';
+        return 'in ' + Math.round(absDiff / 86400) + 'd';
+    }
+    const seconds = Math.floor(diff);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return minutes + ' min ago';
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return hours + 'h ago';
+    const days = Math.floor(hours / 24);
+    if (days < 7) {
+        return date.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    }
+    const monthDay = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    if (date.getFullYear() !== now.getFullYear()) {
+        return monthDay + ', ' + date.getFullYear();
+    }
+    return monthDay;
+}

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -75,11 +75,11 @@
                     <!-- Global sync status indicator -->
                     <div x-show="activeSyncCount > 0" x-cloak
                          class="flex items-center space-x-1.5 px-2 py-1 rounded-md bg-gray-700 text-xs text-gray-200">
-                        <svg class="animate-spin h-3.5 w-3.5 text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <svg class="animate-spin h-3.5 w-3.5" :class="_postSyncSources.size === activeSyncCount ? 'text-purple-400' : 'text-blue-400'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
                         </svg>
-                        <span x-text="'Syncing ' + activeSyncCount + ' source' + (activeSyncCount > 1 ? 's' : '')"></span>
+                        <span x-text="(_postSyncSources.size === activeSyncCount ? 'Processing' : 'Syncing') + ' ' + activeSyncCount + ' source' + (activeSyncCount > 1 ? 's' : '')"></span>
                     </div>
                     {% if request.state.user %}
                     <span class="text-xs text-gray-400 hidden lg:inline mr-2">{{ request.state.user.email }}</span>
@@ -164,6 +164,7 @@
         return {
             activeSyncCount: 0,
             _activeSources: new Set(),
+            _postSyncSources: new Set(),
             _ws: null,
             _reconnectTimer: null,
             init() {
@@ -183,8 +184,13 @@
                         const source = data.source || '';
                         if (data.event === 'sync_started' && source) {
                             this._activeSources.add(source);
+                        } else if (data.event === 'post_sync_started' && source) {
+                            this._postSyncSources.add(source);
+                        } else if (data.event === 'post_sync_completed' && source) {
+                            this._postSyncSources.delete(source);
                         } else if ((data.event === 'sync_completed' || data.event === 'sync_failed') && source) {
                             this._activeSources.delete(source);
+                            this._postSyncSources.delete(source);
                         }
                         this.activeSyncCount = this._activeSources.size;
                     } catch {}

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -15,6 +15,9 @@
     <!-- Alpine.js via CDN (ADR-007: used for new page interactivity) -->
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
 
+    <!-- Shared Dango utilities (timeAgoIso, etc.) -->
+    <script src="{{ static_url('js/utils.js') }}"></script>
+
     <style>[x-cloak] { display: none !important; }</style>
 </head>
 <body class="bg-gray-50">

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -72,14 +72,19 @@
 
                 <!-- Right side: sync indicator + user email + settings gear + hamburger (mobile) -->
                 <div class="flex items-center space-x-2 ml-auto" x-data="globalSyncIndicator()" x-init="init()">
-                    <!-- Global sync status indicator -->
-                    <div x-show="activeSyncCount > 0" x-cloak
+                    <!-- Global sync status indicator (queued + active) -->
+                    <div x-show="queuedCount > 0 || activeSyncCount > 0" x-cloak
                          class="flex items-center space-x-1.5 px-2 py-1 rounded-md bg-gray-700 text-xs text-gray-200">
-                        <svg class="animate-spin h-3.5 w-3.5" :class="_postSyncSources.size === activeSyncCount ? 'text-purple-400' : 'text-blue-400'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <!-- Clock icon when queued (not yet syncing) -->
+                        <svg x-show="activeSyncCount === 0 && queuedCount > 0" class="h-3.5 w-3.5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                        </svg>
+                        <!-- Spinner when actively syncing (purple = post-sync, blue = syncing) -->
+                        <svg x-show="activeSyncCount > 0" class="animate-spin h-3.5 w-3.5" :class="_postSyncSources.size === activeSyncCount && activeSyncCount > 0 ? 'text-purple-400' : 'text-blue-400'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
                         </svg>
-                        <span x-text="(_postSyncSources.size === activeSyncCount ? 'Processing' : 'Syncing') + ' ' + activeSyncCount + ' source' + (activeSyncCount > 1 ? 's' : '')"></span>
+                        <span x-text="statusText"></span>
                     </div>
                     {% if request.state.user %}
                     <span class="text-xs text-gray-400 hidden lg:inline mr-2">{{ request.state.user.email }}</span>
@@ -163,8 +168,10 @@
     function globalSyncIndicator() {
         return {
             activeSyncCount: 0,
+            queuedCount: 0,
             _activeSources: new Set(),
             _postSyncSources: new Set(),
+            _queuedSources: new Set(),
             _ws: null,
             _reconnectTimer: null,
             init() {
@@ -174,6 +181,18 @@
                 if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
                 if (this._ws) this._ws.close();
             },
+            get statusText() {
+                if (this.activeSyncCount > 0) {
+                    let verb = this._postSyncSources.size === this.activeSyncCount ? 'Processing' : 'Syncing';
+                    let text = verb + ' ' + this.activeSyncCount;
+                    if (this.queuedCount > 0) text += ' (+' + this.queuedCount + ' queued)';
+                    return text;
+                }
+                if (this.queuedCount > 0) {
+                    return 'Queued ' + this.queuedCount + ' source' + (this.queuedCount > 1 ? 's' : '');
+                }
+                return '';
+            },
             _connect() {
                 const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
                 this._ws = new WebSocket(`${proto}//${location.host}/ws`);
@@ -182,7 +201,14 @@
                     try {
                         const data = JSON.parse(e.data);
                         const source = data.source || '';
-                        if (data.event === 'sync_started' && source) {
+                        if (data.event === 'sync_queued' && source) {
+                            this._activeSources.delete(source);
+                            this._queuedSources.add(source);
+                        } else if (data.event === 'sync_started' && source) {
+                            this._queuedSources.delete(source);
+                            this._activeSources.add(source);
+                        } else if (data.event === 'sync_progress' && source && data.phase === 'data_load' && this._queuedSources.has(source)) {
+                            this._queuedSources.delete(source);
                             this._activeSources.add(source);
                         } else if (data.event === 'post_sync_started' && source) {
                             this._postSyncSources.add(source);
@@ -191,8 +217,10 @@
                         } else if ((data.event === 'sync_completed' || data.event === 'sync_failed') && source) {
                             this._activeSources.delete(source);
                             this._postSyncSources.delete(source);
+                            this._queuedSources.delete(source);
                         }
                         this.activeSyncCount = this._activeSources.size;
+                        this.queuedCount = this._queuedSources.size;
                     } catch {}
                 };
                 this._ws.onclose = () => {

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -428,37 +428,7 @@ function schedulesPage() {
             return m[status] || 'bg-gray-100 text-gray-800';
         },
         timeAgo(iso) {
-            if (!iso) return '—';
-            let ts = String(iso);
-            if (!ts.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(ts)) { ts += 'Z'; }
-            const date = new Date(ts);
-            if (isNaN(date.getTime())) return '—';
-            const now = new Date();
-            const diff = (now - date) / 1000;
-            if (diff < 0) {
-                const absDiff = Math.abs(diff);
-                if (absDiff < 60) return 'in ' + Math.round(absDiff) + 's';
-                if (absDiff < 3600) return 'in ' + Math.round(absDiff / 60) + ' min';
-                if (absDiff < 86400) return 'in ' + Math.round(absDiff / 3600) + 'h';
-                return 'in ' + Math.round(absDiff / 86400) + 'd';
-            }
-            // Unified thresholds (FUP-13)
-            const seconds = Math.floor(diff);
-            if (seconds < 60) return 'just now';
-            const minutes = Math.floor(seconds / 60);
-            if (minutes < 60) return minutes + ' min ago';
-            const hours = Math.floor(minutes / 60);
-            if (hours < 24) return hours + 'h ago';
-            const days = Math.floor(hours / 24);
-            if (days < 7) {
-                return date.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-            }
-            // 7+ days — month + day, add year if not current year
-            const monthDay = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-            if (date.getFullYear() !== now.getFullYear()) {
-                return monthDay + ', ' + date.getFullYear();
-            }
-            return monthDay;
+            return timeAgoIso(iso);
         },
         formatDuration(seconds) {
             if (seconds == null) return '—';

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -50,8 +50,13 @@
                                       :class="sched.type.startsWith('sync') ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800'"
                                       x-text="sched.type"></span>
                             </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden md:table-cell"
-                                x-text="sched.sources.join(', ')"></td>
+                            <td class="px-6 py-4 text-sm text-gray-500 hidden md:table-cell">
+                                <ul class="list-disc list-inside space-y-0.5">
+                                    <template x-for="src in sched.sources.sort()" :key="src">
+                                        <li x-text="src"></li>
+                                    </template>
+                                </ul>
+                            </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
                                 x-text="humanCron(sched.cron)"></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden lg:table-cell"

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -51,11 +51,7 @@
                                       x-text="sched.type"></span>
                             </td>
                             <td class="px-6 py-4 text-sm text-gray-500 hidden md:table-cell">
-                                <ul class="list-disc list-inside space-y-0.5">
-                                    <template x-for="src in sched.sources.sort()" :key="src">
-                                        <li x-text="src"></li>
-                                    </template>
-                                </ul>
+                                <span x-text="sched.sources.sort().join(' • ')"></span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
                                 x-text="humanCron(sched.cron)"></td>
@@ -435,7 +431,10 @@ function schedulesPage() {
             if (!iso) return '—';
             let ts = String(iso);
             if (!ts.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(ts)) { ts += 'Z'; }
-            const diff = (new Date() - new Date(ts)) / 1000;
+            const date = new Date(ts);
+            if (isNaN(date.getTime())) return '—';
+            const now = new Date();
+            const diff = (now - date) / 1000;
             if (diff < 0) {
                 const absDiff = Math.abs(diff);
                 if (absDiff < 60) return 'in ' + Math.round(absDiff) + 's';
@@ -443,10 +442,23 @@ function schedulesPage() {
                 if (absDiff < 86400) return 'in ' + Math.round(absDiff / 3600) + 'h';
                 return 'in ' + Math.round(absDiff / 86400) + 'd';
             }
-            if (diff < 60) return Math.round(diff) + 's ago';
-            if (diff < 3600) return Math.round(diff / 60) + ' min ago';
-            if (diff < 86400) return Math.round(diff / 3600) + 'h ago';
-            return Math.round(diff / 86400) + 'd ago';
+            // Unified thresholds (FUP-13)
+            const seconds = Math.floor(diff);
+            if (seconds < 60) return 'just now';
+            const minutes = Math.floor(seconds / 60);
+            if (minutes < 60) return minutes + ' min ago';
+            const hours = Math.floor(minutes / 60);
+            if (hours < 24) return hours + 'h ago';
+            const days = Math.floor(hours / 24);
+            if (days < 7) {
+                return date.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+            }
+            // 7+ days — month + day, add year if not current year
+            const monthDay = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+            if (date.getFullYear() !== now.getFullYear()) {
+                return monthDay + ', ' + date.getFullYear();
+            }
+            return monthDay;
         },
         formatDuration(seconds) {
             if (seconds == null) return '—';

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -104,6 +104,18 @@ exemptions:
     reason: "Platform lifecycle commands (start/stop/status) + port helpers. Extracted from cli/main.py by TASK-005. Further splitting would scatter tightly coupled startup/shutdown logic. R12-I2 added cloud systemd status check."
     review_by: "v1.1"
 
+  - file: dango/platform/docker.py
+    lines: 508
+    category: exempt
+    reason: "P0-3: Added all_projects parameter and conditional docker ps filtering for project-scoped container cleanup (+26 lines). Marginally over limit."
+    review_by: "v1.1"
+
+  - file: tests/unit/test_process_manager.py
+    lines: 619
+    category: exempt
+    reason: "P0-3: Added 3 new tests for CWD-verified port fallback (cross-project isolation, CWD unreadable, symlink resolution) (+120 lines). Test files are verbose by design."
+    review_by: "v1.1"
+
   - file: dango/cli/commands/oauth.py
     lines: 813
     category: exempt

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -487,6 +487,12 @@ exemptions:
     reason: "R12-L: v1.6 with 107 checks across 12 categories. Categories 10-12 cover R12 fix regression tests. Linear structure — each category is independent."
     review_by: "v1.1"
 
+  - file: tests/unit/test_notebook_manager.py
+    lines: 518
+    category: exempt
+    reason: "Marimo lifecycle tests. FUP-15 added _is_marimo_responding mocks for while True loop."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/tests/unit/test_data_fixes.py
+++ b/tests/unit/test_data_fixes.py
@@ -9,12 +9,36 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dango.config.models import DataSource, SourceType
-from dango.transformation.generator import DbtModelGenerator
+from dango.transformation.generator import DbtModelGenerator, _quote_column_name
 
 
 def _make_source(name: str, source_type: str) -> DataSource:
     """Create a minimal DataSource for testing."""
     return DataSource(name=name, type=SourceType(source_type))
+
+
+# ---------------------------------------------------------------------------
+# _quote_column_name unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestQuoteColumnName:
+    def test_alphanumeric_unquoted(self):
+        """Column names with only alphanumeric and underscore are not quoted."""
+        assert _quote_column_name("id") == "id"
+        assert _quote_column_name("customer_id") == "customer_id"
+        assert _quote_column_name("_dlt_load_id") == "_dlt_load_id"
+
+    def test_special_chars_quoted(self):
+        """Column names with spaces, hyphens, or other special chars are double-quoted."""
+        assert _quote_column_name("spaces in name") == '"spaces in name"'
+        assert _quote_column_name("column-name") == '"column-name"'
+        assert _quote_column_name("col.name") == '"col.name"'
+
+    def test_empty_string_quoted(self):
+        """Empty column name is quoted (edge case, shouldn't occur in practice)."""
+        assert _quote_column_name("") == '""'
 
 
 # ---------------------------------------------------------------------------
@@ -156,9 +180,13 @@ class TestGA4DateCast:
             table_name="sessions",
             schema_name="raw_my_ga4",
             date_cast_columns=["date"],
+            staging_columns=[
+                {"name": "date", "type": "TIMESTAMP WITH TIME ZONE"},
+                {"name": "sessions", "type": "BIGINT"},
+            ],
         )
 
-        assert "REPLACE" in sql
+        assert "WITH source AS" in sql
         assert "CAST(date AS DATE) AS date" in sql
         assert "source('my_ga4', 'sessions')" in sql
 
@@ -175,10 +203,14 @@ class TestGA4DateCast:
             source=source,
             table_name="charges",
             schema_name="raw_my_stripe",
+            staging_columns=[
+                {"name": "id", "type": "VARCHAR"},
+                {"name": "amount", "type": "BIGINT"},
+            ],
         )
 
-        assert "REPLACE" not in sql
-        assert "SELECT *" in sql
+        assert "WITH source AS" in sql
+        assert "CAST" not in sql
         assert "source('my_stripe', 'charges')" in sql
 
     def test_ga4_no_cast_when_already_date(self, tmp_path: Path):
@@ -196,10 +228,14 @@ class TestGA4DateCast:
             table_name="sessions",
             schema_name="raw_my_ga4",
             date_cast_columns=[],
+            staging_columns=[
+                {"name": "date", "type": "DATE"},
+                {"name": "sessions", "type": "BIGINT"},
+            ],
         )
 
-        assert "REPLACE" not in sql
-        assert "SELECT *" in sql
+        assert "WITH source AS" in sql
+        assert "CAST" not in sql
 
     def test_ga4_date_detection_in_generate_all_models(self, tmp_path: Path):
         """generate_all_models detects TIMESTAMP date columns for GA4 sources."""
@@ -235,7 +271,15 @@ class TestGA4DateCast:
             gen.generate_all_models([source], generate_schema_yml=False)
 
             mock_gen.assert_called_once()
-            assert mock_gen.call_args.kwargs.get("date_cast_columns") == ["date"]
+            call_kwargs = mock_gen.call_args.kwargs
+            assert call_kwargs.get("date_cast_columns") == ["date"]
+            # Verify staging_columns is passed with _dlt_*/_dango_* filtered out
+            staging_cols = call_kwargs.get("staging_columns")
+            assert staging_cols is not None
+            staging_names = [c["name"] for c in staging_cols]
+            assert "_dlt_load_id" not in staging_names
+            assert "_dlt_id" not in staging_names
+            assert "sessions" in staging_names
 
     def test_ga4_no_detection_when_date_is_date_type(self, tmp_path: Path):
         """generate_all_models does NOT add date_cast_columns when type is already DATE."""
@@ -272,6 +316,8 @@ class TestGA4DateCast:
 
             mock_gen.assert_called_once()
             assert mock_gen.call_args.kwargs.get("date_cast_columns") == []
+            # Verify staging_columns is passed even when no date casts needed
+            assert mock_gen.call_args.kwargs.get("staging_columns") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dbt_lock_stale.py
+++ b/tests/unit/test_dbt_lock_stale.py
@@ -93,10 +93,63 @@ class TestDbtLockCleanupStaleIntegration:
 
         try:
             contender = DbtLock(tmp_path, source="contender", operation="contend")
-            with pytest.raises(DbtLockErr, match="Another sync operation"):
+            with pytest.raises(DbtLockErr, match="Sync queue timeout"):
                 contender.acquire(timeout=0)
         finally:
             holder.release()
+
+    def test_acquire_immediate_no_contention(self, tmp_path: Path) -> None:
+        """Lock acquired immediately when no contention."""
+        lock = DbtLock(tmp_path, source="test", operation="test op")
+        acquired = lock.acquire(timeout=0)
+        assert acquired is True
+        lock.release()
+
+    def test_lock_wait_times_out(self, tmp_path: Path) -> None:
+        """Lock wait raises DbtLockError after timeout."""
+        from dango.exceptions import DbtLockError as DbtLockErr
+
+        holder = DbtLock(tmp_path, source="holder", operation="hold")
+        holder.acquire(timeout=0)
+
+        try:
+            contender = DbtLock(tmp_path, source="contender", operation="contend")
+            with pytest.raises(DbtLockErr, match="Sync queue timeout"):
+                contender.acquire(timeout=1)  # short timeout for test speed
+        finally:
+            holder.release()
+
+    def test_lock_wait_succeeds_when_released(self, tmp_path: Path) -> None:
+        """Lock acquired when holder releases within timeout."""
+        import threading
+
+        from dango.exceptions import DbtLockError as DbtLockErr
+
+        holder = DbtLock(tmp_path, source="holder", operation="hold")
+        holder.acquire(timeout=0)
+
+        result = {"acquired": False, "error": None}
+
+        def _contend():
+            try:
+                c = DbtLock(tmp_path, source="contender", operation="contend")
+                c.acquire(timeout=5)
+                result["acquired"] = True
+                c.release()
+            except DbtLockErr as e:
+                result["error"] = e
+
+        t = threading.Thread(target=_contend)
+        t.start()
+
+        import time
+
+        time.sleep(0.1)  # let contender start waiting
+        holder.release()
+        t.join(timeout=6)
+
+        assert result["acquired"] is True
+        assert result["error"] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -1,0 +1,123 @@
+"""tests/unit/test_docker.py
+
+Tests for dango.platform.docker — Docker Compose lifecycle management.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.platform.docker import DockerManager
+
+
+@pytest.mark.unit
+class TestStopAllDangoContainers:
+    @patch("dango.platform.docker.console")
+    def test_default_stops_containers_for_current_project(self, _mock_console, tmp_path):
+        """Default call (all_projects=False) filters by compose project label."""
+        manager = DockerManager(tmp_path)
+        project_name = manager.compose_project_name
+
+        with patch("subprocess.run") as mock_run:
+            # docker ps returns empty (no containers found)
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            manager.stop_all_dango_containers()
+
+        # Verify docker ps was called with project label filter
+        ps_call = mock_run.call_args_list[0]
+        ps_cmd = ps_call[0][0]
+        assert "docker" in ps_cmd[0]
+        assert "ps" in ps_cmd[1]
+        assert "--filter" in ps_cmd
+        assert f"label=com.docker.compose.project={project_name}" in ps_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_all_projects_true_uses_name_filter(self, _mock_console, tmp_path):
+        """all_projects=True uses the global name-based filter (metabase, dbt)."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            manager.stop_all_dango_containers(all_projects=True)
+
+        ps_call = mock_run.call_args_list[0]
+        ps_cmd = ps_call[0][0]
+        # Should filter by name instead of label
+        assert "name=metabase" in ps_cmd
+        assert "name=dbt" in ps_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_stops_found_containers(self, _mock_console, tmp_path):
+        """Found container IDs are passed to docker stop."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            # First call (docker ps) returns container IDs, second (docker stop) succeeds
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="abc123\ndef456\n"),
+                MagicMock(returncode=0, stdout=""),
+            ]
+
+            result = manager.stop_all_dango_containers()
+
+        assert result is True
+
+        # Second call should be docker stop with the container IDs
+        stop_call = mock_run.call_args_list[1]
+        stop_cmd = stop_call[0][0]
+        assert "docker" in stop_cmd[0]
+        assert "stop" in stop_cmd[1]
+        assert "abc123" in stop_cmd
+        assert "def456" in stop_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_no_containers_found(self, _mock_console, tmp_path):
+        """Returns True when no containers match the filter."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            result = manager.stop_all_dango_containers()
+
+        assert result is True
+        # Only docker ps was called, not docker stop
+        assert mock_run.call_count == 1
+
+    @patch("dango.platform.docker.console")
+    def test_docker_ps_failure_returns_false(self, _mock_console, tmp_path):
+        """Non-zero returncode from docker ps returns False."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+
+            result = manager.stop_all_dango_containers()
+
+        assert result is False
+
+    @patch("dango.platform.docker.console")
+    def test_timeout_returns_false(self, _mock_console, tmp_path):
+        """TimeoutExpired from subprocess is caught and returns False."""
+        manager = DockerManager(tmp_path)
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="docker ps", timeout=10),
+        ):
+            result = manager.stop_all_dango_containers()
+
+        assert result is False
+
+    @patch("dango.platform.docker.console")
+    def test_generic_exception_returns_false(self, _mock_console, tmp_path):
+        """Any exception is caught and returns False gracefully."""
+        manager = DockerManager(tmp_path)
+
+        with patch("subprocess.run", side_effect=RuntimeError("unexpected")):
+            result = manager.stop_all_dango_containers()
+
+        assert result is False

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -44,31 +44,31 @@ def _reset_logging():
 class TestConfigureLogging:
     def test_creates_log_directory(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         assert log_dir.exists()
 
     def test_creates_log_file(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         assert (log_dir / "dango.log").exists()
 
     def test_creates_file_handler(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         root = logging.getLogger()
         handler_types = [type(h).__name__ for h in root.handlers]
         assert "_DangoFileHandler" in handler_types
 
     def test_creates_console_handler(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         root = logging.getLogger()
         handler_types = [type(h).__name__ for h in root.handlers]
         assert "StreamHandler" in handler_types
 
     def test_writes_json_to_file(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         logger = get_logger("test")
         logger.info("test_event", key="value")
 
@@ -81,7 +81,7 @@ class TestConfigureLogging:
 
     def test_idempotent_reconfiguration(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         configure_logging(log_dir=log_dir, json_console=True, log_level="DEBUG")
 
         # Should still be functional after reconfiguration
@@ -127,7 +127,7 @@ class TestGetLogger:
 
     def test_preserves_logger_name_in_output(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         logger = get_logger("my.custom.name")
         logger.info("name_test")
 
@@ -138,7 +138,8 @@ class TestGetLogger:
 
 @pytest.mark.unit
 class TestLogLevelConfiguration:
-    def test_default_level_is_info(self, tmp_path: Path) -> None:
+    def test_default_level_is_info(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DANGO_LOG_LEVEL", raising=False)
         log_dir = tmp_path / "logs"
         configure_logging(log_dir=log_dir, json_console=True)
         root = logging.getLogger()
@@ -175,7 +176,7 @@ class TestLogLevelConfiguration:
 class TestJSONOutput:
     def test_required_fields_present(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         logger = get_logger("fields.test")
         logger.info("check_fields")
 
@@ -205,7 +206,7 @@ class TestJSONOutput:
 
     def test_structlog_kv_pairs_in_json(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         logger = get_logger("kv.test")
         logger.info("sync_done", source="stripe", rows=42)
 
@@ -218,7 +219,7 @@ class TestJSONOutput:
 class TestFileRotation:
     def _get_file_handler(self, tmp_path: Path) -> logging.Handler:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         root = logging.getLogger()
         timed_handlers = [
             h for h in root.handlers if isinstance(h, logging.handlers.TimedRotatingFileHandler)
@@ -282,7 +283,7 @@ class TestFileRotation:
 class TestCorrelationIds:
     def test_bind_adds_fields_to_output(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         bind_contextvars(request_id="req-123", user_id="usr-456")
         logger = get_logger("ctx.test")
         logger.info("with_context")
@@ -293,7 +294,7 @@ class TestCorrelationIds:
 
     def test_clear_removes_all_context(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         bind_contextvars(request_id="req-123")
         clear_contextvars()
         logger = get_logger("ctx.test")
@@ -304,7 +305,7 @@ class TestCorrelationIds:
 
     def test_unbind_removes_specific_keys(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         bind_contextvars(request_id="req-123", user_id="usr-456")
         unbind_contextvars("request_id")
         logger = get_logger("ctx.test")
@@ -319,7 +320,7 @@ class TestCorrelationIds:
 class TestStdlibIntegration:
     def test_stdlib_logger_produces_structured_json(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         stdlib_logger = logging.getLogger("stdlib.test")
         stdlib_logger.info("stdlib_event")
 
@@ -330,7 +331,7 @@ class TestStdlibIntegration:
 
     def test_stdlib_logger_includes_bound_correlation_ids(self, tmp_path: Path) -> None:
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
         bind_contextvars(trace_id="trace-abc")
         stdlib_logger = logging.getLogger("stdlib.corr")
         stdlib_logger.info("stdlib_with_ctx")

--- a/tests/unit/test_notebook_manager.py
+++ b/tests/unit/test_notebook_manager.py
@@ -30,9 +30,12 @@ class TestGetMarimoPidFilePath:
 @pytest.mark.unit
 class TestStartMarimo:
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
+    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
-    def test_start_creates_pid_file(self, mock_popen, mock_running, mock_timeout, tmp_path):
+    def test_start_creates_pid_file(
+        self, mock_popen, mock_running, mock_responding, mock_timeout, tmp_path
+    ):
         mock_proc = MagicMock()
         mock_proc.pid = 12345
         mock_proc.poll.return_value = None
@@ -59,9 +62,12 @@ class TestStartMarimo:
             self._call(tmp_path, port=7805)
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
+    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
-    def test_start_cleans_stale_pid(self, mock_popen, mock_running, mock_timeout, tmp_path):
+    def test_start_cleans_stale_pid(
+        self, mock_popen, mock_running, mock_responding, mock_timeout, tmp_path
+    ):
         pid_file = tmp_path / ".dango" / "marimo.pid"
         pid_file.parent.mkdir(parents=True, exist_ok=True)
         pid_file.write_text("99999")
@@ -322,6 +328,7 @@ class TestStartMarimoCloudBaseUrl:
     """Tests for --base-url flag when running in cloud mode."""
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=3600)
+    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     @patch("dango.config.helpers.is_running_on_cloud", return_value=True)
@@ -330,6 +337,7 @@ class TestStartMarimoCloudBaseUrl:
         mock_cloud: MagicMock,
         mock_popen: MagicMock,
         mock_running: MagicMock,
+        mock_responding: MagicMock,
         mock_timeout: MagicMock,
         tmp_path: Path,
     ) -> None:
@@ -350,6 +358,7 @@ class TestStartMarimoCloudBaseUrl:
         assert cmd[idx + 1] == "/notebooks/marimo"
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
+    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     @patch("dango.config.helpers.is_running_on_cloud", return_value=False)
@@ -358,6 +367,7 @@ class TestStartMarimoCloudBaseUrl:
         mock_cloud: MagicMock,
         mock_popen: MagicMock,
         mock_running: MagicMock,
+        mock_responding: MagicMock,
         mock_timeout: MagicMock,
         tmp_path: Path,
     ) -> None:
@@ -381,9 +391,14 @@ class TestStartMarimoSnapshotPath:
     """Tests for snapshot_path env var in start_marimo()."""
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
+    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
     @patch("dango.notebooks.manager.is_process_running", return_value=True)
     def test_with_snapshot_path_sets_env_var(
-        self, mock_running: MagicMock, mock_timeout: MagicMock, tmp_path: Path
+        self,
+        mock_running: MagicMock,
+        mock_responding: MagicMock,
+        mock_timeout: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from dango.notebooks.manager import start_marimo
 
@@ -410,9 +425,14 @@ class TestStartMarimoSnapshotPath:
             assert env["DANGO_NOTEBOOK_DB_PATH"] == str(snapshot)
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
+    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
     @patch("dango.notebooks.manager.is_process_running", return_value=True)
     def test_without_snapshot_no_env_var(
-        self, mock_running: MagicMock, mock_timeout: MagicMock, tmp_path: Path
+        self,
+        mock_running: MagicMock,
+        mock_responding: MagicMock,
+        mock_timeout: MagicMock,
+        tmp_path: Path,
     ) -> None:
         from dango.notebooks.manager import start_marimo
 

--- a/tests/unit/test_notebook_manager.py
+++ b/tests/unit/test_notebook_manager.py
@@ -30,7 +30,7 @@ class TestGetMarimoPidFilePath:
 @pytest.mark.unit
 class TestStartMarimo:
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     def test_start_creates_pid_file(
@@ -62,7 +62,7 @@ class TestStartMarimo:
             self._call(tmp_path, port=7805)
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     def test_start_cleans_stale_pid(
@@ -328,7 +328,7 @@ class TestStartMarimoCloudBaseUrl:
     """Tests for --base-url flag when running in cloud mode."""
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=3600)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     @patch("dango.config.helpers.is_running_on_cloud", return_value=True)
@@ -358,7 +358,7 @@ class TestStartMarimoCloudBaseUrl:
         assert cmd[idx + 1] == "/notebooks/marimo"
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=False)
     @patch("dango.notebooks.manager.subprocess.Popen")
     @patch("dango.config.helpers.is_running_on_cloud", return_value=False)
@@ -391,7 +391,7 @@ class TestStartMarimoSnapshotPath:
     """Tests for snapshot_path env var in start_marimo()."""
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=True)
     def test_with_snapshot_path_sets_env_var(
         self,
@@ -425,7 +425,7 @@ class TestStartMarimoSnapshotPath:
             assert env["DANGO_NOTEBOOK_DB_PATH"] == str(snapshot)
 
     @patch("dango.notebooks.manager._get_idle_timeout", return_value=7200)
-    @patch("dango.notebooks.manager._is_marimo_responding", side_effect=[False, True])
+    @patch("dango.notebooks.manager._is_marimo_responding", return_value=True)
     @patch("dango.notebooks.manager.is_process_running", return_value=True)
     def test_without_snapshot_no_env_var(
         self,

--- a/tests/unit/test_process_manager.py
+++ b/tests/unit/test_process_manager.py
@@ -313,14 +313,20 @@ class TestStopFastapiServer:
 
     # --- Port-based fallback phase ---
 
+    @patch("psutil.Process")
     @patch("dango.cli.helpers.process_manager.kill_process", return_value=True)
     @patch("dango.cli.helpers.process_manager.subprocess.run")
     @patch("dango.cli.helpers.process_manager.console")
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
     def test_no_pid_dango_process_on_port(
-        self, _mock_running, _mock_console, mock_sub_run, mock_kill, tmp_path
+        self, _mock_running, _mock_console, mock_sub_run, mock_kill, mock_psutil, tmp_path
     ):
         self._setup_project(tmp_path)
+
+        # Mock psutil.Process to return CWD matching project root
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = str(tmp_path)
+        mock_psutil.return_value = mock_proc
 
         with patch("dango.config.ConfigLoader") as mock_cl:
             mock_config = MagicMock()
@@ -374,14 +380,20 @@ class TestStopFastapiServer:
 
             assert stop_fastapi_server(tmp_path) is False
 
+    @patch("psutil.Process")
     @patch("dango.cli.helpers.process_manager.kill_process", return_value=False)
     @patch("dango.cli.helpers.process_manager.subprocess.run")
     @patch("dango.cli.helpers.process_manager.console")
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
     def test_dango_pids_found_but_all_kills_fail(
-        self, _mock_running, _mock_console, mock_sub_run, mock_kill, tmp_path
+        self, _mock_running, _mock_console, mock_sub_run, mock_kill, mock_psutil, tmp_path
     ):
         self._setup_project(tmp_path)
+
+        # Mock psutil.Process to return CWD matching project root
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = str(tmp_path)
+        mock_psutil.return_value = mock_proc
 
         with patch("dango.config.ConfigLoader") as mock_cl:
             mock_config = MagicMock()
@@ -460,6 +472,115 @@ class TestStopFastapiServer:
             mock_sub_run.side_effect = subprocess.TimeoutExpired(cmd="lsof", timeout=5)
 
             assert stop_fastapi_server(tmp_path) is False
+
+    @patch("psutil.Process")
+    @patch("dango.cli.helpers.process_manager.subprocess.run")
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
+    def test_dango_process_from_another_project_not_killed(
+        self, _mock_running, mock_console, mock_sub_run, mock_psutil, tmp_path
+    ):
+        """Port fallback finds a Dango process but CWD differs → skip, don't kill."""
+        self._setup_project(tmp_path)
+
+        # Mock psutil.Process so CWD points to a different project
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = "/tmp/other-project"
+        mock_psutil.return_value = mock_proc
+
+        with patch("dango.config.ConfigLoader") as mock_cl:
+            mock_config = MagicMock()
+            mock_config.platform.port = 8080
+            mock_cl.return_value.load_config.return_value = mock_config
+
+            lsof_result = MagicMock(returncode=0, stdout="1234\n")
+            ps_result = MagicMock(
+                returncode=0,
+                stdout="python -m uvicorn dango.web.app:app --host 0.0.0.0 --port 8080",
+            )
+            mock_sub_run.side_effect = [lsof_result, ps_result]
+
+            with patch("dango.cli.helpers.process_manager.kill_process") as mock_kill:
+                result = stop_fastapi_server(tmp_path, verbose=True)
+                assert result is False
+                mock_kill.assert_not_called()
+
+        # Should print a warning about skipping (different project)
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        assert any("different project" in str(c).lower() for c in print_calls)
+
+    @patch("psutil.Process")
+    @patch("dango.cli.helpers.process_manager.subprocess.run")
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
+    def test_dango_process_cwd_unreadable_skips_safely(
+        self, _mock_running, mock_console, mock_sub_run, mock_psutil, tmp_path
+    ):
+        """Port fallback: Dango process found but CWD is unreadable → skip gracefully."""
+        import psutil as psutil_mod
+
+        self._setup_project(tmp_path)
+
+        mock_proc = MagicMock()
+        mock_proc.cwd.side_effect = psutil_mod.AccessDenied()
+        mock_psutil.return_value = mock_proc
+
+        with patch("dango.config.ConfigLoader") as mock_cl:
+            mock_config = MagicMock()
+            mock_config.platform.port = 8080
+            mock_cl.return_value.load_config.return_value = mock_config
+
+            lsof_result = MagicMock(returncode=0, stdout="1234\n")
+            ps_result = MagicMock(
+                returncode=0,
+                stdout="python -m uvicorn dango.web.app:app",
+            )
+            mock_sub_run.side_effect = [lsof_result, ps_result]
+
+            with patch("dango.cli.helpers.process_manager.kill_process") as mock_kill:
+                result = stop_fastapi_server(tmp_path, verbose=True)
+                assert result is False
+                mock_kill.assert_not_called()
+
+        # Should print a warning about being unable to verify CWD
+        print_calls = [str(c) for c in mock_console.print.call_args_list]
+        assert any("Could not verify CWD" in str(c) for c in print_calls)
+
+    @patch("psutil.Process")
+    @patch("dango.cli.helpers.process_manager.kill_process", return_value=True)
+    @patch("dango.cli.helpers.process_manager.subprocess.run")
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
+    def test_symlinked_project_root_matches_after_resolution(
+        self, _mock_running, _mock_console, mock_sub_run, mock_kill, mock_psutil, tmp_path
+    ):
+        """Port fallback: symlinked project root matches resolved CWD → kills process."""
+        self._setup_project(tmp_path)
+
+        # Create a symlink pointing to tmp_path
+        link_dir = tmp_path / "link-to-project"
+        link_dir.symlink_to(tmp_path, target_is_directory=True)
+
+        # Mock CWD returns the real path (not the symlink)
+        mock_proc = MagicMock()
+        mock_proc.cwd.return_value = str(tmp_path)
+        mock_psutil.return_value = mock_proc
+
+        with patch("dango.config.ConfigLoader") as mock_cl:
+            mock_config = MagicMock()
+            mock_config.platform.port = 8080
+            mock_cl.return_value.load_config.return_value = mock_config
+
+            lsof_result = MagicMock(returncode=0, stdout="1234\n")
+            ps_result = MagicMock(
+                returncode=0,
+                stdout="python -m uvicorn dango.web.app:app",
+            )
+            mock_sub_run.side_effect = [lsof_result, ps_result]
+
+            result = stop_fastapi_server(link_dir, verbose=True)
+            assert result is True
+            mock_kill.assert_called_once_with(1234, timeout=5)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_quality_gate.py
+++ b/tests/unit/test_quality_gate.py
@@ -124,7 +124,7 @@ class TestConfigureLoggingWiring:
         from dango.logging import configure_logging, get_logger
 
         log_dir = tmp_path / "logs"
-        configure_logging(log_dir=log_dir, json_console=True)
+        configure_logging(log_dir=log_dir, json_console=True, log_level="INFO")
 
         logger = get_logger("fup4.test")
         logger.info("check_configured")

--- a/tests/unit/test_quality_gate.py
+++ b/tests/unit/test_quality_gate.py
@@ -1,0 +1,221 @@
+"""tests/unit/test_quality_gate.py
+
+Automated quality gate checks for S2 — verifies version consistency across
+API responses, logging configuration, activity log entries, audit events,
+and sync subprocess headers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog
+
+import dango
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging():
+    """Reset logging state between tests (same pattern as test_logging.py)."""
+    yield
+
+    from dango.logging import clear_contextvars
+
+    clear_contextvars()
+
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        handler.close()
+        root.removeHandler(handler)
+
+    structlog.reset_defaults()
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — Version in API responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestApiVersionEndpoints:
+    """API endpoints must return the current dango version."""
+
+    def test_api_status_returns_dango_version(self, tmp_path: Path) -> None:
+        """GET /api/status returns dango_version matching dango.__version__."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from dango.web.routes.health import router
+
+        app = FastAPI()
+        app.state.project_root = tmp_path
+        app.state.scheduler = None
+        app.include_router(router)
+
+        with (
+            patch("dango.web.routes.health.get_project_root", return_value=tmp_path),
+            patch(
+                "dango.web.routes.health.get_duckdb_path",
+                return_value=tmp_path / "nonexistent.duckdb",
+            ),
+            patch(
+                "dango.web.routes.health.check_service_status_async",
+                new_callable=AsyncMock,
+                return_value="healthy",
+            ),
+        ):
+            client = TestClient(app)
+            resp = client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dango_version"] == dango.__version__
+
+    def test_api_info_returns_version(self) -> None:
+        """GET /api returns version matching dango.__version__."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from dango.web.routes.ui import router
+
+        app = FastAPI()
+        app.include_router(router)
+
+        client = TestClient(app)
+        resp = client.get("/api")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["version"] == dango.__version__
+
+    def test_fastapi_app_version(self) -> None:
+        """FastAPI().version matches dango.__version__."""
+        from fastapi import FastAPI
+
+        app = FastAPI(version=dango.__version__)
+        assert app.version == dango.__version__
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — configure_logging() is wired up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConfigureLoggingWiring:
+    """configure_logging() must be importable, functional, and env-aware."""
+
+    def test_configure_logging_runs_without_error(self, tmp_path: Path) -> None:
+        """Import and call configure_logging() — no exception raised."""
+        from dango.logging import configure_logging
+
+        configure_logging(log_dir=tmp_path / "logs", json_console=True)
+
+    def test_structlog_configured_after_call(self, tmp_path: Path) -> None:
+        """After configure_logging(), a structlog logger produces structured JSON output."""
+        from dango.logging import configure_logging, get_logger
+
+        log_dir = tmp_path / "logs"
+        configure_logging(log_dir=log_dir, json_console=True)
+
+        logger = get_logger("fup4.test")
+        logger.info("check_configured")
+
+        log_file = log_dir / "dango.log"
+        assert log_file.exists()
+        content = log_file.read_text().strip()
+        assert content
+
+        record = json.loads(content)
+        assert record["event"] == "check_configured"
+        assert record["logger"] == "fup4.test"
+        assert "timestamp" in record
+        assert "level" in record
+        assert "dango_version" in record
+        assert record["dango_version"] == dango.__version__
+
+    def test_default_log_dir_is_cwd_dot_dango_logs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When log_dir is None, defaults to cwd/.dango/logs."""
+
+        from dango.logging import configure_logging
+
+        monkeypatch.chdir(tmp_path)
+
+        configure_logging(json_console=True)
+
+        log_file = tmp_path / ".dango" / "logs" / "dango.log"
+        assert log_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — Version in log schemas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestVersionInActivityLog:
+    """log_activity() must include dango_version in written entries."""
+
+    def test_log_activity_has_dango_version(self, tmp_path: Path) -> None:
+        from dango.utils.activity_log import log_activity
+
+        log_activity(tmp_path, "info", "test_source", "test message")
+
+        log_file = tmp_path / ".dango" / "logs" / "activity.jsonl"
+        assert log_file.exists()
+
+        content = log_file.read_text().strip()
+        entry = json.loads(content)
+
+        assert "dango_version" in entry
+        assert entry["dango_version"] == dango.__version__
+
+
+@pytest.mark.unit
+class TestVersionInAuditLog:
+    """log_auth_event() must include dango_version in written entries."""
+
+    def test_log_auth_event_has_dango_version(self, tmp_path: Path) -> None:
+        from dango.auth.audit import AuditEvent, log_auth_event
+
+        log_auth_event(AuditEvent.LOGIN_SUCCESS, log_dir=tmp_path)
+
+        log_file = tmp_path / "audit.jsonl"
+        assert log_file.exists()
+
+        content = log_file.read_text().strip()
+        entry = json.loads(content)
+
+        assert "dango_version" in entry
+        assert entry["dango_version"] == dango.__version__
+
+
+@pytest.mark.unit
+class TestVersionInSyncSubprocess:
+    """launch_sync_subprocess() must write a dango_version header line."""
+
+    def test_launch_sync_subprocess_writes_version_header(self, tmp_path: Path) -> None:
+        from dango.platform.sync_process import launch_sync_subprocess
+
+        mock_process = MagicMock()
+        mock_process.pid = 99999
+
+        with (
+            patch("dango.platform.sync_process.subprocess.Popen", return_value=mock_process),
+            patch("dango.utils.process.ensure_std_fds"),
+        ):
+            _, _, log_path = launch_sync_subprocess(tmp_path, sources=["test_source"])
+            assert log_path.exists()
+
+            first_line = log_path.read_text().splitlines()[0]
+            assert first_line == f"# dango_version={dango.__version__}"

--- a/tests/unit/test_sync_jobs.py
+++ b/tests/unit/test_sync_jobs.py
@@ -173,7 +173,7 @@ class TestRunScheduledSync:
         assert call_kwargs["sources"] == ["src1"]
         assert call_kwargs["skip_dbt"] is True
         assert call_kwargs["source_label"] == "scheduler"
-        assert call_kwargs["max_lock_wait"] == 300
+        assert call_kwargs["max_lock_wait"] == 60
 
     def test_broadcasts_sync_started_and_completed(self, tmp_path):
         config = _make_config_with_sources("src1")
@@ -451,7 +451,7 @@ class TestRunScheduledDbt:
 
             run_scheduled_dbt("nightly", "model_name+", project_root=str(tmp_path))
 
-        mock_lock.acquire.assert_called_once()
+        mock_lock.acquire.assert_called_once_with(timeout=60)
         mock_lock.release.assert_called_once()
 
     def test_broadcasts_dbt_events(self, tmp_path):

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -743,3 +743,176 @@ class TestBroadcastDbtError:
         call_msg = broadcast_fn.call_args[0][0]
         assert call_msg["event"] == "dbt_run_all_failed"
         assert call_msg["source"] == "dbt (triggered by hubspot)"
+
+
+@pytest.mark.unit
+class TestPhaseToEvent:
+    """Tests for _phase_to_event mapping function."""
+
+    def test_post_sync_phase_mappings(self):
+        """post_sync_started and post_sync_completed map to themselves."""
+        from dango.platform.sync_process import _phase_to_event
+
+        assert _phase_to_event("post_sync_started") == "post_sync_started"
+        assert _phase_to_event("post_sync_completed") == "post_sync_completed"
+
+    def test_existing_mappings_unchanged(self):
+        """Existing phase mappings are not affected."""
+        from dango.platform.sync_process import _phase_to_event
+
+        assert _phase_to_event("starting") == "sync_started"
+        assert _phase_to_event("data_load_complete") == "data_load_complete"
+        assert _phase_to_event("dbt_started") == "dbt_run_all_started"
+        assert _phase_to_event("dbt_complete") == "dbt_run_all_completed"
+        assert _phase_to_event("completed") == "sync_completed"
+        assert _phase_to_event("failed") == "sync_failed"
+
+    def test_unknown_phase_defaults_to_sync_progress(self):
+        """Unknown phases fall back to sync_progress."""
+        from dango.platform.sync_process import _phase_to_event
+
+        assert _phase_to_event("nonexistent_phase") == "sync_progress"
+
+
+@pytest.mark.unit
+class TestBroadcastPostSyncPhases:
+    """Tests for broadcast behavior with post_sync phase events."""
+
+    @pytest.mark.anyio
+    async def test_broadcast_post_sync_started_includes_source(self):
+        """_broadcast_phase_transition for post_sync_started includes source name."""
+        from dango.platform.sync_process import _broadcast_phase_transition
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        status = {"message": "Running post-sync hooks (profiling, PII scan, analysis, snapshots)"}
+        await _broadcast_phase_transition(mock_ws, "hubspot", "post_sync_started", status)
+
+        call_msg = mock_ws.broadcast.call_args[0][0]
+        assert call_msg["event"] == "post_sync_started"
+        assert call_msg["source"] == "hubspot"
+        assert call_msg["message"] == status["message"]
+
+    @pytest.mark.anyio
+    async def test_broadcast_post_sync_completed_includes_source(self):
+        """_broadcast_phase_transition for post_sync_completed includes source name."""
+        from dango.platform.sync_process import _broadcast_phase_transition
+
+        mock_ws = MagicMock()
+        mock_ws.broadcast = AsyncMock()
+
+        status = {"message": "Post-sync hooks complete"}
+        await _broadcast_phase_transition(mock_ws, "stripe", "post_sync_completed", status)
+
+        call_msg = mock_ws.broadcast.call_args[0][0]
+        assert call_msg["event"] == "post_sync_completed"
+        assert call_msg["source"] == "stripe"
+        assert call_msg["message"] == status["message"]
+
+
+@pytest.mark.unit
+class TestBlockingPollPostSyncPhases:
+    """Tests for poll_sync_status_blocking with post_sync phase transitions."""
+
+    def test_blocking_poll_post_sync_started(self, tmp_path):
+        """poll_sync_status_blocking broadcasts post_sync_started for new phase."""
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(
+            tmp_path,
+            phase="post_sync_started",
+            sync_id="ps_block",
+            message="Running post-sync hooks",
+        )
+        process = MagicMock()
+        process.poll.return_value = None  # still running
+        broadcast_fn = MagicMock()
+
+        read_count = [0]
+
+        def _side_effect(proj_root, sync_id=None):
+            read_count[0] += 1
+            if read_count[0] == 1:
+                return {
+                    "pid": os.getpid(),
+                    "phase": "post_sync_started",
+                    "message": "Running post-sync hooks",
+                    "sources": ["hubspot"],
+                }
+            # Return completed on next read to terminate
+            return {
+                "pid": os.getpid(),
+                "phase": "completed",
+                "message": "Done",
+                "sources": ["hubspot"],
+            }
+
+        with (
+            patch(f"{_MOD}.read_sync_status", side_effect=_side_effect),
+            patch(f"{_MOD}.time.sleep"),
+        ):
+            success, _ = poll_sync_status_blocking(
+                tmp_path,
+                process,
+                source_name="hubspot",
+                sync_id="ps_block",
+                broadcast_fn=broadcast_fn,
+                poll_interval=0.01,
+            )
+
+        assert success is True
+        # Should have broadcast at least post_sync_started and sync_completed
+        events = [c[0][0]["event"] for c in broadcast_fn.call_args_list]
+        assert "post_sync_started" in events
+        assert "sync_completed" in events
+
+    def test_blocking_poll_post_sync_completed(self, tmp_path):
+        """poll_sync_status_blocking broadcasts post_sync_completed for completed phase."""
+        from dango.platform.sync_process import poll_sync_status_blocking
+
+        _write_status_file(
+            tmp_path,
+            phase="post_sync_completed",
+            sync_id="ps_comp",
+            message="Post-sync hooks complete",
+        )
+        process = MagicMock()
+        process.poll.return_value = None  # still running
+        broadcast_fn = MagicMock()
+
+        read_count = [0]
+
+        def _side_effect(proj_root, sync_id=None):
+            read_count[0] += 1
+            if read_count[0] == 1:
+                return {
+                    "pid": os.getpid(),
+                    "phase": "post_sync_completed",
+                    "message": "Post-sync hooks complete",
+                    "sources": ["stripe"],
+                }
+            return {
+                "pid": os.getpid(),
+                "phase": "completed",
+                "message": "Done",
+                "sources": ["stripe"],
+            }
+
+        with (
+            patch(f"{_MOD}.read_sync_status", side_effect=_side_effect),
+            patch(f"{_MOD}.time.sleep"),
+        ):
+            success, _ = poll_sync_status_blocking(
+                tmp_path,
+                process,
+                source_name="stripe",
+                sync_id="ps_comp",
+                broadcast_fn=broadcast_fn,
+                poll_interval=0.01,
+            )
+
+        assert success is True
+        events = [c[0][0]["event"] for c in broadcast_fn.call_args_list]
+        assert "post_sync_completed" in events
+        assert "sync_completed" in events

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -760,7 +760,7 @@ class TestPhaseToEvent:
         """Existing phase mappings are not affected."""
         from dango.platform.sync_process import _phase_to_event
 
-        assert _phase_to_event("starting") == "sync_started"
+        assert _phase_to_event("lock_waiting") == "sync_queued"
         assert _phase_to_event("data_load_complete") == "data_load_complete"
         assert _phase_to_event("dbt_started") == "dbt_run_all_started"
         assert _phase_to_event("dbt_complete") == "dbt_run_all_completed"
@@ -768,9 +768,10 @@ class TestPhaseToEvent:
         assert _phase_to_event("failed") == "sync_failed"
 
     def test_unknown_phase_defaults_to_sync_progress(self):
-        """Unknown phases fall back to sync_progress."""
+        """Unknown phases (including removed 'starting') fall back to sync_progress."""
         from dango.platform.sync_process import _phase_to_event
 
+        assert _phase_to_event("starting") == "sync_progress"
         assert _phase_to_event("nonexistent_phase") == "sync_progress"
 
 

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -143,7 +144,9 @@ class TestLaunchSyncSubprocess:
 
         assert process is mock_process
         assert len(sync_id) == 12  # uuid hex[:12]
-        assert log_path.name == f"sync_{sync_id}.log"
+
+        name_match = re.match(r"^sync_hubspot_\d{8}_\d{6}\.log$", log_path.name)
+        assert name_match, f"Unexpected log name: {log_path.name}"
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
         assert cmd[0] == sys.executable

--- a/tests/unit/test_sync_trigger.py
+++ b/tests/unit/test_sync_trigger.py
@@ -72,7 +72,7 @@ class TestRunManualSync:
         assert result["status"] == "success"
         assert result["record_id"] == 1
         assert "duration_seconds" in result
-        mock_lock_cls.return_value.acquire.assert_called_once()
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=300)
         mock_lock_cls.return_value.release.assert_called_once()
         mock_sync.assert_called_once()
         mock_complete.assert_called_once()
@@ -136,6 +136,7 @@ class TestRunManualSync:
         assert result["status"] == "failed"
         assert "Lock unavailable" in result["error"]
         mock_failure.assert_called_once()
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=300)
 
     @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
     @patch(f"{_PATCH_CONFIG}.load_config")
@@ -378,47 +379,61 @@ class TestRunManualSync:
         assert result["status"] == "success"
         assert result["rows_loaded"] == 150
 
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
+    @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_UTILS}.DbtLock")
-    @patch(f"{_PATCH_HISTORY}.record_failure")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
     @patch(f"{_PATCH_HISTORY}.record_start", return_value=10)
     @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
-    @patch(f"{_PATCH_CONFIG}.load_config")
     @patch(f"{_PATCH_OAUTH}.validate_before_sync")
-    def test_lock_retry_loop(
+    def test_acquire_passes_timeout(
         self,
         mock_oauth,
-        mock_config,
         mock_db_path,
         mock_start,
-        mock_failure,
+        mock_complete,
         mock_lock_cls,
+        mock_config,
+        mock_sync,
         tmp_path,
     ):
-        """With max_lock_wait > 0, should retry before failing."""
-        from dango.exceptions import DbtLockError
+        """Lock acquire() should pass max_lock_wait as timeout."""
         from dango.platform.scheduling.sync_trigger import run_manual_sync
 
         mock_config.return_value = _make_config(["src1"])
 
-        # Fail first 2 attempts, succeed on third
-        attempts = [0]
+        result = run_manual_sync(tmp_path, sources=["src1"], max_lock_wait=30)
 
-        def _side_effect():
-            attempts[0] += 1
-            if attempts[0] < 3:
-                raise DbtLockError("lock held")
-
-        mock_lock_cls.return_value.acquire.side_effect = _side_effect
-
-        with (
-            patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0}),
-            patch(f"{_PATCH_HISTORY}.record_completion"),
-            patch(f"{_PATCH_HISTORY}.time.sleep"),
-        ):
-            result = run_manual_sync(tmp_path, sources=["src1"], max_lock_wait=30)
-
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=30)
         assert result["status"] == "success"
-        assert attempts[0] == 3
+
+    @patch(f"{_PATCH_INGESTION}.run_sync", return_value={"results": [], "failed_count": 0})
+    @patch(f"{_PATCH_CONFIG}.load_config")
+    @patch(f"{_PATCH_UTILS}.DbtLock")
+    @patch(f"{_PATCH_HISTORY}.record_completion")
+    @patch(f"{_PATCH_HISTORY}.record_start", return_value=11)
+    @patch(f"{_PATCH_HISTORY}.get_scheduler_db_path")
+    @patch(f"{_PATCH_OAUTH}.validate_before_sync")
+    def test_default_timeout_is_300(
+        self,
+        mock_oauth,
+        mock_db_path,
+        mock_start,
+        mock_complete,
+        mock_lock_cls,
+        mock_config,
+        mock_sync,
+        tmp_path,
+    ):
+        """Without max_lock_wait, should use 300s default timeout."""
+        from dango.platform.scheduling.sync_trigger import run_manual_sync
+
+        mock_config.return_value = _make_config(["src1"])
+
+        result = run_manual_sync(tmp_path, sources=["src1"])
+
+        mock_lock_cls.return_value.acquire.assert_called_once_with(timeout=300)
+        assert result["status"] == "success"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

S2 release — 19 fixes across 11 PRs. Covers credential flow, process isolation, sync pipeline, staging models, sync queue, logging infrastructure, and quality-of-life improvements. Plus automated quality gate tests.

## Included PRs

- #342: schedules page sources as sorted bullet list
- #343: scope port kill and Docker cleanup to current project (P0-3)
- #344: WebSocket sync phase events for post-sync progress (P1-2)
- #345: defer OAuth credential save to after token exchange (P2-3, P2-5)
- #346: staging models with explicit columns, type casts, _dlt exclusion (P7-2)
- #347: sync queue — wait instead of failing on lock contention (F-1)
- #348: wire up structured logging + add version to all log schemas
- #349: remove --merge-queue references + add quality gate tests (FUP-3, FUP-4)
- #350: CLI + frontend fixes — source list, --source flag, timestamps, bullet list (FUP-6, FUP-9, FUP-13, FUP-14)
- #351: logging noise + sync log filenames + shared JS + notebook startup (FUP-5, FUP-7, FUP-8, FUP-10, FUP-13, FUP-15)
- #352: remove duplicate _is_marimo_responding call + scope log level to CI

## Verification

- `pytest -x`: 3900 pass, 0 fail
- Quality gate: M1-M8 manual checks passed on beta-1
- CI: DANGO_LOG_LEVEL scoped to workflow, not global