### PR TITLE
fix: auto-discover custom dlt sources, eliminate config duplication

### DIFF
--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -339,11 +339,13 @@ class DltNativeConfig(BaseModel):
                 endpoint: "https://api.example.com"
     """
 
-    source_module: str = Field(
-        description="Python module name (from custom_sources/ directory or dlt package name)"
+    source_module: str | None = Field(
+        default=None,
+        description="Python module name (auto-discovered from custom_sources/ if not specified)",
     )
-    source_function: str = Field(
-        description="Function name to call for source (e.g., 'google_ads', 'my_custom_source')"
+    source_function: str | None = Field(
+        default=None,
+        description="Function name to call (auto-discovered from custom_sources/ if not specified)",
     )
     function_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Keyword arguments to pass to source function"

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -884,6 +884,27 @@ class DltPipelineRunner:
         config = source_config.dlt_native
         source_name = source_config.name
 
+        # Auto-discover module/function from custom_sources/ if not specified
+        if not config.source_module or not config.source_function:
+            from dango.ingestion.sources.custom_discovery import discover_custom_sources
+
+            custom_sources_dir = self.project_root / "custom_sources"
+            if custom_sources_dir.exists():
+                discovered = discover_custom_sources(custom_sources_dir)
+                discovered_source = discovered.get(source_name)
+                if discovered_source:
+                    if not config.source_module:
+                        config.source_module = discovered_source.module_name
+                    if not config.source_function:
+                        config.source_function = discovered_source.function_name
+            if not config.source_module or not config.source_function:
+                raise ValueError(
+                    f"Could not determine source module/function for '{source_name}'.\n"
+                    f"  - No source_module/source_function in sources.yml\n"
+                    f"  - No matching @dlt.source function found in custom_sources/\n"
+                    f"  - Specify source_module and source_function in sources.yml"
+                )
+
         console.print(
             f"  📦 Loading dlt native source: {config.source_module}.{config.source_function}"
         )
@@ -1072,6 +1093,7 @@ class DltPipelineRunner:
                 "status": "success",
                 "source": source_name,
                 "rows_loaded": rows_loaded,
+                "uses_replace_mode": uses_replace_mode,
                 **stats,
             }
             if getattr(self, "_current_oauth_warning", None):

--- a/dango/ingestion/sources/custom_discovery.py
+++ b/dango/ingestion/sources/custom_discovery.py
@@ -1,0 +1,339 @@
+"""dango/ingestion/sources/custom_discovery.py
+
+Auto-discovery engine for custom dlt sources in custom_sources/ directory.
+
+Scans Python files for @dlt.source decorated functions and extracts metadata
+without requiring manual sources.yml configuration.
+
+Two-phase extraction:
+1. AST parsing (safe, no code execution): write_disposition from @dlt.resource()
+2. importlib (executes user code, same as dlt_runner.py): function signature + docstring
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import importlib.util
+import inspect
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from dango.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Module-level discovery cache: {file_path_str: (mtime, DiscoveredCustomSource)}
+_discovery_cache: dict[str, tuple[float, DiscoveredCustomSource]] = {}
+
+
+@dataclass
+class DiscoveredCustomSource:
+    """Metadata extracted from a single custom dlt source Python file."""
+
+    module_name: str  # e.g., "investment_desk_prices_daily"
+    function_name: str  # e.g., "investment_desk_prices_daily"
+    source_name: str | None = None  # from @dlt.source(name=...) kwarg
+    docstring: str | None = None  # function __doc__
+    parameters: dict[str, Any] = field(default_factory=dict)  # {param: default}
+    is_replace_mode: bool = False  # True if ANY resource uses replace write_disposition
+    file_mtime: float = 0.0  # for cache invalidation
+
+
+def _parse_dlt_source_ast(filepath: Path) -> dict[str, Any]:
+    """AST-based extraction of @dlt.source and @dlt.resource decorator metadata.
+
+    Does NOT execute the Python file. Safe for untrusted code.
+
+    Returns dict with keys:
+        function_name: str | None
+        source_name: str | None  (from @dlt.source(name=...) kwarg)
+        is_replace_mode: bool
+    """
+    try:
+        source = filepath.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except SyntaxError:
+        logger.warning("Syntax error parsing %s, skipping", filepath.name)
+        return {}
+
+    result: dict[str, Any] = {
+        "function_name": None,
+        "source_name": None,
+        "is_replace_mode": False,
+    }
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+
+        for decorator in node.decorator_list:
+            # Match @dlt.source or @dlt.source(...)
+            source_info = _match_dlt_source_decorator(decorator)
+            if source_info is not None:
+                result["function_name"] = node.name
+                if source_info.get("name"):
+                    result["source_name"] = source_info["name"]
+                continue
+
+            # Match @dlt.resource(...) or @dlt.resource
+            resource_info = _match_dlt_resource_decorator(decorator)
+            if resource_info is not None and resource_info.get("write_disposition") == "replace":
+                result["is_replace_mode"] = True
+
+    return result
+
+
+def _match_dlt_source_decorator(decorator: ast.expr) -> dict[str, Any] | None:
+    """Check if decorator matches @dlt.source or @dlt.source(...).
+
+    Returns dict with 'name' kwarg if present, or empty dict for bare @dlt.source.
+    Returns None if decorator does not match.
+    """
+    # Bare @dlt.source (no parentheses)
+    if isinstance(decorator, ast.Attribute):
+        if (
+            isinstance(decorator.value, ast.Name)
+            and decorator.value.id == "dlt"
+            and decorator.attr == "source"
+        ):
+            return {}
+
+    # @dlt.source(...) with arguments
+    if isinstance(decorator, ast.Call):
+        func = decorator.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "dlt"
+            and func.attr == "source"
+        ):
+            info: dict[str, Any] = {}
+            for kw in decorator.keywords:
+                if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                    info["name"] = kw.value.value
+            return info
+
+    return None
+
+
+def _match_dlt_resource_decorator(decorator: ast.expr) -> dict[str, Any] | None:
+    """Check if decorator matches @dlt.resource or @dlt.resource(...).
+
+    Returns dict with keyword argument values (write_disposition, name, primary_key).
+    Returns None if decorator does not match.
+    """
+    # Bare @dlt.resource (no parentheses) — no kwargs to extract
+    if isinstance(decorator, ast.Attribute):
+        if (
+            isinstance(decorator.value, ast.Name)
+            and decorator.value.id == "dlt"
+            and decorator.attr == "resource"
+        ):
+            return {}
+
+    # @dlt.resource(...) with arguments
+    if isinstance(decorator, ast.Call):
+        func = decorator.func
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "dlt"
+            and func.attr == "resource"
+        ):
+            info: dict[str, Any] = {}
+            for kw in decorator.keywords:
+                if kw.arg in ("write_disposition", "name") and isinstance(kw.value, ast.Constant):
+                    info[kw.arg] = kw.value.value
+                elif kw.arg == "primary_key":
+                    info["has_primary_key"] = True
+            return info
+
+    return None
+
+
+def _import_and_inspect(filepath: Path, module_name: str) -> dict[str, Any]:
+    """Import the module and extract function signature + docstring.
+
+    Executes the Python file (same as dlt_runner.py does at sync time).
+    Falls back gracefully on import errors.
+
+    Returns dict with keys: parameters, docstring
+    """
+    result: dict[str, Any] = {
+        "parameters": {},
+        "docstring": None,
+    }
+
+    try:
+        # Ensure the custom_sources parent directory is on sys.path
+        custom_sources_dir = str(filepath.parent)
+        if custom_sources_dir not in sys.path:
+            sys.path.insert(0, custom_sources_dir)
+
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, str(filepath))
+            if spec is None or spec.loader is None:
+                logger.warning("Could not create module spec for %s", module_name)
+                return result
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        except Exception:
+            logger.warning(
+                "Could not import %s for metadata extraction", module_name, exc_info=True
+            )
+            return result
+
+        # Find the @dlt.source decorated function
+        source_func = None
+        for _attr_name in dir(module):
+            obj = getattr(module, _attr_name)
+            if callable(obj) and getattr(obj, "__module__", None) == module_name:
+                # dlt.source-decorated functions retain __wrapped__ or are DltSource
+                # Check if it has the dlt source marker
+                if hasattr(obj, "__name__") and obj.__name__ != module_name:
+                    # The decorated function might be wrapped; try to inspect
+                    try:
+                        sig = inspect.signature(obj)
+                        # Only consider functions with dlt source indicators
+                        func_module = getattr(obj, "__module__", "")
+                        if func_module == module_name:
+                            source_func = obj
+                            break
+                    except (ValueError, TypeError):
+                        continue
+
+        # If no function found via __module__, try functions defined in the module
+        if source_func is None:
+            for _attr_name in dir(module):
+                obj = getattr(module, _attr_name)
+                if callable(obj) and not _attr_name.startswith("_"):
+                    try:
+                        sig = inspect.signature(obj)
+                        source_func = obj
+                        break
+                    except (ValueError, TypeError):
+                        continue
+
+        if source_func is not None:
+            # Extract docstring
+            result["docstring"] = inspect.getdoc(source_func)
+
+            # Extract parameter defaults
+            try:
+                sig = inspect.signature(source_func)
+                for param_name, param in sig.parameters.items():
+                    if param.default is not inspect.Parameter.empty:
+                        result["parameters"][param_name] = param.default
+            except (ValueError, TypeError):
+                logger.debug(
+                    "Could not inspect signature for %s.%s",
+                    module_name,
+                    source_func.__name__,
+                )
+
+    finally:
+        # Clean up sys.path
+        if custom_sources_dir in sys.path:
+            sys.path.remove(custom_sources_dir)
+
+    return result
+
+
+def discover_custom_sources(
+    custom_sources_dir: Path,
+    cache: dict[str, tuple[float, DiscoveredCustomSource]] | None = None,
+) -> dict[str, DiscoveredCustomSource]:
+    """Scan custom_sources/ directory for @dlt.source decorated Python files.
+
+    Uses two-phase extraction:
+    1. AST parsing for write_disposition (safe, no code execution)
+    2. importlib for function signature + docstring (same as dlt_runner.py)
+
+    Args:
+        custom_sources_dir: Path to the custom_sources/ directory.
+        cache: Optional mutable cache dict keyed by file path string.
+               If provided, entries with unchanged mtime are reused.
+
+    Returns:
+        Dict mapping canonical source name -> DiscoveredCustomSource.
+    """
+    if cache is None:
+        cache = _discovery_cache
+
+    if not custom_sources_dir.exists() or not custom_sources_dir.is_dir():
+        return {}
+
+    discovered: dict[str, DiscoveredCustomSource] = {}
+
+    for filepath in sorted(custom_sources_dir.glob("*.py")):
+        if filepath.name.startswith("_"):
+            continue
+
+        mtime = filepath.stat().st_mtime
+        cache_key = str(filepath)
+
+        # Check cache
+        if cache_key in cache:
+            cached_mtime, cached_source = cache[cache_key]
+            if cached_mtime == mtime:
+                discovered[cached_source.source_name or cached_source.function_name] = cached_source
+                continue
+
+        module_name = filepath.stem
+
+        # Phase 1: AST parsing (safe, no code execution)
+        ast_data = _parse_dlt_source_ast(filepath)
+        function_name = ast_data.get("function_name") or module_name
+        source_name = ast_data.get("source_name")
+        is_replace_mode = ast_data.get("is_replace_mode", False)
+
+        if ast_data.get("function_name") is None:
+            # No @dlt.source decorator found; skip this file
+            logger.debug("No @dlt.source decorator in %s, skipping", filepath.name)
+            continue
+
+        # Phase 2: Import + inspect for signature and docstring
+        import_data = _import_and_inspect(filepath, module_name)
+
+        canonical_name = source_name or function_name
+
+        dcs = DiscoveredCustomSource(
+            module_name=module_name,
+            function_name=function_name,
+            source_name=source_name,
+            docstring=import_data.get("docstring"),
+            parameters=import_data.get("parameters", {}),
+            is_replace_mode=is_replace_mode,
+            file_mtime=mtime,
+        )
+
+        # Update cache
+        cache[cache_key] = (mtime, dcs)
+        discovered[canonical_name] = dcs
+
+    return discovered
+
+
+def get_discovered_source(
+    custom_sources_dir: Path,
+    source_name: str,
+) -> DiscoveredCustomSource | None:
+    """Look up a single discovered custom source by name.
+
+    Args:
+        custom_sources_dir: Path to the custom_sources/ directory.
+        source_name: Canonical source name to look up.
+
+    Returns:
+        DiscoveredCustomSource if found, None otherwise.
+    """
+    discovered = discover_custom_sources(custom_sources_dir)
+    return discovered.get(source_name)
+
+
+def clear_discovery_cache() -> None:
+    """Clear the module-level discovery cache (useful for testing)."""
+    _discovery_cache.clear()

