### PR TITLE
fix: S3 QG seed & CSV path portability

### DIFF
--- a/dango/cli/commands/seed.py
+++ b/dango/cli/commands/seed.py
@@ -56,6 +56,13 @@ def seed_add(ctx: click.Context, path: str, model_name: str | None) -> None:
     try:
         project_root = require_project_context(ctx)
         src = Path(path)
+
+        if src.suffix.lower() != ".csv":
+            console.print(
+                f"[red]Error:[/red] '{src.name}' is not a CSV file. dbt seeds must be CSV files."
+            )
+            raise click.Abort()
+
         seed_name = src.stem
 
         if not _VALID_DBT_IDENTIFIER_RE.match(seed_name):
@@ -84,7 +91,7 @@ def seed_add(ctx: click.Context, path: str, model_name: str | None) -> None:
         shutil.copy2(src, dest)
 
         console.print(f"[green]✓[/green] Copied [bold]{src.name}[/bold] → dbt/seeds/")
-        console.print(f"Reference in a model: {{{{ ref('{seed_name}') }}}}")
+        console.print(f"Reference in a model: {{{{ ref('{seed_name}') }}}}", highlight=False)
 
         if model_name:
             staging_dir = project_root / "dbt" / "models" / "staging"
@@ -144,7 +151,7 @@ def seed_list(ctx: click.Context) -> None:
 
         console.print("[bold]dbt seeds:[/bold]")
         for f in csv_files:
-            console.print(f"  {f.name}  →  {{{{ ref('{f.stem}') }}}}")
+            console.print(f"  {f.name}  →  {{{{ ref('{f.stem}') }}}}", highlight=False)
 
     except click.Abort:
         raise

