### PR TITLE
S3-FUP-B: log cleanup scheduling, activity log dedup, event audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `cli/commands/deploy_wizard.py` | 923 | — (interactive deploy wizard + BYOS) |
 | `transformation/generator.py` | 706 | — |
 | `web/routes/catalog.py` | 1350 | — (data catalog: columns, profiling, lineage, impact, models, search, raw table discovery, per-source stats) |
+| `web/templates/catalog.html` | 1029 | — (Alpine.js data catalog page) |
 | `cli/commands/deploy_provision.py` | 1000 | — (provisioning orchestration + BYOS) |
 | `platform/cloud/digitalocean.py` | 547 | — (DO REST API v2 client) |
 | `platform/cloud/server_setup.py` | 743 | — (server setup + install source detection) |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -44,6 +44,8 @@ within SemVer constraints.
 1. Check the [Metabase DuckDB driver releases](https://github.com/motherduckdb/metabase_duckdb_driver/releases)
    for the driver version matching your target Metabase.
 2. Identify the DuckDB major.minor bundled in that driver.
+   (The driver's bundled DuckDB version must be checked from the driver
+   release notes — it does not always match the Python DuckDB package version.)
 3. Update **all three** together:
    - `pyproject.toml`: `duckdb>=X.Y.0,<X.(Y+1)`
    - `dango/utils/driver.py`: `METABASE_DUCKDB_DRIVER_VERSION`

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -142,6 +142,7 @@ class SchedulerService:
 
         self._setup_history_cleanup()
         self._setup_login_attempts_cleanup()
+        self._setup_sync_log_cleanup()
         self._log_startup_summary()
         self._check_dual_scheduler()
 
@@ -427,6 +428,25 @@ class SchedulerService:
             )
         except Exception:  # noqa: BLE001
             logger.debug("login_attempts_cleanup_setup_failed", exc_info=True)
