### PR TITLE
fix: table double-scrollbar + reorder columns by daily usefulness

### DIFF
--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1394,26 +1394,26 @@ function renderSourcesTable() {
                     ${source.needs_attention ? '<span class="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Needs Attention</span>' : ''}
                 </div>
             </td>
+            <td class="px-6 py-4 whitespace-nowrap cursor-pointer tooltip" data-col="status" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" data-tooltip="Click to view sync history">
+                ${renderStatusPill(source, isSyncing, hasFileOps)}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="last-sync">
+                ${formatRelativeTime(source.last_sync)}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                ${actionColumn}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
+                ${source.has_schedule ? `<span class="tooltip" data-tooltip="${source.schedule_display || ''}">${source.schedule_display || 'Scheduled'}</span>` : '<span class="inline-block w-full text-center text-gray-300">—</span>'}
+            </td>
             <td class="px-6 py-4 whitespace-nowrap">
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
                     ${formatSourceType(source.type)}
                 </span>
                 <div class="text-xs text-gray-400 mt-0.5">${source.lookback_days ? `Incremental (${source.lookback_days}d lookback)` : source.sync_mode === 'full_refresh' ? 'Full Refresh' : 'Incremental'}</div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap cursor-pointer tooltip" data-col="status" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" data-tooltip="Click to view sync history">
-                ${renderStatusPill(source, isSyncing, hasFileOps)}
-            </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="rows">
                 ${renderRowCount(source)}
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="last-sync">
-                ${formatRelativeTime(source.last_sync)}
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
-                ${source.has_schedule ? `<span class="tooltip" data-tooltip="${source.schedule_display || ''}">${source.schedule_display || 'Scheduled'}</span>` : '<span class="inline-block w-full text-center text-gray-300">—</span>'}
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                ${actionColumn}
             </td>
         </tr>
         `;
@@ -2694,17 +2694,6 @@ function renderDbtModelsTable() {
                 <td class="px-6 py-4 whitespace-nowrap">
                     <div class="text-sm font-medium text-gray-900">${escapeHtml(model.name)}</div>
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                    ${escapeHtml(model.schema || '-')}
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap">
-                    <span class="px-2 py-1 text-xs rounded-full bg-blue-100 text-blue-800">
-                        ${model.materialization || 'view'}
-                    </span>
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                    ${rowCount}
-                </td>
                 <td class="px-6 py-4 whitespace-nowrap">
                     ${statusBadge}
                 </td>
@@ -2720,6 +2709,17 @@ function renderDbtModelsTable() {
                     >
                         📖
                     </a>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                    ${escapeHtml(model.schema || '-')}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <span class="px-2 py-1 text-xs rounded-full bg-blue-100 text-blue-800">
+                        ${model.materialization || 'view'}
+                    </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                    ${rowCount}
                 </td>
             </tr>
         `;

--- a/dango/web/templates/models.html
+++ b/dango/web/templates/models.html
@@ -34,12 +34,12 @@
                     <thead class="bg-gray-50">
                         <tr>
                             <th data-sort-key="name" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Model</th>
-                            <th data-sort-key="schema" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Schema</th>
-                            <th data-sort-key="materialization" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>
-                            <th data-sort-key="rows" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
                             <th data-sort-key="status" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Status</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Run</th>
                             <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                            <th data-sort-key="schema" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Schema</th>
+                            <th data-sort-key="materialization" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>
+                            <th data-sort-key="rows" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
                         </tr>
                     </thead>
                     <tbody id="dbt-models-table-body" class="bg-white divide-y divide-gray-200">

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -34,12 +34,12 @@
                     <thead class="bg-gray-50">
                         <tr>
                             <th data-sort-key="name" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Source</th>
-                            <th data-sort-key="type" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>
                             <th data-sort-key="status" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Status</th>
-                            <th data-sort-key="rows" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
                             <th data-sort-key="last-sync" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Last Sync</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Schedule</th>
                             <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Schedule</th>
+                            <th data-sort-key="type" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>
+                            <th data-sort-key="rows" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
                         </tr>
                     </thead>
                     <tbody id="sources-table-body" class="bg-white divide-y divide-gray-200">


### PR DESCRIPTION
## Summary
- Reorder Sources page columns: Name, Status, Last Sync, Actions, Schedule, Type, Rows
- Reorder Models page columns: Name, Status, Last Run, Actions, Schema, Type, Rows
- Primary columns (Name, Status, Last Sync/Actions) now fit viewport without horizontal scrolling
- overflow-x-auto stays as safety net for narrow viewports
- Schedules and Scripts pages already have good column order + responsive hiding

## Verification
- pytest -x: 3981 pass, 0 fail
- ruff check + ruff format --check: all pass
- grep verified: template <th> order matches JS renderer <td> order for both pages
- data-sort-key attributes unchanged (semantic, not positional) — sort/filter unaffected