### PR TITLE
fix: notebook startup hang + admin Marimo restart with warnings

### DIFF
--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -67,6 +67,7 @@ class AuditEvent(str, Enum):
     NOTEBOOK_CREATED          = "notebook_created"
     NOTEBOOK_DELETED          = "notebook_deleted"
     NOTEBOOK_LOCK_FORCE_RELEASED = "notebook_lock_force_released"
+    NOTEBOOK_MARIMO_RESTARTED    = "notebook_marimo_restarted"
     GOVERNANCE_DRIFT_VIEWED      = "governance_drift_viewed"
     GOVERNANCE_PII_VIEWED        = "governance_pii_viewed"
     CATALOG_VIEWED               = "catalog_viewed"

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -70,10 +70,15 @@ async def _start_marimo_background(project_root: Path, user_email: str) -> None:
         snapshot_path = await asyncio.to_thread(create_snapshot, project_root, user_email)
     except FileNotFoundError:  # noqa: BLE001
         pass  # no warehouse yet
+    except Exception:
+        logger.warning("Snapshot creation failed", exc_info=True)
+        return
     try:
         await asyncio.to_thread(start_marimo, project_root, snapshot_path=snapshot_path)
     except RuntimeError:
         pass  # already running (race condition)
+    except Exception:
+        logger.warning("Marimo startup failed", exc_info=True)
 
 
 def _audit(

--- a/dango/web/routes/notebooks.py
+++ b/dango/web/routes/notebooks.py
@@ -30,7 +30,7 @@ from dango.notebooks.locking import (
     refresh_lock,
     release_lock,
 )
-from dango.notebooks.manager import get_marimo_status, start_idle_checker, start_marimo
+from dango.notebooks.manager import get_marimo_status, start_idle_checker, start_marimo, stop_marimo
 from dango.notebooks.snapshot import create_snapshot
 from dango.utils.dango_db import connect
 from dango.validation import validate_identifier
@@ -57,6 +57,23 @@ def _validate_name(name: str) -> str | JSONResponse:
                 "message": "Invalid notebook name. Use only letters, numbers, and underscores.",
             },
         )
