### PR TITLE
S3-C: dlt 1.24->1.28.1 upgrade

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,7 +12,7 @@ the tested stack and upgrade process.
 | Metabase | v0.59.1 | pinned | `dango/templates/Dockerfile.metabase` |
 | dbt-core | 1.10.22 | ~=1.10.0 | `pyproject.toml` |
 | dbt-duckdb | 1.10.1 | >=1.10.0,<1.11 | `pyproject.toml` |
-| dlt | 1.24.0 | ~=1.24.0 | `pyproject.toml` |
+| dlt | 1.28.1 | ~=1.28.0 | `pyproject.toml` |
 
 Tested versions are recorded in `constraints.txt` for reproducible installs.
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@ dbt-duckdb==1.10.1
 #
 # Tier 2 — semi-coupled (patch safe, minor needs testing)
 dbt-core==1.10.22
-dlt==1.24.0
+dlt==1.28.1
 #
 # Transitive — prevent known breakage
 starlette>=1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "dbt-duckdb>=1.10.0,<1.11",   # Tier 1 — must match dbt-core
     # ── Tier 2: semi-coupled (patch safe, minor needs testing) ────────────
     "dbt-core~=1.10.0",           # Tier 2 — 1.11 is breaking
-    "dlt[duckdb]~=1.24.0",        # Tier 2 — latest stable
+    "dlt[duckdb]~=1.28.0",        # Tier 2 — latest stable
 
     # Framework and utilities - flexible versions
     "click>=8.1.7",


### PR DESCRIPTION
## Summary
- dlt: 1.24.0 -> 1.28.1 (4 minor versions)
- API audit: 13 dlt public API call sites checked, all compatible
- 1 internal import (LoadInfo from dlt.common.pipeline) with hasattr guards
- LoadInfo.load_id renamed to loads_ids in 1.28.1 — hasattr guard handles gracefully
- Benefits: DuckDB 1.5.3+, credential refresh, normalizer speedup, Python 3.14 support
- Breaking changes assessed: 5 total, 0 affect Dango (S3-B mitigates replace truncation)

## Verification
- pytest -x: 3968 pass, 31 skip, 0 fail
- ruff check/format: pass
- Vendored sources: 20/27 import cleanly (7 fail on missing optional third-party deps — pre-existing, not dlt-related)
- LoadInfo API: `metrics` and `dataset_name` confirmed present; `load_id` -> `loads_ids` (hasattr guard handles)

## Regression check
- All existing tests pass
- LoadInfo attributes (load_id via hasattr fallback, metrics, dataset_name) compatible with 1.28.1
- Pipeline state backup/restore works (filesystem-based, no dlt API dependency)
- OAuth credential injection unaffected (uses toml library, not dlt API)

## Changes
- `pyproject.toml`: `dlt[duckdb]~=1.24.0` -> `dlt[duckdb]~=1.28.0`
- `constraints.txt`: `dlt==1.24.0` -> `dlt==1.28.1`
- `VERSIONS.md`: update tested stack entry