--- a/dango/ingestion/sources/custom_discovery.py
+++ b/dango/ingestion/sources/custom_discovery.py
@@ -154,11 +154,19 @@ def _match_dlt_resource_decorator(decorator: ast.expr) -> dict[str, Any] | None:
     return None
 
 
-def _import_and_inspect(filepath: Path, module_name: str) -> dict[str, Any]:
+def _import_and_inspect(
+    filepath: Path, module_name: str, target_function_name: str
+) -> dict[str, Any]:
     """Import the module and extract function signature + docstring.
 
     Executes the Python file (same as dlt_runner.py does at sync time).
     Falls back gracefully on import errors.
+
+    Args:
+        filepath: Path to the Python file.
+        module_name: Module name for import.
+        target_function_name: Name of the @dlt.source function (from AST phase).
+            Used to find the exact function rather than guessing.
 
     Returns dict with keys: parameters, docstring
     """
@@ -186,53 +194,31 @@ def _import_and_inspect(filepath: Path, module_name: str) -> dict[str, Any]:
             )
             return result
 
-        # Find the @dlt.source decorated function
-        source_func = None
-        for _attr_name in dir(module):
-            obj = getattr(module, _attr_name)
-            if callable(obj) and getattr(obj, "__module__", None) == module_name:
-                # dlt.source-decorated functions retain __wrapped__ or are DltSource
-                # Check if it has the dlt source marker
-                if hasattr(obj, "__name__") and obj.__name__ != module_name:
-                    # The decorated function might be wrapped; try to inspect
-                    try:
-                        sig = inspect.signature(obj)
-                        # Only consider functions with dlt source indicators
-                        func_module = getattr(obj, "__module__", "")
-                        if func_module == module_name:
-                            source_func = obj
-                            break
-                    except (ValueError, TypeError):
-                        continue
+        # Look up the exact function identified by AST parsing
+        source_func = getattr(module, target_function_name, None)
+        if source_func is None or not callable(source_func):
+            logger.debug(
+                "Function %s not found in module %s after import",
+                target_function_name,
+                module_name,
+            )
+            return result
 
