### PR TITLE
S3-UI: table sorting/search + schedule status transitions

### DIFF
--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -101,6 +101,51 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 - **Alpine.js object reactivity:** Proxy doesn't track `delete obj[key]` or direct property mutation. Must use object spread reassignment (`this.obj = {...updated}`) for reactive updates. Arrays with `.push()`/`.splice()` work fine; objects do not.
 - **`routes/sync.py` uses subprocess model (R10-N):** Syncs run in a subprocess via `sync_process.py` — the web server process never holds the DuckDB write lock. `run_sync_task()` launches subprocess + polls status file.
 
+## Sort/Filter Patterns
+
+All data tables support column sorting and text filtering, with state persisted to localStorage.
+
+### Architecture
+
+**Vanilla JS (Sources, Models pages):**
+- Sort/filter state in global variables: `sourceSortColumn`, `sourceSortDirection`, `sourceFilterText` (model equivalents with `model*` prefix)
+- `applySourcesSort()` / `applyModelsSort()` sort before render; computed columns (Status) use numeric order functions
+- `applySourcesFilter()` / `applyModelsFilter()` filter by case-insensitive substring match
+- Column headers get `data-sort-key` attributes; event delegation on `<thead>` handles clicks (cycle asc→desc→unsorted)
+- `updateSourcesSortArrows()` / `updateModelsSortArrows()` refresh ▲/▼ indicators after each render
+- Filter input + clear button are outside `overflow-x-auto` for horizontal scroll visibility
+- See `app.js`: `renderSourcesTable()`, `renderDbtModelsTable()`
+
+**Alpine.js (Schedules, Catalog, Scripts pages):**
+- Sort/filter state as reactive properties on the component object
+- Sorted/filtered data via computed getter (e.g., `sortedSchedules`, `sortedFilteredItems`, `sortedScripts`)
+- localStorage read on init, written via `$watch` (filter) or in `toggleSort()` method (sort)
+- Template `x-for` iterates the computed getter, not the raw data array
+- Column header `@click` handlers call `toggleSort(col)` with `x-if` for arrow rendering
+
+### localStorage Keys
+
+| Page | Sort Column | Sort Direction | Filter |
+|------|------------|---------------|--------|
+| Sources | `dango-sources-sort-column` | `dango-sources-sort-direction` | `dango-sources-filter` |
+| Models | `dango-models-sort-column` | `dango-models-sort-direction` | `dango-models-filter` |
+| Schedules | `dango-schedules-sort-column` | `dango-schedules-sort-direction` | `dango-schedules-filter` |
+| Catalog | `dango-catalog-sort-column` | `dango-catalog-sort-direction` | (not filtered) |
+| Scripts | `dango-scripts-sort-column` | `dango-scripts-sort-direction` | `dango-scripts-filter` |
+
+### Sort Behavior
+- Click cycles: asc → desc → unsorted (preserves API order)
+- Missing (null/undefined) values always sort last
+- String comparison is case-insensitive (`localeCompare`); numeric values compare as numbers
+- Computed columns (Status) use a numeric order function (0=active, 10=success, 20=failed, etc.)
+- Sort arrows (▲/▼) appear on the active sort column only
+
+### Filter Behavior
+- Case-insensitive substring match across relevant text fields (name, type for sources; name, schema, materialization for models; name, type, cron for schedules; name for scripts)
+- Clear button visible only when filter text is present
+- Filter input placed outside `overflow-x-auto` container
+- Empty filter shows all items; filtered-empty state shows "No X match 'query'" message
+
 ## Adding a New Page
 
 1. **Create a template** in `templates/` extending `base.html`:

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -41,6 +41,16 @@ let activeFileOperations = new Map();
 let syncTimers = new Map();
 let syncResults = new Map();  // Stores sync_completed data for in-place updates
 
