### PR TITLE
S3-3: Wizard bucket reuse + destroy keep-Spaces default + post-restore guidance

### DIFF
--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -272,6 +272,7 @@ def _handle_do_deploy_with_config(
         admin_password=result.admin_password,
         warnings=result.warnings,
         domain=config.domain,
+        backup_enabled=config.enable_backups,
     )
 
 
@@ -284,6 +285,7 @@ def _print_byos_success(result: Any, config: Any) -> None:
         admin_password=result.admin_password,
         warnings=result.warnings,
         domain=config.domain,
+        backup_enabled=False,
     )
 
 
@@ -295,6 +297,7 @@ def _print_deploy_success(
     admin_password: str = "",
     warnings: list[str],
     domain: str | None = None,
+    backup_enabled: bool = False,
 ) -> None:
     """Print deployment success output (shared by DO and BYOS paths)."""
     console.print("\n[bold green]Deployment complete![/bold green]")
@@ -306,6 +309,11 @@ def _print_deploy_success(
         console.print("  [dim]Save this password — it will not be shown again.[/dim]")
     if domain:
         console.print(f"\n  [bold]DNS setup:[/bold] Point an A record for {domain} to {ip}")
+    if backup_enabled:
+        console.print(
+            "\n  [bold]Backups:[/bold] Enabled (daily at 02:00 UTC to Spaces). "
+            "Run [bold]dango remote backup download[/bold] to save a local copy."
+        )
     if warnings:
         for w in warnings:
             console.print(f"  [yellow]Warning:[/yellow] {w}")
@@ -368,40 +376,56 @@ def _compute_ssh_fingerprint(public_key_path: Path) -> str | None:
 
 @deploy.command("destroy")
 @click.option("--force", is_flag=True, help="Skip confirmation and backup prompts.")
-@click.option("--keep-spaces", is_flag=True, help="Keep the Spaces bucket and its contents.")
+@click.option(
+    "--delete-spaces",
+    is_flag=True,
+    help="Also delete the Spaces bucket and all its contents.",
+)
+@click.option(
+    "--keep-spaces",
+    is_flag=True,
+    hidden=True,
+    help="Deprecated. Spaces are preserved by default now.",
+)
 @click.option("--keep-ssh-key", is_flag=True, help="Keep the SSH key on DigitalOcean.")
 @click.pass_context
 def deploy_destroy(
     ctx: click.Context,
     force: bool,
+    delete_spaces: bool,
     keep_spaces: bool,
     keep_ssh_key: bool,
 ) -> None:
     """Tear down all cloud infrastructure for this project.
 
-    For DigitalOcean: deletes the Droplet, firewall, SSH key (from DO), and Spaces bucket.
+    For DigitalOcean: deletes the Droplet, firewall, SSH key (from DO),
+    and optionally the Spaces bucket.  Spaces buckets are preserved by
+    default — use ``--delete-spaces`` to remove them.
+
     For BYOS: optionally stops remote services and removes local cloud.yml.
     Local SSH keys and project files are never deleted.
 
-    Use --force to skip confirmation prompts.  Use --keep-spaces or
-    --keep-ssh-key to preserve specific resources.
+    Use --force to skip confirmation prompts.
 
     Examples:
       dango deploy destroy
       dango deploy destroy --force
-      dango deploy destroy --keep-spaces --keep-ssh-key
+      dango deploy destroy --delete-spaces
     """
     cloud_cfg, project_root = _load_deploy_config(ctx)
 
+    # --delete-spaces takes precedence; --keep-spaces is a no-op (keep is default)
+    should_delete_spaces = delete_spaces
+
     if cloud_cfg.provider == "byos":
-        if keep_spaces or keep_ssh_key:
+        if keep_spaces or delete_spaces:
             console.print(
-                "[yellow]Note:[/yellow] --keep-spaces and --keep-ssh-key are "
+                "[yellow]Note:[/yellow] --keep-spaces and --delete-spaces are "
                 "DigitalOcean-only options and have no effect for BYOS deployments."
             )
         _destroy_byos(cloud_cfg, project_root, force)
     else:
-        _destroy_do(cloud_cfg, project_root, force, keep_spaces, keep_ssh_key)
+        _destroy_do(cloud_cfg, project_root, force, should_delete_spaces, keep_ssh_key)
 
 
 def _destroy_byos(cloud_cfg: Any, project_root: Path, force: bool) -> None:
@@ -523,7 +547,7 @@ def _destroy_do(
     cloud_cfg: Any,
     project_root: Path,
     force: bool,
-    keep_spaces: bool,
+    delete_spaces: bool,
     keep_ssh_key: bool,
 ) -> None:
     """Tear down a DigitalOcean deployment (delete cloud resources)."""
@@ -541,8 +565,13 @@ def _destroy_do(
     summary_lines.append(f"  SSH key (DO): will {ssh_action}")
 
     if cloud_cfg.spaces:
-        spaces_action = "keep" if keep_spaces else "delete (all contents + bucket)"
-        summary_lines.append(f"  Spaces bucket: {cloud_cfg.spaces.bucket} — will {spaces_action}")
+        if delete_spaces:
+            spaces_action = "DELETED (all contents + bucket)"
+        else:
+            spaces_action = "KEPT (use --delete-spaces to remove)"
+        summary_lines.append(
+            f"  Spaces bucket: {cloud_cfg.spaces.bucket} — will be {spaces_action}"
+        )
 
     console.print(
         Panel(
@@ -612,8 +641,8 @@ def _destroy_do(
     if not keep_ssh_key:
         _delete_ssh_key(client, cloud_cfg, project_root, errors)
 
-    # 4. Delete Spaces bucket
-    if cloud_cfg.spaces and not keep_spaces:
+    # 4. Delete Spaces bucket (only with explicit --delete-spaces)
+    if cloud_cfg.spaces and delete_spaces:
         _delete_spaces_bucket(cloud_cfg, errors)
 
     # --- Clean local config ---
@@ -624,6 +653,14 @@ def _destroy_do(
             console.print("[green]Removed[/green] .dango/cloud.yml")
         except OSError as exc:
             errors.append(f"Config cleanup: {exc}")
+
+    # --- Show Spaces reuse note if bucket was kept ---
+    if cloud_cfg.spaces and not delete_spaces:
+        console.print(
+            f"\n[dim]Spaces bucket '{cloud_cfg.spaces.bucket}' was preserved.[/dim] "
+            "[dim]Re-deploying with the same project name and region will reuse "
+            "this bucket and its backups.[/dim]"
+        )
 
     # --- Report results ---
     key_path = _resolve_key_path(cloud_cfg, project_root)
@@ -646,9 +683,37 @@ def _resolve_key_path(cloud_cfg: Any, project_root: Path) -> Path:
 
 
 def _offer_backup_download(cloud_cfg: Any, project_root: Path) -> None:
-    """Offer to download the latest backup before destroying."""
+    """Offer to download the latest backup before destroying.
+
+    Checks both on-server backups (via SSH) and Spaces backups (via the
+    Spaces API).  Shows the latest from each location so the user can
+    make an informed decision.
+    """
     from dango.platform.cloud.ssh import SSHManager
 
+    # --- Check Spaces for available backups (best-effort) ---
+    spaces_latest: str | None = None
+    spaces_count: int = 0
+    if cloud_cfg.spaces:
+        try:
+            from dango.platform.cloud.spaces import SpacesClient
+
+            spaces_client = SpacesClient(
+                bucket=cloud_cfg.spaces.bucket,
+                region=cloud_cfg.spaces.region or cloud_cfg.region,
+                access_key_env=cloud_cfg.spaces.access_key_env,
+                secret_key_env=cloud_cfg.spaces.secret_key_env,
+            )
+            objects = spaces_client.list_objects(prefix="backups/")
+            archives = [o for o in objects if o.get("Key", "").endswith(".tar.gz")]
+            if archives:
+                archives.sort(key=lambda x: x["Key"], reverse=True)
+                spaces_count = len(archives)
+                spaces_latest = archives[0]["Key"].rsplit("/", 1)[-1]
+        except Exception:  # noqa: BLE001
+            pass  # Best-effort — silently skip if Spaces is unreachable
+
+    # --- Check on-server backups via SSH ---
     key_path = _resolve_key_path(cloud_cfg, project_root)
     if not key_path.exists():
         return
@@ -658,42 +723,111 @@ def _offer_backup_download(cloud_cfg: Any, project_root: Path) -> None:
         known_hosts_path=key_path.parent / "known_hosts",
     )
 
+    server_latest: str | None = None
+
     try:
         ssh.connect(cloud_cfg.droplet_ip)
     except Exception:  # noqa: BLE001
+        # If we have Spaces backups but can't reach the server, still offer Spaces download
+        if spaces_latest:
+            if not _prompt_download_spaces(cloud_cfg, project_root, spaces_latest, spaces_count):
+                return
+            console.print(
+                "[yellow]Warning:[/yellow] Could not connect to server to check "
+                "for backups, but Spaces backups are available."
+            )
+            return
         console.print("[yellow]Warning:[/yellow] Could not connect to server to check for backups.")
         return
 
     try:
         result = ssh.exec_command("ls -t /srv/dango/backups/deploy/ 2>/dev/null | head -1")
-        if not result.success or not result.stdout.strip():
+        if result.success and result.stdout.strip():
+            candidate = result.stdout.strip()
+            if not ("/" in candidate or "\\" in candidate) and candidate:
+                server_latest = candidate
+
+        # No backups anywhere
+        if not server_latest and not spaces_latest:
             console.print(
-                "[yellow]Warning:[/yellow] No backups found on server. "
+                "[yellow]Warning:[/yellow] No backups found on server or in Spaces. "
                 "Consider backing up your data before proceeding."
             )
             return
 
-        latest_backup = result.stdout.strip()
-        if "/" in latest_backup or "\\" in latest_backup or not latest_backup:
-            console.print(
-                "[yellow]Warning:[/yellow] Unexpected backup filename — skipping download."
-            )
-            return
+        # Build prompt with info from both sources
+        server_info = f"server: {server_latest}" if server_latest else "no server backups"
+        spaces_info = ""
+        if spaces_latest:
+            label = "backup" if spaces_count == 1 else "backups"
+            spaces_info = f"Spaces: {spaces_latest} ({spaces_count} {label})"
+
+        hint_parts = [server_info]
+        if spaces_info:
+            hint_parts.append(spaces_info)
+        hint = ", ".join(hint_parts)
+
         _dl_answer = click.prompt(
-            f"Download latest backup ({latest_backup}) before destroying? (yes/no)",
+            f"Download latest backup before destroying? ({hint}) (yes/no)",
             default="no",
             show_default=True,
         )
-        if str(_dl_answer).lower().strip() in ("yes", "y"):
-            remote_path = f"/srv/dango/backups/deploy/{latest_backup}"
-            local_path = project_root / f"dango-backup-{latest_backup}"
+        if str(_dl_answer).lower().strip() not in ("yes", "y"):
+            return
+
+        # Prefer server backup for download (already have SSH connection)
+        if server_latest:
+            remote_path = f"/srv/dango/backups/deploy/{server_latest}"
+            local_path = project_root / f"dango-backup-{server_latest}"
             try:
                 ssh.download_file(remote_path, local_path)
                 console.print(f"[green]Downloaded[/green] backup to {local_path}")
             except Exception as exc:
                 console.print(f"[yellow]Warning:[/yellow] Failed to download backup: {exc}")
+        elif spaces_latest:
+            _download_from_spaces(cloud_cfg, project_root, spaces_latest)
     finally:
         ssh.disconnect()
+
+
+def _prompt_download_spaces(
+    cloud_cfg: Any,
+    project_root: Path,
+    spaces_latest: str,
+    spaces_count: int,
+) -> bool:
+    """Prompt to download a Spaces backup. Returns True if download attempted."""
+    label = "backup" if spaces_count == 1 else "backups"
+    _dl_answer = click.prompt(
+        f"Download latest Spaces backup ({spaces_latest}, {spaces_count} {label}) "
+        "before destroying? (yes/no)",
+        default="no",
+        show_default=True,
+    )
+    if str(_dl_answer).lower().strip() in ("yes", "y"):
+        _download_from_spaces(cloud_cfg, project_root, spaces_latest)
+        return True
+    return False
+
+
+def _download_from_spaces(cloud_cfg: Any, project_root: Path, backup_name: str) -> None:
+    """Download a backup from Spaces to the local project root."""
+    try:
+        from dango.platform.cloud.spaces import SpacesClient
+
+        client = SpacesClient(
+            bucket=cloud_cfg.spaces.bucket,
+            region=cloud_cfg.spaces.region or cloud_cfg.region,
+            access_key_env=cloud_cfg.spaces.access_key_env,
+            secret_key_env=cloud_cfg.spaces.secret_key_env,
+        )
+        key = f"backups/{backup_name}"
+        data = client.download(key)
+        local_path = project_root / f"dango-backup-{backup_name}"
+        local_path.write_bytes(data)
+        console.print(f"[green]Downloaded[/green] backup to {local_path}")
+    except Exception as exc:
+        console.print(f"[yellow]Warning:[/yellow] Failed to download Spaces backup: {exc}")
 
 
 def _delete_ssh_key(

--- a/dango/cli/commands/deploy_provision.py
+++ b/dango/cli/commands/deploy_provision.py
@@ -796,7 +796,7 @@ def _setup_backups(
     )
     from dango.platform.cloud.spaces import SpacesClient
 
-    bucket_name = f"dango-backup-{project_root.name}-{config.region}"
+    bucket_name = config.spaces_bucket_name or f"dango-backup-{project_root.name}-{config.region}"
     spaces = SpacesClient(
         bucket=bucket_name,
         region=config.region,
@@ -806,8 +806,11 @@ def _setup_backups(
     tracker.spaces_client = spaces
     tracker.spaces_bucket = bucket_name
 
-    # Create bucket (idempotent)
-    spaces.create_bucket()
+    # Create bucket (idempotent) — skip if reusing an existing bucket
+    if not config.spaces_bucket_name:
+        spaces.create_bucket()
+    else:
+        console.print(f"  [dim]Using existing bucket '{bucket_name}'.[/dim]")
 
     # Write Spaces credentials to remote .env
     env_lines = (

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -62,6 +62,7 @@ class WizardConfig:
     # Backup credentials (only set if enable_backups is True)
     spaces_access_key: str | None = None
     spaces_secret_key: str | None = None
+    spaces_bucket_name: str | None = None  # Existing bucket to reuse, None = create new
 
 
 @dataclass
@@ -400,11 +401,13 @@ def _step_oauth() -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _step_backups() -> tuple[bool, str | None, str | None]:
+def _step_backups(
+    project_root: Path, region: str
+) -> tuple[bool, str | None, str | None, str | None]:
     """Step 7: Enable automated backups?
 
     Returns:
-        Tuple of (enable_backups, access_key, secret_key).
+        Tuple of (enable_backups, access_key, secret_key, bucket_name).
     """
     console.print("\n[bold]Step 7: Automated Backups[/bold]")
     console.print("  Daily backups at 2:00 AM UTC to DigitalOcean Spaces ($5/mo for 250GB).")
@@ -415,7 +418,7 @@ def _step_backups() -> tuple[bool, str | None, str | None]:
 
     enable = _safe_confirm("  Enable automated backups?", default=True)
     if not enable:
-        return False, None, None
+        return False, None, None, None
 
     # Offer to enter keys now or skip
     import inquirer
@@ -438,7 +441,7 @@ def _step_backups() -> tuple[bool, str | None, str | None]:
     if not answers or answers["backup_action"].startswith("Skip"):
         console.print("  [yellow]Backups enabled but keys not configured.[/yellow]")
         console.print("  [dim]Run 'dango remote backup enable' later to add Spaces keys.[/dim]")
-        return True, None, None
+        return True, None, None, None
 
     console.print(
         "\n  Create Spaces access keys at: "
@@ -469,7 +472,103 @@ def _step_backups() -> tuple[bool, str | None, str | None]:
             "Backups may fail if keys are incorrect."
         )
 
-    return True, access_key, secret_key
+    # Discover existing dango backup buckets for reuse
+    bucket_name = _discover_existing_buckets(access_key, secret_key, project_root, region)
+
+    return True, access_key, secret_key, bucket_name
+
+
+def _discover_existing_buckets(
+    access_key: str,
+    secret_key: str,
+    project_root: Path,
+    region: str,
+) -> str | None:
+    """Offer to reuse an existing dango backup bucket.
+
+    Returns the bucket name if the user selects an existing one, or None
+    to create a new bucket.
+    """
+    import inquirer
+    from inquirer import themes
+
+    from dango.platform.cloud.spaces import SpacesClient
+
+    try:
+        discovery_client = SpacesClient(
+            bucket="",
+            region=region,
+            access_key=access_key,
+            secret_key=secret_key,
+        )
+        all_buckets = discovery_client.list_buckets()
+    except Exception:
+        console.print(
+            "  [dim]Could not enumerate existing Spaces buckets. "
+            "A new bucket will be created.[/dim]"
+        )
+        return None
+
+    # Filter to dango backup buckets
+    dango_buckets = [b for b in all_buckets if b["Name"].startswith("dango-backup-")]
+    if not dango_buckets:
+        return None
+
+    # Sort by creation date, newest first
+    dango_buckets.sort(key=lambda b: str(b["CreationDate"]), reverse=True)
+
+    # Build choice list with backup counts
+    choices: list[str] = []
+    for bucket in dango_buckets:
+        try:
+            count_client = SpacesClient(
+                bucket=bucket["Name"],
+                region=region,
+                access_key=access_key,
+                secret_key=secret_key,
+            )
+            objects = count_client.list_objects(prefix="backups/")
+            archives = [o for o in objects if o.get("Key", "").endswith(".tar.gz")]
+            count = len(archives)
+            total_size_mb = sum(o.get("Size", 0) for o in archives) // (1024 * 1024)
+            created_str = str(bucket["CreationDate"])[:10]
+            label = (
+                f"{bucket['Name']} ({count} backup{'s' if count != 1 else ''}, "
+                f"{total_size_mb} MB, created {created_str})"
+            )
+        except Exception:
+            label = f"{bucket['Name']} (could not enumerate)"
+        choices.append(label)
+
+    new_bucket_name = f"dango-backup-{project_root.name}-{region}"
+    choices.append(f"Create new bucket \u2192 {new_bucket_name}")
+
+    bucket_answers = inquirer.prompt(
+        [
+            inquirer.List(
+                "bucket_choice",
+                message="Select a Spaces bucket to use for backups",
+                choices=choices,
+                carousel=True,
+            )
+        ],
+        theme=themes.GreenPassion(),
+    )
+    if not bucket_answers:
+        raise click.Abort()
+
+    selected: str = bucket_answers["bucket_choice"]
+    if selected.startswith("Create new bucket"):
+        return None
+
+    # Extract bucket name from the label (format: "name (X backups...)")
+    selected_name = selected.split(" (")[0]
+    console.print(f"  [yellow]Using existing bucket '{selected_name}'.[/yellow]")
+    console.print(
+        "  [dim]Note: Existing backups in this bucket will be subject "
+        "to the current retention policy.[/dim]"
+    )
+    return selected_name
 
 
 # ---------------------------------------------------------------------------
@@ -568,7 +667,9 @@ def run_wizard(project_root: Path) -> WizardConfig:
     skip_oauth = _step_oauth()
 
     # Step 7: Backups
-    enable_backups, spaces_access_key, spaces_secret_key = _step_backups()
+    enable_backups, spaces_access_key, spaces_secret_key, spaces_bucket_name = _step_backups(
+        project_root, region
+    )
 
     # Step 8: Cost summary + confirm
     monthly_cost = _step_cost_summary(region, size_slug, enable_backups)
@@ -586,6 +687,7 @@ def run_wizard(project_root: Path) -> WizardConfig:
         push_secrets=push_secrets,
         spaces_access_key=spaces_access_key,
         spaces_secret_key=spaces_secret_key,
+        spaces_bucket_name=spaces_bucket_name,
     )
 
 

--- a/dango/cli/commands/deploy_wizard.py
+++ b/dango/cli/commands/deploy_wizard.py
@@ -518,6 +518,7 @@ def _discover_existing_buckets(
     dango_buckets.sort(key=lambda b: str(b["CreationDate"]), reverse=True)
 
     # Build choice list with backup counts
+    region_suffix = f"-{region}"
     choices: list[str] = []
     for bucket in dango_buckets:
         try:
@@ -536,6 +537,9 @@ def _discover_existing_buckets(
                 f"{bucket['Name']} ({count} backup{'s' if count != 1 else ''}, "
                 f"{total_size_mb} MB, created {created_str})"
             )
+            # Warn if the bucket region doesn't match the deployment region
+            if not bucket["Name"].endswith(region_suffix):
+                label += " [dim](different region)[/dim]"
         except Exception:
             label = f"{bucket['Name']} (could not enumerate)"
         choices.append(label)
@@ -568,6 +572,11 @@ def _discover_existing_buckets(
         "  [dim]Note: Existing backups in this bucket will be subject "
         "to the current retention policy.[/dim]"
     )
+    if not selected_name.endswith(region_suffix):
+        console.print(
+            f"  [yellow]Warning:[/yellow] This bucket appears to be in a different "
+            f"region than '{region}'. Backups may fail if the region is incorrect."
+        )
     return selected_name
 
 

--- a/dango/cli/commands/remote_backup.py
+++ b/dango/cli/commands/remote_backup.py
@@ -489,7 +489,7 @@ def _print_post_restore_credential_guidance() -> None:
     console.print(
         "  [bold]dango remote env set KEY VALUE[/bold]  (for server environment variables)"
     )
-    console.print("  [bold]dango remote backup download[/bold]     (save a local copy)")
+    console.print("  [bold]dango remote backup download --from-server[/bold]  (save a local copy)")
 
 
 # ---------------------------------------------------------------------------

--- a/dango/cli/commands/remote_backup.py
+++ b/dango/cli/commands/remote_backup.py
@@ -468,6 +468,31 @@ def _backup_download_from_server(ctx: click.Context, output: str | None) -> None
 
 
 # ---------------------------------------------------------------------------
+# Post-restore credential guidance
+# ---------------------------------------------------------------------------
+
+
+def _print_post_restore_credential_guidance() -> None:
+    """Print guidance about re-configuring credentials after restore.
+
+    Secrets (.env, .dlt/secrets.toml) are deliberately excluded from
+    backup archives for security, so they must be reconfigured after
+    every restore.
+    """
+    console.print()
+    console.print(
+        "[yellow]Note:[/yellow] Credentials (.env, .dlt/secrets.toml) were excluded "
+        "from the backup for security."
+    )
+    console.print("To reconnect your data sources:")
+    console.print("  [bold]dango oauth setup[/bold]              (for OAuth sources)")
+    console.print(
+        "  [bold]dango remote env set KEY VALUE[/bold]  (for server environment variables)"
+    )
+    console.print("  [bold]dango remote backup download[/bold]     (save a local copy)")
+
+
+# ---------------------------------------------------------------------------
 # backup restore
 # ---------------------------------------------------------------------------
 
@@ -531,6 +556,7 @@ def backup_restore(ctx: click.Context, source: str, yes: bool, from_local: bool)
 
         if result.success:
             console.print(f"[green]Restore complete.[/green] Restored from: {source}")
+            _print_post_restore_credential_guidance()
         else:
             msg = format_structured_error(
                 what_failed=f"Restore failed from backup '{source}'",
@@ -591,6 +617,7 @@ def _backup_restore_from_local(ctx: click.Context, source: str, yes: bool) -> No
 
         if result.health_check_passed:
             console.print(f"[green]Restore complete.[/green] Restored from: {local_path.name}")
+            _print_post_restore_credential_guidance()
         else:
             console.print(
                 f"[yellow]Restore finished[/yellow] from {local_path.name}, "

--- a/dango/platform/cloud/spaces.py
+++ b/dango/platform/cloud/spaces.py
@@ -282,6 +282,35 @@ class SpacesClient:
                 return False
             raise self._wrap_client_error(exc, "exists", key) from exc
 
+    def list_buckets(self) -> list[dict[str, Any]]:
+        """List all Spaces buckets accessible with the configured credentials.
+
+        Uses boto3's ``list_buckets()`` which returns all buckets the
+        credentials have access to.  The *bucket* argument passed to the
+        constructor is ignored by this method — ``list_buckets`` is an
+        account-level S3 operation.
+
+        Returns:
+            List of dicts with keys ``Name`` and ``CreationDate``.
+
+        Raises:
+            CloudError: If the API call fails (bad credentials, network, etc.).
+        """
+        client = self._get_client()
+        try:
+            response: dict[str, Any] = client.list_buckets()
+        except Exception as exc:
+            _reraise_if_not_client_error(exc)
+            raise CloudError(
+                f"Failed to list Spaces buckets: {exc}",
+                context={"operation": "list_buckets"},
+            ) from exc
+
+        return [
+            {"Name": b["Name"], "CreationDate": b["CreationDate"]}
+            for b in response.get("Buckets", [])
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers

--- a/tests/unit/test_deploy_destroy.py
+++ b/tests/unit/test_deploy_destroy.py
@@ -284,7 +284,7 @@ class TestDestroyResourceDeletion:
 @patch.dict(os.environ, {"DIGITALOCEAN_TOKEN": "test-token"})
 class TestDestroyWithSpaces:
     def test_deletes_spaces_bucket(self, tmp_path):
-        """Destroy empties and deletes the Spaces bucket."""
+        """--delete-spaces empties and deletes the Spaces bucket."""
         cloud_yml = tmp_path / ".dango" / "cloud.yml"
         cloud_yml.parent.mkdir(parents=True, exist_ok=True)
         cloud_yml.touch()
@@ -306,13 +306,34 @@ class TestDestroyWithSpaces:
             ]
             mock_spaces_cls.return_value = mock_spaces
 
-            _run(["destroy", "--force"], tmp_path)
+            _run(["destroy", "--force", "--delete-spaces"], tmp_path)
 
         assert mock_spaces.delete.call_count == 2
         mock_spaces.delete_bucket.assert_called_once()
 
-    def test_keep_spaces_skips_bucket_deletion(self, tmp_path):
-        """--keep-spaces prevents bucket deletion."""
+    def test_keeps_spaces_by_default(self, tmp_path):
+        """Spaces is kept by default when no --delete-spaces flag."""
+        cloud_yml = tmp_path / ".dango" / "cloud.yml"
+        cloud_yml.parent.mkdir(parents=True, exist_ok=True)
+        cloud_yml.touch()
+        cloud_cfg = _make_cloud_config(spaces=_make_spaces_config())
+        mock_loader = _make_loader(cloud_cfg=cloud_cfg)
+
+        with (
+            patch(_PATCH_REQUIRE_CTX, return_value=tmp_path),
+            patch(_PATCH_LOADER, return_value=mock_loader),
+            patch(_PATCH_DO_CLIENT) as mock_client_cls,
+            patch(_PATCH_SPACES) as mock_spaces_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+
+            _run(["destroy", "--force"], tmp_path)
+
+        mock_spaces_cls.assert_not_called()
+
+    def test_keep_spaces_backward_compat(self, tmp_path):
+        """--keep-spaces (deprecated) still works — Spaces is kept."""
         cloud_yml = tmp_path / ".dango" / "cloud.yml"
         cloud_yml.parent.mkdir(parents=True, exist_ok=True)
         cloud_yml.touch()


### PR DESCRIPTION
## Summary
- Deploy wizard Step 7: offer to reuse existing Spaces buckets with backup count/size enumeration; fallback to create-new on listing failure
- Destroy flow: Spaces buckets are now KEPT by default; added `--delete-spaces` flag for explicit opt-in deletion; `--keep-spaces` kept as hidden no-op for backward compat
- `_offer_backup_download()`: now checks both server (SSH) and Spaces (API) for available backups before destroy; Spaces download fallback when server unreachable
- Post-deploy summary: shows backup status when backups enabled
- Post-restore credential guidance: displayed after successful restore from both Spaces and local, explaining secrets exclusion and how to reconnect sources
- `SpacesClient.list_buckets()`: new method for bucket discovery
- Destroy tests: updated for new default behavior + backward compat test

## Verification
- `ruff check dango/`: All checks passed
- `ruff format --check dango/`: 220 files already formatted
- `pytest -x`: 3969 passed, 31 skipped, 0 failures

## Regression check
- Existing deploy wizard works unchanged when no Spaces buckets exist
- `--force` flag still skips all prompts in destroy
- `--keep-spaces` flag still accepted (hidden, no-op)
- Non-interactive deploy wizard unchanged (always creates new bucket)

## Docs PR
- `docs/docs/deployment/backup-and-recovery.md`: new comprehensive guide
- `docs/docs/deployment/destroy.md`: updated for new `--delete-spaces` default
- `docs/docs/deployment/digitalocean.md`: added Backup Configuration section
- `docs/mkdocs.yml`: added backup-and-recovery.md to nav
- Docs PR: https://github.com/getdango/docs/pull/new/feat/s3-backup-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)