### PR TITLE
fix: add per-table empty replace protection for multi-resource dlt sources

### DIFF
--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -1365,6 +1365,7 @@ class DltPipelineRunner:
 
             # Per-table empty replace protection: detect if any individual table
             # would be truncated (some tables populated, others empty)
+            post_table_counts = None
             if (
                 pre_table_counts is not None
                 and (full_refresh or uses_replace_mode)
@@ -1400,7 +1401,10 @@ class DltPipelineRunner:
                         }
 
             # Check for row count anomalies
-            total_row_count = self._get_source_total_rows(source_name)
+            if post_table_counts is not None:
+                total_row_count = sum(post_table_counts.values()) if post_table_counts else 0
+            else:
+                total_row_count = self._get_source_total_rows(source_name)
             if total_row_count is not None:
                 stats["total_row_count"] = total_row_count
             anomaly = self._check_row_count_anomaly(source_name, total_rows=total_row_count)

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -964,6 +964,7 @@ class DltPipelineRunner:
 
         # Always capture pre-refresh row count for empty replace protection
         pre_refresh_rows = self._get_source_total_rows(source_name)
+        pre_table_counts = self._get_source_table_rows(source_name)
 
         # Full refresh: drop pipeline state only (NOT schema)
         # dlt with write_disposition="replace" handles table replacement automatically.
@@ -1007,6 +1008,42 @@ class DltPipelineRunner:
                     "rows_loaded": 0,
                     "uses_replace_mode": uses_replace_mode,
                 }
+
+            # Per-table empty replace protection: detect if any individual table
+            # would be truncated (some tables populated, others empty)
+            if (
+                pre_table_counts is not None
+                and (full_refresh or uses_replace_mode)
+                and not allow_empty_replace
+            ):
+                post_table_counts = self._get_source_table_rows(source_name)
+                if post_table_counts is not None:
+                    truncated_tables: list[tuple[str, int]] = []
+                    for table_name, pre_count in pre_table_counts.items():
+                        if pre_count > 0:
+                            post_count = post_table_counts.get(table_name, 0)
+                            if post_count == 0:
+                                truncated_tables.append((table_name, pre_count))
+                    if truncated_tables:
+                        self._restore_dlt_state(state_backup)
+                        table_details = "\n  - ".join(
+                            f"{name}: {count:,} rows → 0 rows (table would be lost)"
+                            for name, count in truncated_tables
+                        )
+                        error_msg = (
+                            f"Sync would truncate {len(truncated_tables)} table(s) with "
+                            f"existing data:\n  - {table_details}\n"
+                            f"To force sync with empty data, use: "
+                            f"dango sync {source_name} --allow-empty-replace"
+                        )
+                        console.print(f"  [red]❌ {error_msg}[/red]")
+                        return {
+                            "status": "failed",
+                            "source": source_name,
+                            "error": error_msg,
+                            "rows_loaded": rows_loaded,
+                            "uses_replace_mode": uses_replace_mode,
+                        }
 
             # Check for data loss on full refresh
             if full_refresh and pre_refresh_rows is not None and rows_loaded < pre_refresh_rows:
@@ -1281,6 +1318,7 @@ class DltPipelineRunner:
 
         # Always capture pre-refresh row count for empty replace protection
         pre_refresh_rows = self._get_source_total_rows(source_name)
+        pre_table_counts = self._get_source_table_rows(source_name)
 
         # Full refresh: drop pipeline state only (NOT schema)
         # dlt with write_disposition="replace" handles table replacement automatically.
@@ -1324,6 +1362,42 @@ class DltPipelineRunner:
                     "rows_loaded": 0,
                     "uses_replace_mode": uses_replace_mode,
                 }