+
+
+async def _start_marimo_background(project_root: Path, user_email: str) -> None:
+    """Create snapshot and start Marimo in the background (non-blocking).
+
+    Launched via ``asyncio.create_task()`` so the lock endpoint can return
+    immediately while the snapshot copy and Marimo startup complete.
+    """
+    snapshot_path = None
+    try:
+        snapshot_path = await asyncio.to_thread(create_snapshot, project_root, user_email)
+    except FileNotFoundError:  # noqa: BLE001
+        pass  # no warehouse yet
+    try:
+        await asyncio.to_thread(start_marimo, project_root, snapshot_path=snapshot_path)
+    except RuntimeError:
+        pass  # already running (race condition)
 
 
 def _audit(
@@ -385,22 +402,15 @@ async def lock_notebook(
     status = await asyncio.to_thread(get_marimo_status, project_root)
     already_running = status["running"]
     if not already_running:
-        # Create DuckDB snapshot so notebooks use a read-only copy
-        snapshot_path = None
-        try:
-            snapshot_path = await asyncio.to_thread(create_snapshot, project_root, user.email)
-        except FileNotFoundError:  # noqa: BLE001
-            pass  # no warehouse yet
+        # Launch snapshot creation + Marimo startup as a background task
+        # so the API returns immediately (non-blocking).
+        asyncio.create_task(_start_marimo_background(project_root, user.email))
+        start_idle_checker(project_root)
+        return JSONResponse(
+            content={"locked": True, "ready": False, "status": "starting", "marimo_url": None}
+        )
 
-        try:
-            await asyncio.to_thread(start_marimo, project_root, snapshot_path=snapshot_path)
-            status = await asyncio.to_thread(get_marimo_status, project_root)
-        except RuntimeError:
-            # Already running (race condition) — get status again
-            status = await asyncio.to_thread(get_marimo_status, project_root)
-            already_running = True
-    else:
-        logger.debug("Marimo already running — skipping snapshot creation")
+    logger.debug("Marimo already running — skipping snapshot creation")
 
     port = status.get("port") or _DEFAULT_MARIMO_PORT  # type: ignore[assignment]
 
@@ -416,8 +426,77 @@ async def lock_notebook(
 
     start_idle_checker(project_root)
 
+    return JSONResponse(content={"locked": True, "marimo_url": marimo_url, "ready": True})
+
+
+@router.get("/api/notebooks/status")
+async def notebook_status(
+    request: Request,
+    file: str | None = None,
+) -> JSONResponse:
+    """Poll notebook server readiness. Used by frontend after non-blocking open."""
+    project_root = get_project_root()
+    status = await asyncio.to_thread(get_marimo_status, project_root)
+    if not status["running"]:
+        return JSONResponse(content={"ready": False, "marimo_url": None})
+
+    port = status.get("port") or _DEFAULT_MARIMO_PORT  # type: ignore[assignment]
+    from dango.config.helpers import is_running_on_cloud
+
+    if is_running_on_cloud():
+        base = "/notebooks/marimo/"
+        marimo_url = f"{base}?file={file}" if file else base
+    else:
+        marimo_url = (
+            f"http://localhost:{port}/?file={file}" if file else f"http://localhost:{port}/"
+        )
+
+    return JSONResponse(content={"ready": True, "marimo_url": marimo_url})
+
+
+@router.post("/api/notebooks/marimo/restart")
+async def restart_marimo(
+    request: Request,
+    user: User = Depends(require_permission("notebooks.manage")),
+) -> JSONResponse:
+    """Admin/editor: restart Marimo server, releasing all locks.
+
+    Returns the list of affected lock holders so the frontend can warn users.
+    The next notebook open will create a fresh DuckDB snapshot.
+    """
+    project_root = get_project_root()
+
+    # Collect active (non-expired) lock holders for the warning
+    active_locks: list[dict[str, str]] = []
+    with connect(project_root) as conn:
+        conn.execute("DELETE FROM notebook_locks WHERE expires_at < datetime('now')")
+        rows = conn.execute("SELECT notebook_id, locked_by FROM notebook_locks").fetchall()
+        active_locks = [{"notebook": r["notebook_id"], "user": r["locked_by"]} for r in rows]
+
+    # Stop Marimo
+    stop_marimo(project_root)
+
+    # Release all locks (inlined from manager._release_all_locks to avoid
+    # importing a private function across modules)
+    with connect(project_root) as conn:
+        conn.execute("DELETE FROM notebook_locks")
+        conn.commit()
+
+    # Audit
+    log_auth_event(
+        AuditEvent.NOTEBOOK_MARIMO_RESTARTED,
+        user_id=user.id,
+        email=user.email,
+        ip=request.client.host if request.client else None,
+        details={"active_locks": len(active_locks)},
+    )
+
     return JSONResponse(
-        content={"locked": True, "marimo_url": marimo_url, "ready": already_running}
+        content={
+            "restarted": True,
+            "affected_users": active_locks,
+            "message": "Marimo restarted. Next notebook open will create a fresh snapshot.",
+        }
     )
 
 

--- a/dango/web/templates/notebooks.html
+++ b/dango/web/templates/notebooks.html
@@ -8,20 +8,28 @@
         <!-- Header -->
         <div class="flex items-center justify-between mb-6">
             <h2 class="text-xl font-bold text-gray-900">Notebooks</h2>
-            <template x-if="canExecute">
-                <div class="relative">
-                    <button @click="showCreateDropdown = !showCreateDropdown"
-                            class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors">
-                        New Notebook
+            <div class="flex items-center space-x-3">
+                <template x-if="canManage">
+                    <button @click="checkRestartImpact()"
+                            class="px-4 py-2 bg-yellow-500 text-white rounded-md hover:bg-yellow-600 text-sm font-medium transition-colors">
+                        Restart Server
                     </button>
-                    <div x-show="showCreateDropdown" @click.away="showCreateDropdown = false" x-cloak
-                         class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50">
-                        <button @click="createNotebook('blank')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Blank</button>
-                        <button @click="createNotebook('explore')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Data Exploration</button>
-                        <button @click="createNotebook('quality')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Data Quality</button>
+                </template>
+                <template x-if="canExecute">
+                    <div class="relative">
+                        <button @click="showCreateDropdown = !showCreateDropdown"
+                                class="px-4 py-2 bg-dango-600 text-white rounded-md hover:bg-dango-700 text-sm font-medium transition-colors">
+                            New Notebook
+                        </button>
+                        <div x-show="showCreateDropdown" @click.away="showCreateDropdown = false" x-cloak
+                             class="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-50">
+                            <button @click="createNotebook('blank')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Blank</button>
+                            <button @click="createNotebook('explore')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Data Exploration</button>
+                            <button @click="createNotebook('quality')" class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">Data Quality</button>
+                        </div>
                     </div>
-                </div>
-            </template>
+                </template>
+            </div>
         </div>
 
         <!-- Error banner -->
@@ -173,6 +181,38 @@
                 </div>
             </div>
         </div>
+
+        <!-- Restart Marimo Confirmation Modal -->
+        <div x-show="showRestartModal" x-cloak class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="showRestartModal = false"></div>
+                <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6 relative z-10">
+                    <h3 class="text-lg font-medium text-yellow-600 mb-2">Restart Notebook Server</h3>
+                    <p class="text-sm text-gray-500 mb-4">
+                        This will stop the Marimo server and release all notebook locks.
+                        <span x-show="restartAffectedCount > 0" class="font-medium text-yellow-700">
+                            <span x-text="restartAffectedCount"></span> active notebook lock(s) will be released.
+                        </span>
+                        <span x-show="restartAffectedCount === 0" class="text-gray-400">
+                            No active notebook locks.
+                        </span>
+                    </p>
+                    <p class="text-sm text-gray-500 mb-4">
+                        The next notebook opened will get a fresh snapshot of your data.
+                        Users currently editing notebooks will lose their locks.
+                    </p>
+                    <div class="flex justify-end space-x-3">
+                        <button @click="showRestartModal = false"
+                                class="px-4 py-2 text-sm text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Cancel</button>
+                        <button @click="restartMarimo()" :disabled="restartLoading"
+                                class="px-4 py-2 text-sm text-white bg-yellow-600 rounded-md hover:bg-yellow-700 disabled:opacity-50">
+                            <span x-show="!restartLoading">Restart Server</span>
+                            <span x-show="restartLoading" x-cloak>Restarting...</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </main>
 {% endblock %}
@@ -210,6 +250,11 @@ function notebooksPage() {
         // Lock revocation
         lockRevoked: false,
         revokedNotebook: '',
+
+        // Marimo restart
+        showRestartModal: false,
+        restartLoading: false,
+        restartAffectedCount: 0,
 
         async init() {
             await this.loadNotebooks();
@@ -270,31 +315,44 @@ function notebooksPage() {
 
                 // Navigate to Marimo
                 if (nbWindow) {
-                    const url = data.marimo_url;
                     if (data.ready) {
                         // Marimo was already running — navigate immediately
-                        nbWindow.location.href = url;
+                        nbWindow.location.href = data.marimo_url;
+                        setTimeout(() => { if (infoEl) infoEl.classList.add('hidden'); }, 8000);
                     } else {
-                        // New Marimo just started — poll until ready
+                        // Marimo starting in background — poll /api/notebooks/status
+                        const startTime = Date.now();
+                        const updateInfo = () => {
+                            const elapsed = Math.floor((Date.now() - startTime) / 1000);
+                            if (infoEl) {
+                                infoEl.textContent = `Starting notebook server... (${elapsed}s elapsed)`;
+                                infoEl.classList.remove('hidden');
+                            }
+                        };
+                        updateInfo();
                         const poll = async () => {
-                            for (let i = 0; i < 60; i++) {
+                            for (let i = 0; i < 120; i++) {  // 4 min timeout for large snapshots
+                                await new Promise(r => setTimeout(r, 2000));
+                                updateInfo();
                                 try {
-                                    const r = await fetch(url);
-                                    if (r.ok || r.status === 200) {
-                                        nbWindow.location.href = url;
+                                    const r = await fetch(`/api/notebooks/status?file=${nb.name}.py`);
+                                    const s = await r.json();
+                                    if (s.ready) {
+                                        nbWindow.location.href = s.marimo_url;
+                                        if (infoEl) infoEl.classList.add('hidden');
                                         return;
                                     }
-                                } catch { /* not ready yet */ }
-                                await new Promise(r => setTimeout(r, 1000));
+                                } catch { /* not ready */ }
                             }
-                            nbWindow.location.href = url; // try anyway after 60s
+                            // After 4 min, fall back to proxy URL
+                            nbWindow.location.href = `/notebooks/marimo/?file=${nb.name}.py`;
+                            if (infoEl) infoEl.classList.add('hidden');
                         };
                         poll();
                     }
                 }
                 this.activeNotebook = nb.name;
                 this.startHeartbeat(nb.name);
-                setTimeout(() => { if (infoEl) infoEl.classList.add('hidden'); }, 8000);
                 await this.loadNotebooks();
             } catch (e) {
                 if (nbWindow) nbWindow.close();
@@ -402,6 +460,34 @@ function notebooksPage() {
                 setTimeout(() => this.success = '', 3000);
                 await this.loadNotebooks();
             } catch (e) { this.error = 'Failed to force unlock'; }
+        },
+
+        async checkRestartImpact() {
+            try {
+                const res = await fetch('/api/notebooks', { headers });
+                const data = await res.json();
+                this.restartAffectedCount = data.filter(n => n.lock).length;
+            } catch { this.restartAffectedCount = 0; }
+            this.showRestartModal = true;
+        },
+
+        async restartMarimo() {
+            this.restartLoading = true;
+            try {
+                const res = await fetch('/api/notebooks/marimo/restart', { method: 'POST', headers });
+                const data = await res.json();
+                if (res.ok) {
+                    this.showRestartModal = false;
+                    this.success = data.message;
+                    setTimeout(() => this.success = '', 5000);
+                    this.activeNotebook = null;
+                    this.stopHeartbeat();
+                    await this.loadNotebooks();
+                } else {
+                    this.error = data.message || 'Failed to restart server';
+                }
+            } catch (e) { this.error = 'Failed to restart server'; }
+            this.restartLoading = false;
         },
 
         timeAgo(iso) {

--- a/tests/unit/test_notebook_lock_snapshot.py
+++ b/tests/unit/test_notebook_lock_snapshot.py
@@ -90,14 +90,14 @@ def _seed_notebook(tmp_path: Path, name: str, created_by: str = "test@test.com")
 
 @pytest.mark.unit
 class TestLockCreatesSnapshot:
-    """Verify lock_notebook() creates a DuckDB snapshot."""
+    """Verify lock_notebook() returns immediately when Marimo is not running."""
 
     @patch(f"{_P}.start_idle_checker")
     @patch(f"{_P}.start_marimo")
     @patch(f"{_P}.get_marimo_status")
     @patch(f"{_P}.create_snapshot")
     @patch(f"{_P}.get_project_root")
-    def test_lock_calls_create_snapshot(
+    def test_lock_returns_starting_when_marimo_not_running(
         self,
         mock_root: MagicMock,
         mock_snapshot: MagicMock,
@@ -106,19 +106,21 @@ class TestLockCreatesSnapshot:
         mock_idle: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Acquiring a lock should call create_snapshot when Marimo is not running."""
+        """Lock returns immediately with ready=false when Marimo is not running."""
         mock_root.return_value = tmp_path
         snap_path = tmp_path / ".dango" / "snapshots" / "warehouse_test_20260101.duckdb"
         mock_snapshot.return_value = snap_path
-        not_running = {"running": False, "port": None, "pid": None, "log_file": None}
-        running = {"running": True, "port": 7805, "pid": 123, "log_file": None}
-        mock_status.side_effect = [not_running, running]
+        mock_status.return_value = {"running": False, "port": None, "pid": None, "log_file": None}
         _init_db(tmp_path)
         _seed_notebook(tmp_path, "test_nb")
 
         resp = _client(tmp_path).post("/api/notebooks/test_nb/lock", json={})
         assert resp.status_code == 200
-        mock_snapshot.assert_called_once_with(tmp_path, "test@test.com")
+        data = resp.json()
+        assert data["locked"] is True
+        assert data["ready"] is False
+        assert data["status"] == "starting"
+        assert data["marimo_url"] is None
 
     @patch(f"{_P}.start_idle_checker")
     @patch(f"{_P}.start_marimo")
@@ -136,9 +138,7 @@ class TestLockCreatesSnapshot:
     ) -> None:
         """Lock should succeed even if warehouse doesn't exist (no snapshot)."""
         mock_root.return_value = tmp_path
-        not_running = {"running": False, "port": None, "pid": None, "log_file": None}
-        running = {"running": True, "port": 7805, "pid": 123, "log_file": None}
-        mock_status.side_effect = [not_running, running]
+        mock_status.return_value = {"running": False, "port": None, "pid": None, "log_file": None}
         _init_db(tmp_path)
         _seed_notebook(tmp_path, "test_nb")
 
@@ -169,29 +169,28 @@ class TestLockCreatesSnapshot:
         mock_snapshot.assert_not_called()
 
     @patch(f"{_P}.start_idle_checker")
-    @patch(f"{_P}.start_marimo")
+    @patch(f"{_P}.asyncio.create_task")
     @patch(f"{_P}.get_marimo_status")
     @patch(f"{_P}.create_snapshot")
     @patch(f"{_P}.get_project_root")
-    def test_lock_passes_snapshot_to_start_marimo(
+    def test_lock_launches_background_task(
         self,
         mock_root: MagicMock,
         mock_snapshot: MagicMock,
         mock_status: MagicMock,
-        mock_start: MagicMock,
+        mock_create_task: MagicMock,
         mock_idle: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """When Marimo isn't running, start_marimo receives snapshot_path."""
+        """When Marimo isn't running, a background task is launched for startup."""
         mock_root.return_value = tmp_path
         snap_path = tmp_path / ".dango" / "snapshots" / "warehouse_test.duckdb"
         mock_snapshot.return_value = snap_path
-        not_running = {"running": False, "port": None, "pid": None, "log_file": None}
-        running = {"running": True, "port": 7805, "pid": 123, "log_file": None}
-        mock_status.side_effect = [not_running, running]
+        mock_status.return_value = {"running": False, "port": None, "pid": None, "log_file": None}
         _init_db(tmp_path)
         _seed_notebook(tmp_path, "test_nb")
 
         resp = _client(tmp_path).post("/api/notebooks/test_nb/lock", json={})
         assert resp.status_code == 200
-        mock_start.assert_called_once_with(tmp_path, snapshot_path=snap_path)
+        assert resp.json()["ready"] is False
+        mock_create_task.assert_called_once()


### PR DESCRIPTION
## Summary
- Fix notebook startup hanging: snapshot creation + Marimo startup moved to background task, client polls for readiness
- Add admin Marimo restart: stops server, releases all locks, fresh snapshot on next open
- Warning shows affected users before restart
- Stopgaps until Quack (DuckDB concurrent RO+RW, Sep 2026)

## Changes
- `dango/auth/audit.py`: Add `NOTEBOOK_MARIMO_RESTARTED` audit event
- `dango/web/routes/notebooks.py`: Background task `_start_marimo_background()`, non-blocking lock endpoint, `GET /api/notebooks/status` polling endpoint, `POST /api/notebooks/marimo/restart` admin endpoint
- `dango/web/templates/notebooks.html`: Updated `openNotebook()` with elapsed-time polling, Restart Server button, confirmation modal

## Verification
- `ruff check dango/`: All checks passed
- `ruff format --check dango/`: 220 files already formatted
- `pytest -x`: 3981 pass, 0 fail, 31 skipped