-        # If no function found via __module__, try functions defined in the module
-        if source_func is None:
-            for _attr_name in dir(module):
-                obj = getattr(module, _attr_name)
-                if callable(obj) and not _attr_name.startswith("_"):
-                    try:
-                        sig = inspect.signature(obj)
-                        source_func = obj
-                        break
-                    except (ValueError, TypeError):
-                        continue
+        # Extract docstring
+        result["docstring"] = inspect.getdoc(source_func)
 
-        if source_func is not None:
-            # Extract docstring
-            result["docstring"] = inspect.getdoc(source_func)
-
-            # Extract parameter defaults
-            try:
-                sig = inspect.signature(source_func)
-                for param_name, param in sig.parameters.items():
-                    if param.default is not inspect.Parameter.empty:
-                        result["parameters"][param_name] = param.default
-            except (ValueError, TypeError):
-                logger.debug(
-                    "Could not inspect signature for %s.%s",
-                    module_name,
-                    source_func.__name__,
-                )
+        # Extract parameter defaults
+        try:
+            sig = inspect.signature(source_func)
+            for param_name, param in sig.parameters.items():
+                if param.default is not inspect.Parameter.empty:
+                    result["parameters"][param_name] = param.default
+        except (ValueError, TypeError):
+            logger.debug(
+                "Could not inspect signature for %s.%s",
+                module_name,
+                target_function_name,
+            )
 
     finally:
         # Clean up sys.path