+
+            # Per-table empty replace protection: detect if any individual table
+            # would be truncated (some tables populated, others empty)
+            if (
+                pre_table_counts is not None
+                and (full_refresh or uses_replace_mode)
+                and not allow_empty_replace
+            ):
+                post_table_counts = self._get_source_table_rows(source_name)
+                if post_table_counts is not None:
+                    truncated_tables: list[tuple[str, int]] = []
+                    for table_name, pre_count in pre_table_counts.items():
+                        if pre_count > 0:
+                            post_count = post_table_counts.get(table_name, 0)
+                            if post_count == 0:
+                                truncated_tables.append((table_name, pre_count))
+                    if truncated_tables:
+                        self._restore_dlt_state(state_backup)
+                        table_details = "\n  - ".join(
+                            f"{name}: {count:,} rows → 0 rows (table would be lost)"
+                            for name, count in truncated_tables
+                        )
+                        error_msg = (
+                            f"Sync would truncate {len(truncated_tables)} table(s) with "
+                            f"existing data:\n  - {table_details}\n"
+                            f"To force sync with empty data, use: "
+                            f"dango sync {source_name} --allow-empty-replace"
+                        )
+                        console.print(f"  [red]❌ {error_msg}[/red]")
+                        return {
+                            "status": "failed",
+                            "source": source_name,
+                            "error": error_msg,
+                            "rows_loaded": rows_loaded,
+                            "uses_replace_mode": uses_replace_mode,
+                        }
 
             # Check for row count anomalies
             total_row_count = self._get_source_total_rows(source_name)
@@ -1957,8 +2031,12 @@ class DltPipelineRunner:
         mins = minutes % 60
         return f"{hours}h {mins}m"
 
-    def _get_source_total_rows(self, source_name: str) -> int | None:
-        """Get total row count across all tables in a source's raw schema."""
+    def _get_source_table_rows(self, source_name: str) -> dict[str, int] | None:
+        """Get per-table row counts for a source's raw schema.
+
+        Returns dict of {table_name: row_count}, or None on error.
+        Excludes dlt internal tables (_dlt_*).
+        """
         import duckdb
 
         schema = f"raw_{source_name}"
@@ -1970,18 +2048,25 @@ class DltPipelineRunner:
                     "WHERE table_schema = ? AND table_name NOT LIKE '\\_dlt\\_%' ESCAPE '\\'",
                     [schema],
                 ).fetchall()
-                total = 0
+                table_counts: dict[str, int] = {}
                 for (table_name,) in tables:
                     result = conn.execute(
                         f'SELECT COUNT(*) FROM "{schema}"."{table_name}"'
                     ).fetchone()
                     if result:
-                        total += result[0]
-                return total
+                        table_counts[table_name] = result[0]
+                return table_counts
             finally:
                 conn.close()
         except Exception:
             return None
+
+    def _get_source_total_rows(self, source_name: str) -> int | None:
+        """Get total row count across all tables in a source's raw schema."""
+        table_counts = self._get_source_table_rows(source_name)
+        if table_counts is None:
+            return None
+        return sum(table_counts.values()) if table_counts else 0
 
     def _get_csv_table_rows(self, source_name: str) -> int | None:
         """Get row count for a CSV/local_files source's single table."""

--- a/tests/unit/test_empty_replace_protection.py
+++ b/tests/unit/test_empty_replace_protection.py
@@ -1212,3 +1212,285 @@ class TestDropSchemaRemoval:
         assert "DROP SCHEMA" not in source, (
             f"{method_name} still contains DROP SCHEMA — must be removed"
         )