--- a/dango/cli/commands/seed.py
+++ b/dango/cli/commands/seed.py
@@ -1,0 +1,153 @@
+"""dango/cli/commands/seed.py
+
+dbt seed management commands (add, list).
+
+Seeds are the portable way to reference external CSV data from models: drop a
+CSV into ``dbt/seeds/`` and reference it with ``{{ ref('seed_name') }}``.
+"""
+
+import re
+import shutil
+from pathlib import Path
+
+import click
+
+from dango.cli import console
+
+# dbt identifier rules: start with a letter/underscore, then letters/digits/underscores.
+_VALID_DBT_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@click.group()
+@click.pass_context
+def seed(ctx: click.Context) -> None:
+    """
+    Manage dbt seed CSV files.
+
+    Seeds are the portable way to reference external CSV data from models:
+    add a CSV to dbt/seeds/ and reference it with {{ ref('seed_name') }}.
+
+    Commands:
+      dango seed add     Copy a CSV into dbt/seeds/
+      dango seed list    List seeds and their ref() names
+    """
+    pass
+
+
+@seed.command("add")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--model",
+    "model_name",
+    default=None,
+    help="Scaffold a staging model stub referencing this seed",
+)
+@click.pass_context
+def seed_add(ctx: click.Context, path: str, model_name: str | None) -> None:
+    """
+    Copy a CSV file into dbt/seeds/ and report its ref() name.
+
+    Examples:
+      dango seed add path/to/data.csv
+      dango seed add path/to/data.csv --model int_test
+    """
+    from ..utils import require_project_context
+
+    try:
+        project_root = require_project_context(ctx)
+        src = Path(path)
+        seed_name = src.stem
+
+        if not _VALID_DBT_IDENTIFIER_RE.match(seed_name):
+            console.print(
+                f"[red]Error:[/red] '{src.name}' is not a valid dbt seed name. "
+                "Rename the file to use only letters, digits, and underscores "
+                "(no spaces or dashes), then try again."
+            )
+            raise click.Abort()
+
+        if model_name and not _VALID_DBT_IDENTIFIER_RE.match(model_name):
+            console.print(
+                f"[red]Error:[/red] '{model_name}' is not a valid dbt model name. "
+                "Use only letters, digits, and underscores (no spaces or dashes)."
+            )
+            raise click.Abort()
+
+        seeds_dir = project_root / "dbt" / "seeds"
+        seeds_dir.mkdir(parents=True, exist_ok=True)
+        dest = seeds_dir / src.name
+
+        if dest.exists():
+            console.print(
+                f"[yellow]⚠[/yellow] {dest.name} already exists in dbt/seeds/ (overwriting)"
+            )
+        shutil.copy2(src, dest)
+
+        console.print(f"[green]✓[/green] Copied [bold]{src.name}[/bold] → dbt/seeds/")
+        console.print(f"Reference in a model: {{{{ ref('{seed_name}') }}}}")
+
+        if model_name:
+            staging_dir = project_root / "dbt" / "models" / "staging"
+            model_dest = staging_dir / f"{model_name}.sql"
+            if model_dest.exists():
+                console.print(
+                    f"[yellow]⚠[/yellow] Model 'dbt/models/staging/{model_name}.sql' already exists (skipping)"
+                )
+            else:
+                staging_dir.mkdir(parents=True, exist_ok=True)
+                model_sql = (
+                    "{{ config(materialized='table', schema='staging') }}\n\n"
+                    f"SELECT *\nFROM {{{{ ref('{seed_name}') }}}}\n"
+                )
+                model_dest.write_text(model_sql, encoding="utf-8")
+                console.print(
+                    f"[green]✓[/green] Scaffolded model: dbt/models/staging/{model_name}.sql"
+                )
+
+    except click.Abort:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        from dango.exceptions import is_debug_mode
+
+        if is_debug_mode():
+            import traceback
+
+            console.print(traceback.format_exc())
+        raise click.Abort() from e
+
+
+@seed.command("list")
+@click.pass_context
+def seed_list(ctx: click.Context) -> None:
+    """
+    List seed CSV files in dbt/seeds/ with their ref() names.
+    """
+    from ..utils import require_project_context
+
+    try:
+        project_root = require_project_context(ctx)
+        seeds_dir = project_root / "dbt" / "seeds"
+
+        if not seeds_dir.exists():
+            console.print(
+                "[dim]No dbt/seeds/ directory yet. Run 'dango seed add <file.csv>'.[/dim]"
+            )
+            return
+
+        csv_files = sorted(seeds_dir.glob("*.csv"))
+        if not csv_files:
+            console.print(
+                "[dim]No seed files in dbt/seeds/. Run 'dango seed add <file.csv>'.[/dim]"
+            )
+            return
+
+        console.print("[bold]dbt seeds:[/bold]")
+        for f in csv_files:
+            console.print(f"  {f.name}  →  {{{{ ref('{f.stem}') }}}}")
+
+    except click.Abort:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise click.Abort() from e

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -28,6 +28,7 @@ from dango.cli.commands.platform import start, status, stop
 from dango.cli.commands.project import info, init, rename
 from dango.cli.commands.remote import remote
 from dango.cli.commands.schedule import schedule
+from dango.cli.commands.seed import seed
 from dango.cli.commands.serve import serve
 from dango.cli.commands.snapshot import snapshot
 from dango.cli.commands.source import source, sync
@@ -108,6 +109,7 @@ cli.add_command(db)
 cli.add_command(auth)
 cli.add_command(oauth)
 cli.add_command(model)
+cli.add_command(seed)
 cli.add_command(dashboard)
 cli.add_command(metabase)
 cli.add_command(migrate)

--- a/dango/cli/model_wizard.py
+++ b/dango/cli/model_wizard.py
@@ -407,6 +407,14 @@ class ModelWizard:
         lines.append("--")
         lines.append("--    These are final business tables for reporting/dashboards.")
         lines.append("--")
