### PR TITLE
S3-TECHA: except:pass audit + extract shared set_password()

### DIFF
--- a/dango/auth/__init__.py
+++ b/dango/auth/__init__.py
@@ -96,6 +96,7 @@ from dango.auth.security import (
     hash_password,
     hash_recovery_code,
     hash_token,
+    set_password,
     verify_password,
 )
 from dango.auth.sessions import (
@@ -240,5 +241,6 @@ __all__ = [
     "hash_password",
     "hash_recovery_code",
     "hash_token",
+    "set_password",
     "verify_password",
 ]

--- a/dango/auth/security.py
+++ b/dango/auth/security.py
@@ -16,9 +16,14 @@ from __future__ import annotations
 
 import hashlib
 import secrets
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pwdlib import PasswordHash
 from pwdlib.hashers.bcrypt import BcryptHasher
+
+if TYPE_CHECKING:
+    from dango.auth.models import User
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -186,6 +191,61 @@ def hash_password(password: str) -> str:
         Bcrypt hash string (``$2b$12$...``).
     """
     return _hasher.hash(password)
+
+
+def set_password(
+    email: str,
+    new_password: str,
+    db_path: Path,
+    *,
+    must_change_password: bool = False,
+) -> User:
+    """Set a user's password and update related fields.
+
+    Consolidates bcrypt hashing + database write + password_changed_at
+    timestamp + must_change_password flag management. All password-setting
+    paths that operate on existing users should use this function.
+
+    Args:
+        email: User's email address.
+        new_password: New password in plain text (will be bcrypt-hashed).
+        db_path: Path to the SQLite auth database.
+        must_change_password: If ``True``, user must change password on
+            next login. Default ``False`` (used by self-serve change and
+            invite acceptance; admin reset passes ``True``).
+
+    Returns:
+        The updated ``User`` object (re-fetched from the database).
+
+    Raises:
+        UserNotFoundError: If no user exists with the given email.
+    """
+    from datetime import datetime, timezone
+
+    from dango.auth.database import get_user_by_email, get_user_by_id, update_user
+    from dango.auth.models import UserUpdate
+    from dango.exceptions import UserNotFoundError
+
+    user = get_user_by_email(db_path, email)
+    if user is None:
+        raise UserNotFoundError(
+            f"No user found with email: {email}",
+            context={"email": email},
+        )
+
+    update_user(
+        db_path,
+        user.id,
+        UserUpdate(
+            password_hash=hash_password(new_password),
+            must_change_password=must_change_password,
+            password_changed_at=datetime.now(timezone.utc),
+        ),
+    )
+
+    updated = get_user_by_id(db_path, user.id)
+    assert updated is not None  # We just confirmed it exists
+    return updated
 
 
 def verify_password(password: str, password_hash: str) -> bool:

--- a/dango/cli/commands/auth.py
+++ b/dango/cli/commands/auth.py
@@ -247,9 +247,8 @@ def auth_list_users(ctx: click.Context) -> None:
 def auth_reset_password(ctx: click.Context, email: str) -> None:
     """Generate a new temporary password for a user."""
     from dango.auth.admin import format_credentials_panel
-    from dango.auth.database import get_user_by_email, invalidate_all_user_sessions, update_user
-    from dango.auth.models import UserUpdate
-    from dango.auth.security import generate_temp_password, hash_password
+    from dango.auth.database import get_user_by_email, invalidate_all_user_sessions
+    from dango.auth.security import generate_temp_password, set_password
     from dango.cli.utils import print_error
 
     try:
@@ -260,15 +259,7 @@ def auth_reset_password(ctx: click.Context, email: str) -> None:
             raise click.Abort()
 
         password = generate_temp_password()
-        update_user(
-            db_path,
-            user.id,
-            UserUpdate(
-                password_hash=hash_password(password),
-                must_change_password=True,
-                password_changed_at=datetime.now(timezone.utc),
-            ),
-        )
+        set_password(user.email, password, db_path, must_change_password=True)
         invalidate_all_user_sessions(db_path, user.id)
         console.print(format_credentials_panel(user.email, password, title="Password reset"))
         from dango.auth.audit import AuditEvent, log_auth_event

--- a/dango/cli/commands/cleanup.py
+++ b/dango/cli/commands/cleanup.py
@@ -346,7 +346,7 @@ def cleanup(ctx: click.Context, dry_run: bool, yes: bool, logs_only: bool, docke
                     )
                     if result.returncode == 0:
                         removed += 1
-                except (FileNotFoundError, subprocess.TimeoutExpired):
+                except (FileNotFoundError, subprocess.TimeoutExpired):  # noqa: BLE001
                     pass
             if removed:
                 console.print(f"[green]\u2713[/green] Removed {removed} dangling Docker volume(s)")

--- a/dango/cli/commands/dashboard.py
+++ b/dango/cli/commands/dashboard.py
@@ -67,7 +67,7 @@ def dashboard_provision(ctx: click.Context, url: str, username: str | None, pass
                     admins = [u for u in users if u.role == Role.ADMIN]
                     if admins and admins[0].email != "admin@localhost":
                         username = admins[0].email
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         if not username:
             username = "admin@example.com"

--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -145,7 +145,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
                 ).fetchone()
                 table_exists = (result[0] > 0) if result else False
                 conn.close()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
         # Check for downstream dependencies
@@ -163,7 +163,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
                                 or f'ref("{model_name}")' in content
                             ):
                                 downstream_models.append(f"{layer_to_check}.{sql_file.stem}")
-                        except Exception:
+                        except Exception:  # noqa: BLE001
                             pass
 
         # Check monitors.yml for references
@@ -176,7 +176,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
                 # source_table is "layer.table_name", check if model_name matches
                 if m.source_table.endswith(f".{model_name}"):
                     monitor_refs.append(m.name)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
         # Dry run: show what would be removed and exit
@@ -268,7 +268,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
                         console.print(
                             f"[green]✓[/green] Removed from {schema_path.relative_to(project_root)}"
                         )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass  # Non-critical — don't block removal
 
         # Remove monitor references from monitors.yml
@@ -288,7 +288,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
                     console.print(
                         f"[green]✓[/green] Removed {removed_count} monitor(s) from monitors.yml"
                     )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass  # Non-critical
 
         # Handle table deletion if it exists
@@ -327,7 +327,7 @@ def model_remove(ctx: click.Context, model_name: str, yes: bool, dry_run: bool) 
 
                 if sync_metabase_schema(project_root):
                     console.print("[green]✓[/green] Metabase schema refreshed")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass  # Non-critical — Metabase may not be running
 
         console.print()

--- a/dango/cli/commands/notebook.py
+++ b/dango/cli/commands/notebook.py
@@ -50,7 +50,7 @@ def notebook(ctx: click.Context) -> None:
             rows = conn.execute("SELECT name, created_by FROM notebook_metadata").fetchall()
             for row in rows:
                 authors[row["name"]] = row["created_by"]
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass  # DB not initialized yet — show "--" for all
 
     for f in sorted(notebooks_dir.glob("*.py")):
@@ -183,7 +183,7 @@ def notebook_open(ctx: click.Context, name: str) -> None:
             try:
                 snapshot_path = create_snapshot(project_root, "cli")
                 console.print(f"[green]✓[/green] Created DuckDB snapshot at {snapshot_path.name}")
-            except FileNotFoundError:
+            except FileNotFoundError:  # noqa: BLE001
                 pass  # no warehouse yet — notebooks will use default path
 
             console.print("[cyan]Starting Marimo server...[/cyan]")
@@ -200,7 +200,7 @@ def notebook_open(ctx: click.Context, name: str) -> None:
 
         console.print("\n[dim]Press Ctrl+C to release lock and exit.[/dim]")
         stop_event.wait()
-    except KeyboardInterrupt:
+    except KeyboardInterrupt:  # noqa: BLE001
         pass
     finally:
         stop_event.set()

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -668,7 +668,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                     "[dim]🔑 Forgot password? Run 'dango auth reset-password <email>'[/dim]"
                 )
                 console.print()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass  # auth module may not be initialized yet
 
         console.print("[dim]Run 'dango stop' to shut down services.[/dim]")
@@ -703,7 +703,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                     if response.status_code == 200:
                         fastapi_ready = True
                         console.print("[dim]  ✓ Web UI ready[/dim]")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
             try:
@@ -712,7 +712,7 @@ def start(ctx: click.Context, yes: bool) -> None:
                     if metabase_response.status_code == 200:
                         metabase_ready = True
                         console.print("[dim]  ✓ Metabase ready[/dim]")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
             if fastapi_ready and metabase_ready:

--- a/dango/cli/commands/remote_backup.py
+++ b/dango/cli/commands/remote_backup.py
@@ -421,7 +421,7 @@ def _backup_download_from_server(ctx: click.Context, output: str | None) -> None
             if line.startswith("__BACKUP_RESULT__"):
                 try:
                     info = json.loads(line[len("__BACKUP_RESULT__") :])
-                except json.JSONDecodeError:
+                except json.JSONDecodeError:  # noqa: BLE001
                     pass
                 break
         if info is None:
@@ -444,7 +444,7 @@ def _backup_download_from_server(ctx: click.Context, output: str | None) -> None
                         console.print(
                             f"[yellow]Warning:[/yellow] Server disk is {usage_pct}% full."
                         )
-                except (ValueError, IndexError):
+                except (ValueError, IndexError):  # noqa: BLE001
                     pass
 
         with Status(f"[bold blue]Downloading {archive_name}...", console=console):

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -147,7 +147,7 @@ def _get_local_timezone() -> str:
             iana = link.split("zoneinfo/")[-1]
             if iana:
                 return iana
-    except (OSError, ValueError):
+    except (OSError, ValueError):  # noqa: BLE001
         pass
 
     # Method 1.5: Windows — try tzlocal (IANA names), then time.tzname
@@ -158,7 +158,7 @@ def _get_local_timezone() -> str:
             tz_name = get_localzone_name()
             if tz_name:
                 return tz_name
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
         try:
             import time as _time
@@ -166,7 +166,7 @@ def _get_local_timezone() -> str:
             tz_name = _time.tzname[0]
             if tz_name:
                 return tz_name
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     # Method 2: tzinfo.key (Python 3.12+)
@@ -176,7 +176,7 @@ def _get_local_timezone() -> str:
         tz = datetime.now(timezone.utc).astimezone().tzinfo
         if tz is not None and hasattr(tz, "key"):
             return str(tz.key)
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     return "UTC"

--- a/dango/cli/commands/serve.py
+++ b/dango/cli/commands/serve.py
@@ -160,7 +160,7 @@ def serve(ctx: click.Context, host: str, port: int | None, workers: int | None) 
     # 6. Dashboard import (non-critical)
     try:
         import_dashboards(project_root)
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     # H4: Check port availability before starting uvicorn
@@ -211,5 +211,5 @@ def _stop_docker_quiet(project_root: Path) -> None:
         from dango.platform import DockerManager
 
         DockerManager(project_root).stop_services()
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass

--- a/dango/cli/commands/snapshot.py
+++ b/dango/cli/commands/snapshot.py
@@ -357,7 +357,7 @@ def snapshot_run(ctx: click.Context, select: str | None) -> None:
         if lock is not None and lock._acquired:
             try:
                 lock.release()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
 

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -157,7 +157,7 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
                 if source_names:
                     console.print(f"[dim]Available sources: {', '.join(source_names)}[/dim]")
                 return
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass  # Fall through to editor
 
     import os
@@ -185,7 +185,7 @@ def source_edit(ctx: click.Context, name: str | None) -> None:
                         console.print(yaml.dump({"sources": [src]}, default_flow_style=False))
                         console.print(f"[dim]File: {sources_file}[/dim]")
                         return
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         console.print("[yellow]No changes made.[/yellow]")
         console.print(f"[dim]Edit manually: {sources_file}[/dim]")
@@ -333,7 +333,7 @@ def source_list(ctx: click.Context, enabled_only: bool) -> None:
                                     total += cnt[0]
                             if total > 0:
                                 row_counts[src.name] = total
-                        except Exception:
+                        except Exception:  # noqa: BLE001
                             pass
                 finally:
                     conn.close()
@@ -915,7 +915,7 @@ def sync(
         if lock is not None and lock._acquired:
             try:
                 lock.release()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         # Restart Metabase on cloud
         if _metabase_was_stopped:

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -138,7 +138,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
         if lock is not None and lock._acquired:
             try:
                 lock.release()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         # Restart Metabase on cloud
         if _metabase_was_stopped:

--- a/dango/cli/env_helpers.py
+++ b/dango/cli/env_helpers.py
@@ -103,7 +103,7 @@ def create_env_template(
             try:
                 if temp_file.exists():
                     temp_file.unlink()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
             raise Exception(f"Failed to update .env file: {e}") from e
 

--- a/dango/cli/helpers/port_manager.py
+++ b/dango/cli/helpers/port_manager.py
@@ -43,7 +43,7 @@ def get_process_using_port(port: int) -> int | None:
             laddr = conn.laddr
             if hasattr(laddr, "port") and laddr.port == port and conn.status == "LISTEN":  # type: ignore[union-attr]
                 return int(conn.pid) if conn.pid is not None else None
-    except (psutil.AccessDenied, AttributeError):
+    except (psutil.AccessDenied, AttributeError):  # noqa: BLE001
         pass
 
     return None

--- a/dango/cli/helpers/process_manager.py
+++ b/dango/cli/helpers/process_manager.py
@@ -68,7 +68,7 @@ def remove_pid_file(project_root: Path) -> None:
     try:
         if pid_file.exists():
             pid_file.unlink()
-    except OSError:
+    except OSError:  # noqa: BLE001
         pass
 
 
@@ -367,7 +367,7 @@ def get_fastapi_status(project_root: Path) -> dict:
 
         config = ConfigLoader(project_root).load_config()
         port = config.platform.port
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     status: dict = {"running": False, "pid": None, "port": port, "url": None, "log_file": log_file}

--- a/dango/cli/oauth.py
+++ b/dango/cli/oauth.py
@@ -437,7 +437,7 @@ def check_token_expiry(project_root: Path, source_type: str) -> str | None:
                             return f"[red]Facebook token expired {abs(days_remaining)} days ago[/red]\nRun: dango oauth facebook_ads"
                         elif days_remaining < 7:
                             return f"[yellow]Facebook token expires in {days_remaining} days[/yellow]\nConsider running: dango oauth facebook_ads"
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
     return None

--- a/dango/cli/utils.py
+++ b/dango/cli/utils.py
@@ -172,7 +172,7 @@ def get_git_branch(project_root: Path | None = None) -> str | None:
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     return None

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -691,7 +691,7 @@ class ProjectValidator:
                         )
                         break  # One match per file is enough
 
-        except (subprocess.TimeoutExpired, FileNotFoundError):
+        except (subprocess.TimeoutExpired, FileNotFoundError):  # noqa: BLE001
             pass  # git not installed or timed out — skip silently
 
     def _create_summary(self) -> dict[str, Any]:

--- a/dango/config/loader.py
+++ b/dango/config/loader.py
@@ -148,7 +148,7 @@ class ConfigLoader:
             try:
                 if temp_path.exists():
                     temp_path.unlink()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
             raise ConfigError(f"Error writing {file_path}: {e}") from e
 

--- a/dango/governance/pii_detector.py
+++ b/dango/governance/pii_detector.py
@@ -119,7 +119,7 @@ def _get_analyzer() -> Any | None:
             finally:
                 try:
                     os.unlink(whl_path)
-                except OSError:
+                except OSError:  # noqa: BLE001
                     pass
         except Exception:
             _analyzer_init_failed = True

--- a/dango/governance/pii_overrides.py
+++ b/dango/governance/pii_overrides.py
@@ -96,7 +96,7 @@ def _save_overrides(project_root: Path, overrides: list[dict[str, Any]]) -> None
         # Clean up temp file on failure
         try:
             os.unlink(tmp)
-        except OSError:
+        except OSError:  # noqa: BLE001
             pass
         raise
 

--- a/dango/ingestion/csv_loader.py
+++ b/dango/ingestion/csv_loader.py
@@ -385,7 +385,7 @@ class CSVLoader:
             # Clean up view if it exists
             try:
                 conn.execute(f"DROP VIEW IF EXISTS {temp_view}")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
             raise Exception(f"Failed to read file schema from {filepath}: {e}") from e
 
@@ -431,7 +431,7 @@ class CSVLoader:
         except Exception:
             try:
                 conn.execute(f"DROP VIEW IF EXISTS {temp_view}")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
             return {}
 

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -1194,7 +1194,7 @@ class DltPipelineRunner:
                     doc = tomlkit.parse(config_toml_path.read_text())
                     source_section = doc.get("sources", {}).get(source_type.value, {})
                     config_toml_keys = set(source_section.keys())
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass  # If we can't read config.toml, fall back to defaults
 
             for key, value in default_config.items():
@@ -1661,7 +1661,7 @@ class DltPipelineRunner:
                     try:
                         days = int(dv.replace("daysAgo", ""))
                         resolved_config[dk] = (date.today() - timedelta(days=days)).isoformat()
-                    except ValueError:
+                    except ValueError:  # noqa: BLE001
                         pass  # Leave as-is if not parseable
 
         # Convert date strings to pendulum DateTime for sources that expect it
@@ -1681,7 +1681,7 @@ class DltPipelineRunner:
                     except Exception:
                         try:
                             resolved_config[date_key] = datetime.fromisoformat(date_val)
-                        except ValueError:
+                        except ValueError:  # noqa: BLE001
                             pass  # Leave as string — dlt may handle it
 
         # Override dates if provided
@@ -2730,7 +2730,7 @@ def run_sync(
                     console.print(f"[dim]🧹 Cleaned up {len(dropped)} staging schema(s)[/dim]")
             finally:
                 conn.close()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass  # Don't fail sync for cleanup errors
 
     # Initialize transform tracking (used in summary dict below)

--- a/dango/ingestion/dlt_sources/google_sheets/helpers/data_processing.py
+++ b/dango/ingestion/dlt_sources/google_sheets/helpers/data_processing.py
@@ -198,7 +198,7 @@ def get_data_types(data_row_metadata: List[DictStrAny]) -> List[TDataType]:
                     data_types[idx] = "timestamp"
                 elif data_type == "DATE":
                     data_types[idx] = "date"
-            except KeyError:
+            except KeyError:  # noqa: BLE001
                 pass
         return data_types
     except IndexError:

--- a/dango/ingestion/dlt_sources/inbox/helpers.py
+++ b/dango/ingestion/dlt_sources/inbox/helpers.py
@@ -23,7 +23,7 @@ def decode_header_word(v: Any) -> Any:
         return v
     try:
         v = str(make_header(decode_header(v)))
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     return v

--- a/dango/ingestion/dlt_sources/mongodb/helpers.py
+++ b/dango/ingestion/dlt_sources/mongodb/helpers.py
@@ -147,7 +147,7 @@ class CollectionLoader:
                 try:
                     # ensure primary_key isn't excluded
                     projection_dict.pop(self.incremental.primary_key)  # type: ignore
-                except KeyError:
+                except KeyError:  # noqa: BLE001
                     pass  # primary_key was properly not included in exclusion projection
                 else:
                     dlt.common.logger.warn(

--- a/dango/notebooks/manager.py
+++ b/dango/notebooks/manager.py
@@ -213,7 +213,7 @@ def stop_marimo(project_root: Path) -> bool:
 
     try:
         pid_file.unlink()
-    except OSError:
+    except OSError:  # noqa: BLE001
         pass
 
     if success:
@@ -259,7 +259,7 @@ def get_marimo_status(project_root: Path) -> dict[str, bool | int | Path | None]
                     status["port"] = config.platform.marimo_port
                 except Exception:
                     status["port"] = 7805
-        except (ValueError, OSError):
+        except (ValueError, OSError):  # noqa: BLE001
             pass
 
     return status
@@ -298,7 +298,7 @@ async def _broadcast_idle_warning(remaining_seconds: int) -> None:
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass  # web server may not be running for CLI-launched notebooks
 
 

--- a/dango/notebooks/proxy.py
+++ b/dango/notebooks/proxy.py
@@ -164,7 +164,7 @@ async def proxy_websocket_to_marimo(
                     while True:
                         data = await websocket.receive_text()
                         await marimo_ws.send(data)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
             async def marimo_to_client() -> None:
@@ -175,7 +175,7 @@ async def proxy_websocket_to_marimo(
                             await websocket.send_text(message)
                         else:
                             await websocket.send_bytes(message)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
             tasks = [
@@ -191,5 +191,5 @@ async def proxy_websocket_to_marimo(
     finally:
         try:
             await websocket.close()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass

--- a/dango/oauth/__init__.py
+++ b/dango/oauth/__init__.py
@@ -300,12 +300,12 @@ class OAuthManager:
             finally:
                 try:
                     server.server_close()
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
                 if server_thread is not None:
                     try:
                         server_thread.join(timeout=5)
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         pass
 
             answers = inquirer.prompt(

--- a/dango/platform/cloud/backup.py
+++ b/dango/platform/cloud/backup.py
@@ -152,7 +152,7 @@ def _check_disk_space(ssh: SSHManager, required_mb: int = 500) -> None:
                     available_mb=available,
                     total_mb=total_mb,
                 )
-        except (ValueError, IndexError):
+        except (ValueError, IndexError):  # noqa: BLE001
             pass  # Best-effort — silently skip if df format unexpected
 
 

--- a/dango/platform/cloud/migrate.py
+++ b/dango/platform/cloud/migrate.py
@@ -432,7 +432,7 @@ def migrate_server(
         if new_droplet_id is not None:
             try:
                 client.delete_droplet(new_droplet_id)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         if new_ssh is not None:
             try:
@@ -444,7 +444,7 @@ def migrate_server(
     if new_ssh is not None:
         try:
             new_ssh.disconnect()
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     return MigrateResult(

--- a/dango/platform/cloud/provisioning.py
+++ b/dango/platform/cloud/provisioning.py
@@ -372,7 +372,7 @@ def provision_droplet(
         # Best-effort cleanup — swallow delete errors, re-raise original
         try:
             client.delete_droplet(droplet_id)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
         raise
 

--- a/dango/platform/cloud/resize.py
+++ b/dango/platform/cloud/resize.py
@@ -155,7 +155,7 @@ def regenerate_dbt_profiles(
         data: dict[str, Any] = yaml.safe_load(result.stdout)
         if isinstance(data, dict) and "name" in data:
             project_name = str(data["name"])
-    except yaml.YAMLError:
+    except yaml.YAMLError:  # noqa: BLE001
         pass  # Fall back to default name
 
     # Determine specs from tier or defaults
@@ -172,12 +172,12 @@ def regenerate_dbt_profiles(
             if part.endswith("vcpu"):
                 try:
                     vcpus = int(part[:-4])
-                except ValueError:
+                except ValueError:  # noqa: BLE001
                     pass
             elif part.endswith("gb"):
                 try:
                     ram_gb = int(part[:-2])
-                except ValueError:
+                except ValueError:  # noqa: BLE001
                     pass
 
     content = generate_dbt_profiles_yml(project_name, vcpus, ram_gb, dbt_overrides)
@@ -306,7 +306,7 @@ def resize_droplet(
         # Best effort: try to power on if we failed after power off
         try:
             client.power_on(droplet_id)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
         raise
 

--- a/dango/platform/cloud/scheduled_backup.py
+++ b/dango/platform/cloud/scheduled_backup.py
@@ -154,7 +154,7 @@ def _get_metabase_volume_path() -> str | None:
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired:  # noqa: BLE001
         pass
     return None
 
@@ -317,7 +317,7 @@ def _warn_spaces_reuse(
             existing = json.loads(HEALTH_FILE.read_text())
             if existing.get("last_success"):
                 return  # Not first run
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError):  # noqa: BLE001
             pass
 
     try:
@@ -342,7 +342,7 @@ def _warn_spaces_reuse(
                     f"Older backups will be deleted over time."
                 ),
             )
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass  # Best-effort warning — never fail backup for this
 
 
@@ -368,7 +368,7 @@ def _check_spaces_reuse(
                 }
             )
         )
-    except OSError:
+    except OSError:  # noqa: BLE001
         pass  # Best-effort — never fail backup for marker file write
 
 
@@ -448,7 +448,7 @@ def _write_health_status(success: bool, error: str | None = None) -> None:
     if HEALTH_FILE.exists():
         try:
             existing = json.loads(HEALTH_FILE.read_text())
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError):  # noqa: BLE001
             pass
     now_iso = datetime.now(tz=timezone.utc).isoformat()
     if success:
@@ -527,7 +527,7 @@ def run_scheduled_backup() -> ScheduledBackupResult:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
                 lock_fd.close()
-            except OSError:
+            except OSError:  # noqa: BLE001
                 pass
     result.duration_seconds = round(time.monotonic() - start_time, 1)
     return result

--- a/dango/platform/cloud/server_status.py
+++ b/dango/platform/cloud/server_status.py
@@ -136,7 +136,7 @@ def _get_cpu_usage(ssh: Any) -> float | None:
             if part.strip().endswith("id"):
                 idle = float(part.strip().split()[0])
                 return round(100.0 - idle, 1)
-    except (ValueError, IndexError):
+    except (ValueError, IndexError):  # noqa: BLE001
         pass
     return None
 
@@ -158,7 +158,7 @@ def _get_ram(ssh: Any, field_name: str) -> int | None:
                     return int(parts[1])
                 if field_name == "used":
                     return int(parts[2])
-    except (ValueError, IndexError):
+    except (ValueError, IndexError):  # noqa: BLE001
         pass
     return None
 
@@ -180,7 +180,7 @@ def _get_disk(ssh: Any, field_name: str) -> int | None:
             idx = {"total": 1, "used": 2, "available": 3}.get(field_name)
             if idx is not None:
                 return int(parts[idx].rstrip("M"))
-    except (ValueError, IndexError):
+    except (ValueError, IndexError):  # noqa: BLE001
         pass
     return None
 
@@ -335,7 +335,7 @@ def get_local_resource_usage() -> dict[str, Any]:
         result["disk_total_mb"] = usage.total // (1024 * 1024)
         result["disk_used_mb"] = usage.used // (1024 * 1024)
         result["disk_free_mb"] = usage.free // (1024 * 1024)
-    except OSError:
+    except OSError:  # noqa: BLE001
         pass
 
     # RAM — Linux only (/proc/meminfo)
@@ -352,7 +352,7 @@ def get_local_resource_usage() -> dict[str, Any]:
             if total_kb:
                 result["ram_total_mb"] = total_kb // 1024
                 result["ram_used_mb"] = (total_kb - available_kb) // 1024
-    except (OSError, ValueError):
+    except (OSError, ValueError):  # noqa: BLE001
         pass
 
     # CPU — Linux only (/proc/loadavg, 1-min load average normalized by CPU count)
@@ -364,7 +364,7 @@ def get_local_resource_usage() -> dict[str, Any]:
         cpu_count = os.cpu_count() or 1
         # Normalize load average to percentage (capped at 100%)
         result["cpu_usage_pct"] = round(min(100.0, 100.0 * load_1min / cpu_count), 1)
-    except (OSError, ValueError, IndexError):
+    except (OSError, ValueError, IndexError):  # noqa: BLE001
         pass
 
     return result

--- a/dango/platform/cloud/ssh.py
+++ b/dango/platform/cloud/ssh.py
@@ -366,7 +366,7 @@ class SSHManager:
         if self._client is not None:
             try:
                 self._client.close()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
             self._client = None
 

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -170,7 +170,7 @@ def ensure_duckdb_driver(project_root: Path) -> None:
                 try:
                     if driver_path.exists():
                         driver_path.unlink()
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
     raise RuntimeError(

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -118,7 +118,7 @@ class DockerManager:
             )
             if result.returncode == 0:
                 return ["docker", "compose"]
-        except (subprocess.TimeoutExpired, FileNotFoundError):
+        except (subprocess.TimeoutExpired, FileNotFoundError):  # noqa: BLE001
             pass
 
         # Fall back to docker-compose (v1)
@@ -294,7 +294,7 @@ class DockerManager:
                     "[yellow]⚠[/yellow]  Other Dango containers still running. "
                     "Run [cyan]dango stop --all[/cyan] to stop them."
                 )
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass  # Best-effort, never block stop
 
     def stop_all_dango_containers(self, all_projects: bool = False) -> bool:

--- a/dango/platform/local/watcher_lifecycle.py
+++ b/dango/platform/local/watcher_lifecycle.py
@@ -170,7 +170,7 @@ def stop_file_watcher(project_root: Path) -> bool:
     # Clean up PID file
     try:
         pid_file.unlink()
-    except OSError:
+    except OSError:  # noqa: BLE001
         pass
 
     if success:
@@ -209,7 +209,7 @@ def get_watcher_status(project_root: Path) -> dict:
             if is_process_running(pid):
                 status["running"] = True
                 status["pid"] = pid
-        except (ValueError, OSError):
+        except (ValueError, OSError):  # noqa: BLE001
             pass
 
     return status

--- a/dango/platform/scheduling/sync_trigger.py
+++ b/dango/platform/scheduling/sync_trigger.py
@@ -80,7 +80,7 @@ def _write_status(state_dir: Path, sync_id: str | None = None, **fields: Any) ->
         tmp_f.close()
         try:
             os.unlink(tmp_f.name)
-        except OSError:
+        except OSError:  # noqa: BLE001
             pass
         raise
 
@@ -356,7 +356,7 @@ def run_manual_sync(
         if lock is not None:
             try:
                 lock.release()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
         # --- Restart Metabase on cloud ---
         if _metabase_was_stopped:
@@ -388,7 +388,7 @@ def _trigger_metabase_schema_scan(project_root: Path) -> None:
             resp = requests.get(f"{metabase_url}/api/health", timeout=3)
             if resp.status_code == 200:
                 break
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
         time.sleep(5)
     else:

--- a/dango/platform/sync_process.py
+++ b/dango/platform/sync_process.py
@@ -85,7 +85,7 @@ def cleanup_sync_status(project_root: Path, sync_id: str | None = None) -> None:
         path = get_sync_status_path(project_root, sync_id)
         try:
             path.unlink(missing_ok=True)
-        except OSError:
+        except OSError:  # noqa: BLE001
             pass
 
 

--- a/dango/transformation/generator.py
+++ b/dango/transformation/generator.py
@@ -236,7 +236,7 @@ class DbtModelGenerator:
                 queries = source_dict.get("queries", [])
                 if isinstance(queries, list) and queries:
                     return [q.get("resource_name") for q in queries if q.get("resource_name")]
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
         return []

--- a/dango/utils/dango_db.py
+++ b/dango/utils/dango_db.py
@@ -206,5 +206,5 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         try:
             conn.execute(stmt)
             conn.commit()
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError:  # noqa: BLE001
             pass  # Column already exists

--- a/dango/utils/data_validation.py
+++ b/dango/utils/data_validation.py
@@ -245,7 +245,7 @@ def validate_data_completeness(
 
                 if last_load and last_load[0]:
                     result["last_loaded"] = str(last_load[0])
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
             # Determine health score

--- a/dango/utils/db_health.py
+++ b/dango/utils/db_health.py
@@ -324,7 +324,7 @@ def _dir_size_bytes(path: Path) -> int:
                     total += f.stat().st_size
                 except OSError:
                     continue
-    except OSError:
+    except OSError:  # noqa: BLE001
         pass
     return total
 

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -141,7 +141,7 @@ class DbtLock:
                     lock_info.get("operation", "unknown"),
                 )
                 return True
-            except OSError:
+            except OSError:  # noqa: BLE001
                 pass
 
         return False
@@ -224,7 +224,7 @@ class DbtLock:
                     # Windows: use msvcrt
                     try:
                         msvcrt.locking(self._lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-                    except OSError:
+                    except OSError:  # noqa: BLE001
                         pass  # Lock may already be released
                 else:
                     # Unix: use fcntl
@@ -240,7 +240,7 @@ class DbtLock:
                 self.lock_info_path.unlink()
 
             self._acquired = False
-        except OSError:
+        except OSError:  # noqa: BLE001
             pass
 
     def __enter__(self) -> DbtLock:

--- a/dango/utils/dbt_status.py
+++ b/dango/utils/dbt_status.py
@@ -152,5 +152,5 @@ def _save_persistent_status(project_root: Path, status: dict[str, dict[str, Any]
     try:
         with open(status_path, "w") as f:
             json.dump(status, f, indent=2)
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass

--- a/dango/utils/git_info.py
+++ b/dango/utils/git_info.py
@@ -50,7 +50,7 @@ def _run_git(args: list[str], cwd: Path) -> str | None:
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except (subprocess.TimeoutExpired, OSError):
+    except (subprocess.TimeoutExpired, OSError):  # noqa: BLE001
         pass
     return None
 

--- a/dango/utils/log_rotation.py
+++ b/dango/utils/log_rotation.py
@@ -86,7 +86,7 @@ def _cleanup_old_sync_logs_impl(project_root: Path, max_age_days: int) -> None:
             if log_file.stat().st_mtime < cutoff_ts:
                 log_file.unlink(missing_ok=True)
                 _logger.info("sync_log_deleted", path=str(log_file))
-        except OSError:
+        except OSError:  # noqa: BLE001
             pass
 
 

--- a/dango/utils/process.py
+++ b/dango/utils/process.py
@@ -70,7 +70,7 @@ def kill_process(pid: int, timeout: int = 10) -> bool:
         for child in children:
             try:
                 child.terminate()
-            except psutil.NoSuchProcess:
+            except psutil.NoSuchProcess:  # noqa: BLE001
                 pass
 
         # Wait for processes to exit
@@ -80,7 +80,7 @@ def kill_process(pid: int, timeout: int = 10) -> bool:
             # Process didn't exit gracefully, force kill
             try:
                 proc.kill()
-            except psutil.NoSuchProcess:
+            except psutil.NoSuchProcess:  # noqa: BLE001
                 pass
 
             for child in alive:

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -795,7 +795,7 @@ def setup_metabase(
                             f"  ℹ DuckDB connection already exists (ID: {existing_db_id}), will update it"
                         )
                         break
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass  # If check fails, proceed with creation
 
         # Add or update DuckDB connection
@@ -848,7 +848,7 @@ def setup_metabase(
                         json={"is_sample": False, "is_full_sync": True},
                         timeout=10,
                     )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass  # Not critical
 
                 # NOTE: hide_internal_tables disabled - it breaks Metabase schema navigation
@@ -911,9 +911,9 @@ def setup_metabase(
                                 if hide_response.status_code == 200:
                                     summary["h2_hidden"] = True
                                     print(f"  ✓ Hidden H2 sample database (ID: {db_id})")
-                        except Exception:
+                        except Exception:  # noqa: BLE001
                             pass
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass  # Not critical
 
         # Remove example dashboards and collections
@@ -969,7 +969,7 @@ def setup_metabase(
                 if coll_response.status_code == 200:
                     collections_created.append(collection_name)
                     print(f"  ✓ Created '{collection_name}' collection")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass  # Not critical
 
         summary["collections_created"] = collections_created
@@ -1240,7 +1240,7 @@ def refresh_metabase_connection(
                 response = session.get(f"{metabase_url}/api/health", timeout=1)
                 if response.status_code == 200:
                     return (True, None)
-            except requests.exceptions.RequestException:
+            except requests.exceptions.RequestException:  # noqa: BLE001
                 pass
             time.sleep(1)
 

--- a/dango/web/app.py
+++ b/dango/web/app.py
@@ -215,7 +215,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     try:
                         if path.stat().st_mtime < cutoff:
                             path.unlink(missing_ok=True)
-                    except OSError:
+                    except OSError:  # noqa: BLE001
                         pass
     except Exception:
         logger.debug("old_sync_log_cleanup_failed", exc_info=True)
@@ -250,7 +250,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         mb_task.cancel()
         try:
             await mb_task
-        except asyncio.CancelledError:
+        except asyncio.CancelledError:  # noqa: BLE001
             pass
 
     sync_task = getattr(app.state, "sync_watcher_task", None)
@@ -258,7 +258,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         sync_task.cancel()
         try:
             await sync_task
-        except asyncio.CancelledError:
+        except asyncio.CancelledError:  # noqa: BLE001
             pass
 
     sched = getattr(app.state, "scheduler", None)
@@ -279,14 +279,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         from dango.web.helpers import close_health_check_client
 
         close_health_check_client()
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     try:
         from dango.utils.activity_log import log_activity
 
         log_activity(project_root, "info", "system", "Dango server shutting down")
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
 
     logger.info("api_shutting_down")
@@ -398,7 +398,7 @@ def _get_cors_origins(project_root: Path | None) -> list[str]:
         origin = get_cloud_origin(root)
         if origin is not None:
             return [origin]
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return ["*"]
 

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -781,7 +781,7 @@ async def get_platform_health_data():
                                 "last_error": most_recent.get("error_message", "Unknown error"),
                             }
                         )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
     # Check execution_history for schedule-level failures (M3)
@@ -828,9 +828,9 @@ async def get_platform_health_data():
                                         }
                                     )
                                     already_failed_sources.add(src)
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         pass
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass  # Don't break health page if scheduler.db is unavailable
 
     # Check for failed dbt runs

--- a/dango/web/routes/auth.py
+++ b/dango/web/routes/auth.py
@@ -41,6 +41,7 @@ from dango.auth.security import (
     check_password_strength,
     hash_password,
     hash_token,
+    set_password,
     verify_password,
 )
 from dango.auth.sessions import (
@@ -434,16 +435,7 @@ async def change_password(request: Request) -> JSONResponse:
         )
 
     # Update password, clear must_change_password, and record change timestamp
-    new_hash = hash_password(data.new_password)
-    update_user(
-        db_path,
-        user.id,
-        UserUpdate(
-            password_hash=new_hash,
-            must_change_password=False,
-            password_changed_at=datetime.now(timezone.utc),
-        ),
-    )
+    set_password(user.email, data.new_password, db_path)
 
     # Invalidate all sessions, then create a fresh one
     invalidate_all_sessions(db_path, user.id)
@@ -655,15 +647,13 @@ async def accept_invite(request: Request) -> JSONResponse:
         )
 
     # Set password and clear invite fields
+    set_password(user.email, data.password, db_path)
     update_user(
         db_path,
         user.id,
         UserUpdate(
-            password_hash=hash_password(data.password),
             invite_token_hash=None,
             invite_expires_at=None,
-            must_change_password=False,
-            password_changed_at=datetime.now(timezone.utc),
         ),
     )
 

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -274,7 +274,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
         if lock is not None:
             try:
                 lock.release()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass
 
 

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -184,7 +184,7 @@ async def get_platform_health() -> dict[str, Any]:
                 warnings.append(
                     f"Orphaned tables found ({', '.join(orphan_names[:3])}) \u2014 run `dango db clean`"
                 )
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass  # Non-critical check
 
     if failed_dbt:

--- a/dango/web/routes/initial_sync.py
+++ b/dango/web/routes/initial_sync.py
@@ -156,7 +156,7 @@ def _validate_deploy_token(token: str) -> bool:
     # One-time use — delete after validation
     try:
         token_path.unlink()
-    except OSError:
+    except OSError:  # noqa: BLE001
         pass
     return True
 

--- a/dango/web/routes/monitoring.py
+++ b/dango/web/routes/monitoring.py
@@ -135,7 +135,7 @@ def _read_dbt_test_results(project_root: Path) -> list[DbtTestResult]:
                     raw = r.get("status", "")
                     result_status[uid] = "pass" if raw == "success" else raw
                     result_time[uid] = r.get("execution_time", 0.0)
-        except Exception:
+        except Exception:  # noqa: BLE001
             pass
 
     tests: list[DbtTestResult] = []

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -389,7 +389,7 @@ async def lock_notebook(
         snapshot_path = None
         try:
             snapshot_path = await asyncio.to_thread(create_snapshot, project_root, user.email)
-        except FileNotFoundError:
+        except FileNotFoundError:  # noqa: BLE001
             pass  # no warehouse yet
 
         try:

--- a/dango/web/routes/scripts.py
+++ b/dango/web/routes/scripts.py
@@ -103,7 +103,7 @@ async def script_log_page(
     if meta_path.exists():
         try:
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError):  # noqa: BLE001
             pass
 
     return _render_template(

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -125,7 +125,7 @@ async def get_sources() -> list[SourceStatus]:
             if status.name in attention_map:
                 status.needs_attention = True
                 status.attention_reason = attention_map[status.name]
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass  # Non-critical enrichment
 
     # Sort sources alphabetically by name for consistent ordering

--- a/dango/web/routes/ui.py
+++ b/dango/web/routes/ui.py
@@ -250,7 +250,7 @@ async def query_redirect(request: Request) -> HTMLResponse:
                 )
                 encoded = base64.b64encode(query_state.encode()).decode()
                 target_url = f"/metabase/question#{encoded}"
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     # JavaScript redirect — meta refresh and 302 both strip hash fragments
     return HTMLResponse(
@@ -304,7 +304,7 @@ async def login_page(request: Request) -> Response:
                 user = validate_session(get_auth_db_path(project_root), token)
                 if user is not None:
                     return RedirectResponse(url="/", status_code=302)
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass  # Fall through to login page on any error
     oauth_providers: list[dict[str, str]] = []
     try:
@@ -317,7 +317,7 @@ async def login_page(request: Request) -> Response:
             {"name": p.name, "display_name": p.display_name, "icon_svg": p.icon_svg}
             for p in providers
         ]
-    except Exception:
+    except Exception:  # noqa: BLE001
         pass
     return _render_template(
         request,

--- a/dango/web/routes/upload.py
+++ b/dango/web/routes/upload.py
@@ -540,7 +540,7 @@ async def delete_csv_file(
                 try:
                     conn.close()
                     logger.info("DB connection closed")
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass
 
         # Delete file from filesystem
@@ -771,5 +771,5 @@ async def run_dbt_after_delete(source_name: str):
         if lock is not None:
             try:
                 lock.release()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass

--- a/dango/web/routes/users.py
+++ b/dango/web/routes/users.py
@@ -30,7 +30,12 @@ from dango.auth.database import (
 )
 from dango.auth.models import Role, User, UserResponse, UserUpdate
 from dango.auth.permissions import require_permission
-from dango.auth.security import generate_invite_token, generate_temp_password, hash_password
+from dango.auth.security import (
+    generate_invite_token,
+    generate_temp_password,
+    hash_password,
+    set_password,
+)
 from dango.exceptions import UserExistsError
 from dango.logging import get_logger
 from dango.web.models import ChangeRoleRequest, CreateUserRequest, DeleteUserConfirmation
@@ -315,18 +320,8 @@ async def admin_reset_password(
     if target is None:
         return JSONResponse(status_code=404, content={"message": "User not found"})
 
-    from datetime import datetime, timezone
-
     password = generate_temp_password()
-    updated = update_user(
-        db_path,
-        user_id,
-        UserUpdate(
-            password_hash=hash_password(password),
-            must_change_password=True,
-            password_changed_at=datetime.now(timezone.utc),
-        ),
-    )
+    updated = set_password(target.email, password, db_path, must_change_password=True)
     invalidate_all_user_sessions(db_path, user_id)
     log_auth_event(
         AuditEvent.PASSWORD_RESET,

--- a/dango/web/routes/websocket.py
+++ b/dango/web/routes/websocket.py
@@ -76,7 +76,7 @@ class ConnectionManager:
         for connection in disconnected:
             try:
                 self.active_connections.remove(connection)
-            except ValueError:
+            except ValueError:  # noqa: BLE001
                 pass
 
 

--- a/tests/unit/test_auth_security.py
+++ b/tests/unit/test_auth_security.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 import time
+from pathlib import Path
 
 import pytest
 from pwdlib.exceptions import UnknownHashError
@@ -24,6 +25,7 @@ from dango.auth.security import (
     hash_password,
     hash_recovery_code,
     hash_token,
+    set_password,
     verify_password,
 )
 
@@ -309,3 +311,81 @@ class TestCommonPasswordsList:
     def test_well_known_passwords_present(self) -> None:
         for pwd in ("password", "123456", "qwerty", "admin", "letmein"):
             assert pwd in _COMMON_PASSWORDS, f"Missing well-known password: {pwd}"
+
+
+# ---------------------------------------------------------------------------
+# set_password() tests
+# ---------------------------------------------------------------------------
+
+
+def _make_auth_db(tmp_path: Path) -> Path:
+    """Initialize a fresh auth database via migration runner."""
+    from dango.migrations.runner import MigrationRunner
+
+    db_path = tmp_path / "auth.db"
+    migrations_dir = Path(__file__).resolve().parents[2] / "dango" / "migrations" / "auth"
+    runner = MigrationRunner(db_path=db_path, db_name="auth", migrations_dir=migrations_dir)
+    runner.apply_pending()
+    return db_path
+
+
+class TestSetPassword:
+    """Tests for set_password()."""
+
+    def test_updates_hash_and_clears_flag(self, tmp_path: Path) -> None:
+        """set_password() hashes the password, updates DB, returns updated user."""
+        from dango.auth.database import create_user
+        from dango.auth.models import Role, User
+        from dango.auth.security import verify_password
+
+        db_path = _make_auth_db(tmp_path)
+        user = User(email="test@example.com", role=Role.EDITOR, must_change_password=True)
+        create_user(db_path, user)
+
+        result = set_password("test@example.com", "newpassword123", db_path)
+
+        assert result.email == "test@example.com"
+        assert verify_password("newpassword123", result.password_hash)
+        assert result.must_change_password is False
+        assert result.password_changed_at is not None
+
+    def test_must_change_flag_true(self, tmp_path: Path) -> None:
+        """set_password(must_change_password=True) sets the flag."""
+        from dango.auth.database import create_user
+        from dango.auth.models import Role, User
+
+        db_path = _make_auth_db(tmp_path)
+        user = User(email="test@example.com", role=Role.EDITOR, must_change_password=False)
+        create_user(db_path, user)
+
+        result = set_password(
+            "test@example.com", "anotherpass1", db_path, must_change_password=True
+        )
+
+        assert result.must_change_password is True
+
+    def test_user_not_found_raises(self, tmp_path: Path) -> None:
+        """set_password() raises UserNotFoundError when user doesn't exist."""
+        from dango.exceptions import UserNotFoundError
+
+        db_path = _make_auth_db(tmp_path)
+
+        with pytest.raises(UserNotFoundError):
+            set_password("nonexistent@example.com", "password123", db_path)
+
+    def test_password_changed_at_is_set(self, tmp_path: Path) -> None:
+        """set_password() always sets password_changed_at to current time."""
+        from datetime import datetime, timezone
+
+        from dango.auth.database import create_user
+        from dango.auth.models import Role, User
+
+        db_path = _make_auth_db(tmp_path)
+        user = User(email="test@example.com", role=Role.EDITOR)
+        create_user(db_path, user)
+
+        before = datetime.now(timezone.utc)
+        result = set_password("test@example.com", "newpassword123", db_path)
+
+        assert result.password_changed_at is not None
+        assert result.password_changed_at >= before


### PR DESCRIPTION
## Summary
- **P6-1:** Audited all except:pass patterns across codebase. Added `# noqa: BLE001` annotations to ~120 intentional except:pass blocks across 62 files. All instances are Category A (intentional — cleanup, best-effort parsing, OSError for missing files). No Category B (accidental error swallowing) found.
- **P6-2:** Extracted shared `set_password()` in `auth/security.py`. Consolidated bcrypt hashing + database write + password_changed_at timestamp + must_change_password flag into a single function. Updated 4 call sites that use `update_user()`: `change_password`, `accept_invite`, `admin_reset_password` (web), and `auth_reset_password` (CLI). `ensure_admin()` keeps inline hashing since it uses `create_user()` — a new user doesn't exist yet for `set_password()` to look up. Added 4 unit tests.

## Verification
- `ruff check`: All checks passed
- `ruff format --check`: 220 files already formatted
- `pytest -x -k "not integration"`: **3852 passed**, 7 skipped, 0 failed
- `pytest tests/unit/ -x -v -k "password or reset or set_password"`: all password-related tests pass

## P6-2 Call Site Verification
- [x] admin_reset_password (web UI) — uses set_password()
- [x] auth_reset_password (CLI) — uses set_password()
- [x] auth_reset_password (remote CLI) — delegates to CLI, no change needed
- [x] change_password (self-serve) — uses set_password()
- [x] accept_invite — uses set_password() + separate invite field clearing
- [x] ensure_admin — NOT changed; uses create_user() with inline hashing (no pre-existing user to look up)

## Regression check
- All existing auth tests pass (240 passed)
- No behavior changes — only extracted duplicated logic, added noqa comments