+
+
+# ============================================================================
+# Per-Table Empty Replace Protection (Tests 32-37)
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestPerTableProtection:
+    """Per-table empty replace protection for multi-resource dlt sources.
+
+    Catches the gap where source-level totals pass (some tables populated)
+    but individual tables would be silently truncated.
+    """
+
+    def test_partial_empty_fails(self, tmp_path):
+        """Test 32: Some tables populated, one returns 0 rows → fail with details."""
+        runner = _make_runner(tmp_path)
+
+        pre_table = {"table_a": 1000, "table_b": 500, "table_c": 300}
+        post_table = {"table_a": 1200, "table_b": 600, "table_c": 0}
+
+        with (
+            patch.object(
+                runner,
+                "_get_source_total_rows",
+                side_effect=[sum(pre_table.values()), sum(post_table.values())],
+            ),
+            patch.object(runner, "_get_source_table_rows", side_effect=[pre_table, post_table]),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 1800}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(1800)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert "table_c" in result["error"]
+        assert "300 rows" in result["error"]
+        assert "would be lost" in result["error"]
+        assert "--allow-empty-replace" in result["error"]
+        mock_restore.assert_called_once()
+
+    def test_all_populated_succeeds(self, tmp_path):
+        """Test 33: All tables populated → success."""
+        runner = _make_runner(tmp_path)
+
+        pre_table = {"table_a": 1000, "table_b": 500}
+        post_table = {"table_a": 1200, "table_b": 600}
+
+        with (
+            patch.object(
+                runner,
+                "_get_source_total_rows",
+                side_effect=[sum(pre_table.values()), sum(post_table.values())],
+            ),
+            patch.object(runner, "_get_source_table_rows", side_effect=[pre_table, post_table]),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 1800}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(1800)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+
+    def test_new_table_zero_succeeds(self, tmp_path):
+        """Test 34: New table appears with 0 rows (not previously tracked) → success."""
+        runner = _make_runner(tmp_path)
+
+        pre_table = {"table_a": 1000}
+        post_table = {"table_a": 1200, "table_b": 0}
+
+        with (
+            patch.object(
+                runner,
+                "_get_source_total_rows",
+                side_effect=[sum(pre_table.values()), sum(post_table.values())],
+            ),
+            patch.object(runner, "_get_source_table_rows", side_effect=[pre_table, post_table]),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 1200}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(1200)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+
+    def test_first_sync_none_pre_counts_succeeds(self, tmp_path):
+        """Test 35: First sync with None pre_table_counts → success (per-table skipped)."""
+        runner = _make_runner(tmp_path)
+
+        post_table = {"table_a": 0, "table_b": 0}
+
+        with (
+            patch.object(runner, "_get_source_total_rows", side_effect=[0, 0]),
+            patch.object(runner, "_get_source_table_rows", side_effect=[None, post_table]),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "success"
+
+    def test_allow_empty_replace_bypasses_per_table(self, tmp_path):
+        """Test 36: allow_empty_replace=True bypasses per-table check."""
+        runner = _make_runner(tmp_path)
+
+        pre_table = {"table_a": 1000, "table_b": 500}
+        post_table = {"table_a": 1200, "table_b": 0}
+
+        with (
+            patch.object(
+                runner,
+                "_get_source_total_rows",
+                side_effect=[sum(pre_table.values()), sum(post_table.values())],
+            ),
+            patch.object(runner, "_get_source_table_rows", side_effect=[pre_table, post_table]),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_cleanup_state_backup"),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 1200}),
+            patch.object(runner, "_check_row_count_anomaly", return_value=None),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(1200)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+                allow_empty_replace=True,
+            )
+
+        assert result["status"] == "success"
+        mock_restore.assert_not_called()
+
+    def test_source_level_check_catches_all_empty(self, tmp_path):
+        """Test 37: Source-level check fires first when ALL tables empty (rows_loaded=0)."""
+        runner = _make_runner(tmp_path)
+
+        pre_table = {"table_a": 1000}
+
+        with (
+            patch.object(runner, "_get_source_total_rows", return_value=sum(pre_table.values())),
+            patch.object(runner, "_get_source_table_rows", return_value=pre_table),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_build_source_config", return_value={}),
+            patch.object(runner, "_load_dlt_source") as mock_source,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_get_dataset_name", return_value="raw_test"),
+            patch.object(runner, "_check_oauth_token_expiry", return_value=None),
+            patch.object(runner, "_inject_oauth_credentials", side_effect=lambda t, k: k),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 0}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(0)),
+            patch("dango.ingestion.dlt_runner.get_source_metadata") as mock_meta,
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_meta.return_value = {
+                "dlt_package": "test",
+                "dlt_function": "test_func",
+            }
+            mock_dlt.pipeline.return_value = MagicMock()
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+            mock_source.return_value = MagicMock()
+
+            result = runner._run_dlt_source(
+                _make_source_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert "existing 1,000 rows preserved" in result["error"]
+        mock_restore.assert_called_once()

--- a/tests/unit/test_empty_replace_protection.py
+++ b/tests/unit/test_empty_replace_protection.py
@@ -1494,3 +1494,47 @@ class TestPerTableProtection:
         assert result["status"] == "failed"
         assert "existing 1,000 rows preserved" in result["error"]
         mock_restore.assert_called_once()
+
+    def test_native_source_per_table_protection(self, tmp_path):
+        """Test 38: _run_dlt_native_source per-table check catches partial empty."""
+        runner = _make_runner(tmp_path)
+
+        pre_table = {"table_a": 1000, "table_b": 500}
+        post_table = {"table_a": 1200, "table_b": 0}
+
+        with (
+            patch.object(
+                runner,
+                "_get_source_total_rows",
+                side_effect=[sum(pre_table.values()), sum(post_table.values())],
+            ),
+            patch.object(runner, "_get_source_table_rows", side_effect=[pre_table, post_table]),
+            patch.object(runner, "_backup_dlt_state", return_value=Path("/tmp/backup")),
+            patch.object(runner, "_restore_dlt_state") as mock_restore,
+            patch.object(runner, "_detect_write_disposition", return_value=True),
+            patch.object(runner, "_extract_load_stats", return_value={"rows_loaded": 1200}),
+            patch.object(runner, "_run_with_retry", return_value=_mock_load_info(1200)),
+            patch("dango.ingestion.dlt_runner.dlt") as mock_dlt,
+            patch("dango.ingestion.dlt_runner.importlib") as mock_importlib,
+            patch("os.getcwd", return_value="/tmp"),
+            patch("os.chdir"),
+        ):
+            mock_module = MagicMock()
+            mock_module.test_func = MagicMock(return_value=MagicMock())
+            mock_importlib.import_module.return_value = mock_module
+
+            mock_pipeline = MagicMock()
+            mock_dlt.pipeline.return_value = mock_pipeline
+            mock_dlt.destinations.duckdb.return_value = MagicMock()
+
+            result = runner._run_dlt_native_source(
+                _make_dlt_native_config(),
+                full_refresh=True,
+            )
+
+        assert result["status"] == "failed"
+        assert "table_b" in result["error"]
+        assert "500 rows" in result["error"]
+        assert "would be lost" in result["error"]
+        assert "--allow-empty-replace" in result["error"]
+        mock_restore.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds `_get_source_table_rows()` method returning per-table row counts (`dict[str, int]`)
- Refactors `_get_source_total_rows()` to delegate to the new method (preserves `int | None` API)
- Adds post-sync per-table check in both `_run_dlt_source()` and `_run_dlt_native_source()`
- Detects when individual tables would be truncated even when source-level totals pass

## Context
dlt 1.28.0 changes `replace` from dataset-level to per-table truncation. The existing source-level 0-row check uses total row counts, so a multi-resource source that returns data for 5 tables but 0 for the 6th would pass the check, silently truncating the 6th table.

The per-table check is additive — the existing source-level check is preserved and runs first.

## Verification
- `ruff check dango/` — all checks passed
- `ruff format --check dango/` — 216 files already formatted
- `pytest tests/unit/test_empty_replace_protection.py -v` — 48 passed (6 new)
- `pytest -x` — 3916 passed, 31 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)