### PR TITLE
fix: S3 QG polish — column alignment + underscore-name empty-replace edge case

### DIFF
--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -988,8 +988,12 @@ class DltPipelineRunner:
         state_backup = self._backup_dlt_state(pipeline_name)
 
         # Always capture pre-refresh row count for empty replace protection
-        pre_refresh_rows = self._get_source_total_rows(source_name)
-        pre_table_counts = self._get_source_table_rows(source_name)
+        pre_refresh_rows = self._get_source_total_rows(
+            source_name, schema_name=pipeline.dataset_name
+        )
+        pre_table_counts = self._get_source_table_rows(
+            source_name, schema_name=pipeline.dataset_name
+        )
 
         # Full refresh: for merge/append sources, drop schema + state to force a
         # true reload. Replace sources skip the schema drop since they overwrite
@@ -1062,7 +1066,9 @@ class DltPipelineRunner:
                 and (full_refresh or uses_replace_mode)
                 and not allow_empty_replace
             ):
-                post_table_counts = self._get_source_table_rows(source_name)
+                post_table_counts = self._get_source_table_rows(
+                    source_name, schema_name=pipeline.dataset_name
+                )
                 if post_table_counts is not None:
                     truncated_tables: list[tuple[str, int]] = []
                     for table_name, pre_count in pre_table_counts.items():
@@ -1365,8 +1371,12 @@ class DltPipelineRunner:
         state_backup = self._backup_dlt_state(source_name)
 
         # Always capture pre-refresh row count for empty replace protection
-        pre_refresh_rows = self._get_source_total_rows(source_name)
-        pre_table_counts = self._get_source_table_rows(source_name)
+        pre_refresh_rows = self._get_source_total_rows(
+            source_name, schema_name=pipeline.dataset_name
+        )
+        pre_table_counts = self._get_source_table_rows(
+            source_name, schema_name=pipeline.dataset_name
+        )
 
         # Full refresh: for merge/append sources, drop schema + state to force a
         # true reload. Replace sources skip the schema drop since they overwrite
@@ -1440,7 +1450,9 @@ class DltPipelineRunner:
                 and (full_refresh or uses_replace_mode)
                 and not allow_empty_replace
             ):
-                post_table_counts = self._get_source_table_rows(source_name)
+                post_table_counts = self._get_source_table_rows(
+                    source_name, schema_name=pipeline.dataset_name
+                )
                 if post_table_counts is not None:
                     truncated_tables: list[tuple[str, int]] = []
                     for table_name, pre_count in pre_table_counts.items():
@@ -1473,7 +1485,9 @@ class DltPipelineRunner:
             if post_table_counts is not None:
                 total_row_count = sum(post_table_counts.values()) if post_table_counts else 0
             else:
-                total_row_count = self._get_source_total_rows(source_name)
+                total_row_count = self._get_source_total_rows(
+                    source_name, schema_name=pipeline.dataset_name
+                )
             if total_row_count is not None:
                 stats["total_row_count"] = total_row_count
             anomaly = self._check_row_count_anomaly(source_name, total_rows=total_row_count)
@@ -2107,7 +2121,9 @@ class DltPipelineRunner:
         mins = minutes % 60
         return f"{hours}h {mins}m"
 
-    def _get_source_table_rows(self, source_name: str) -> dict[str, int] | None:
+    def _get_source_table_rows(
+        self, source_name: str, schema_name: str | None = None
+    ) -> dict[str, int] | None:
         """Get per-table row counts for a source's raw schema.
 
         Returns dict of {table_name: row_count}, or None on error.
@@ -2115,7 +2131,7 @@ class DltPipelineRunner:
         """
         import duckdb
 
-        schema = f"raw_{source_name}"
+        schema = schema_name or f"raw_{source_name}"
         try:
             conn = duckdb.connect(str(self.duckdb_path), config={"access_mode": "read_only"})
             try:
@@ -2137,9 +2153,11 @@ class DltPipelineRunner:
         except Exception:
             return None
 