+// Sort/filter state for Sources table (persisted in localStorage)
+let sourceSortColumn = localStorage.getItem('dango-sources-sort-column') || null;
+let sourceSortDirection = localStorage.getItem('dango-sources-sort-direction') || null;
+let sourceFilterText = localStorage.getItem('dango-sources-filter') || '';
+
+// Sort/filter state for Models table (persisted in localStorage)
+let modelSortColumn = localStorage.getItem('dango-models-sort-column') || null;
+let modelSortDirection = localStorage.getItem('dango-models-sort-direction') || null;
+let modelFilterText = localStorage.getItem('dango-models-filter') || '';
+
 /**
  * Format a file size in bytes to a human-readable string (B/KB/MB/GB).
  * @param {number} bytes - Size in bytes
@@ -190,11 +200,15 @@ document.addEventListener('DOMContentLoaded', () => {
     // Sources page or legacy dashboard with tabs
     if (hasSources) {
         loadSources();
+        initSourcesSortHeaders();
+        initSourcesFilter();
     }
 
     // Models page or legacy dashboard with tabs
     if (hasModels) {
         loadDbtModels();
+        initModelsSortHeaders();
+        initModelsFilter();
     }
 
     // Activity log (dashboard overview)
@@ -1143,6 +1157,108 @@ function showSourcesLoading() {
     `;
 }
 
+// ============================================================================
+// Sources Table Sort & Filter
+// ============================================================================
+
+function applySourcesSort(srcs) {
+    if (!sourceSortColumn || !sourceSortDirection || sourceSortDirection === 'none') return srcs;
+    const sortable = {
+        'name': 'name',
+        'type': 'type',
+        'rows': 'row_count',
+        'last-sync': 'last_sync',
+    };
+    if (sourceSortColumn === 'status') {
+        const dir = sourceSortDirection === 'desc' ? -1 : 1;
+        return [...srcs].sort((a, b) => {
+            const va = sourceStatusOrder(a), vb = sourceStatusOrder(b);
+            return (va - vb) * dir;
+        });
+    }
+    const accessor = sortable[sourceSortColumn];
+    return accessor ? sortByProp(srcs, accessor, sourceSortDirection) : srcs;
+}
+
+function sourceStatusOrder(src) {
+    if (activeSyncs.has(src.name)) return 0;
+    if (postSyncSources.has(src.name)) return 1;
+    const order = { 'synced': 10, 'partial': 20, 'empty': 30, 'not_synced': 40, 'failed': 50, 'never_synced': 60 };
+    return order[src.freshness?.status] != null ? order[src.freshness.status] : 99;
+}
+
+function applySourcesFilter(srcs) {
+    if (!sourceFilterText) return srcs;
+    return filterByText(srcs, sourceFilterText, ['name', 'type']);
+}
+
+function updateSourcesSortArrows() {
+    const table = document.querySelector('#sources-table-body')?.closest('table');
+    if (!table) return;
+    table.querySelectorAll('thead th[data-sort-key]').forEach((th) => {
+        const colKey = th.dataset.sortKey;
+        // Remove any existing arrow
+        th.innerHTML = th.innerHTML.replace(/[▲▼]/g, '').trim();
+        if (colKey === sourceSortColumn && sourceSortDirection && sourceSortDirection !== 'none') {
+            th.innerHTML += sourceSortDirection === 'asc' ? ' ▲' : ' ▼';
+        }
+    });
+}
+
+function initSourcesSortHeaders() {
+    const table = document.querySelector('#sources-table-body')?.closest('table');
+    if (!table) return;
+    const thead = table.querySelector('thead');
+    if (!thead || thead.dataset.sortInit) return;
+    thead.dataset.sortInit = '1';
+
+    thead.addEventListener('click', (e) => {
+        const th = e.target.closest('th[data-sort-key]');
+        if (!th) return;
+        const colKey = th.dataset.sortKey;
+
+        if (sourceSortColumn === colKey) {
+            if (sourceSortDirection === 'asc') sourceSortDirection = 'desc';
+            else if (sourceSortDirection === 'desc') { sourceSortDirection = null; sourceSortColumn = null; }
+            else { sourceSortColumn = colKey; sourceSortDirection = 'asc'; }
+        } else {
+            sourceSortColumn = colKey;
+            sourceSortDirection = 'asc';
+        }
+        localStorage.setItem('dango-sources-sort-column', sourceSortColumn || '');
+        localStorage.setItem('dango-sources-sort-direction', sourceSortDirection || '');
+        renderSourcesTable();
+    });
+}
+
+function initSourcesFilter() {
+    const input = document.getElementById('sources-filter-input');
+    if (!input) return;
+    const clearBtn = document.getElementById('sources-filter-clear');
+
+    input.value = sourceFilterText || '';
+    if (clearBtn) {
+        clearBtn.classList.toggle('hidden', !sourceFilterText);
+    }
+
+    input.addEventListener('input', () => {
+        sourceFilterText = input.value;
+        localStorage.setItem('dango-sources-filter', sourceFilterText);
+        if (clearBtn) clearBtn.classList.toggle('hidden', !sourceFilterText);
+        renderSourcesTable();
+    });
+
+    if (clearBtn) {
+        clearBtn.addEventListener('click', () => {
+            input.value = '';
+            sourceFilterText = '';
+            localStorage.setItem('dango-sources-filter', '');
+            clearBtn.classList.add('hidden');
+            renderSourcesTable();
+        });
+    }
+}
+
 function renderSourcesTable() {
     console.log('🎨 [renderSourcesTable] Called with sources:', sources.length, 'activeSyncs:', activeSyncs.size);
     const tbody = document.getElementById('sources-table-body');
@@ -1169,7 +1285,23 @@ function renderSourcesTable() {
 
     const canSync = window.DANGO_USER_ROLE === 'admin' || window.DANGO_USER_ROLE === 'editor';
 
-    tbody.innerHTML = sources.map(source => {
+    // Apply sort and filter
+    const sorted = applySourcesSort(sources);
+    const filtered = applySourcesFilter(sorted);
+
+    if (filtered.length === 0 && sourceFilterText) {
+        tbody.innerHTML = `
+            <tr>
+                <td colspan="7" class="px-6 py-8 text-center text-gray-500">
+                    <p>No sources match "<span class="font-medium">${escapeHtml(sourceFilterText)}</span>"</p>
+                </td>
+            </tr>
+        `;
+        updateSourcesSortArrows();
+        return;
+    }
+
+    tbody.innerHTML = filtered.map(source => {
         const isSyncing = activeSyncs.has(source.name);
         const hasFileOps = activeFileOperations.has(source.name);
         const isPostSync = postSyncSources.has(source.name);
@@ -1279,6 +1411,7 @@ function renderSourcesTable() {
         </tr>
         `;
     }).join('');
+    updateSourcesSortArrows();
 }
 
 function getStatusBadge(status) {
@@ -2312,6 +2445,106 @@ async function loadDbtModels(retryCount = 0) {
     }
 }
 
+// ============================================================================
+// Models Table Sort & Filter
+// ============================================================================
+
+function applyModelsSort(models) {
+    if (!modelSortColumn || !modelSortDirection || modelSortDirection === 'none') return models;
+    const sortable = {
+        'name': 'name',
+        'schema': 'schema',
+        'materialization': 'materialization',
+        'rows': 'row_count',
+    };
+    if (modelSortColumn === 'status') {
+        const dir = modelSortDirection === 'desc' ? -1 : 1;
+        return [...models].sort((a, b) => {
+            const va = modelStatusOrder(a), vb = modelStatusOrder(b);
+            return (va - vb) * dir;
+        });
+    }
+    const accessor = sortable[modelSortColumn];
+    return accessor ? sortByProp(models, accessor, modelSortDirection) : models;
+}
+
+function modelStatusOrder(model) {
+    if (runningModels.has(model.name) || dbtRunStartTime !== null) return 0;
+    const order = { 'success': 10, 'stale': 20, 'error': 30, 'skipped': 40 };
+    return order[model.status] != null ? order[model.status] : 99;
+}
+
+function applyModelsFilter(models) {
+    if (!modelFilterText) return models;
+    return filterByText(models, modelFilterText, ['name', 'schema', 'materialization']);
+}
+
+function updateModelsSortArrows() {
+    const table = document.querySelector('#dbt-models-table-body')?.closest('table');
+    if (!table) return;
+    table.querySelectorAll('thead th[data-sort-key]').forEach((th) => {
+        const colKey = th.dataset.sortKey;
+        th.innerHTML = th.innerHTML.replace(/[▲▼]/g, '').trim();
+        if (colKey === modelSortColumn && modelSortDirection && modelSortDirection !== 'none') {
+            th.innerHTML += modelSortDirection === 'asc' ? ' ▲' : ' ▼';
+        }
+    });
+}
+
+function initModelsSortHeaders() {
+    const table = document.querySelector('#dbt-models-table-body')?.closest('table');
+    if (!table) return;
+    const thead = table.querySelector('thead');
+    if (!thead || thead.dataset.sortInit) return;
+    thead.dataset.sortInit = '1';
+
+    thead.addEventListener('click', (e) => {
+        const th = e.target.closest('th[data-sort-key]');
+        if (!th) return;
+        const colKey = th.dataset.sortKey;
+
+        if (modelSortColumn === colKey) {
+            if (modelSortDirection === 'asc') modelSortDirection = 'desc';
+            else if (modelSortDirection === 'desc') { modelSortDirection = null; modelSortColumn = null; }
+            else { modelSortColumn = colKey; modelSortDirection = 'asc'; }
+        } else {
+            modelSortColumn = colKey;
+            modelSortDirection = 'asc';
+        }
+        localStorage.setItem('dango-models-sort-column', modelSortColumn || '');
+        localStorage.setItem('dango-models-sort-direction', modelSortDirection || '');
+        renderDbtModelsTable();
+    });
+}
+
+function initModelsFilter() {
+    const input = document.getElementById('models-filter-input');
+    if (!input) return;
+    const clearBtn = document.getElementById('models-filter-clear');
+
+    input.value = modelFilterText || '';
+    if (clearBtn) {
+        clearBtn.classList.toggle('hidden', !modelFilterText);
+    }
+
+    input.addEventListener('input', () => {
+        modelFilterText = input.value;
+        localStorage.setItem('dango-models-filter', modelFilterText);
+        if (clearBtn) clearBtn.classList.toggle('hidden', !modelFilterText);
+        renderDbtModelsTable();
+    });
+
+    if (clearBtn) {
+        clearBtn.addEventListener('click', () => {
+            input.value = '';
+            modelFilterText = '';
+            localStorage.setItem('dango-models-filter', '');
+            clearBtn.classList.add('hidden');
+            renderDbtModelsTable();
+        });
+    }
+}
+
 function renderDbtModelsTable() {
     const tbody = document.getElementById('dbt-models-table-body');
     if (!tbody) return;
@@ -2343,7 +2576,23 @@ function renderDbtModelsTable() {
 
     const canRun = window.DANGO_USER_ROLE === 'admin' || window.DANGO_USER_ROLE === 'editor';
 
-    tbody.innerHTML = dbtModels.map(model => {
+    // Apply sort and filter
+    const sorted = applyModelsSort(dbtModels);
+    const filtered = applyModelsFilter(sorted);
+
+    if (filtered.length === 0 && modelFilterText) {
+        tbody.innerHTML = `
+            <tr>
+                <td colspan="7" class="px-6 py-8 text-center text-gray-500">
+                    <p>No models match "<span class="font-medium">${escapeHtml(modelFilterText)}</span>"</p>
+                </td>
+            </tr>
+        `;
+        updateModelsSortArrows();
+        return;
+    }
+
+    tbody.innerHTML = filtered.map(model => {
         // Disable ALL buttons if ANY model is running (prevents concurrent runs and DuckDB locking)
         const anyModelRunning = runningModels.size > 0 || dbtRunStartTime !== null;
         const buttonDisabled = anyModelRunning ? 'disabled' : '';
@@ -2428,10 +2677,10 @@ function renderDbtModelsTable() {
         return `
             <tr class="hover:bg-gray-50 transition-colors duration-150">
                 <td class="px-6 py-4 whitespace-nowrap">
-                    <div class="text-sm font-medium text-gray-900">${model.name}</div>
+                    <div class="text-sm font-medium text-gray-900">${escapeHtml(model.name)}</div>
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                    ${model.schema || '-'}
+                    ${escapeHtml(model.schema || '-')}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap">
                     <span class="px-2 py-1 text-xs rounded-full bg-blue-100 text-blue-800">
@@ -2460,6 +2709,7 @@ function renderDbtModelsTable() {
             </tr>
         `;
     }).join('');
+    updateModelsSortArrows();
 }
 
 async function runDbtModel(modelName, cascade) {

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1197,10 +1197,17 @@ function updateSourcesSortArrows() {
     if (!table) return;
     table.querySelectorAll('thead th[data-sort-key]').forEach((th) => {
         const colKey = th.dataset.sortKey;
-        // Remove any existing arrow
-        th.innerHTML = th.innerHTML.replace(/[▲▼]/g, '').trim();
+        // Use a dedicated span for the arrow to avoid mutating label text
+        let arrow = th.querySelector('.sort-arrow');
+        if (!arrow) {
+            arrow = document.createElement('span');
+            arrow.className = 'sort-arrow';
+            th.appendChild(arrow);
+        }
         if (colKey === sourceSortColumn && sourceSortDirection && sourceSortDirection !== 'none') {
-            th.innerHTML += sourceSortDirection === 'asc' ? ' ▲' : ' ▼';
+            arrow.textContent = sourceSortDirection === 'asc' ? ' ▲' : ' ▼';
+        } else {
+            arrow.textContent = '';
         }
     });
 }
@@ -2484,9 +2491,17 @@ function updateModelsSortArrows() {
     if (!table) return;
     table.querySelectorAll('thead th[data-sort-key]').forEach((th) => {
         const colKey = th.dataset.sortKey;
-        th.innerHTML = th.innerHTML.replace(/[▲▼]/g, '').trim();
+        // Use a dedicated span for the arrow to avoid mutating label text
+        let arrow = th.querySelector('.sort-arrow');
+        if (!arrow) {
+            arrow = document.createElement('span');
+            arrow.className = 'sort-arrow';
+            th.appendChild(arrow);
+        }
         if (colKey === modelSortColumn && modelSortDirection && modelSortDirection !== 'none') {
-            th.innerHTML += modelSortDirection === 'asc' ? ' ▲' : ' ▼';
+            arrow.textContent = modelSortDirection === 'asc' ? ' ▲' : ' ▼';
+        } else {
+            arrow.textContent = '';
         }
     });
 }

--- a/dango/web/static/js/utils.js
+++ b/dango/web/static/js/utils.js
@@ -30,6 +30,63 @@ function formatSource(source) {
 }
 
 /**
+ * Resolve a dot-delimited property path on an object.
+ * Used by sortByProp and filterByText to access nested fields.
+ * @param {Object} obj
+ * @param {string} path - e.g., "freshness.status"
+ * @returns {*} The resolved value, or undefined if any segment is null/undefined
+ */
+function resolveNested(obj, path) {
+    if (!obj || !path) return undefined;
+    return path.split('.').reduce((o, k) => (o != null ? o[k] : undefined), obj);
+}
+
+/**
+ * Sort an array of objects by a property path or computed accessor.
+ * Missing values sort last. Case-insensitive string comparison.
+ * @param {Array} arr
+ * @param {string|Function} accessor - Property path string or function(item) => value
+ * @param {string} dir - "asc" or "desc"
+ * @returns {Array} New sorted array (does not mutate input)
+ */
+function sortByProp(arr, accessor, dir) {
+    if (!dir || dir === 'none' || !accessor) return [...arr];
+    const copy = [...arr];
+    const desc = dir === 'desc' ? -1 : 1;
+    const get = typeof accessor === 'function' ? accessor : (item) => resolveNested(item, accessor);
+    copy.sort((a, b) => {
+        const va = get(a);
+        const vb = get(b);
+        if (va == null && vb == null) return 0;
+        if (va == null) return 1;
+        if (vb == null) return -1;
+        if (typeof va === 'number' && typeof vb === 'number') {
+            return (va - vb) * desc;
+        }
+        return String(va).toLowerCase().localeCompare(String(vb).toLowerCase()) * desc;
+    });
+    return copy;
+}
+
+/**
+ * Filter an array of objects by case-insensitive substring match across named fields.
+ * @param {Array} arr
+ * @param {string} query - Filter text
+ * @param {Array<string>} fields - Property paths to search
+ * @returns {Array} Filtered copy (returns original if query is empty/whitespace)
+ */
+function filterByText(arr, query, fields) {
+    if (!query || !query.trim()) return [...arr];
+    const q = query.trim().toLowerCase();
+    return arr.filter(item =>
+        fields.some(field => {
+            const val = resolveNested(item, field);
+            return val != null && String(val).toLowerCase().includes(q);
+        })
+    );
+}
+
+/**
  * Format an ISO timestamp for display.
  * Thresholds: <60s "just now", <1h "X min ago", <24h "Xh ago",
  * <7d "Mon 15:39", >=7d "Jun 16" (with year if not current).

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -171,17 +171,38 @@
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
-                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Description</th>
-                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Tests</th>
-                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Last Updated</th>
-                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Documented</th>
-                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Tags</th>
+                                            <th @click="toggleCatalogSort('name')"
+                                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
+                                                Name<template x-if="sortColumn === 'name'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                            </th>
+                                            <th @click="toggleCatalogSort('type')"
+                                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
+                                                Type<template x-if="sortColumn === 'type'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                            </th>
+                                            <th @click="toggleCatalogSort('description')"
+                                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
+                                                Description<template x-if="sortColumn === 'description'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                            </th>
+                                            <th @click="toggleCatalogSort('tests')"
+                                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden md:table-cell">
+                                                Tests<template x-if="sortColumn === 'tests'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                            </th>
+                                            <th @click="toggleCatalogSort('last_updated')"
+                                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden md:table-cell">
+                                                Last Updated<template x-if="sortColumn === 'last_updated'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                            </th>
+                                            <th @click="toggleCatalogSort('documented')"
+                                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden md:table-cell">
+                                                Documented<template x-if="sortColumn === 'documented'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                            </th>
+                                            <th @click="toggleCatalogSort('tags')"
+                                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden lg:table-cell">
+                                                Tags<template x-if="sortColumn === 'tags'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                            </th>
                                         </tr>
                                     </thead>
                                     <tbody class="bg-white divide-y divide-gray-200">
-                                        <template x-for="item in filteredItems" :key="item.unique_id">
+                                        <template x-for="item in sortedFilteredItems" :key="item.unique_id">
                                             <tr class="hover:bg-gray-50 cursor-pointer" @click="openModel(item.name)">
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     <a :href="'/catalog?model=' + encodeURIComponent(item.name)" @click.prevent class="text-sm font-medium text-blue-600 hover:text-blue-800" x-text="item.schema ? item.schema + '.' + item.name : item.name"></a>
@@ -550,6 +571,9 @@ function catalogPage() {
         // Guard flag: suppresses pushState during URL restoration and popstate
         // handling to prevent feedback loops (restoreFromUrl → openModel → updateUrl).
         _skipPush: false,
+        // Sort state
+        sortColumn: localStorage.getItem('dango-catalog-sort-column') || null,
+        sortDirection: localStorage.getItem('dango-catalog-sort-direction') || null,
         // Tab config
         tabs: [
             { key: 'all', label: 'All' },
@@ -723,6 +747,52 @@ function catalogPage() {
             const items = [...this.allSources, ...this.allModels];
             if (this.activeTab === 'all') return items;
             return items.filter(i => i.type === this.activeTab);
+        },
+
+        get sortedFilteredItems() {
+            let items = this.filteredItems;
+            if (this.sortColumn && this.sortDirection && this.sortDirection !== 'none') {
+                const dir = this.sortDirection === 'desc' ? -1 : 1;
+                const col = this.sortColumn;
+                items = [...items].sort((a, b) => {
+                    const va = this._resolveCatalogField(a, col);
+                    const vb = this._resolveCatalogField(b, col);
+                    if (va == null && vb == null) return 0;
+                    if (va == null) return 1;
+                    if (vb == null) return -1;
+                    const cmp = typeof va === 'number'
+                        ? va - vb
+                        : String(va).toLowerCase().localeCompare(String(vb).toLowerCase());
+                    return cmp * dir;
+                });
+            }
+            return items;
+        },
+
+        _resolveCatalogField(item, col) {
+            switch (col) {
+                case 'name': return item.schema ? item.schema + '.' + item.name : item.name;
+                case 'type': return item.type;
+                case 'description': return item.description || '';
+                case 'tests': return item.test_count ?? 0;
+                case 'last_updated': return item.last_run || null;
+                case 'documented': return item.columns_total > 0 ? item.columns_documented / item.columns_total : 0;
+                case 'tags': return (item.tags && item.tags.length > 0) ? item.tags[0] : '';
+                default: return undefined;
+            }
+        },
+
+        toggleCatalogSort(col) {
+            if (this.sortColumn === col) {
+                if (this.sortDirection === 'asc') this.sortDirection = 'desc';
+                else if (this.sortDirection === 'desc') { this.sortDirection = null; this.sortColumn = null; }
+                else this.sortDirection = 'asc';
+            } else {
+                this.sortColumn = col;
+                this.sortDirection = 'asc';
+            }
+            localStorage.setItem('dango-catalog-sort-column', this.sortColumn || '');
+            localStorage.setItem('dango-catalog-sort-direction', this.sortDirection || '');
         },
 
         tabCount(key) {

--- a/dango/web/templates/models.html
+++ b/dango/web/templates/models.html
@@ -20,15 +20,24 @@
                 </div>
             </div>
 
+            <div class="px-6 py-3 border-b border-gray-200 flex items-center gap-2">
+                <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                </svg>
+                <input type="text" id="models-filter-input" placeholder="Filter models..."
+                       class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                <button id="models-filter-clear" class="text-xs text-gray-400 hover:text-gray-600 hidden">Clear</button>
+            </div>
+
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Model</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Schema</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rows</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                            <th data-sort-key="name" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Model</th>
+                            <th data-sort-key="schema" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Schema</th>
+                            <th data-sort-key="materialization" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>
+                            <th data-sort-key="rows" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
+                            <th data-sort-key="status" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Status</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Run</th>
                             <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                         </tr>

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -168,8 +168,13 @@
                         </tr>
                     </tbody>
                 </template>
-                <tbody x-show="sortedSchedules.length === 0" x-cloak>
+                <tbody x-show="schedules.length === 0" x-cloak>
                     <tr><td colspan="8" class="px-6 py-8 text-center text-sm text-gray-500">No schedules configured.</td></tr>
+                </tbody>
+                <tbody x-show="schedules.length > 0 && sortedSchedules.length === 0" x-cloak>
+                    <tr><td colspan="8" class="px-6 py-8 text-center text-sm text-gray-500">
+                        No schedules match "<span class="font-medium" x-text="filterText"></span>"
+                    </td></tr>
                 </tbody>
             </table>
         </div>

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -22,21 +22,45 @@
         </div>
 
         <!-- Scheduled sources table -->
-        <div class="bg-white shadow rounded-lg overflow-x-auto mb-6">
+        <div x-show="schedules.length > 0" class="px-6 py-3 border-b border-gray-200 flex items-center gap-2 bg-white shadow rounded-t-lg">
+            <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+            </svg>
+            <input type="text" x-model="filterText" placeholder="Filter schedules..."
+                   class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+            <button x-show="filterText" @click="filterText = ''"
+                    class="text-xs text-gray-400 hover:text-gray-600">Clear</button>
+        </div>
+        <div class="bg-white shadow rounded-b-lg overflow-x-auto mb-6">
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
                     <tr>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                        <th @click="toggleSort('name')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
+                            Name<template x-if="sortColumn === 'name'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
+                        <th @click="toggleSort('type')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
+                            Type<template x-if="sortColumn === 'type'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Sources</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Cron</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">Next Run</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                        <th @click="toggleSort('cron')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
+                            Cron<template x-if="sortColumn === 'cron'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
+                        <th @click="toggleSort('next_run')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden lg:table-cell">
+                            Next Run<template x-if="sortColumn === 'next_run'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
+                        <th @click="toggleSort('status')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
+                            Status<template x-if="sortColumn === 'status'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Enabled</th>
                         <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
-                <template x-for="sched in schedules" :key="sched.name">
+                <template x-for="sched in sortedSchedules" :key="sched.name">
                     <tbody class="bg-white border-b border-gray-200">
                         <tr>
                             <td class="px-6 py-4 whitespace-nowrap">
@@ -63,8 +87,15 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden lg:table-cell"
                                 x-text="sched.next_run_time ? timeAgo(sched.next_run_time) : '—'"></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm">
-                                <template x-if="runningJobs[sched.name]">
-                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 animate-pulse">running</span>
+                                <template x-if="runningJobs[sched.name] && runningJobs[sched.name].status === 'queued'">
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                                        Queued: <span class="ml-1 font-normal" x-text="runningJobs[sched.name].source"></span>
+                                    </span>
+                                </template>
+                                <template x-if="runningJobs[sched.name] && runningJobs[sched.name].status !== 'queued'">
+                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 animate-pulse">
+                                        Running: <span class="ml-1 font-normal" x-text="runningJobs[sched.name].source"></span>
+                                    </span>
                                 </template>
                                 <template x-if="!runningJobs[sched.name] && sched.last_run">
                                     <span>
@@ -137,7 +168,7 @@
                         </tr>
                     </tbody>
                 </template>
-                <tbody x-show="schedules.length === 0" x-cloak>
+                <tbody x-show="sortedSchedules.length === 0" x-cloak>
                     <tr><td colspan="8" class="px-6 py-8 text-center text-sm text-gray-500">No schedules configured.</td></tr>
                 </tbody>
             </table>
@@ -280,6 +311,11 @@ function schedulesPage() {
         reconnectInterval: null,
         pollInterval: null,
 
+        // Sort/filter state
+        sortColumn: localStorage.getItem('dango-schedules-sort-column') || null,
+        sortDirection: localStorage.getItem('dango-schedules-sort-direction') || null,
+        filterText: localStorage.getItem('dango-schedules-filter') || '',
+
         async init() {
             await Promise.all([
                 this.loadSchedules(),
@@ -287,6 +323,68 @@ function schedulesPage() {
                 this.loadNotifConfig()
             ]);
             this.connectWebSocket();
+            this.$watch('filterText', val => {
+                localStorage.setItem('dango-schedules-filter', val || '');
+            });
+        },
+
+        // --- Sort/filter ---
+        get sortedSchedules() {
+            let items = this.filterText
+                ? this.schedules.filter(s => {
+                    const q = this.filterText.toLowerCase();
+                    return (s.name && s.name.toLowerCase().includes(q))
+                        || (s.type && s.type.toLowerCase().includes(q))
+                        || (s.cron && s.cron.toLowerCase().includes(q));
+                  })
+                : [...this.schedules];
+
+            if (this.sortColumn && this.sortDirection && this.sortDirection !== 'none') {
+                const dir = this.sortDirection === 'desc' ? -1 : 1;
+                const col = this.sortColumn;
+                items.sort((a, b) => {
+                    const va = this._resolveScheduleField(a, col);
+                    const vb = this._resolveScheduleField(b, col);
+                    if (va == null && vb == null) return 0;
+                    if (va == null) return 1;
+                    if (vb == null) return -1;
+                    const cmp = typeof va === 'number'
+                        ? va - vb
+                        : String(va).toLowerCase().localeCompare(String(vb).toLowerCase());
+                    return cmp * dir;
+                });
+            }
+            return items;
+        },
+
+        _resolveScheduleField(sched, col) {
+            switch (col) {
+                case 'name': return sched.name;
+                case 'type': return sched.type;
+                case 'cron': return sched.cron;
+                case 'next_run': return sched.next_run_time;
+                case 'status':
+                    if (this.runningJobs[sched.name]) return 0;
+                    if (sched.last_run) {
+                        const order = { 'success': 10, 'completed': 10, 'failed': 20, 'cancelled': 30, 'timeout': 40 };
+                        return order[sched.last_run.status] != null ? order[sched.last_run.status] : 99;
+                    }
+                    return 99;
+                default: return undefined;
+            }
+        },
+
+        toggleSort(col) {
+            if (this.sortColumn === col) {
+                if (this.sortDirection === 'asc') this.sortDirection = 'desc';
+                else if (this.sortDirection === 'desc') { this.sortDirection = null; this.sortColumn = null; }
+                else this.sortDirection = 'asc';
+            } else {
+                this.sortColumn = col;
+                this.sortDirection = 'asc';
+            }
+            localStorage.setItem('dango-schedules-sort-column', this.sortColumn || '');
+            localStorage.setItem('dango-schedules-sort-direction', this.sortDirection || '');
         },
 
         // --- Data loading ---
@@ -487,18 +585,34 @@ function schedulesPage() {
             const source = data.source;
             const schedule = data.schedule;
 
-            if (ev === 'sync_started' || ev === 'dbt_started' || ev === 'script_started') {
+            if (ev === 'job_queued') {
                 const updated = {...this.runningJobs};
                 for (const sched of this.schedules) {
+                    if (sched.name === schedule) {
+                        updated[sched.name] = { event: 'queued', source: schedule, status: 'queued' };
+                    }
+                }
+                this.runningJobs = updated;
+            }
+
+            if (ev === 'sync_started' || ev === 'dbt_started' || ev === 'script_started') {
+                const updated = {...this.runningJobs};
+                // Determine display name: prefer source name, fall back to schedule name
+                const displayName = source || (data.sources && data.sources[0]) || schedule || '';
+                for (const sched of this.schedules) {
                     let match = false;
-                    if (ev === 'sync_started') {
+                    if (schedule) {
+                        match = sched.name === schedule;
+                    } else if (ev === 'sync_started') {
                         match = sched.sources.includes(source);
                     } else if (ev === 'dbt_started') {
                         match = sched.type === 'dbt';
                     } else if (ev === 'script_started') {
-                        match = sched.type === 'script' && sched.name === schedule;
+                        match = sched.type === 'script';
                     }
-                    if (match) updated[sched.name] = true;
+                    if (match) {
+                        updated[sched.name] = { event: ev, source: displayName, status: 'running' };
+                    }
                 }
                 this.runningJobs = updated;
             }
@@ -508,12 +622,14 @@ function schedulesPage() {
                 const updated = {...this.runningJobs};
                 for (const sched of this.schedules) {
                     let match = false;
-                    if (ev.startsWith('sync_')) {
+                    if (schedule) {
+                        match = sched.name === schedule;
+                    } else if (ev.startsWith('sync_')) {
                         match = sched.sources.includes(source);
                     } else if (ev.startsWith('dbt_')) {
                         match = sched.type === 'dbt';
                     } else if (ev.startsWith('script_')) {
-                        match = sched.type === 'script' && sched.name === schedule;
+                        match = sched.type === 'script';
                     }
                     if (match) delete updated[sched.name];
                 }

--- a/dango/web/templates/scripts.html
+++ b/dango/web/templates/scripts.html
@@ -22,18 +22,39 @@
         </div>
 
         <!-- Scripts table -->
-        <div class="bg-white shadow rounded-lg overflow-x-auto mb-6">
+        <div x-show="scripts.length > 0" class="px-6 py-3 border-b border-gray-200 flex items-center gap-2 bg-white shadow rounded-t-lg">
+            <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+            </svg>
+            <input type="text" x-model="filterText" placeholder="Filter scripts..."
+                   class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+            <button x-show="filterText" @click="filterText = ''"
+                    class="text-xs text-gray-400 hover:text-gray-600">Clear</button>
+        </div>
+        <div class="bg-white shadow rounded-b-lg overflow-x-auto mb-6">
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
                     <tr>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Script</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Last Run</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Schedule</th>
+                        <th @click="toggleScriptSort('name')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
+                            Script<template x-if="sortColumn === 'name'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
+                        <th @click="toggleScriptSort('last_run')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
+                            Last Run<template x-if="sortColumn === 'last_run'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
+                        <th @click="toggleScriptSort('status')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
+                            Status<template x-if="sortColumn === 'status'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
+                        <th @click="toggleScriptSort('schedule')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
+                            Schedule<template x-if="sortColumn === 'schedule'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
                         <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
-                <template x-for="script in scripts" :key="script.name">
+                <template x-for="script in sortedScripts" :key="script.name">
                     <tbody class="bg-white border-b border-gray-200">
                         <tr>
                             <td class="px-6 py-4 whitespace-nowrap">
@@ -121,6 +142,11 @@
                 <tbody x-show="scripts.length === 0" x-cloak>
                     <tr><td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">No scripts found. Add <code class="bg-gray-100 px-1 rounded">.py</code> files to the <code class="bg-gray-100 px-1 rounded">scripts/</code> directory.</td></tr>
                 </tbody>
+                <tbody x-show="scripts.length > 0 && sortedScripts.length === 0" x-cloak>
+                    <tr><td colspan="5" class="px-6 py-8 text-center text-sm text-gray-500">
+                        No scripts match "<span class="font-medium" x-text="filterText"></span>"
+                    </td></tr>
+                </tbody>
             </table>
         </div>
     </div>
@@ -147,9 +173,73 @@ function scriptsPage() {
         ws: null,
         reconnectInterval: null,
 
+        // Sort/filter state
+        sortColumn: localStorage.getItem('dango-scripts-sort-column') || null,
+        sortDirection: localStorage.getItem('dango-scripts-sort-direction') || null,
+        filterText: localStorage.getItem('dango-scripts-filter') || '',
+
         async init() {
             await this.loadScripts();
             this.connectWebSocket();
+            this.$watch('filterText', val => {
+                localStorage.setItem('dango-scripts-filter', val || '');
+            });
+        },
+
+        // --- Sort/filter ---
+        get sortedScripts() {
+            let items = this.filterText
+                ? this.scripts.filter(s => {
+                    const q = this.filterText.toLowerCase();
+                    return (s.name && s.name.toLowerCase().includes(q));
+                  })
+                : [...this.scripts];
+
+            if (this.sortColumn && this.sortDirection && this.sortDirection !== 'none') {
+                const dir = this.sortDirection === 'desc' ? -1 : 1;
+                const col = this.sortColumn;
+                items.sort((a, b) => {
+                    const va = this._resolveScriptField(a, col);
+                    const vb = this._resolveScriptField(b, col);
+                    if (va == null && vb == null) return 0;
+                    if (va == null) return 1;
+                    if (vb == null) return -1;
+                    const cmp = typeof va === 'number'
+                        ? va - vb
+                        : String(va).toLowerCase().localeCompare(String(vb).toLowerCase());
+                    return cmp * dir;
+                });
+            }
+            return items;
+        },
+
+        _resolveScriptField(script, col) {
+            switch (col) {
+                case 'name': return script.name;
+                case 'last_run': return script.last_run?.started_at || null;
+                case 'status':
+                    if (script.running) return 0;
+                    if (script.last_run) {
+                        const order = { 'success': 10, 'completed': 10, 'failed': 20, 'cancelled': 30, 'timeout': 40 };
+                        return order[script.last_run.status] != null ? order[script.last_run.status] : 99;
+                    }
+                    return 99;
+                case 'schedule': return null;
+                default: return undefined;
+            }
+        },
+
+        toggleScriptSort(col) {
+            if (this.sortColumn === col) {
+                if (this.sortDirection === 'asc') this.sortDirection = 'desc';
+                else if (this.sortDirection === 'desc') { this.sortDirection = null; this.sortColumn = null; }
+                else this.sortDirection = 'asc';
+            } else {
+                this.sortColumn = col;
+                this.sortDirection = 'asc';
+            }
+            localStorage.setItem('dango-scripts-sort-column', this.sortColumn || '');
+            localStorage.setItem('dango-scripts-sort-direction', this.sortDirection || '');
         },
 
         // --- Data loading ---

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -20,15 +20,24 @@
                 </div>
             </div>
 
+            <div class="px-6 py-3 border-b border-gray-200 flex items-center gap-2">
+                <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                </svg>
+                <input type="text" id="sources-filter-input" placeholder="Filter sources..."
+                       class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                <button id="sources-filter-clear" class="text-xs text-gray-400 hover:text-gray-600 hidden">Clear</button>
+            </div>
+
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Source</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rows</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Sync</th>
+                            <th data-sort-key="name" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Source</th>
+                            <th data-sort-key="type" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>
+                            <th data-sort-key="status" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Status</th>
+                            <th data-sort-key="rows" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
+                            <th data-sort-key="last-sync" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Last Sync</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Schedule</th>
                             <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                         </tr>


### PR DESCRIPTION
## Summary
- Add client-side column sorting to Sources, Models, Schedules, Catalog, and Scripts tables (click header to cycle asc/desc/unsorted)
- Add text filter inputs on Sources, Models, Schedules, and Scripts pages (Catalog already has API search)
- Sort/filter state persists in localStorage per page
- Enhance Schedule status badge: shows "Running: <source>" (blue pulsing) and "Queued: <schedule>" (yellow) via `job_queued` WS event
- Add shared sort/filter utilities (`sortByProp`, `filterByText`, `resolveNested`) to `utils.js`
- Fix XSS: `escapeHtml()` on `model.name` and `model.schema` in `renderDbtModelsTable()`
- Document sort/filter patterns in `web/CLAUDE.md`
- Scripts page: apply Alpine.js sort/filter pattern matching Schedules

## Verification
- `ruff check`: All checks passed
- `ruff format --check`: 220 files already formatted
- `pytest -x`: 2292 passed, 24 skipped, 1 pre-existing failure (`test_download_fallback` in test_pii_detection.py — spaCy model download, unrelated)

## Regression check
- Existing sync flow: sort/filter applied inside `renderSourcesTable()` / `renderDbtModelsTable()` — all WebSocket event callers automatically get sorted/filtered output
- File uploads, modals, sync buttons: no changes to those code paths
- WebSocket events: handler changes are additive (new `job_queued` case); existing `sync_started`/`sync_completed` paths updated to include source name in `runningJobs` structure
- Alpine.js reactivity: spread reassignment used for `runningJobs` (per `web/CLAUDE.md` convention)

## Notes
- `sync_queued` event does not exist in backend — used `job_queued` instead (fires for dbt lock timeout scenarios from `jobs.py:853`). General sync queue visibility needs a future backend change.
- Scripts page sort/filter implemented (page already existed with Alpine.js component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)