### PR TITLE
S3: Script schedule integration (ScheduleType.SCRIPT + CLI + UI)

### DIFF
--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -44,6 +44,7 @@ _TYPE_CHOICES = [
     ("Sync & Transform (recommended)", "sync"),
     ("Sync only (no transform)", "sync_only"),
     ("Transform only (dbt)", "dbt"),
+    ("Script (custom Python)", "script"),
 ]
 
 _DAY_CHOICES = [
@@ -450,7 +451,12 @@ def schedule_list(ctx: click.Context) -> None:
     for sched in schedules:
         sources = sched.get("sources", [])
         enabled = sched.get("enabled", True)
-        sources_str = ", ".join(sources) if sources else "—"
+        if sources:
+            sources_str = ", ".join(sources)
+        elif sched.get("type") == "script":
+            sources_str = sched.get("script_path", "—")
+        else:
+            sources_str = "—"
         table.add_row(
             sched.get("name", "?"),
             sched.get("type", "sync"),
@@ -488,6 +494,10 @@ def _show_schedule_detail(project_root: Path, schedules: list[dict[str, Any]], n
         console.print(f"  Sources:  {', '.join(sched['sources'])}")
     if sched.get("dbt_command"):
         console.print(f"  dbt cmd:  {sched['dbt_command']}")
+    if sched.get("script_path"):
+        console.print(f"  Script:   {sched['script_path']}")
+    if sched.get("timeout_minutes") is not None:
+        console.print(f"  Timeout:  {sched['timeout_minutes']} min")
     if sched.get("notify_on"):
         console.print(f"  Notify:   {', '.join(sched['notify_on'])}")
 
@@ -691,9 +701,11 @@ def schedule_add(ctx: click.Context) -> None:
         return
     sched_type: str = dict(_TYPE_CHOICES)[answers["type"]]
 
-    # 3a. Sources (sync only) / 3b. dbt command
+    # 3a. Sources (sync only) / 3b. dbt command / 3c. script path
     sources: list[str] = []
     dbt_command: str | None = None
+    script_path: str | None = None
+    timeout_minutes: int = 30
     if sched_type in ("sync", "sync_only"):
         try:
             from dango.config.loader import ConfigLoader
@@ -727,6 +739,54 @@ def schedule_add(ctx: click.Context) -> None:
         if not sources:
             console.print("[red]Error:[/red] Sync schedules require at least one source.")
             return
+    elif sched_type == "script":
+        # Discover .py files in scripts/ directory
+        scripts_dir = project_root / "scripts"
+        script_choices: list[tuple[str, str]] = []
+        if scripts_dir.exists():
+            for py_file in sorted(scripts_dir.rglob("*.py")):
+                if py_file.name == "__init__.py":
+                    continue
+                if py_file.name.startswith(".") or py_file.name.startswith("_"):
+                    continue
+                if any(part.startswith("_") for part in py_file.parts[:-1]):
+                    continue
+                rel = str(py_file.relative_to(scripts_dir))
+                script_choices.append((rel, rel))
+
+        if not script_choices:
+            console.print(
+                "[red]No Python scripts found in scripts/ directory.[/red] Add a .py file first."
+            )
+            return
+
+        answers = inquirer.prompt(
+            [
+                inquirer.List(
+                    "script_path",
+                    message="Select a script to run",
+                    choices=[label for label, _ in script_choices],
+                )
+            ]
+        )
+        if answers is None:
+            return
+        script_path = answers["script_path"]
+
+        # Timeout prompt
+        answers = inquirer.prompt(
+            [
+                inquirer.Text(
+                    "timeout_minutes",
+                    message="Timeout (minutes)",
+                    default="30",
+                    validate=lambda _, x: x.isdigit() and int(x) > 0,
+                )
+            ]
+        )
+        if answers is None:
+            return
+        timeout_minutes = int(answers["timeout_minutes"])
     else:
         answers = inquirer.prompt(
             [
@@ -818,6 +878,9 @@ def schedule_add(ctx: click.Context) -> None:
         entry["sources"] = sources
     if dbt_command:
         entry["dbt_command"] = dbt_command
+    if sched_type == "script":
+        entry["script_path"] = script_path
+        entry["timeout_minutes"] = timeout_minutes
     if notify_on:
         entry["notify_on"] = notify_on
 
@@ -828,6 +891,9 @@ def schedule_add(ctx: click.Context) -> None:
         console.print(f"  Sources: {', '.join(sources)}")
     if dbt_command:
         console.print(f"  dbt cmd: {dbt_command}")
+    if sched_type == "script":
+        console.print(f"  Script:  {script_path}")
+        console.print(f"  Timeout: {timeout_minutes} min")
     console.print(f"  Timezone: {timezone_str}")
     if notify_on:
         console.print(f"  Notify on: {', '.join(notify_on)}")

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -740,19 +740,11 @@ def schedule_add(ctx: click.Context) -> None:
             console.print("[red]Error:[/red] Sync schedules require at least one source.")
             return
     elif sched_type == "script":
-        # Discover .py files in scripts/ directory
-        scripts_dir = project_root / "scripts"
-        script_choices: list[tuple[str, str]] = []
-        if scripts_dir.exists():
-            for py_file in sorted(scripts_dir.rglob("*.py")):
-                if py_file.name == "__init__.py":
-                    continue
-                if py_file.name.startswith(".") or py_file.name.startswith("_"):
-                    continue
-                if any(part.startswith("_") for part in py_file.parts[:-1]):
-                    continue
-                rel = str(py_file.relative_to(scripts_dir))
-                script_choices.append((rel, rel))
+        # Discover .py files in scripts/ directory (reuses shared discovery)
+        from dango.web.routes.scripts_helpers import _discover_scripts
+
+        scripts = _discover_scripts(project_root)
+        script_choices: list[tuple[str, str]] = [(s["name"], s["path"]) for s in scripts]
 
         if not script_choices:
             console.print(

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -559,8 +559,8 @@ def reload_schedules(
         elif sched.type == ScheduleType.SCRIPT:
             _install_script_dependencies(project_root)
             error = _validate_script_path_for_schedule(
-                sched.script_path,
-                project_root,  # type: ignore[arg-type]
+                sched.script_path,  # type: ignore[arg-type]
+                project_root,
             )
             if error:
                 logger.warning(

--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -32,6 +32,8 @@ __all__ = [
     "ScheduleConfig",
     "ScheduleType",
     "SchedulesConfig",
+    "_install_script_dependencies",
+    "_validate_script_path_for_schedule",
     "get_schedule_job_id",
     "load_schedules_config",
     "log_startup_checks",
@@ -79,6 +81,7 @@ class ScheduleType(str, Enum):
     SYNC = "sync"
     SYNC_ONLY = "sync_only"
     DBT = "dbt"
+    SCRIPT = "script"
 
 
 class ScheduleConfig(BaseModel):
@@ -97,6 +100,9 @@ class ScheduleConfig(BaseModel):
     timeout_minutes: int | None = None
     notify_on: list[str] = []
     dbt_command: str | None = None
+    script_path: str | None = None
+    run_on: str = "both"  # reserved, not used in v1
+    script_args: str | None = None  # reserved, not used in v1
 
     @field_validator("name")
     @classmethod
@@ -142,6 +148,16 @@ class ScheduleConfig(BaseModel):
         if self.type == ScheduleType.DBT and not self.dbt_command:
             msg = "dbt schedules must specify a dbt_command"
             raise ValueError(msg)
+        if self.type == ScheduleType.SCRIPT:
+            if not self.script_path:
+                msg = "Script schedules must specify a script_path"
+                raise ValueError(msg)
+            if self.sources:
+                msg = "Script schedules must not specify sources"
+                raise ValueError(msg)
+            if self.dbt_command:
+                msg = "Script schedules must not specify a dbt_command"
+                raise ValueError(msg)
         return self
 
     def get_notify_on_dict(self) -> dict[str, bool] | None:
@@ -262,6 +278,8 @@ def validate_schedules(
 
     # 2. Unknown sources
     for sched in schedules:
+        if sched.type == ScheduleType.SCRIPT:
+            continue
         for src in sched.sources:
             if src not in source_names:
                 errors.append(f"Schedule {sched.name!r} references unknown source: {src!r}")
@@ -400,6 +418,69 @@ def log_startup_checks(
 
 
 # ---------------------------------------------------------------------------
+# Script support helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_script_dependencies(project_root: Path) -> None:
+    """Install script dependencies from ``scripts/requirements.txt`` if it exists.
+
+    Uses ``pip install`` via subprocess. Never raises — warns on failure.
+    """
+    import subprocess
+    import sys
+
+    req_file = project_root / "scripts" / "requirements.txt"
+    if not req_file.exists():
+        return
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-r", str(req_file)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "script_deps_install_failed",
+                stderr=result.stderr.strip(),
+            )
+    except subprocess.TimeoutExpired:
+        logger.warning("script_deps_install_timed_out")
+    except Exception:  # noqa: BLE001
+        logger.debug("script_deps_install_error", exc_info=True)
+
+
+def _validate_script_path_for_schedule(script_path: str, project_root: Path) -> str | None:
+    """Validate a script path at schedule activation time.
+
+    Checks path traversal, file existence, and ``ast.parse()`` syntax.
+
+    Returns an error message string on failure, or ``None`` on success.
+    """
+    import ast
+
+    scripts_dir = (project_root / "scripts").resolve()
+    script_full = (scripts_dir / script_path).resolve()
+
+    # Prevent path traversal — path must be inside scripts/
+    if not str(script_full).startswith(str(scripts_dir)):
+        return f"Script path {script_path!r} escapes scripts/ directory"
+
+    if not script_full.exists() or not script_full.is_file():
+        return f"Script {script_path!r} not found in scripts/"
+
+    # Syntax validation (does not execute code)
+    try:
+        source = script_full.read_text(encoding="utf-8")
+        ast.parse(source)
+    except SyntaxError as e:
+        return f"Script {script_path!r} has syntax error: {e}"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Reload
 # ---------------------------------------------------------------------------
 
@@ -417,7 +498,11 @@ def reload_schedules(
     """
     from apscheduler.triggers.cron import CronTrigger
 
-    from dango.platform.scheduling.jobs import run_scheduled_dbt, run_scheduled_sync
+    from dango.platform.scheduling.jobs import (
+        run_scheduled_dbt,
+        run_scheduled_script,
+        run_scheduled_sync,
+    )
 
     # Collect current schedule jobs
     existing_jobs: dict[str, Any] = {}
@@ -470,6 +555,25 @@ def reload_schedules(
                 "sources": list(sched.sources),
                 "project_root": str(project_root),
                 "skip_dbt": sched.type == ScheduleType.SYNC_ONLY,
+            }
+        elif sched.type == ScheduleType.SCRIPT:
+            _install_script_dependencies(project_root)
+            error = _validate_script_path_for_schedule(
+                sched.script_path,
+                project_root,  # type: ignore[arg-type]
+            )
+            if error:
+                logger.warning(
+                    "script_schedule_validation_failed",
+                    schedule=sched.name,
+                    error=error,
+                )
+                continue
+            func = run_scheduled_script
+            func_kwargs = {
+                "schedule_name": sched.name,
+                "script_path": sched.script_path,
+                "project_root": str(project_root),
             }
         else:
             func = run_scheduled_dbt

--- a/dango/platform/cloud/deployer.py
+++ b/dango/platform/cloud/deployer.py
@@ -540,6 +540,29 @@ def push_deploy(
                     logger.info("requirements_installed", path="requirements.txt")
                 _notify(on_progress, "install_deps", "done")
 
+            # Step 5c: Install script dependencies (if scripts/requirements.txt exists)
+            script_req_check = ssh.exec_command(
+                f"test -f {REMOTE_PROJECT_DIR}/scripts/requirements.txt && echo exists"
+            )
+            if script_req_check.stdout.strip() == "exists":
+                _notify(on_progress, "install_script_deps", "running")
+                script_pip_result = ssh.exec_command(
+                    f"sudo -u dango {VENV_BIN}/pip install "
+                    f"-r {REMOTE_PROJECT_DIR}/scripts/requirements.txt",
+                    timeout=300,
+                )
+                if script_pip_result.exit_code != 0:
+                    warnings.append(
+                        "pip install -r scripts/requirements.txt failed: "
+                        f"{script_pip_result.stderr.strip()}"
+                    )
+                else:
+                    logger.info(
+                        "script_requirements_installed",
+                        path="scripts/requirements.txt",
+                    )
+                _notify(on_progress, "install_script_deps", "done")
+
             # Step 6: Validate sources
             _notify(on_progress, "validate_sources", "running")
             source_errors = _validate_remote_sources(ssh)

--- a/dango/platform/scheduling/__init__.py
+++ b/dango/platform/scheduling/__init__.py
@@ -27,6 +27,7 @@ from dango.platform.scheduling.history import (
 from dango.platform.scheduling.jobs import (
     configure_jobs,
     run_scheduled_dbt,
+    run_scheduled_script,
     run_scheduled_sync,
 )
 from dango.platform.scheduling.resilience import (
@@ -59,6 +60,7 @@ __all__ = [
     "record_start",
     "record_timeout",
     "run_scheduled_dbt",
+    "run_scheduled_script",
     "run_scheduled_sync",
     "run_with_resilience",
 ]

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -1056,6 +1056,51 @@ def run_scheduled_dbt(
         lock.release()
 
 
+def _write_script_logs(
+    project_root: Path,
+    script_path: str,
+    schedule_name: str,
+    stdout: str | None,
+    stderr: str | None,
+    exit_code: int | None,
+    duration_seconds: float,
+    status: str,
+) -> None:
+    """Write script stdout, stderr, and metadata to log files. Never raises."""
+    import json as _json
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+
+    try:
+        safe_name = script_path.replace("/", "__").replace("\\", "__")
+        ts = _dt.now(tz=_tz).strftime("%Y%m%dT%H%M%S")
+        log_dir = project_root / ".dango" / "logs" / "scripts" / f"{safe_name}_{ts}"
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        _MAX = 1_048_576  # 1 MB
+        stdout_str = stdout or ""
+        stderr_str = stderr or ""
+        if len(stdout_str) > _MAX:
+            stdout_str = stdout_str[:_MAX] + "\n\n[TRUNCATED at 1MB]"
+        if len(stderr_str) > _MAX:
+            stderr_str = stderr_str[:_MAX] + "\n\n[TRUNCATED at 1MB]"
+
+        (log_dir / "stdout.txt").write_text(stdout_str, encoding="utf-8", errors="replace")
+        (log_dir / "stderr.txt").write_text(stderr_str, encoding="utf-8", errors="replace")
+
+        meta: dict[str, Any] = {
+            "script_name": script_path,
+            "schedule_name": schedule_name,
+            "finished_at": _dt.now(tz=_tz).isoformat(),
+            "duration_seconds": round(duration_seconds, 1),
+            "exit_code": exit_code if exit_code is not None else -1,
+            "status": status,
+        }
+        (log_dir / "meta.json").write_text(_json.dumps(meta))
+    except Exception:  # noqa: BLE001
+        logger.debug("script_log_write_failed", script=script_path, exc_info=True)
+
+
 def run_scheduled_script(
     schedule_name: str,
     script_path: str | None = None,
@@ -1232,6 +1277,16 @@ def run_scheduled_script(
                 stdout, stderr = proc.communicate()
 
             elapsed = time.monotonic() - t0
+            _write_script_logs(
+                project_root,
+                script_path,
+                schedule_name,
+                stdout,
+                stderr,
+                proc.returncode,
+                elapsed,
+                "timeout",
+            )
             log_activity(project_root, "error", script_label, "Scheduled script timed out")
             _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
             _log_execution_event(
@@ -1261,6 +1316,17 @@ def run_scheduled_script(
 
         elapsed = time.monotonic() - t0
         exit_code = proc.returncode if proc.returncode is not None else -1
+
+        _write_script_logs(
+            project_root,
+            script_path,
+            schedule_name,
+            stdout,
+            stderr,
+            exit_code,
+            elapsed,
+            "success" if exit_code == 0 else "failed",
+        )
 
         if exit_code == 0:
             log_activity(

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -1068,12 +1068,11 @@ def _write_script_logs(
 ) -> None:
     """Write script stdout, stderr, and metadata to log files. Never raises."""
     import json as _json
-    from datetime import datetime as _dt
-    from datetime import timezone as _tz
+    from datetime import datetime, timezone
 
     try:
         safe_name = script_path.replace("/", "__").replace("\\", "__")
-        ts = _dt.now(tz=_tz).strftime("%Y%m%dT%H%M%S")
+        ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S")
         log_dir = project_root / ".dango" / "logs" / "scripts" / f"{safe_name}_{ts}"
         log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1091,7 +1090,7 @@ def _write_script_logs(
         meta: dict[str, Any] = {
             "script_name": script_path,
             "schedule_name": schedule_name,
-            "finished_at": _dt.now(tz=_tz).isoformat(),
+            "finished_at": datetime.now(tz=timezone.utc).isoformat(),
             "duration_seconds": round(duration_seconds, 1),
             "exit_code": exit_code if exit_code is not None else -1,
             "status": status,

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -10,6 +10,7 @@ Public API:
     configure_jobs(loop, scheduler)  -- set event loop + scheduler service
     run_scheduled_sync(...)          -- sync one or more data sources on schedule
     run_scheduled_dbt(...)           -- run dbt models on schedule
+    run_scheduled_script(...)        -- run a Python script in a subprocess on schedule
 """
 
 from __future__ import annotations
@@ -1053,3 +1054,379 @@ def run_scheduled_dbt(
         )
     finally:
         lock.release()
+
+
+def run_scheduled_script(
+    schedule_name: str,
+    script_path: str | None = None,
+    **kwargs: Any,
+) -> None:
+    """Run a scheduled Python script in a subprocess.
+
+    Called by APScheduler from a thread-pool executor.  Launches the script
+    via ``sys.executable`` with ``DANGO_PROJECT_ROOT`` env var set, captures
+    stdout/stderr, and records execution history + broadcasts.
+
+    Args:
+        schedule_name: Human-readable schedule identifier.
+        script_path: Relative path to script in ``scripts/`` directory.
+        **kwargs: Must include ``project_root`` (str).
+    """
+    import os
+    import subprocess
+
+    project_root = Path(kwargs.get("project_root", "."))
+    t0 = time.monotonic()
+
+    from dango.exceptions import JobCancelledError, JobTimeoutError
+    from dango.platform.notifications.webhook import (
+        EventType,
+        WebhookSender,
+        load_notification_config,
+    )
+    from dango.utils.activity_log import log_activity
+
+    sender = WebhookSender(load_notification_config(project_root))
+    script_label = f"script:{script_path or schedule_name}"
+    timeout_minutes = int(kwargs.get("timeout_minutes", 30))
+
+    record_id: int | None = None
+
+    try:
+        # Resolve and validate script path
+        scripts_dir = (project_root / "scripts").resolve()
+        if not script_path:
+            elapsed = time.monotonic() - t0
+            logger.warning(
+                "script_path_missing",
+                schedule=schedule_name,
+            )
+            _log_execution_event(
+                schedule_name=schedule_name,
+                job_type="script",
+                status="failed",
+                duration_seconds=elapsed,
+                error="No script_path configured",
+            )
+            _broadcast(
+                {
+                    "event": "script_failed",
+                    "schedule": schedule_name,
+                    "error": "No script_path configured",
+                    "timestamp": _ts(),
+                }
+            )
+            return
+
+        script_full = (scripts_dir / script_path).resolve()
+
+        # Belt-and-suspenders path traversal check
+        if not str(script_full).startswith(str(scripts_dir)):
+            elapsed = time.monotonic() - t0
+            logger.warning(
+                "script_path_invalid",
+                schedule=schedule_name,
+                path=script_path,
+            )
+            log_activity(
+                project_root,
+                "error",
+                script_label,
+                f"Invalid script path: {script_path}",
+            )
+            _log_execution_event(
+                schedule_name=schedule_name,
+                job_type="script",
+                status="failed",
+                duration_seconds=elapsed,
+                error=f"Invalid script path: {script_path}",
+            )
+            _broadcast(
+                {
+                    "event": "script_failed",
+                    "schedule": schedule_name,
+                    "script_path": script_path,
+                    "error": f"Invalid script path: {script_path}",
+                    "timestamp": _ts(),
+                }
+            )
+            return
+
+        if not script_full.exists():
+            elapsed = time.monotonic() - t0
+            logger.warning(
+                "script_not_found",
+                schedule=schedule_name,
+                path=script_path,
+            )
+            log_activity(
+                project_root,
+                "error",
+                script_label,
+                f"Script not found: {script_path}",
+            )
+            _log_execution_event(
+                schedule_name=schedule_name,
+                job_type="script",
+                status="failed",
+                duration_seconds=elapsed,
+                error=f"Script not found: {script_path}",
+            )
+            _broadcast(
+                {
+                    "event": "script_failed",
+                    "schedule": schedule_name,
+                    "script_path": script_path,
+                    "error": f"Script not found: {script_path}",
+                    "timestamp": _ts(),
+                }
+            )
+            return
+
+        record_id = _try_record_start(project_root, schedule_name, source_names=None)
+
+        log_activity(
+            project_root,
+            "info",
+            script_label,
+            f"Scheduled script starting ({schedule_name})",
+        )
+
+        _broadcast(
+            {
+                "event": "script_started",
+                "schedule": schedule_name,
+                "script_path": script_path,
+                "timestamp": _ts(),
+            }
+        )
+
+        # Check cancellation before launching subprocess
+        job_id = f"schedule:{schedule_name}"
+        if _scheduler_service is not None and _scheduler_service.is_cancelled(job_id):
+            raise JobCancelledError(f"Script cancelled before launch for {schedule_name}")
+
+        # Launch subprocess
+        env = os.environ.copy()
+        env["DANGO_PROJECT_ROOT"] = str(project_root)
+
+        _script_timeout = max(timeout_minutes * 60, 60)  # minimum 60s
+
+        proc = subprocess.Popen(
+            [sys.executable, str(script_full)],
+            cwd=str(project_root),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        try:
+            stdout, stderr = proc.communicate(timeout=_script_timeout)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            try:
+                stdout, stderr = proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                stdout, stderr = proc.communicate()
+
+            elapsed = time.monotonic() - t0
+            log_activity(project_root, "error", script_label, "Scheduled script timed out")
+            _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
+            _log_execution_event(
+                schedule_name=schedule_name,
+                job_type="script",
+                status="timeout",
+                duration_seconds=elapsed,
+                error="Script timed out",
+            )
+            _broadcast(
+                {
+                    "event": "script_failed",
+                    "schedule": schedule_name,
+                    "script_path": script_path,
+                    "error": "Script timed out",
+                    "timestamp": _ts(),
+                }
+            )
+            _notify(
+                sender,
+                event_type=EventType.SYNC_FAILED,
+                schedule_name=schedule_name,
+                error="Script timed out",
+                duration_seconds=round(elapsed, 2),
+            )
+            return
+
+        elapsed = time.monotonic() - t0
+        exit_code = proc.returncode if proc.returncode is not None else -1
+
+        if exit_code == 0:
+            log_activity(
+                project_root,
+                "success",
+                script_label,
+                f"Scheduled script completed ({round(elapsed, 1)}s)",
+            )
+            _try_finish_record(project_root, schedule_name, record_id, "record_completion")
+            _log_execution_event(
+                schedule_name=schedule_name,
+                job_type="script",
+                status="completed",
+                duration_seconds=elapsed,
+            )
+            _broadcast(
+                {
+                    "event": "script_completed",
+                    "schedule": schedule_name,
+                    "script_path": script_path,
+                    "duration_seconds": round(elapsed, 2),
+                    "timestamp": _ts(),
+                }
+            )
+            _notify(
+                sender,
+                event_type=EventType.SYNC_COMPLETED,
+                schedule_name=schedule_name,
+                duration_seconds=round(elapsed, 2),
+                dashboard_url=_build_dashboard_url(project_root),
+            )
+        else:
+            error_msg = stderr.strip() if stderr and stderr.strip() else f"Exit code: {exit_code}"
+            log_activity(
+                project_root,
+                "error",
+                script_label,
+                f"Scheduled script failed: {error_msg}",
+            )
+            _try_finish_record(
+                project_root,
+                schedule_name,
+                record_id,
+                "record_failure",
+                error=error_msg,
+            )
+            _log_execution_event(
+                schedule_name=schedule_name,
+                job_type="script",
+                status="failed",
+                duration_seconds=elapsed,
+                error=error_msg,
+            )
+            _broadcast(
+                {
+                    "event": "script_failed",
+                    "schedule": schedule_name,
+                    "script_path": script_path,
+                    "error": error_msg,
+                    "timestamp": _ts(),
+                }
+            )
+            _notify(
+                sender,
+                event_type=EventType.SYNC_FAILED,
+                schedule_name=schedule_name,
+                error=error_msg,
+                duration_seconds=round(elapsed, 2),
+            )
+
+    except JobTimeoutError:
+        elapsed = time.monotonic() - t0
+        log_activity(project_root, "error", script_label, "Scheduled script timed out")
+        _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
+        _log_execution_event(
+            schedule_name=schedule_name,
+            job_type="script",
+            status="timeout",
+            duration_seconds=elapsed,
+            error="Job timed out",
+        )
+        _broadcast(
+            {
+                "event": "script_failed",
+                "schedule": schedule_name,
+                "error": "Job timed out",
+                "timestamp": _ts(),
+            }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            error="Job timed out",
+            duration_seconds=elapsed,
+        )
+
+    except JobCancelledError:
+        elapsed = time.monotonic() - t0
+        log_activity(project_root, "warning", script_label, "Scheduled script cancelled")
+        _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")
+        _log_execution_event(
+            schedule_name=schedule_name,
+            job_type="script",
+            status="cancelled",
+            duration_seconds=elapsed,
+            error="Job cancelled",
+        )
+        _broadcast(
+            {
+                "event": "script_failed",
+                "schedule": schedule_name,
+                "error": "Job cancelled",
+                "timestamp": _ts(),
+            }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            error="Job cancelled",
+            duration_seconds=elapsed,
+        )
+
+    except Exception as exc:  # noqa: BLE001
+        elapsed = time.monotonic() - t0
+        error_msg = str(exc)
+        log_activity(
+            project_root,
+            "error",
+            script_label,
+            f"Scheduled script failed: {error_msg}",
+        )
+        logger.error(
+            "scheduled_script_failed",
+            schedule=schedule_name,
+            script_path=script_path,
+            error=error_msg,
+            exc_info=True,
+        )
+        _try_finish_record(
+            project_root,
+            schedule_name,
+            record_id,
+            "record_failure",
+            error=error_msg,
+        )
+        _log_execution_event(
+            schedule_name=schedule_name,
+            job_type="script",
+            status="failed",
+            duration_seconds=elapsed,
+            error=error_msg,
+        )
+        _broadcast(
+            {
+                "event": "script_failed",
+                "schedule": schedule_name,
+                "error": error_msg,
+                "timestamp": _ts(),
+            }
+        )
+        _notify(
+            sender,
+            event_type=EventType.SYNC_FAILED,
+            schedule_name=schedule_name,
+            error=error_msg,
+            duration_seconds=elapsed,
+        )

--- a/dango/web/routes/schedules.py
+++ b/dango/web/routes/schedules.py
@@ -23,6 +23,7 @@ from dango.auth.permissions import require_permission
 from dango.config.schedules import (
     ScheduleConfig,
     SchedulesConfig,
+    ScheduleType,
     get_schedule_job_id,
     load_schedules_config,
     reload_schedules,
@@ -303,13 +304,14 @@ async def list_schedules(
             "type": sched.type.value,
             "cron": sched.cron,
             "sources": list(sched.sources),
+            "script_path": sched.script_path,
             "enabled": sched.enabled,
             "next_run_time": next_runs.get(job_id),
             "last_run": last_run,
         }
         # Add per-source error details for failed runs
         entry["source_errors"] = None
-        if last_run and last_run.get("status") == "failed":
+        if last_run and last_run.get("status") == "failed" and sched.type != ScheduleType.SCRIPT:
             entry["source_errors"] = await asyncio.to_thread(
                 _get_source_errors, list(sched.sources), last_run.get("started_at")
             )
@@ -497,6 +499,7 @@ async def trigger_schedule(
     from dango.config.schedules import ScheduleType
     from dango.platform.scheduling.jobs import (
         run_scheduled_dbt,
+        run_scheduled_script,
         run_scheduled_sync,
     )
 
@@ -508,6 +511,13 @@ async def trigger_schedule(
             "sources": list(sched.sources),
             "project_root": str(project_root),
             "skip_dbt": sched.type == ScheduleType.SYNC_ONLY,
+        }
+    elif sched.type == ScheduleType.SCRIPT:
+        func = run_scheduled_script
+        func_kwargs = {
+            "schedule_name": sched.name,
+            "script_path": sched.script_path,
+            "project_root": str(project_root),
         }
     else:
         func = run_scheduled_dbt

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -47,11 +47,16 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap">
                                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full"
-                                      :class="sched.type.startsWith('sync') ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800'"
+                                      :class="sched.type.startsWith('sync') ? 'bg-blue-100 text-blue-800' : sched.type === 'dbt' ? 'bg-purple-100 text-purple-800' : sched.type === 'script' ? 'bg-teal-100 text-teal-800' : 'bg-gray-100 text-gray-800'"
                                       x-text="sched.type"></span>
                             </td>
                             <td class="px-6 py-4 text-sm text-gray-500 hidden md:table-cell">
-                                <span x-text="sched.sources.sort().join(' • ')"></span>
+                                <template x-if="sched.type === 'script'">
+                                    <span class="font-mono text-xs" x-text="sched.script_path"></span>
+                                </template>
+                                <template x-if="sched.type !== 'script'">
+                                    <span x-text="sched.sources.sort().join(' • ')"></span>
+                                </template>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
                                 x-text="humanCron(sched.cron)"></td>
@@ -480,24 +485,36 @@ function schedulesPage() {
         handleWsMessage(data) {
             const ev = data.event;
             const source = data.source;
+            const schedule = data.schedule;
 
-            if (ev === 'sync_started' || ev === 'dbt_started') {
+            if (ev === 'sync_started' || ev === 'dbt_started' || ev === 'script_started') {
                 const updated = {...this.runningJobs};
                 for (const sched of this.schedules) {
-                    const match = ev === 'sync_started'
-                        ? sched.sources.includes(source)
-                        : sched.type === 'dbt';
+                    let match = false;
+                    if (ev === 'sync_started') {
+                        match = sched.sources.includes(source);
+                    } else if (ev === 'dbt_started') {
+                        match = sched.type === 'dbt';
+                    } else if (ev === 'script_started') {
+                        match = sched.type === 'script' && sched.name === schedule;
+                    }
                     if (match) updated[sched.name] = true;
                 }
                 this.runningJobs = updated;
             }
             if (ev === 'sync_completed' || ev === 'sync_failed' ||
-                ev === 'dbt_completed' || ev === 'dbt_failed') {
+                ev === 'dbt_completed' || ev === 'dbt_failed' ||
+                ev === 'script_completed' || ev === 'script_failed') {
                 const updated = {...this.runningJobs};
                 for (const sched of this.schedules) {
-                    const match = ev.startsWith('sync_')
-                        ? sched.sources.includes(source)
-                        : sched.type === 'dbt';
+                    let match = false;
+                    if (ev.startsWith('sync_')) {
+                        match = sched.sources.includes(source);
+                    } else if (ev.startsWith('dbt_')) {
+                        match = sched.type === 'dbt';
+                    } else if (ev.startsWith('script_')) {
+                        match = sched.type === 'script' && sched.name === schedule;
+                    }
                     if (match) delete updated[sched.name];
                 }
                 this.runningJobs = updated;

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -25,7 +25,7 @@ class TestScheduleType:
     def test_enum_count(self):
         from dango.config.schedules import ScheduleType
 
-        assert len(ScheduleType) == 3
+        assert len(ScheduleType) == 4
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add `ScheduleType.SCRIPT` to config/schedules.py with `script_path`, `run_on`, `script_args` fields
- New `run_scheduled_script()` job function in jobs.py — subprocess execution with timeout, WebSocket broadcasts, webhook notifications, activity logging, execution history
- CLI wizard now offers "Script (custom Python)" as 4th schedule type with script discovery from `scripts/` dir
- Script schedules displayed on Schedules page with teal badge and `script_path` in Sources column
- WebSocket events: `script_started`, `script_completed`, `script_failed`
- Webhook notifications for script failures
- Cloud deploy installs `scripts/requirements.txt` when present
- Script validation at schedule activation (`ast.parse()` syntax check, path traversal guard)

## Verification
- `pytest -x`: 3968 pass, 0 fail, 31 skipped
- `ruff check dango/`: All checks passed
- `ruff format --check dango/`: 220 files already formatted

## Regression check
- Existing sync/dbt schedules continue to work — `else` clause in `reload_schedules()` dispatch preserved exactly
- `schedules.yml` backwards compatible — new fields default to `None`
- CLI wizard: sync/dbt flow unchanged
- Test update: `test_enum_count` bumped from 3 to 4