### PR TITLE
fix: S3 QG staleness detection + unknown sync toast

### DIFF
--- a/dango/config/schedules.py
+++ b/dango/config/schedules.py
@@ -297,7 +297,7 @@ def validate_schedules(
         for sched in schedules:
             if sched.type not in (ScheduleType.SYNC, ScheduleType.SYNC_ONLY):
                 continue
-            interval = _get_cron_interval_seconds(sched.cron)
+            interval = get_cron_interval_seconds(sched.cron)
             for src in sched.sources:
                 avg = average_durations.get(src)
                 if avg is not None and interval < avg * 0.8:
@@ -312,7 +312,7 @@ def validate_schedules(
     return errors, warnings
 
 
-def _get_cron_interval_seconds(cron_expr: str, sample_count: int = 5) -> float:
+def get_cron_interval_seconds(cron_expr: str, sample_count: int = 5) -> float:
     """Return the minimum interval between consecutive cron runs in seconds.
 
     Samples ``sample_count`` consecutive intervals and returns the smallest one.

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -713,6 +713,7 @@ def _run_scheduled_sync_impl(schedule_name: str, sources: list[str], **kwargs: A
                     "event": "sync_completed",
                     "schedule": schedule_name,
                     "sources": source_names,
+                    "source": source_names[0] if len(source_names) == 1 else schedule_name,
                     "duration_seconds": round(elapsed, 2),
                     "timestamp": _ts(),
                 }

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -905,6 +905,45 @@ async def get_platform_health_data():
     }
 
 
+def build_staleness_thresholds() -> dict[str, float | None]:
+    """Pre-compute staleness thresholds for all scheduled sources.
+
+    Loads schedules config once and returns a ``{source_name: threshold_hours}``
+    dict. Sources not in any enabled schedule with a cron are excluded from the
+    dict (they are never stale). Callers look up a source and treat a missing
+    key as "not scheduled, never stale."
+
+    Returns:
+        Dict mapping source names to their staleness threshold in hours
+        (2x the minimum cron interval). Sources not in any schedule are omitted.
+    """
+    from dango.config.schedules import get_cron_interval_seconds, load_schedules_config
+
+    try:
+        config = load_schedules_config(get_project_root())
+    except Exception:
+        return {}
+
+    # Collect all cron intervals per source across all enabled schedules
+    source_intervals: dict[str, list[float]] = {}
+    for schedule in config.schedules:
+        if not schedule.enabled or not schedule.cron:
+            continue
+        try:
+            interval = get_cron_interval_seconds(schedule.cron)
+        except Exception:
+            interval = None
+        if interval is None:
+            interval = 24 * 3600  # complex/unresolvable cron fallback
+        for src in schedule.sources:
+            source_intervals.setdefault(src, []).append(interval)
+
+    # 2x the minimum interval per source
+    return {
+        src: (min(intervals) / 3600) * 2 for src, intervals in source_intervals.items() if intervals
+    }
+
+
 def _get_staleness_threshold_hours(source_name: str) -> float | None:
     """Return the staleness threshold in hours for a scheduled source.
 
@@ -912,7 +951,7 @@ def _get_staleness_threshold_hours(source_name: str) -> float | None:
     include this source. Returns None if the source is not scheduled or all
     its schedules are manual-only (no cron).
     """
-    from dango.config.schedules import _get_cron_interval_seconds, load_schedules_config
+    from dango.config.schedules import get_cron_interval_seconds, load_schedules_config
 
     try:
         config = load_schedules_config(get_project_root())
@@ -929,7 +968,7 @@ def _get_staleness_threshold_hours(source_name: str) -> float | None:
             # Manual-only trigger — skip
             continue
         try:
-            interval = _get_cron_interval_seconds(schedule.cron)
+            interval = get_cron_interval_seconds(schedule.cron)
         except Exception:
             interval = None
         if interval is not None:
@@ -945,8 +984,17 @@ def _get_staleness_threshold_hours(source_name: str) -> float | None:
     return (min(intervals) / 3600) * 2
 
 
-async def get_source_status_data(source: dict) -> SourceStatus:
-    """Get status data for a single source (runs blocking operations in thread pool)."""
+async def get_source_status_data(
+    source: dict, *, staleness_thresholds: dict[str, float | None] | None = None
+) -> SourceStatus:
+    """Get status data for a single source (runs blocking operations in thread pool).
+
+    Args:
+        source: Source configuration dict.
+        staleness_thresholds: Optional pre-computed ``{source_name: threshold_hours}``
+            dict from :func:`build_staleness_thresholds`. When provided, avoids
+            re-loading schedules config per source.
+    """
     source_name = source.get("name", "unknown")
     source_type = source.get("type", "unknown")
     enabled = source.get("enabled", True)
@@ -998,7 +1046,10 @@ async def get_source_status_data(source: dict) -> SourceStatus:
     if status == "synced":
         hours_since = freshness.get("hours_since_sync")
         if hours_since is not None:
-            threshold_hours = _get_staleness_threshold_hours(source_name)
+            if staleness_thresholds is not None:
+                threshold_hours = staleness_thresholds.get(source_name)
+            else:
+                threshold_hours = _get_staleness_threshold_hours(source_name)
             if threshold_hours is not None and hours_since > threshold_hours:
                 logger.info(
                     "source_marked_stale",

--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -905,6 +905,46 @@ async def get_platform_health_data():
     }
 
 
+def _get_staleness_threshold_hours(source_name: str) -> float | None:
+    """Return the staleness threshold in hours for a scheduled source.
+
+    Returns 2x the minimum cron interval across all enabled schedules that
+    include this source. Returns None if the source is not scheduled or all
+    its schedules are manual-only (no cron).
+    """
+    from dango.config.schedules import _get_cron_interval_seconds, load_schedules_config
+
+    try:
+        config = load_schedules_config(get_project_root())
+    except Exception:
+        return None
+
+    intervals: list[float] = []
+    for schedule in config.schedules:
+        if not schedule.enabled:
+            continue
+        if source_name not in schedule.sources:
+            continue
+        if not schedule.cron:
+            # Manual-only trigger — skip
+            continue
+        try:
+            interval = _get_cron_interval_seconds(schedule.cron)
+        except Exception:
+            interval = None
+        if interval is not None:
+            intervals.append(interval)
+        else:
+            # Complex/unresolvable cron — fall back to 24h
+            intervals.append(24 * 3600)
+
+    if not intervals:
+        return None
+
+    # 2x the minimum interval
+    return (min(intervals) / 3600) * 2
+
+
 async def get_source_status_data(source: dict) -> SourceStatus:
     """Get status data for a single source (runs blocking operations in thread pool)."""
     source_name = source.get("name", "unknown")
@@ -953,6 +993,20 @@ async def get_source_status_data(source: dict) -> SourceStatus:
     else:
         # Edge case
         status = "not_synced"
+
+    # Check staleness for successfully synced sources that have schedules
+    if status == "synced":
+        hours_since = freshness.get("hours_since_sync")
+        if hours_since is not None:
+            threshold_hours = _get_staleness_threshold_hours(source_name)
+            if threshold_hours is not None and hours_since > threshold_hours:
+                logger.info(
+                    "source_marked_stale",
+                    source=source_name,
+                    hours_since_sync=hours_since,
+                    threshold_hours=threshold_hours,
+                )
+                status = "stale"
 
     # Look up source capabilities from registry
     from dango.ingestion.sources.registry import get_source_capabilities

--- a/dango/web/routes/sources.py
+++ b/dango/web/routes/sources.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException
 
 from dango.validation import validate_source_name
 from dango.web.helpers import (
+    build_staleness_thresholds,
     get_source_freshness,
     get_source_row_count,
     get_source_status_data,
@@ -102,8 +103,14 @@ async def get_sources() -> list[SourceStatus]:
     # Load sources config in thread pool
     sources_config = await asyncio.to_thread(load_sources_config)
 
+    # Pre-compute staleness thresholds once (avoids re-loading schedules.yml per source)
+    staleness_thresholds = await asyncio.to_thread(build_staleness_thresholds)
+
     # Process all sources concurrently
-    tasks = [get_source_status_data(source) for source in sources_config]
+    tasks = [
+        get_source_status_data(source, staleness_thresholds=staleness_thresholds)
+        for source in sources_config
+    ]
     source_statuses = await asyncio.gather(*tasks)
 
     # Enrich with schedule info

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1183,7 +1183,9 @@ function applySourcesSort(srcs) {
 function sourceStatusOrder(src) {
     if (activeSyncs.has(src.name)) return 0;
     if (postSyncSources.has(src.name)) return 1;
-    const order = { 'synced': 10, 'partial': 20, 'empty': 30, 'not_synced': 40, 'failed': 50, 'never_synced': 60 };
+    const order = { 'synced': 10, 'stale': 15, 'partial': 20, 'empty': 30, 'not_synced': 40, 'failed': 50, 'never_synced': 60 };
+    // Check src.status first (backend-computed staleness overrides freshness.status)
+    if (order[src.status] != null) return order[src.status];
     return order[src.freshness?.status] != null ? order[src.freshness.status] : 99;
 }
 
@@ -1430,6 +1432,7 @@ function getStatusBadge(status) {
         'empty': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Empty</span>',
         'not_synced': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">Not Synced</span>',
         'failed': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Failed</span>',
+        'stale': '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">⚠ Stale</span>',
     };
 
     return badges[status] || badges['not_synced'];
@@ -1487,6 +1490,11 @@ function renderStatusPill(source, isSyncing, hasFileOps) {
 
     if (hasFileOps) {
         return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800 animate-pulse">⚙️ Processing...</span>';
+    }
+
+    // Check source.status for backend-computed staleness
+    if (source.status === 'stale') {
+        return '<span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">⚠ Stale</span>';
     }
 
     // Use freshness data if available

--- a/tests/unit/test_schedules_config.py
+++ b/tests/unit/test_schedules_config.py
@@ -337,16 +337,16 @@ class TestHelpers:
 
     def test_get_cron_interval_uniform(self):
         """Uniform cron (every hour) returns 3600s."""
-        from dango.config.schedules import _get_cron_interval_seconds
+        from dango.config.schedules import get_cron_interval_seconds
 
-        interval = _get_cron_interval_seconds("0 * * * *")
+        interval = get_cron_interval_seconds("0 * * * *")
         assert interval == 3600.0
 
     def test_get_cron_interval_non_uniform(self):
         """Non-uniform cron (6am and 6pm) returns the min gap (12h)."""
-        from dango.config.schedules import _get_cron_interval_seconds
+        from dango.config.schedules import get_cron_interval_seconds
 
-        interval = _get_cron_interval_seconds("0 6,18 * * *")
+        interval = get_cron_interval_seconds("0 6,18 * * *")
         assert interval == 12 * 3600.0
 
     def test_detect_overlaps_identical_crons(self):

--- a/tests/unit/test_staleness.py
+++ b/tests/unit/test_staleness.py
@@ -1,0 +1,201 @@
+"""tests/unit/test_staleness.py
+
+Tests for dango.web.helpers — source staleness detection (QG-005).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGetStalenessThresholdHours:
+    """Tests for _get_staleness_threshold_hours()."""
+
+    @staticmethod
+    def _make_schedule(name, cron, sources, enabled=True):
+        """Build a mock ScheduleConfig."""
+        from dango.config.schedules import ScheduleConfig
+
+        return ScheduleConfig(name=name, cron=cron, sources=sources, enabled=enabled)
+
+    @staticmethod
+    def _make_config(*schedules):
+        """Build a mock SchedulesConfig with the given schedules."""
+        from dango.config.schedules import SchedulesConfig
+
+        return SchedulesConfig(schedules=list(schedules))
+
+    def test_returns_none_when_config_load_fails(self):
+        """When load_schedules_config raises, return None."""
+        with (
+            patch(
+                "dango.config.schedules.load_schedules_config",
+                side_effect=OSError("no file"),
+            ),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            assert _get_staleness_threshold_hours("any_source") is None
+
+    def test_returns_none_for_unscheduled_source(self):
+        """Source not in any schedule returns None (never stale)."""
+        config = self._make_config(
+            self._make_schedule("daily_sync", "0 6 * * *", ["other_source"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            assert _get_staleness_threshold_hours("my_source") is None
+
+    def test_skips_disabled_schedules(self):
+        """Disabled schedules are excluded from staleness calculation."""
+        config = self._make_config(
+            self._make_schedule("enabled", "0 */6 * * *", ["my_source"], enabled=True),
+            self._make_schedule("disabled", "*/5 * * * *", ["my_source"], enabled=False),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            # Only the enabled schedule matters: 6h interval → 12h threshold
+            assert _get_staleness_threshold_hours("my_source") == pytest.approx(12.0)
+
+    def test_returns_two_times_daily_interval(self):
+        """Daily cron (24h) → threshold = 48h."""
+        config = self._make_config(
+            self._make_schedule("daily_sync", "0 6 * * *", ["my_source"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            threshold = _get_staleness_threshold_hours("my_source")
+            assert threshold == pytest.approx(48.0)
+
+    def test_returns_two_times_hourly_interval(self):
+        """Hourly cron → threshold = 2h."""
+        config = self._make_config(
+            self._make_schedule("hourly_sync", "0 * * * *", ["my_source"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            threshold = _get_staleness_threshold_hours("my_source")
+            assert threshold == pytest.approx(2.0)
+
+    def test_falls_back_to_24h_for_unresolvable_cron(self):
+        """When get_cron_interval_seconds returns None, use 24h fallback."""
+        config = self._make_config(
+            self._make_schedule("complex", "0 6,18 * * 1-5", ["my_source"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.config.schedules.get_cron_interval_seconds", return_value=None),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            # 24h fallback → 2x = 48h threshold
+            assert _get_staleness_threshold_hours("my_source") == pytest.approx(48.0)
+
+    def test_falls_back_to_24h_when_cron_raises(self):
+        """When get_cron_interval_seconds raises, use 24h fallback."""
+        config = self._make_config(
+            self._make_schedule("daily", "0 6 * * *", ["my_source"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch(
+                "dango.config.schedules.get_cron_interval_seconds",
+                side_effect=ValueError("bad cron"),
+            ),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            assert _get_staleness_threshold_hours("my_source") == pytest.approx(48.0)
+
+    def test_uses_minimum_interval_when_multiple_schedules(self):
+        """Source in a daily and an hourly schedule → use hourly (2x 1h = 2h)."""
+        config = self._make_config(
+            self._make_schedule("daily_sync", "0 6 * * *", ["my_source"]),
+            self._make_schedule("hourly_sync", "0 * * * *", ["my_source"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import _get_staleness_threshold_hours
+
+            # Shortest interval is 1h → 2x = 2h
+            threshold = _get_staleness_threshold_hours("my_source")
+            assert threshold == pytest.approx(2.0)
+
+
+class TestBuildStalenessThresholds:
+    """Tests for build_staleness_thresholds()."""
+
+    @staticmethod
+    def _make_schedule(name, cron, sources, enabled=True):
+        from dango.config.schedules import ScheduleConfig
+
+        return ScheduleConfig(name=name, cron=cron, sources=sources, enabled=enabled)
+
+    @staticmethod
+    def _make_config(*schedules):
+        from dango.config.schedules import SchedulesConfig
+
+        return SchedulesConfig(schedules=list(schedules))
+
+    def test_returns_empty_dict_when_config_load_fails(self):
+        with (
+            patch(
+                "dango.config.schedules.load_schedules_config",
+                side_effect=OSError("no file"),
+            ),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import build_staleness_thresholds
+
+            assert build_staleness_thresholds() == {}
+
+    def test_returns_thresholds_for_all_scheduled_sources(self):
+        config = self._make_config(
+            self._make_schedule("daily_sync", "0 6 * * *", ["src_a"]),
+            self._make_schedule("hourly_sync", "0 * * * *", ["src_b"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import build_staleness_thresholds
+
+            result = build_staleness_thresholds()
+            assert "src_a" in result
+            assert result["src_a"] == pytest.approx(48.0)  # daily → 48h
+            assert "src_b" in result
+            assert result["src_b"] == pytest.approx(2.0)  # hourly → 2h
+
+    def test_excludes_unscheduled_sources(self):
+        config = self._make_config(
+            self._make_schedule("daily_sync", "0 6 * * *", ["src_a"]),
+        )
+        with (
+            patch("dango.config.schedules.load_schedules_config", return_value=config),
+            patch("dango.web.helpers.get_project_root"),
+        ):
+            from dango.web.helpers import build_staleness_thresholds
+
+            result = build_staleness_thresholds()
+            assert "src_b" not in result  # not in any schedule


### PR DESCRIPTION
## Summary
- QG-005: Add schedule-aware staleness detection to source status (2x interval threshold)
- QG-007: Fix "Unknown sync completed" toast — add source key to schedule broadcast
- Stale only applies to scheduled sources; unscheduled and manual-only unaffected
- Complex/unresolvable crons fall back to 24h threshold

## Verification
- pytest -x: 4030 pass, 0 fail
- ruff check: All checks passed
- ruff format --check: 221 files already formatted