### PR TITLE
fix: format Markdown files for ruff preview mode CI check

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -141,9 +141,11 @@ class ConfigLoader:
     PROJECT_FILE = "project.yml"
     SOURCES_FILE = "sources.yml"
 
+
 # Enum (dango/config/models.py)
 class DeduplicationStrategy(str, Enum):
     """Data deduplication strategies"""
+
     NONE = "none"
     LATEST_ONLY = "latest_only"
     APPEND_ONLY = "append_only"
@@ -249,7 +251,7 @@ except Exception as e:
 ```python
 from dango.validation import validate_source_name, validate_date_string
 
-validate_source_name(name)       # raises InvalidSourceNameError
+validate_source_name(name)  # raises InvalidSourceNameError
 validate_date_string("2024-01-15")  # raises InvalidDateFormatError
 ```
 
@@ -294,6 +296,7 @@ logger.error("sync_failed", source="stripe", error=str(e), retry_in=60)
 
 ```python
 from rich.console import Console
+
 console = Console()
 console.print("[green]Sync complete![/green]")
 ```
@@ -306,6 +309,7 @@ Call `configure_logging()` once at each entry point (CLI, web server) before any
 
 ```python
 from dango.logging import configure_logging
+
 configure_logging()  # uses DANGO_LOG_LEVEL env var or defaults to INFO
 ```
 
@@ -489,19 +493,19 @@ Type hints are enforced by mypy with `disallow_untyped_defs = true` — see `pyp
 
 ```python
 # Function signatures (dango/config/loader.py)
-def find_project_root(self, start_path: Optional[Path] = None) -> Optional[Path]:
-    ...
+def find_project_root(self, start_path: Optional[Path] = None) -> Optional[Path]: ...
 
-def validate_config(self) -> tuple[bool, list[str]]:
-    ...
+
+def validate_config(self) -> tuple[bool, list[str]]: ...
+
 
 # Pydantic fields with descriptions (dango/config/models.py)
 class ProjectContext(BaseModel):
     """Project-level context and metadata"""
+
     name: str
     organization: Optional[str] = Field(
-        None,
-        description="Organization name (used in Metabase, Web UI, etc.)"
+        None, description="Organization name (used in Metabase, Web UI, etc.)"
     )
     purpose: str = Field(description="Why this project exists, what it's used for")
     stakeholders: list[Stakeholder] = Field(default_factory=list)
@@ -611,12 +615,12 @@ Use `require_permission()` as a FastAPI `Depends()` parameter. It returns the au
 ```python
 from dango.auth.permissions import require_permission
 
+
 @router.get("/api/admin/users")
 async def list_users(
     request: Request,
     user: User = Depends(require_permission("users.view")),
-) -> JSONResponse:
-    ...
+) -> JSONResponse: ...
 ```
 
 ### Cookie security flags

--- a/dango/migrations/CLAUDE.md
+++ b/dango/migrations/CLAUDE.md
@@ -37,11 +37,13 @@ migrations/
 
 Create initial auth tables.
 """
+
 from __future__ import annotations
 import sqlite3
 
-VERSION = 1              # Must match NNN in filename
+VERSION = 1  # Must match NNN in filename
 DESCRIPTION = "Create initial auth tables"
+
 
 def upgrade(conn: sqlite3.Connection) -> None:
     """Apply this migration. Do not call conn.commit()."""

--- a/docs/sources/non-wizard-sources.md
+++ b/docs/sources/non-wizard-sources.md
@@ -47,7 +47,7 @@ sources:
 For an API requiring a Bearer token:
 
 1. Set the token in `.env`:
-   ```
+   ```shell
    MY_API_TOKEN=your-token-here
    ```
 
@@ -96,13 +96,15 @@ Create a Python file with `@dlt.source` and `@dlt.resource` decorators:
 # my_source.py
 import dlt
 
+
 @dlt.source
 def my_api_source(api_key=dlt.secrets.value):
     @dlt.resource(write_disposition="merge", primary_key="id")
     def items():
         # Your API logic here
-        response = requests.get("https://api.example.com/items",
-                                headers={"Authorization": f"Bearer {api_key}"})
+        response = requests.get(
+            "https://api.example.com/items", headers={"Authorization": f"Bearer {api_key}"}
+        )
         yield response.json()
 
     return items


### PR DESCRIPTION
## Summary
Format 3 Markdown files to pass `ruff format --check` with preview mode (CI uses ruff >=0.15 which enables Markdown formatting by default).

- `STANDARDS.md`
- `dango/migrations/CLAUDE.md`  
- `docs/sources/non-wizard-sources.md` — also added `shell` tag to `.env` code block to prevent future corruption

Fixes the pre-existing lint failure on all v1.0.s3 PRs.