-    def _get_source_total_rows(self, source_name: str) -> int | None:
+    def _get_source_total_rows(
+        self, source_name: str, schema_name: str | None = None
+    ) -> int | None:
         """Get total row count across all tables in a source's raw schema."""
-        table_counts = self._get_source_table_rows(source_name)
+        table_counts = self._get_source_table_rows(source_name, schema_name=schema_name)
         if table_counts is None:
             return None
         return sum(table_counts.values()) if table_counts else 0

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -1390,31 +1390,31 @@ function renderSourcesTable() {
 
         return `
         <tr id="source-${source.name}" class="hover:bg-gray-50 transition-colors duration-150">
-            <td class="px-6 py-4 whitespace-nowrap cursor-pointer tooltip" onclick="${rowClickHandler}" data-tooltip="${rowClickHelp}">
+            <td class="px-6 py-4 whitespace-nowrap text-left text-sm font-medium">
+                ${actionColumn}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-left cursor-pointer tooltip" onclick="${rowClickHandler}" data-tooltip="${rowClickHelp}">
                 <div class="flex items-center">
                     <div class="text-sm font-medium text-gray-900">${escapeHtml(source.name)}</div>
                     ${source.needs_attention ? '<span class="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Needs Attention</span>' : ''}
                 </div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap cursor-pointer tooltip" data-col="status" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" data-tooltip="Click to view sync history">
+            <td class="px-6 py-4 whitespace-nowrap text-left cursor-pointer tooltip" data-col="status" onclick="event.stopPropagation(); openSyncHistory('${source.name}')" data-tooltip="Click to view sync history">
                 ${renderStatusPill(source, isSyncing, hasFileOps)}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="last-sync">
+            <td class="px-6 py-4 whitespace-nowrap text-left text-sm text-gray-500" data-col="last-sync">
                 ${formatRelativeTime(source.last_sync)}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                ${actionColumn}
-            </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
+            <td class="px-6 py-4 whitespace-nowrap text-left text-sm text-gray-400">
                 ${source.has_schedule ? `<span class="tooltip" data-tooltip="${source.schedule_display || ''}">${source.schedule_display || 'Scheduled'}</span>` : '<span class="inline-block w-full text-center text-gray-300">—</span>'}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap">
+            <td class="px-6 py-4 whitespace-nowrap text-left">
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
                     ${formatSourceType(source.type)}
                 </span>
                 <div class="text-xs text-gray-400 mt-0.5">${source.lookback_days ? `Incremental (${source.lookback_days}d lookback)` : source.sync_mode === 'full_refresh' ? 'Full Refresh' : 'Incremental'}</div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500" data-col="rows">
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-500" data-col="rows">
                 ${renderRowCount(source)}
             </td>
         </tr>

--- a/dango/web/templates/sources.html
+++ b/dango/web/templates/sources.html
@@ -33,13 +33,13 @@
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                             <th data-sort-key="name" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Source</th>
                             <th data-sort-key="status" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Status</th>
                             <th data-sort-key="last-sync" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Last Sync</th>
-                            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Schedule</th>
                             <th data-sort-key="type" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Type</th>
-                            <th data-sort-key="rows" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
+                            <th data-sort-key="rows" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">Rows</th>
                         </tr>
                     </thead>
                     <tbody id="sources-table-body" class="bg-white divide-y divide-gray-200">

--- a/tests/unit/test_dlt_runner_pipeline_phases.py
+++ b/tests/unit/test_dlt_runner_pipeline_phases.py
@@ -30,6 +30,7 @@ def _make_mock_pipeline():
     p = MagicMock(spec=dlt.Pipeline)
     p.extract.return_value = None
     p.normalize.return_value = None
+    p.dataset_name = "raw_test_source"
     load_info = MagicMock()
     load_info.load_id = "test-load-id"
     load_info.metrics = {}


### PR DESCRIPTION
## Summary
- QG-003: Align sources table columns consistently, move Actions to leftmost
- QG-004: Fix empty-replace protection for underscore-prefixed source names

## Verification
- pytest -x: 4041 pass, 0 fail
- ruff check / format --check: all pass