@@ -296,7 +282,7 @@ def discover_custom_sources(
             continue
 
         # Phase 2: Import + inspect for signature and docstring
-        import_data = _import_and_inspect(filepath, module_name)
+        import_data = _import_and_inspect(filepath, module_name, function_name)
 
         canonical_name = source_name or function_name
 
@@ -320,18 +306,23 @@ def discover_custom_sources(
 def get_discovered_source(
     custom_sources_dir: Path,
     source_name: str,
+    discovered: dict[str, DiscoveredCustomSource] | None = None,
 ) -> DiscoveredCustomSource | None:
     """Look up a single discovered custom source by name.
 
     Args:
         custom_sources_dir: Path to the custom_sources/ directory.
         source_name: Canonical source name to look up.
+        discovered: Optional pre-computed discovery result. If provided,
+            avoids re-scanning the directory. Useful when calling in a loop.
 
     Returns:
         DiscoveredCustomSource if found, None otherwise.
     """
-    discovered = discover_custom_sources(custom_sources_dir)
-    return discovered.get(source_name)
+    if discovered is not None:
+        return discovered.get(source_name)
+    all_discovered = discover_custom_sources(custom_sources_dir)
+    return all_discovered.get(source_name)
 
 
 def clear_discovery_cache() -> None:

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -197,7 +197,7 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "capabilities": {
             "performance_metrics": False,
             "date_range": False,
-            "incremental": False,
+            "incremental": None,  # Derived at runtime from actual source (AST + sync history)
             "custom_queries": True,
         },
     },

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -93,7 +93,6 @@ def load_sources_config() -> list[dict[str, Any]]:
                             },
                             "description": d.docstring or "",
                             "tags": [],
