### PR TITLE
fix: write per-source sync history on lock timeout, exception, and poll timeout

### DIFF
--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -204,6 +204,22 @@ def run_manual_sync(
     except DbtLockError as exc:
         error_msg = f"Lock unavailable: {exc}"
         record_failure(db_path, record_id, error_msg)
+
+        from dango.utils.sync_history import save_sync_history_entry
+
+        for name in sources:
+            save_sync_history_entry(
+                project_root,
+                name,
+                {
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                    "status": "failed",
+                    "duration_seconds": 0,
+                    "rows_processed": 0,
+                    "error_message": error_msg,
+                },
+            )
+
         duration = round(time.time() - start_time, 1)
         _progress("failed", error_msg, error=error_msg)
         return {
@@ -345,6 +361,22 @@ def run_manual_sync(
         logger.warning("manual_sync_failed", error=str(exc), exc_info=True)
         error_msg = str(exc)
         record_failure(db_path, record_id, error_msg)
+
+        from dango.utils.sync_history import save_sync_history_entry
+
+        for name in sources:
+            save_sync_history_entry(
+                project_root,
+                name,
+                {
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                    "status": "failed",
+                    "duration_seconds": 0,
+                    "rows_processed": 0,
+                    "error_message": error_msg,
+                },
+            )
+
         duration = round(time.time() - start_time, 1)
         _progress("failed", f"Sync failed: {error_msg}", error=error_msg)
         return {

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -325,6 +325,25 @@ def poll_sync_status_blocking(
         if elapsed >= max_poll_time:
             process.terminate()
             error_msg = f"Sync timed out after {int(elapsed)}s"
+
+            from dango.utils.sync_history import save_sync_history_entry
+
+            for src in source_list:
+                try:
+                    save_sync_history_entry(
+                        project_root,
+                        src,
+                        {
+                            "timestamp": _ts(),
+                            "status": "failed",
+                            "duration_seconds": int(elapsed),
+                            "rows_processed": 0,
+                            "error_message": error_msg,
+                        },
+                    )
+                except Exception:
+                    logger.debug("sync_history_timeout_write_failed", source=src, exc_info=True)
+
             if broadcast_fn is not None:
                 broadcast_fn(
                     {

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -285,9 +285,15 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/sync_process.py
-    lines: 649
+    lines: 667
     category: exempt
-    reason: "Subprocess launch + polling + crash handling for process-isolated syncs. Unified logging added crash handlers (_handle_crash, _read_log_tail, _cleanup_sync_log) that write to activity log and sync history on subprocess failures."
+    reason: "Subprocess launch + polling + crash handling for process-isolated syncs. Unified logging added crash handlers (_handle_crash, _read_log_tail, _cleanup_sync_log) that write to activity log and sync history on subprocess failures. BUG-S3-6: per-source sync history on poll timeout (~15 lines)."
+    review_by: "v1.1"
+
+  - file: dango/platform/scheduling/sync_trigger.py
+    lines: 501
+    category: exempt
+    reason: "BUG-S3-6: Added per-source sync history writes on lock timeout and general exception (~30 lines). Previously under 500 lines."
     review_by: "v1.1"
 
   - file: dango/platform/scheduling/jobs.py


### PR DESCRIPTION
## Summary
- Fix per-source sync history gaps on lock timeout, general exception, and poll timeout
- Three failure paths were missing `save_sync_history_entry()` — Sources tab showed misleading green "Synced"
- Follows existing pattern from OAuth handler (`sync_trigger.py:160-180`)

## Changes
- `sync_trigger.py`: DbtLockError handler — writes per-source history for all sources
- `sync_trigger.py`: General Exception handler — writes per-source history for all sources
- `sync_process.py`: Poll timeout — writes per-source history for all sources in `source_list` (wrapped in try/except)
- `docs/file-exemptions.yml`: Added `sync_trigger.py` (501 lines), updated `sync_process.py` (668 lines)

## Verification
- `ruff check dango/`: All checks passed
- `ruff format --check dango/`: 216 files already formatted
- `pytest tests/unit/test_sync_trigger.py tests/unit/test_sync_process.py -v`: 74 pass, 0 fail
- `pytest -x`: 3910 pass, 31 skipped, 0 fail