+        lines.append("-- 4. EXTERNAL CSV DATA (dbt seeds)")
+        lines.append("--    {# {{ ref('seed_name') }} #}")
+        lines.append("--    1. Add the file:   dango seed add path/to/data.csv")
+        lines.append("--    2. Reference it:   {# {{ ref('data') }} #}")
+        lines.append(
+            "--    (Do NOT use read_csv_auto('/absolute/path') — it breaks on other machines/cloud.)"
+        )
+        lines.append("--")
         lines.append("-- " + "=" * 76)
         lines.append("-- COMMON PATTERNS")
         lines.append("-- " + "=" * 76)

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -220,6 +220,29 @@ class SourceWizard:
 
             # Step 6b: Create directory if this is a file-based source
             if source_type in ("csv", "local_files") and "directory" in params:
+                raw_directory = params["directory"]
+                raw_path = Path(raw_directory)
+
+                # Warn + relativize absolute directory paths (they break on other machines/cloud)
+                if raw_path.is_absolute():
+                    try:
+                        rel_path = raw_path.relative_to(self.project_root)
+                    except ValueError:
+                        rel_path = None
+
+                    if rel_path is not None:
+                        console.print(
+                            f"[yellow]⚠️  '{raw_directory}' is an absolute path. "
+                            f"Using relative path '{rel_path}' instead — portable across machines/cloud.[/yellow]"
+                        )
+                        params["directory"] = str(rel_path)
+                    else:
+                        console.print(
+                            f"[yellow]⚠️  '{raw_directory}' is an absolute path outside the project. "
+                            "Consider a path relative to the project root (e.g. data/uploads/...) "
+                            "so it works on other machines and in the cloud.[/yellow]"
+                        )
+
                 directory_path = self.project_root / params["directory"]
                 if not directory_path.exists():
                     directory_path.mkdir(parents=True, exist_ok=True)

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -4,6 +4,7 @@ Validates Dango project configuration and resources.
 """
 
 import importlib.util
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -68,6 +69,7 @@ class ProjectValidator:
         self._check_source_connectivity()
         self._check_env_vars()
         self._check_dbt_setup()
+        self._check_model_sql_portability()
         self._check_database()
         self._check_dependencies()
         self._check_permissions()
@@ -518,6 +520,48 @@ class ProjectValidator:
                     "dbt: Model validation", "warn", f"Could not validate models: {str(e)[:100]}"
                 )
             )
+
+    def _check_model_sql_portability(self):
+        """Warn on hardcoded DuckDB read_* calls / absolute paths in model SQL.
+
+        Absolute paths and DuckDB ``read_csv_auto``/``read_parquet``/etc. calls
+        break when models run in Metabase (Docker) or on a cloud server. Suggest
+        the portable dbt seed pattern (``dango seed add`` + ``{{ ref() }}``) instead.
+
+        Emits warning-only results (non-fatal): each offending file yields one warn.
+        """
+        models_dir = self.project_root / "dbt" / "models"
+        if not models_dir.exists():
+            return
+
+        read_fn_re = re.compile(r"\bread_(csv_auto|parquet|json_auto|csv)\s*\(")
+        abs_path_re = re.compile(r"~/|/(?:Users|home|srv)/|[A-Za-z]:\\|['\"]/")
+
+        for sql_file in sorted(models_dir.rglob("*.sql")):
+            try:
+                content = sql_file.read_text(encoding="utf-8")
+            except Exception:  # noqa: BLE001
+                continue
+
+            offending_lines: list[int] = []
+            for lineno, raw_line in enumerate(content.splitlines(), 1):
+                # Strip `--` line comments so the wizard's own guidance text
+                # (which documents the seed pattern) is not flagged.
+                code = raw_line.split("--", 1)[0]
+                if read_fn_re.search(code) or abs_path_re.search(code):
+                    offending_lines.append(lineno)
+
+            if offending_lines:
+                rel_path = sql_file.relative_to(self.project_root)
+                lines_str = ", ".join(str(n) for n in offending_lines[:5])
+                self.results.append(
+                    ValidationResult(
+                        "dbt: Model SQL portability",
+                        "warn",
+                        f"{rel_path} (line(s) {lines_str}) uses read_csv_auto/absolute path. "
+                        "Use 'dango seed add <file>' and {{ ref('seed_name') }} instead.",
+                    )
+                )
 
     def _check_database(self):
         """Check if DuckDB database exists and is accessible"""

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -534,7 +534,9 @@ class ProjectValidator:
         if not models_dir.exists():
             return
 
-        read_fn_re = re.compile(r"\bread_(csv_auto|parquet|json_auto|csv)\s*\(")
+        read_fn_re = re.compile(
+            r"\bread_(csv_auto|csv|parquet|json_auto|json|ndjson_auto|ndjson)\s*\("
+        )
         abs_path_re = re.compile(r"~/|/(?:Users|home|srv)/|[A-Za-z]:\\|['\"]/")
 
         for sql_file in sorted(models_dir.rglob("*.sql")):

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -30,6 +30,7 @@ class TestCliCommandRegistration:
             project,  # noqa: F401
             schedule,  # noqa: F401
             schedule_webhook,  # noqa: F401
+            seed,  # noqa: F401
             source,  # noqa: F401
             transform,  # noqa: F401
             upgrade,  # noqa: F401
@@ -64,6 +65,7 @@ class TestCliCommandRegistration:
             "rename",
             "run",
             "schedule",
+            "seed",
             "serve",
             "source",
             "start",
@@ -149,6 +151,14 @@ class TestCliCommandRegistration:
         assert result.exit_code == 0
         assert "add" in result.output
         assert "remove" in result.output
+
+    def test_seed_subcommands(self) -> None:
+        """Seed group has add and list subcommands."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["seed", "--help"])
+        assert result.exit_code == 0
+        assert "add" in result.output
+        assert "list" in result.output
 
     def test_metabase_subcommands(self) -> None:
         """Metabase group has save, load, refresh subcommands."""

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -1,0 +1,111 @@
+"""tests/unit/test_seed.py
+
+Tests for dango.cli.commands.seed — dbt seed management commands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.mark.unit
+class TestSeedAdd:
+    def test_copies_csv_and_reports_ref(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            src = project_root / "source.csv"
+            src.write_text("id,name\n1,Alice\n")
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.seed import seed
+
+                result = runner.invoke(seed, ["add", str(src)])
+
+            assert result.exit_code == 0
+            assert (project_root / "dbt" / "seeds" / "source.csv").exists()
+            assert "ref('source')" in result.output
+
+    def test_rejects_non_csv(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            src = project_root / "data.json"
+            src.write_text('{"a": 1}')
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.seed import seed
+
+                result = runner.invoke(seed, ["add", str(src)])
+
+            assert result.exit_code != 0
+            assert not (project_root / "dbt" / "seeds" / "data.json").exists()
+
+    def test_rejects_invalid_identifier(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            src = project_root / "bad name.csv"
+            src.write_text("id\n1\n")
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.seed import seed
+
+                result = runner.invoke(seed, ["add", str(src)])
+
+            assert result.exit_code != 0
+            assert not (project_root / "dbt" / "seeds" / "bad name.csv").exists()
+
+    def test_scaffolds_model_stub(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            src = project_root / "source.csv"
+            src.write_text("id\n1\n")
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.seed import seed
+
+                result = runner.invoke(seed, ["add", str(src), "--model", "int_test"])
+
+            assert result.exit_code == 0
+            model = project_root / "dbt" / "models" / "staging" / "int_test.sql"
+            assert model.exists()
+            assert "{{ ref('source') }}" in model.read_text()
+
+
+@pytest.mark.unit
+class TestSeedList:
+    def test_lists_seeds(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+            seeds_dir = project_root / "dbt" / "seeds"
+            seeds_dir.mkdir(parents=True)
+            (seeds_dir / "alpha.csv").write_text("id\n1\n")
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.seed import seed
+
+                result = runner.invoke(seed, ["list"])
+
+            assert result.exit_code == 0
+            assert "alpha.csv" in result.output
+            assert "ref('alpha')" in result.output
+
+    def test_no_seeds(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem() as td:
+            project_root = Path(td)
+
+            with patch("dango.cli.utils.find_project_root", return_value=project_root):
+                from dango.cli.commands.seed import seed
+
+                result = runner.invoke(seed, ["list"])
+
+            assert result.exit_code == 0
+            assert "No dbt/seeds" in result.output

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,0 +1,62 @@
+"""tests/unit/test_validate.py
+
+Tests for dango.cli.validate.ProjectValidator._check_model_sql_portability.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dango.cli.validate import ProjectValidator
+
+
+@pytest.mark.unit
+class TestModelSqlPortability:
+    def _validator(self, tmp_path):
+        models_dir = tmp_path / "dbt" / "models" / "marts"
+        models_dir.mkdir(parents=True)
+        return ProjectValidator(tmp_path), models_dir
+
+    def test_flags_read_csv_auto_absolute_path(self, tmp_path):
+        v, models_dir = self._validator(tmp_path)
+        (models_dir / "hard.sql").write_text(
+            "SELECT *\nFROM read_csv_auto('/Users/foo/data.csv')\n"
+        )
+
+        v._check_model_sql_portability()
+
+        assert any(r.status == "warn" and "hard.sql" in r.message for r in v.results)
+
+    def test_flags_read_json(self, tmp_path):
+        v, models_dir = self._validator(tmp_path)
+        (models_dir / "j.sql").write_text("SELECT * FROM read_json('/srv/data.json')\n")
+
+        v._check_model_sql_portability()
+
+        assert any(r.status == "warn" and "j.sql" in r.message for r in v.results)
+
+    def test_flags_windows_absolute_path(self, tmp_path):
+        v, models_dir = self._validator(tmp_path)
+        (models_dir / "win.sql").write_text("COPY t TO 'C:\\Users\\foo\\data.csv'\n")
+
+        v._check_model_sql_portability()
+
+        assert any(r.status == "warn" and "win.sql" in r.message for r in v.results)
+
+    def test_ignores_comment_guidance(self, tmp_path):
+        v, models_dir = self._validator(tmp_path)
+        (models_dir / "guide.sql").write_text(
+            "-- (Do NOT use read_csv_auto('/absolute/path') — it breaks)\nSELECT 1\n"
+        )
+
+        v._check_model_sql_portability()
+
+        assert v.results == []
+
+    def test_ignores_relative_ref(self, tmp_path):
+        v, models_dir = self._validator(tmp_path)
+        (models_dir / "ok.sql").write_text("SELECT * FROM {{ ref('stg_foo') }}\n")
+
+        v._check_model_sql_portability()
+
+        assert v.results == []


### PR DESCRIPTION
## Summary
- Add `dango seed add` / `dango seed list` commands for portable CSV references (dbt seeds + `{{ ref() }}`)
- Add `dango validate` scanner warning on hardcoded `read_csv_auto`/`read_parquet`/absolute paths in model SQL
- Add seed guidance to the model wizard SQL template
- Warn on absolute directory paths in the CSV source wizard

## Verification
- `pytest -x`: 4041 pass, 31 skipped, 0 fail
- `ruff check dango/`: pass
- `ruff format --check dango/`: pass (222 files formatted)
- Manual smoke test (throwaway project, not beta-1):
  - `dango seed add /tmp/test_seed.csv` → copies to `dbt/seeds/`, reports `{{ ref('test_seed') }}`
  - `dango seed add ... --model int_test` → scaffolds `dbt/models/staging/int_test.sql` with `{{ ref('test_seed') }}`
  - `dango seed add "bad name.csv"` → rejected with rename suggestion
  - `dango seed list` → lists seed with ref name
  - Scanner flags `read_csv_auto('/Users/...')` at the correct line; ignores the wizard's own guidance comment