-                            "_discovered": True,
                         }
                     )
     except Exception:

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -53,19 +53,53 @@ def is_cloud_deployment(project_root: Path) -> bool:
 
 
 def load_sources_config() -> list[dict[str, Any]]:
-    """Load sources configuration from .dango/sources.yml."""
+    """Load sources configuration from .dango/sources.yml.
+
+    Auto-discovered custom sources from custom_sources/ are merged in
+    if not already present in sources.yml.
+    """
     sources_file = get_project_root() / ".dango" / "sources.yml"
 
-    if not sources_file.exists():
-        return []
+    sources: list[dict[str, Any]] = []
+    if sources_file.exists():
+        try:
+            with open(sources_file, encoding="utf-8") as f:
+                config = yaml.safe_load(f) or {}
+                sources = config.get("sources", [])
+        except Exception as e:
+            logger.error(f"Error loading sources config: {e}")
+            return []
 
+    # Merge auto-discovered custom sources not already in YAML
     try:
-        with open(sources_file, encoding="utf-8") as f:
-            config = yaml.safe_load(f) or {}
-            return config.get("sources", [])
-    except Exception as e:
-        logger.error(f"Error loading sources config: {e}")
-        return []
+        from dango.ingestion.sources.custom_discovery import discover_custom_sources
+
+        project_root = get_project_root()
+        custom_sources_dir = project_root / "custom_sources"
+        if custom_sources_dir.exists():
+            discovered = discover_custom_sources(custom_sources_dir)
+            existing_names = {s.get("name", "") for s in sources}
+            for name, d in discovered.items():
+                if name not in existing_names:
+                    sources.append(
+                        {
+                            "name": name,
+                            "type": "dlt_native",
+                            "enabled": True,
+                            "dlt_native": {
+                                "source_module": d.module_name,
+                                "source_function": d.function_name,
+                                "function_kwargs": d.parameters,
+                            },
+                            "description": d.docstring or "",
+                            "tags": [],
+                            "_discovered": True,
+                        }
+                    )
+    except Exception:
+        pass  # Non-critical; discovery failures must not break source listing
+
+    return sources
 
 
 def get_duckdb_path() -> Path:
@@ -960,9 +994,30 @@ async def get_source_status_data(source: dict) -> SourceStatus:
         source_wd = source.get("write_disposition")
         if source_wd is None and meta:
             source_wd = (meta.get("default_config") or {}).get("write_disposition")
-        if source_wd == "replace":
+
+        # For dlt_native: check auto-discovered write_disposition from Python source
+        discovered_is_replace: bool | None = None
+        if source_type == "dlt_native" and source_wd is None:
+            try:
+                from dango.ingestion.sources.custom_discovery import (
+                    get_discovered_source,
+                )
+
+                project_root = get_project_root()
+                custom_sources_dir = project_root / "custom_sources"
+                if custom_sources_dir.exists():
+                    discovered = get_discovered_source(custom_sources_dir, source_name)
+                    if discovered is not None:
+                        discovered_is_replace = discovered.is_replace_mode
+            except Exception:
+                pass
+
+        if source_wd == "replace" or discovered_is_replace is True:
             sync_mode = "full_refresh"
         elif supports_incremental:
+            sync_mode = "incremental"
+        elif source_type == "dlt_native":
+            # Default for never-synced custom sources: incremental
             sync_mode = "incremental"
         else:
             sync_mode = "full_refresh"

