### PR TITLE
fix: @dlt.source decorator crashes during custom source import inspection

### DIFF
--- a/dango/ingestion/sources/custom_discovery.py
+++ b/dango/ingestion/sources/custom_discovery.py
@@ -187,7 +187,11 @@ def _import_and_inspect(
                 logger.warning("Could not create module spec for %s", module_name)
                 return result
             module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            finally:
+                sys.modules.pop(module_name, None)
         except Exception:
             logger.warning(
                 "Could not import %s for metadata extraction", module_name, exc_info=True


### PR DESCRIPTION
## Summary
- Fix @dlt.source decorator crash during custom source import inspection
- Register module in sys.modules before exec so dlt's inspect.getmodule() finds it

## Root cause
_import_and_inspect() creates modules via importlib but never registers them
in sys.modules. When the @dlt.source decorator executes and calls
inspect.getmodule(f), it returns None because the module isn't in sys.modules.
dlt then crashes on None.__name__.

## Verification
- ruff check dango/: All checks passed
- ruff format --check dango/: 221 files already formatted
- pytest -x: 4030 pass, 31 skip, 0 fail
- Manual: custom_sources/ @dlt.source imports without warning in dango logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)