### PR TITLE
S3: Script documentation + CLAUDE.md updates

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -65,9 +65,11 @@ config/
 
 ### File size
 
-- **Soft limit:** 500 lines per file.
-- **When to split:** A file exceeds 500 lines, or contains 3+ unrelated responsibilities.
+- **Hard limit:** 500 lines per file. Split before reaching it.
+- **When to split:** A file approaches 500 lines, or contains 3+ unrelated responsibilities.
 - **How to split:** Extract related functions/classes into a new file within the same module. Update `__init__.py` exports.
+- **Exemption process:** Valid reasons — cyclic imports, inseparable logic, shared module-level state, pure data files. Invalid reasons — "too much work," "will refactor later." All new exemptions require maintainer approval.
+- **Pre-existing exemptions:** Files in `docs/file-exemptions.yml` are grandfathered and will be split in v1.1.
 
 ### `__init__.py` pattern
 
@@ -699,9 +701,9 @@ Any time a file is moved or renamed, immediately check:
 
 ### File size conventions
 
-See [§2 File size](#file-size) for the 500-line soft limit and when to split. Additional workflow rules:
+See [§2 File size](#file-size) for the 500-line hard limit and when to split. Additional workflow rules:
 
-- If a new or modified file exceeds 500 lines, add it to `docs/file-exemptions.yml`.
+- **No new exemptions.** New files must not exceed 500 lines. Pre-existing exempted files (listed in `docs/file-exemptions.yml`) will be split in v1.1.
 - **Target ~430 lines pre-format** — ruff format expands code by 10-15%.
 - **Incremental commits for large restructurings:** Tasks touching 10+ files should be split into 2-3 logical commits (e.g., "move files", "add new code", "update tests").
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -37,7 +37,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote_auth.py` (~217 lines) | `remote auth` subgroup (add-user, list-users, remove-user, reset-password) | `auth_group` |
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query`, `remote history` | `remote_status()`, `remote_logs()` |
 | `commands/remote_sync.py` (131 lines) | `remote sync` — trigger data syncs on cloud server via SSH | `remote_sync()` |
-| `commands/schedule.py` (914 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook) | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
+| `commands/schedule.py` (914 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook). Supports SYNC, SYNC_ONLY, DBT, and SCRIPT types. | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/schedule_webhook.py` (226 lines) | `schedule webhook` subgroup (add, list, remove, test) | `webhook_group` |
 | `commands/governance.py` (220 lines) | `governance` group (accept, drift-report, pii-report, pii-set, pii-list) | `governance`, `accept()`, `drift_report()`, `pii_report()`, `pii_set()`, `pii_list()` |
 | `commands/notebook.py` (~209 lines) | `notebook` group (new, open) | `notebook`, `notebook_new()`, `notebook_open()` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -37,7 +37,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/remote_auth.py` (~217 lines) | `remote auth` subgroup (add-user, list-users, remove-user, reset-password) | `auth_group` |
 | `commands/remote_mgmt.py` | `remote status`, `remote logs`, `remote ssh`, `remote query`, `remote history` | `remote_status()`, `remote_logs()` |
 | `commands/remote_sync.py` (131 lines) | `remote sync` — trigger data syncs on cloud server via SSH | `remote_sync()` |
-| `commands/schedule.py` (914 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook). Supports SYNC, SYNC_ONLY, DBT, and SCRIPT types. | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
+| `commands/schedule.py` (972 lines) | `schedule` group (add, list, remove, status, enable, disable, webhook). Supports SYNC, SYNC_ONLY, DBT, and SCRIPT types. | `schedule`, `schedule_add()`, `schedule_list()`, `schedule_status()`, `schedule_webhook()` |
 | `commands/schedule_webhook.py` (226 lines) | `schedule webhook` subgroup (add, list, remove, test) | `webhook_group` |
 | `commands/governance.py` (220 lines) | `governance` group (accept, drift-report, pii-report, pii-set, pii-list) | `governance`, `accept()`, `drift_report()`, `pii_report()`, `pii_set()`, `pii_list()` |
 | `commands/notebook.py` (~209 lines) | `notebook` group (new, open) | `notebook`, `notebook_new()`, `notebook_open()` |

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -12,7 +12,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | `models.py` | Pydantic models for config data | `DangoConfig`, `ProjectContext`, `SourcesConfig`, `DataSource`, `SourceType`, `DeduplicationStrategy`, `PlatformSettings`, `Stakeholder`, `CSVSourceConfig`, `LocalFilesSourceConfig`, `GoogleSheetsSourceConfig`, `StripeSourceConfig`, `CloudConfig` (incl. `provider`, `firewall_id`, `deploy_branch`, `backup`), `BackupConfig`, `SpacesRetentionConfig` |
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
-| `schedules.py` | Schedule config models, validation, reload. `ScheduleType` enum: SYNC, SYNC_ONLY, DBT | `ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`, `CRON_PRESETS`, `load_schedules_config`, `validate_schedules`, `reload_schedules`, `log_startup_checks` |
+| `schedules.py` | Schedule config models, validation, reload. `ScheduleType` enum: SYNC, SYNC_ONLY, DBT, SCRIPT | `ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`, `CRON_PRESETS`, `load_schedules_config`, `validate_schedules`, `reload_schedules`, `log_startup_checks` |
 | `credentials.py` | Credential loading for dlt sources | `CredentialManager`, `init_dlt_directory` |
 | `cloud_credentials.py` | Cloud provider credential persistence (`~/.dango/credentials`, INI, 0o600) | `get_do_token`, `save_do_token`, `clear_do_token` |
 | `exceptions.py` | Re-export shim — classes live in `dango/exceptions.py` | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError`, `ProjectNotFoundError` |

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,7 +12,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (448 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (245 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (1034 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules and `run_scheduled_script` for SCRIPT schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt`, `run_scheduled_script` |
+| `jobs.py` (1551 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules and `run_scheduled_script` for SCRIPT schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt`, `run_scheduled_script` |
 | `sync_trigger.py` (330 lines) | Subprocess entrypoint for sync operations — progress writing (incl. dbt phase passthrough via progress_callback), lock acquisition, OAuth validation | `run_manual_sync()`, `_write_status()` |
 
 ## Key Conventions

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,7 +12,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (448 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (245 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (1034 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `jobs.py` (1034 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules and `run_scheduled_script` for SCRIPT schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt`, `run_scheduled_script` |
 | `sync_trigger.py` (330 lines) | Subprocess entrypoint for sync operations — progress writing (incl. dbt phase passthrough via progress_callback), lock acquisition, OAuth validation | `run_manual_sync()`, `_write_status()` |
 
 ## Key Conventions

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -14,7 +14,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `__init__.py` | Public exports | `app` module |
 | `middleware/auth.py` | Session/API key auth + CSRF check on every request (~324 lines) | `AuthMiddleware`, `is_secure_request()`, `COOKIE_NAME` |
 | `middleware/rate_limit.py` | Rate limiting (login 10/min, API 200/min, localhost exempt, ~235 lines) | `RateLimitMiddleware` |
-| `templates/base.html` | Shared Jinja2 layout: head (compiled Tailwind CSS), header, nav bar (8-item flat: Overview/Sources/Models/Schedules/Catalog/Query/Dashboards/Notebooks + gear dropdown), responsive hamburger menu, footer, script blocks | Blocks: `title`, `subtitle_attrs`, `header_right`, `nav`, `content`, `footer`, `scripts` |
+| `templates/base.html` | Shared Jinja2 layout: head (compiled Tailwind CSS), header, nav bar (9-item flat: Overview/Sources/Models/Schedules/Catalog/Query/Dashboards/Notebooks/Scripts + gear dropdown), responsive hamburger menu, footer, script blocks | Blocks: `title`, `subtitle_attrs`, `header_right`, `nav`, `content`, `footer`, `scripts` |
 | `templates/error.html` | HTML error page (extends `base.html`) — status code, title, message, back/home links | Rendered by `dango_error_handler()` for browser 401/403 requests |
 | `templates/dashboard.html` | Overview page (extends `base.html`) — health widget, service cards, activity log | Loads `app.js` |
 | `templates/sources.html` | Sources page (extends `base.html`) — source table, sync controls, upload/detail modals | Loads `app.js` |
@@ -45,6 +45,9 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/oauth_connect.py` | Web-based OAuth connect/callback for cloud deployments | `router` |
 | `routes/schedules.py` | Schedule list/get, trigger, reload, cancel, history, notification config/test, `/schedules` page (read-only, ~608 lines). Config mutations removed by R10-C (BUG-175) — use CLI instead. | `router` |
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~506 lines) | `router` |
+| `routes/scripts.py` | Script list page and log viewer page routes | `router` |
+| `routes/scripts_api.py` | Script API endpoints: list, run, cancel, history | `router` |
+| `routes/scripts_helpers.py` | Script discovery, path validation, history, audit helpers | `_discover_scripts`, `_validate_script_path`, `_load_history`, `_append_history` |
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1338 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~203 lines) | `router` |
 | `routes/monitoring.py` | Monitor results API (`/api/monitoring`, `/api/monitoring/run`, `/api/monitoring/history`), dbt test results. Page route removed in R12-M2 (test/freshness moved to catalog). Backward-compat `/api/insights*` redirects removed in M2 cloud fix. | `router` |
@@ -53,6 +56,8 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/initial_sync.py` | Initial data sync after first deploy (deploy token auth) | `router` |
 | `templates/schedules.html` | Schedule management page (extends `base.html`) — table, modals, WebSocket | Alpine.js `schedulesPage()` component |
 | `templates/notebooks.html` | Notebook management page (extends `base.html`) — table, create/delete modals, locking | Alpine.js `notebooksPage()` component |
+| `templates/scripts.html` | Script management page (extends `base.html`) — table, run/cancel buttons, log links, WebSocket | Alpine.js `scriptsPage()` component |
+| `templates/script_log.html` | Script run log viewer page (extends `base.html`) — stdout/stderr display with metadata | — |
 | `templates/catalog.html` | Data catalog page (extends `base.html`) — model browser, search, detail view, code view, profiling, lineage (929 lines) | Alpine.js `catalogPage()` component |
 | `templates/monitoring.html` | **Unused** — retained for potential future use. Page route removed in R12-M2 (test/freshness moved to catalog). API endpoints in `routes/monitoring.py` still active. | Alpine.js `monitoringPage()` component |
 | `static/` | CSS and JS assets (`css/tailwind.min.css` (compiled), `css/main.css`, `css/catalog.css`, `css/input.css` (Tailwind source), `js/app.js`, `js/logs.js`, `js/lineage.js`, `js/catalog.js`) | — |


### PR DESCRIPTION
## Summary
- Add SCRIPT to `ScheduleType` enum listings across config/, cli/, and scheduling/ CLAUDE.md files
- Fix nav count: "8-item flat" -> "9-item flat" in web/ CLAUDE.md, add script route/template rows
- Add `run_scheduled_script` to scheduling/ CLAUDE.md jobs.py row
- Update STANDARDS.md: soft limit -> hard limit with permanent exemption framework
  - Valid exemption reasons: cyclic imports, inseparable logic, shared module-level state, pure data files
  - Invalid: "too much work," "will refactor later"
  - All new exemptions require maintainer approval
  - Pre-existing exempted files grandfathered, split in v1.1

## Verification
- All code examples in `docs/scripts.md` parse successfully with `ast.parse()`
- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: 220 files already formatted
- `pytest -x`: 3981 passed, 31 skipped, 0 failures
- Grep for "SYNC, SYNC_ONLY, DBT" without SCRIPT across CLAUDE.md files: 0 results
- Grep for ScheduleType across docs without "script": 0 results

## Notes
- `docs/docs/scripts.md` (new user-facing scripts guide) and docs repo updates to `reference/configuration.md` and `scheduling-monitoring/scheduled-syncs.md` are in the `docs/` repo — not in this PR. Those add `script` to all stale ScheduleType enum listings.