--- a/tests/unit/test_custom_discovery.py
+++ b/tests/unit/test_custom_discovery.py
@@ -1,0 +1,356 @@
+"""tests/unit/test_custom_discovery.py
+
+Tests for dango.ingestion.sources.custom_discovery — auto-discovery engine.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dango.ingestion.sources.custom_discovery import (
+    DiscoveredCustomSource,
+    _match_dlt_resource_decorator,
+    _match_dlt_source_decorator,
+    _parse_dlt_source_ast,
+    clear_discovery_cache,
+    discover_custom_sources,
+    get_discovered_source,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: create temporary .py files simulating custom dlt sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def merge_source_file(tmp_path: Path) -> Path:
+    """A custom source with merge write_disposition and @dlt.source decorator."""
+    content = """\"\"\"Daily prices from yfinance.\"\"\"
+import dlt
+
+@dlt.source
+def investment_desk_prices_daily(
+    start_date: str = "2021-01-01",
+    lookback_days: int = 5,
+):
+    \"\"\"Daily prices and FX rates from yfinance.
+
+    Args:
+        start_date: How far back to load on first sync (YYYY-MM-DD).
+        lookback_days: Days to re-fetch on incremental runs for corrections.
+    \"\"\"
+
+    @dlt.resource(
+        name="prices_daily",
+        write_disposition="merge",
+        primary_key=["ticker", "date"],
+    )
+    def prices_daily():
+        yield {}
+"""
+    filepath = tmp_path / "investment_desk_prices_daily.py"
+    filepath.write_text(content)
+    return filepath
+
+
+@pytest.fixture
+def replace_source_file(tmp_path: Path) -> Path:
+    """A custom source with replace write_disposition."""
+    content = '''"""Latest prices from yfinance. Full refresh every run."""
+import dlt
+
+@dlt.source
+def investment_desk_prices_latest():
+    """Latest prices and FX rates from yfinance. Full refresh every run."""
+
+    prices_latest(tickers=[], fetched_at=None)
+
+
+@dlt.resource(
+    write_disposition="replace",
+    primary_key="ticker",
+)
+def prices_latest(tickers, fetched_at):
+    """Current/last traded price per ticker."""
+    yield {}
+'''
+    filepath = tmp_path / "investment_desk_prices_latest.py"
+    filepath.write_text(content)
+    return filepath
+
+
+@pytest.fixture
+def named_source_file(tmp_path: Path) -> Path:
+    """A custom source with explicit @dlt.source(name=...) kwarg."""
+    content = '''"""Snapshot negative keywords."""
+import dlt
+
+@dlt.source(name="badang_labs_negative_keywords", max_table_nesting=0)
+def badang_labs_negative_keywords():
+    """Snapshot all active negative keywords in the account."""
+
+    @dlt.resource(
+        name="negative_keywords",
+        write_disposition="merge",
+        primary_key=["snapshot_date", "keyword_text"],
+    )
+    def negative_keywords():
+        yield {}
+'''
+    filepath = tmp_path / "badang_labs_negative_keywords.py"
+    filepath.write_text(content)
+    return filepath
+
+
+@pytest.fixture
+def no_dlt_source_file(tmp_path: Path) -> Path:
+    """A Python file without any @dlt.source decorator."""
+    content = '''"""Helper utilities — not a dlt source."""
+import dlt
+
+def helper_function():
+    """Just a regular function."""
+    return 42
+'''
+    filepath = tmp_path / "helpers.py"
+    filepath.write_text(content)
+    return filepath
+
+
+@pytest.fixture
+def syntax_error_file(tmp_path: Path) -> Path:
+    """A Python file with a syntax error."""
+    filepath = tmp_path / "broken.py"
+    filepath.write_text("this is not valid python {{{")
+    return filepath
+
+
+@pytest.fixture
+def simple_importable_source(tmp_path: Path) -> Path:
+    """A simple source that can be imported without dlt dependencies."""
+    content = '''"""A simple test source."""
+def my_test_source(start_date: str = "2024-01-01", lookback_days: int = 7):
+    """This is a test docstring for discovery."""
+    pass
+'''
+    filepath = tmp_path / "my_test_source.py"
+    filepath.write_text(content)
+    return filepath
+
+
+# ---------------------------------------------------------------------------
+# AST parsing tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestASTParsing:
+    def test_detects_merge_write_disposition(self, merge_source_file: Path) -> None:
+        result = _parse_dlt_source_ast(merge_source_file)
+        assert result["function_name"] == "investment_desk_prices_daily"
+        assert result["is_replace_mode"] is False
+        assert result["source_name"] is None
+
+    def test_detects_replace_write_disposition(self, replace_source_file: Path) -> None:
+        result = _parse_dlt_source_ast(replace_source_file)
+        assert result["function_name"] == "investment_desk_prices_latest"
+        assert result["is_replace_mode"] is True
+
+    def test_extracts_source_name_from_decorator_kwarg(self, named_source_file: Path) -> None:
+        result = _parse_dlt_source_ast(named_source_file)
+        assert result["function_name"] == "badang_labs_negative_keywords"
+        assert result["source_name"] == "badang_labs_negative_keywords"
+        assert result["is_replace_mode"] is False
+
+    def test_skips_file_without_dlt_source(self, no_dlt_source_file: Path) -> None:
+        result = _parse_dlt_source_ast(no_dlt_source_file)
+        assert result["function_name"] is None
+
+    def test_handles_syntax_error_gracefully(self, syntax_error_file: Path) -> None:
+        result = _parse_dlt_source_ast(syntax_error_file)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Decorator matching tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDecoratorMatchers:
+    def test_matches_bare_dlt_source(self) -> None:
+        import ast
+
+        code = "@dlt.source\ndef foo():\n    pass"
+        tree = ast.parse(code)
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        decorator = func.decorator_list[0]
+        result = _match_dlt_source_decorator(decorator)
+        assert result == {}
+
+    def test_matches_dlt_source_with_name_kwarg(self) -> None:
+        import ast
+
+        code = '@dlt.source(name="my_source")\ndef foo():\n    pass'
+        tree = ast.parse(code)
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        decorator = func.decorator_list[0]
+        result = _match_dlt_source_decorator(decorator)
+        assert result == {"name": "my_source"}
+
+    def test_does_not_match_dlt_resource_as_source(self) -> None:
+        import ast
+
+        code = '@dlt.resource(write_disposition="merge")\ndef foo():\n    pass'
+        tree = ast.parse(code)
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        decorator = func.decorator_list[0]
+        result = _match_dlt_source_decorator(decorator)
+        assert result is None
+
+    def test_matches_dlt_resource_with_write_disposition(self) -> None:
+        import ast
+
+        code = '@dlt.resource(write_disposition="replace")\ndef foo():\n    pass'
+        tree = ast.parse(code)
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        decorator = func.decorator_list[0]
+        result = _match_dlt_resource_decorator(decorator)
+        assert result == {"write_disposition": "replace"}
+
+    def test_matches_bare_dlt_resource(self) -> None:
+        import ast
+
+        code = "@dlt.resource\ndef foo():\n    pass"
+        tree = ast.parse(code)
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        decorator = func.decorator_list[0]
+        result = _match_dlt_resource_decorator(decorator)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Discovery tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDiscoverCustomSources:
+    def setup_method(self) -> None:
+        clear_discovery_cache()
+
+    def test_discovers_all_sources_in_directory(
+        self,
+        merge_source_file: Path,
+        replace_source_file: Path,
+        named_source_file: Path,
+    ) -> None:
+        custom_sources_dir = merge_source_file.parent
+        result = discover_custom_sources(custom_sources_dir)
+
+        # named_source_file has explicit source_name
+        assert "badang_labs_negative_keywords" in result
+        assert "investment_desk_prices_daily" in result
+        assert "investment_desk_prices_latest" in result
+
+        # Verify merge source
+        merge_src = result["investment_desk_prices_daily"]
+        assert merge_src.module_name == "investment_desk_prices_daily"
+        assert merge_src.is_replace_mode is False
+
+        # Verify replace source
+        replace_src = result["investment_desk_prices_latest"]
+        assert replace_src.is_replace_mode is True
+
+    def test_skips_non_dlt_files(self, merge_source_file: Path, no_dlt_source_file: Path) -> None:
+        result = discover_custom_sources(merge_source_file.parent)
+        # Only @dlt.source files are returned
+        assert "helpers" not in result
+        assert "investment_desk_prices_daily" in result
+
+    def test_skips_syntax_error_files(self, syntax_error_file: Path) -> None:
+        result = discover_custom_sources(syntax_error_file.parent)
+        assert "broken" not in result
+
+    def test_empty_for_nonexistent_directory(self, tmp_path: Path) -> None:
+        nonexistent = tmp_path / "nonexistent"
+        result = discover_custom_sources(nonexistent)
+        assert result == {}
+
+    def test_get_discovered_source_returns_single(self, merge_source_file: Path) -> None:
+        custom_sources_dir = merge_source_file.parent
+        result = get_discovered_source(custom_sources_dir, "investment_desk_prices_daily")
+        assert result is not None
+        assert result.module_name == "investment_desk_prices_daily"
+
+    def test_get_discovered_source_returns_none_for_unknown(self, merge_source_file: Path) -> None:
+        custom_sources_dir = merge_source_file.parent
+        result = get_discovered_source(custom_sources_dir, "nonexistent")
+        assert result is None
+
+    def test_cache_mtime_invalidation(self, merge_source_file: Path) -> None:
+        custom_sources_dir = merge_source_file.parent
+        cache: dict[str, tuple[float, DiscoveredCustomSource]] = {}
+
+        # First call: populate cache
+        result1 = discover_custom_sources(custom_sources_dir, cache=cache)
+        assert len(cache) >= 1
+
+        # Second call with same mtime: uses cache
+        result2 = discover_custom_sources(custom_sources_dir, cache=cache)
+        assert result1.keys() == result2.keys()
+
+        # Third call with empty cache: re-discovers
+        result3 = discover_custom_sources(custom_sources_dir, cache={})
+        assert result1.keys() == result3.keys()
+
+    def test_skips_underscore_prefixed_files(self, tmp_path: Path) -> None:
+        """Files starting with _ (like __init__.py) should be skipped."""
+        content = '''import dlt
+
+@dlt.source
+def hidden_source():
+    """Should not be discovered."""
+    pass
+'''
+        (tmp_path / "_hidden.py").write_text(content)
+
+        result = discover_custom_sources(tmp_path)
+        assert "hidden_source" not in result
+
+
+# ---------------------------------------------------------------------------
+# DiscoveredCustomSource dataclass tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDiscoveredCustomSource:
+    def test_defaults(self) -> None:
+        dcs = DiscoveredCustomSource(
+            module_name="test_module",
+            function_name="test_func",
+        )
+        assert dcs.module_name == "test_module"
+        assert dcs.function_name == "test_func"
+        assert dcs.source_name is None
+        assert dcs.docstring is None
+        assert dcs.parameters == {}
+        assert dcs.is_replace_mode is False
+        assert dcs.file_mtime == 0.0
+
+    def test_canonical_name_prefers_source_name(self) -> None:
+        dcs = DiscoveredCustomSource(
+            module_name="test_module",
+            function_name="test_func",
+            source_name="explicit_name",
+        )
+        # The source_name should be used as canonical name
+        assert dcs.source_name == "explicit_name"

--- a/tests/unit/test_custom_discovery.py
+++ b/tests/unit/test_custom_discovery.py
@@ -127,19 +127,6 @@ def syntax_error_file(tmp_path: Path) -> Path:
     return filepath
 
 
-@pytest.fixture
-def simple_importable_source(tmp_path: Path) -> Path:
-    """A simple source that can be imported without dlt dependencies."""
-    content = '''"""A simple test source."""
-def my_test_source(start_date: str = "2024-01-01", lookback_days: int = 7):
-    """This is a test docstring for discovery."""
-    pass
-'''
-    filepath = tmp_path / "my_test_source.py"
-    filepath.write_text(content)
-    return filepath
-
-
 # ---------------------------------------------------------------------------
 # AST parsing tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -33,12 +33,17 @@ class TestSourceCapabilities:
             )
 
     def test_capabilities_values_are_bool(self) -> None:
-        """All capability values must be booleans."""
+        """All capability values must be booleans, except 'incremental' which may be
+        None to indicate 'derive at runtime' (e.g., dlt_native sources)."""
         for source_type, metadata in SOURCE_REGISTRY.items():
             for key, value in metadata["capabilities"].items():
-                assert isinstance(value, bool), (
-                    f"{source_type}.capabilities.{key} is {type(value).__name__}, expected bool"
+                assert isinstance(value, (bool, type(None))), (
+                    f"{source_type}.capabilities.{key} is {type(value).__name__}, expected bool or None"
                 )
+                if key != "incremental":
+                    assert isinstance(value, bool), (
+                        f"{source_type}.capabilities.{key} is {type(value).__name__}, expected bool"
+                    )
 
     def test_get_source_capabilities_known_source(self) -> None:
         """get_source_capabilities returns correct dict for a known source."""


### PR DESCRIPTION
## Summary
- Auto-discover `@dlt.source` functions from `custom_sources/` via AST parsing + importlib
- Extract `write_disposition` from `@dlt.resource()` decorators (AST, no code execution)
- Extract function name, docstring, parameter defaults via importlib (same as dlt_runner.py)
- `sources.yml` now optional for custom sources — only needed for overrides (enabled, tags, kwarg overrides)
- Fix `_run_dlt_native_source` missing `uses_replace_mode` in success result (sync history was always recording `full_refresh=False`)
- Default never-synced custom sources to incremental instead of full_refresh
- Registry `dlt_native.capabilities.incremental` set to `None` (derive at runtime)

## Verification
- `ruff check`: all checks passed
- `ruff format --check`: all files formatted
- `pytest -x`: 4028 passed, 31 skipped, 0 failed
- 20 new unit tests for custom_discovery.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)