### PR TITLE
fix: S3 QG frontend fixes (7 items)

### DIFF
--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -2463,6 +2463,7 @@ function applyModelsSort(models) {
         'schema': 'schema',
         'materialization': 'materialization',
         'rows': 'row_count',
+        'last_run': 'last_run',
     };
     if (modelSortColumn === 'status') {
         const dir = modelSortDirection === 'desc' ? -1 : 1;
@@ -2704,6 +2705,7 @@ function renderDbtModelsTable() {
                     ${actionButtons}
                     <a
                         href="/catalog?model=${encodeURIComponent(model.name)}"
+                        target="_blank" rel="noopener noreferrer"
                         class="text-blue-600 hover:text-blue-900 tooltip"
                         data-tooltip="View documentation"
                     >
@@ -2765,7 +2767,7 @@ function updateDbtModelStatus(modelName, running) {
         // Update status badge in the same row
         const row = btn.closest('tr');
         if (row) {
-            const statusCell = row.querySelector('td:nth-child(5)'); // 5th column is status
+            const statusCell = row.querySelector('td:nth-child(2)'); // 2nd column is status
             if (statusCell && running) {
                 // Show running badge with pulsing dot
                 statusCell.innerHTML = '<span class="px-2 py-1 text-xs rounded-full bg-yellow-100 text-yellow-800"><span class="inline-block animate-pulse mr-1">●</span>Running</span>';

--- a/dango/web/templates/models.html
+++ b/dango/web/templates/models.html
@@ -24,18 +24,18 @@
                 <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                 </svg>
-                <input type="text" id="models-filter-input" placeholder="Filter models..."
-                       class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                <input type="text" id="models-filter-input" placeholder="Filter by name, schema, or type..."
+                       class="w-full px-3 py-2 border text-sm border-gray-300 rounded-md">
                 <button id="models-filter-clear" class="text-xs text-gray-400 hover:text-gray-600 hidden">Clear</button>
             </div>
 
-            <div class="overflow-x-auto">
+            <div class="overflow-x-auto" style="overflow-y: clip">
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>
                             <th data-sort-key="name" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Model</th>
                             <th data-sort-key="status" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Status</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Run</th>
+                            <th data-sort-key="last_run" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Last Run</th>
                             <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                             <th data-sort-key="schema" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Schema</th>
                             <th data-sort-key="materialization" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -26,8 +26,8 @@
             <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
             </svg>
-            <input type="text" x-model="filterText" placeholder="Filter schedules..."
-                   class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+            <input type="text" x-model="filterText" placeholder="Filter by name, type, or cron..."
+                   class="w-full px-3 py-2 border text-sm border-gray-300 rounded-md">
             <button x-show="filterText" @click="filterText = ''"
                     class="text-xs text-gray-400 hover:text-gray-600">Clear</button>
         </div>
@@ -56,7 +56,10 @@
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
                             Status<template x-if="sortColumn === 'status'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
                         </th>
-                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Enabled</th>
+                        <th @click="toggleSort('enabled')"
+                            class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
+                            Enabled<template x-if="sortColumn === 'enabled'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                        </th>
                         <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
@@ -375,6 +378,7 @@ function schedulesPage() {
                         return order[sched.last_run.status] != null ? order[sched.last_run.status] : 99;
                     }
                     return 99;
+                case 'enabled': return sched.enabled ? 1 : 0;
                 default: return undefined;
             }
         },

--- a/dango/web/templates/scripts.html
+++ b/dango/web/templates/scripts.html
@@ -26,8 +26,8 @@
             <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
             </svg>
-            <input type="text" x-model="filterText" placeholder="Filter scripts..."
-                   class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+            <input type="text" x-model="filterText" placeholder="Filter by name..."
+                   class="w-full px-3 py-2 border text-sm border-gray-300 rounded-md">
             <button x-show="filterText" @click="filterText = ''"
                     class="text-xs text-gray-400 hover:text-gray-600">Clear</button>
         </div>

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -24,12 +24,12 @@
                 <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                 </svg>
-                <input type="text" id="sources-filter-input" placeholder="Filter sources..."
-                       class="w-64 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                <input type="text" id="sources-filter-input" placeholder="Filter by name or type..."
+                       class="w-full px-3 py-2 border text-sm border-gray-300 rounded-md">
                 <button id="sources-filter-clear" class="text-xs text-gray-400 hover:text-gray-600 hidden">Clear</button>
             </div>
 
-            <div class="overflow-x-auto">
+            <div class="overflow-x-auto" style="overflow-y: clip">
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>


### PR DESCRIPTION
## Summary
- QG-006: Fix nth-child selector in updateDbtModelStatus (5->2)
- QG-009: Fix invisible filter inputs -- add border, padding, full width
- QG-010: Make Last Run column sortable on Models page
- QG-011: Fix double scrollbar with overflow-y: clip
- QG-012: Make dbt docs icon open in new tab
- QG-013: Make Enabled column sortable on Schedules page
- QG-014: Update filter placeholders to describe search scope
- Remove non-existent focus:ring/focus:border classes from filter inputs
- Add rel="noopener noreferrer" to docs link target="_blank"

## Verification
- pytest -x: 4030 pass, 31 skipped, 0 fail
- ruff check + format: clean