+
+    def _setup_sync_log_cleanup(self) -> None:
+        """Run initial cleanup and register daily sync log cleanup job."""
+        try:
+            from dango.utils.log_rotation import cleanup_old_sync_logs
+
+            # Run initial cleanup at startup
+            cleanup_old_sync_logs(str(self._project_root))
+
+            self._scheduler.add_job(
+                cleanup_old_sync_logs,
+                "interval",
+                hours=24,
+                args=[str(self._project_root)],
+                id="dango-internal:sync-log-cleanup",
+                replace_existing=True,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("sync_log_cleanup_setup_failed", exc_info=True)
 
     def _log_missed_recovery(self) -> None:
         """Log count of missed jobs that will be recovered on startup."""

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -90,6 +90,24 @@ def _write_status(state_dir: Path, sync_id: str | None = None, **fields: Any) ->
 # ---------------------------------------------------------------------------
 
 
+def _write_failed_sync_history(project_root: Path, sources: list[str], error_msg: str) -> None:
+    """Write a failed sync history entry for each source."""
+    from dango.utils.sync_history import save_sync_history_entry
+
+    for name in sources:
+        save_sync_history_entry(
+            project_root,
+            name,
+            {
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "status": "failed",
+                "duration_seconds": 0,
+                "rows_processed": 0,
+                "error_message": error_msg,
+            },
+        )
+
+
 def run_manual_sync(
     project_root: Path,
     sources: list[str],
@@ -163,21 +181,7 @@ def run_manual_sync(
                 validate_before_sync(src.type.value, project_root)
     except (OAuthTokenExpiredError, OAuthTokenRevokedError) as oauth_err:
         error_msg = f"OAuth validation failed: {oauth_err.user_message}"
-        # Record in per-source sync history so health page sees it
-        from dango.utils.sync_history import save_sync_history_entry
-
-        for name in sources:
-            save_sync_history_entry(
-                project_root,
-                name,
-                {
-                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                    "status": "failed",
-                    "duration_seconds": 0,
-                    "rows_processed": 0,
-                    "error_message": error_msg,
-                },
-            )
+        _write_failed_sync_history(project_root, sources, error_msg)
         record_failure(db_path, record_id, error_msg)
         duration = round(time.time() - start_time, 1)
         _progress("failed", error_msg, error=error_msg)
@@ -204,21 +208,7 @@ def run_manual_sync(
     except DbtLockError as exc:
         error_msg = f"Lock unavailable: {exc}"
         record_failure(db_path, record_id, error_msg)
-
-        from dango.utils.sync_history import save_sync_history_entry
-
-        for name in sources:
-            save_sync_history_entry(
-                project_root,
-                name,
-                {
-                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                    "status": "failed",
-                    "duration_seconds": 0,
-                    "rows_processed": 0,
-                    "error_message": error_msg,
-                },
-            )
+        _write_failed_sync_history(project_root, sources, error_msg)
 
         duration = round(time.time() - start_time, 1)
         _progress("failed", error_msg, error=error_msg)
@@ -249,21 +239,7 @@ def run_manual_sync(
         if not resolved:
             msg = f"No valid sources found for: {', '.join(sources)}"
             logger.warning("manual_sync_no_sources", source_names=sources)
-            # Record failure in sync history so UI shows "failed" not "never synced"
-            from dango.utils.sync_history import save_sync_history_entry
-
-            for name in sources:
-                save_sync_history_entry(
-                    project_root,
-                    name,
-                    {
-                        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                        "status": "failed",
-                        "duration_seconds": 0,
-                        "rows_processed": 0,
-                        "error_message": msg,
-                    },
-                )
+            _write_failed_sync_history(project_root, sources, msg)
             record_failure(db_path, record_id, msg)
             duration = round(time.time() - start_time, 1)
             _progress("failed", msg, error=msg)
@@ -361,21 +337,7 @@ def run_manual_sync(
         logger.warning("manual_sync_failed", error=str(exc), exc_info=True)
         error_msg = str(exc)
         record_failure(db_path, record_id, error_msg)
-
-        from dango.utils.sync_history import save_sync_history_entry
-
-        for name in sources:
-            save_sync_history_entry(
-                project_root,
-                name,
-                {
-                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                    "status": "failed",
-                    "duration_seconds": 0,
-                    "rows_processed": 0,
-                    "error_message": error_msg,
-                },
-            )
+        _write_failed_sync_history(project_root, sources, error_msg)
 
         duration = round(time.time() - start_time, 1)
         _progress("failed", f"Sync failed: {error_msg}", error=error_msg)

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -86,7 +86,7 @@ def _write_status(state_dir: Path, sync_id: str | None = None, **fields: Any) ->
 
 
 # ---------------------------------------------------------------------------
-# Main sync function
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -106,6 +106,11 @@ def _write_failed_sync_history(project_root: Path, sources: list[str], error_msg
                 "error_message": error_msg,
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# Main sync function
+# ---------------------------------------------------------------------------
 
 
 def run_manual_sync(

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -229,7 +229,8 @@ async def poll_sync_status(
                         "source": source_name,
                         "message": error_msg,
                         "timestamp": _ts(),
-                    }
+                    },
+                    log=False,
                 )
                 # Timeout is not a crash — don't call _handle_crash (the caller
                 # has its own timeout handling). Just keep the log for diagnostics.
@@ -270,7 +271,8 @@ async def poll_sync_status(
                         "source": source_name,
                         "message": f"Sync in progress ({elapsed_int}s elapsed)",
                         "timestamp": _ts(),
-                    }
+                    },
+                    log=False,
                 )
                 last_heartbeat = now
 
@@ -288,7 +290,8 @@ async def poll_sync_status(
                         "source": source_name,
                         "message": error_msg,
                         "timestamp": _ts(),
-                    }
+                    },
+                    log=False,
                 )
                 return False, {"error": error_msg, "phase": "failed"}
     finally:
@@ -511,7 +514,19 @@ def _ts() -> str:
 
 
 def _phase_to_event(phase: str) -> str:
-    """Map status file phase to a WebSocket event name."""
+    """Map status file phase to a WebSocket event name.
+
+    Consumers (grep for these to find UI code that handles each event):
+      sync_progress       → app.js:414, schedules.html:484
+      data_load_complete  → app.js:418
+      dbt_run_all_started → app.js:503, schedules.html:484
+      dbt_run_all_completed → app.js:542
+      dbt_run_all_failed  → app.js:595
+      post_sync_started   → app.js:565
+      post_sync_completed → app.js:571
+      sync_completed      → app.js:422, schedules.html:494
+      sync_failed         → app.js:463, schedules.html:494
+    """
     mapping = {
         "data_load": "sync_progress",
         "data_load_complete": "data_load_complete",

--- a/dango/utils/log_rotation.py
+++ b/dango/utils/log_rotation.py
@@ -62,6 +62,34 @@ def cleanup_old_archives(log_dir: Path, pattern: str, max_age_days: int = 90) ->
         _logger.warning("archive_cleanup_failed", log_dir=str(log_dir), exc_info=True)
 
 
+def cleanup_old_sync_logs(project_root_str: str, max_age_days: int = 7) -> None:
+    """Delete sync_*.log files older than *max_age_days* days.
+
+    APScheduler job function — must be module-level and pickle-safe.
+    Never raises."""
+    try:
+        _cleanup_old_sync_logs_impl(Path(project_root_str), max_age_days)
+    except Exception:
+        _logger.warning("sync_log_cleanup_failed", project_root=project_root_str, exc_info=True)
+
+
+def _cleanup_old_sync_logs_impl(project_root: Path, max_age_days: int) -> None:
+    """Core sync log cleanup logic — may raise."""
+    logs_dir = project_root / ".dango" / "logs"
+    if not logs_dir.exists():
+        return
+
+    cutoff_ts = datetime.now(timezone.utc).timestamp() - (max_age_days * 86_400)
+
+    for log_file in logs_dir.glob("sync_*.log"):
+        try:
+            if log_file.stat().st_mtime < cutoff_ts:
+                log_file.unlink(missing_ok=True)
+                _logger.info("sync_log_deleted", path=str(log_file))
+        except OSError:
+            pass
+
+
 def get_log_disk_usage(log_dir: Path) -> dict[str, Any]:
     """Return per-file sizes and total disk usage for a log directory.
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -201,6 +201,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception:
         logger.debug("stale_sync_status_cleanup_failed", exc_info=True)
 
+    # Scheduled cleanup runs daily via APScheduler (_setup_sync_log_cleanup).
+    # This startup cleanup catches logs from before server restart.
     # Clean old sync log files (>7 days)
     try:
         import time as _time

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -78,7 +78,8 @@ async def run_dbt_model(
             "source": f"dbt:{model_name}",
             "message": f"Running dbt model: {model_name}",
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-        }
+        },
+        log=False,
     )
 
     # Run in background
@@ -118,7 +119,8 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "source": f"dbt:{model_name}",
                 "message": str(e).split("\n")[0],  # First line of error message
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            }
+            },
+            log=False,
         )
         from dango.utils.activity_log import log_activity
 
@@ -200,7 +202,8 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                     "source": f"dbt:{model_name}",
                     "message": f"Model '{model_name}' ran successfully in {duration:.1f}s",
                     "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                }
+                },
+                log=False,
             )
 
             # CRITICAL: Refresh Metabase connection to see new/updated tables
@@ -233,7 +236,8 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                     "source": f"dbt:{model_name}",
                     "message": f"Model '{model_name}' failed: {error_msg[:200]}",
                     "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                }
+                },
+                log=False,
             )
 
     except subprocess.TimeoutExpired:
@@ -249,7 +253,8 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "source": f"dbt:{model_name}",
                 "message": f"Model '{model_name}' timed out after 5 minutes",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            }
+            },
+            log=False,
         )
     except Exception as e:
         log_activity(
@@ -262,7 +267,8 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
                 "source": f"dbt:{model_name}",
                 "message": f"Model '{model_name}' failed: {str(e)}",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            }
+            },
+            log=False,
         )
     finally:
         if lock is not None:

--- a/dango/web/routes/sync.py
+++ b/dango/web/routes/sync.py
@@ -205,7 +205,8 @@ async def run_sync_task(
                 "source": source_name,
                 "message": f"Sync failed: {error_message}",
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            }
+            },
+            log=False,
         )
 
         # Cleanup status file even on exception

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -628,7 +628,8 @@ async def run_dbt_after_delete(source_name: str):
                 "source": f"dbt (triggered by {source_name} delete)",
                 "message": error_msg,
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-            }
+            },
+            log=False,
         )
         append_log_entry(
             {
@@ -661,7 +662,8 @@ async def run_dbt_after_delete(source_name: str):
                 "source": f"dbt (triggered by {source_name} delete)",
                 "message": "Updating models after file deletion",
                 "timestamp": sync_timestamp,
-            }
+            },
+            log=False,
         )
 
         # Run dbt for this source and downstream models
@@ -695,7 +697,8 @@ async def run_dbt_after_delete(source_name: str):
                     "source": f"dbt (triggered by {source_name} delete)",
                     "message": "Models updated after file deletion",
                     "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                }
+                },
+                log=False,
             )
 
             # Save sync history with success
@@ -726,7 +729,8 @@ async def run_dbt_after_delete(source_name: str):
                     "source": f"dbt (triggered by {source_name} delete)",
                     "message": "dbt run failed",
                     "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                }
+                },
+                log=False,
             )
 
             # Save sync history with failure


### PR DESCRIPTION
## Summary
- FUP-11: Add daily APScheduler job for sync log cleanup (7-day retention). Follows _setup_history_cleanup() pattern.
- FUP-12: Fix activity log duplicates by adding log=False to 14 ws_manager.broadcast() calls that write their own append_log_entry().
- FUP-17: Audit event emission across sync pipeline. No duplicates found. Added consumer comments to _phase_to_event().
- Extract per-source sync history writes to _write_failed_sync_history() helper (DRY 4 identical copies).
- FUP-20 follow-up: Add catalog.html to Monolithic Files table in CLAUDE.md.
- S3 findings: Add driver version note to VERSIONS.md Upgrade Process step 2.

## Verification
- ruff check + ruff format --check: clean
- pytest -x: 2168 pass, 1 fail (pre-existing: test_pii_detection.py spaCy download, unrelated)
- Tested modules: test_log_rotation.py (20), test_scheduler.py (41), test_sync_trigger.py (33) — all pass
- FUP-11: dango-internal:sync-log-cleanup job registered at startup (APScheduler interval trigger, 24h)
- FUP-12: 14 broadcast() calls now pass log=False:
  - dbt.py: 6 calls (dbt_run_started, 4x dbt_run_failed, dbt_run_completed)
  - upload.py: 4 calls (dbt_run_all_failed lock, dbt_run_all_started, dbt_run_all_completed, dbt_run_all_failed dbt)
  - sync.py: 1 call (sync_failed)
  - sync_process.py: 3 calls (sync_failed timeout, sync_progress heartbeat, sync_failed crash)

## Regression check
- Sync pipeline: WS events fire correctly, no duplicate log entries expected
- dbt model runs: WS events fire, no duplicate log entries expected
- File uploads: WS events fire, no duplicate log entries expected
- Server startup: old sync logs cleaned at startup + daily via APScheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)