### PR TITLE
fix: model row counts in catalog list API

### DIFF
--- a/dango/auth/CLAUDE.md
+++ b/dango/auth/CLAUDE.md
@@ -15,7 +15,7 @@ User authentication and access control for Dango. Handles password-based login w
 | `sessions.py` | 289 | High-level session + API key lifecycle | `create_session()`, `validate_session()`, `validate_partial_session()`, `create_api_key()`, `validate_api_key()` |
 | `permissions.py` | 196 | 29 permissions, 3 role mappings | `PERMISSIONS`, `ROLE_PERMISSIONS`, `has_permission()`, `require_permission()` |
 | `lockout.py` | 459 | Brute-force protection (5 attempts / 15-min, IP-based + user-based) | `record_failed_login()`, `check_account_locked()`, `unlock_account()`, `cleanup_expired_login_attempts()` |
-| `audit.py` | 210 | 44 event types + 1 deprecated alias to `.dango/logs/audit.jsonl` | `AuditEvent`, `log_auth_event()`, `query_audit_log()` |
+| `audit.py` | 238 | 45 event types + 1 deprecated alias to `.dango/logs/audit.jsonl` | `AuditEvent`, `log_auth_event()`, `query_audit_log()` |
 | `admin.py` | 129 | Bootstrap + path helpers | `ensure_admin()`, `is_auth_enabled()`, `get_auth_db_path()` |
 | `totp.py` | 220 | TOTP 2FA: setup/verify/enable/disable, recovery codes | `generate_totp_secret()`, `verify_totp_code()`, `setup_totp()`, `enable_totp()`, `consume_recovery_code()` |
 | `oauth_login.py` | 314 | OAuth provider ABC + Google/GitHub implementations | `OAuthLoginProvider`, `GoogleOAuthProvider`, `GitHubOAuthProvider`, `get_provider()` |

--- a/dango/auth/audit.py
+++ b/dango/auth/audit.py
@@ -79,6 +79,7 @@ class AuditEvent(str, Enum):
     QUERY_EXECUTED              = "query_executed"
     CSV_UPLOADED                = "csv_uploaded"
     CSV_DELETED                 = "csv_deleted"
+    CATALOG_PROFILE_TRIGGERED   = "catalog_profile_triggered"
     # fmt: on
 
 

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -173,7 +173,7 @@ def profile_table(
         conn.close()
 
     try:
-        _cache_stats(project_root, source, table_name, stats)
+        _cache_stats(project_root, source, table_name, stats, row_count=total_rows)
     except Exception:
         logger.warning(
             "profiling_cache_error",
@@ -269,6 +269,8 @@ def _cache_stats(
     source: str,
     table_name: str,
     stats: dict[str, dict[str, str | None]],
+    *,
+    row_count: int | None = None,
 ) -> None:
     """Write profiling stats to the ``profiling_stats`` table.
 
@@ -280,6 +282,9 @@ def _cache_stats(
         source: Source name.
         table_name: Table name.
         stats: Mapping of ``{column_name: {stat_type: stat_value}}``.
+        row_count: Optional table-level row count.  When provided, stored as a
+            synthetic ``__row_count__`` row so the catalog list can read counts
+            without querying DuckDB.
     """
     now = datetime.now(timezone.utc).isoformat()
 
@@ -292,6 +297,13 @@ def _cache_stats(
                     "VALUES (?, ?, ?, ?, ?, ?)",
                     (source, table_name, col_name, stat_type, stat_value, now),
                 )
+        if row_count is not None:
+            conn.execute(
+                "INSERT OR REPLACE INTO profiling_stats "
+                "(source, table_name, column_name, stat_type, stat_value, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (source, table_name, "__row_count__", "value", str(row_count), now),
+            )
         conn.commit()
 
 

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -15,6 +15,7 @@ from typing import Any
 import duckdb
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
 from dango.auth.permissions import require_permission
 from dango.logging import get_logger
@@ -487,6 +488,9 @@ def _build_catalog_models(
         tests_warning = sum(1 for t in tests if t["status"] == "warn")
         tests_failing = sum(1 for t in tests if t["status"] in ("fail", "error"))
 
+        key = _model_profiling_key(src, "source")
+        row_count = cached_row_counts.get(key) if key else None
+
         sources.append(
             {
                 "unique_id": uid,
@@ -501,6 +505,7 @@ def _build_catalog_models(
                 "tests_failing": tests_failing,
                 "columns_total": len(columns),
                 "columns_documented": cols_documented,
+                "row_count": row_count,
             }
         )
 
@@ -908,7 +913,7 @@ async def refresh_table_profile(
 
 @router.post("/api/catalog/profile-all")
 async def profile_all_models(
-    user: User = Depends(require_permission("governance.view")),  # noqa: ARG001
+    user: User = Depends(require_permission("dbt.run")),  # noqa: ARG001
 ) -> dict[str, Any]:
     """Re-profile all raw tables, staging models, and dbt models.
 
@@ -917,7 +922,7 @@ async def profile_all_models(
     every source failed.
 
     Args:
-        user: Authenticated user with ``governance.view`` permission.
+        user: Authenticated user with ``dbt.run`` permission.
 
     Returns:
         Dict with the profiling status and the discovered source names.
@@ -938,6 +943,13 @@ async def profile_all_models(
         raise HTTPException(
             status_code=500, detail=f"Profiling failed: {type(exc).__name__}"
         ) from exc
+
+    log_auth_event(
+        AuditEvent.CATALOG_PROFILE_TRIGGERED,
+        user_id=user.id,
+        email=user.email,
+        details={"sources": source_names},
+    )
 
     return {"status": "ok", "sources": source_names}
 

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -18,7 +19,7 @@ from dango.auth.models import User
 from dango.auth.permissions import require_permission
 from dango.logging import get_logger
 from dango.utils.dango_db import connect
-from dango.utils.post_sync import profile_table
+from dango.utils.post_sync import _run_profiling, profile_table
 from dango.validation import validate_identifier, validate_source_name
 from dango.web.helpers import get_dbt_manifest, get_project_root
 
@@ -82,7 +83,8 @@ def _get_cached_stats(
     with connect(project_root) as conn:
         rows = conn.execute(
             "SELECT column_name, stat_type, stat_value "
-            "FROM profiling_stats WHERE source = ? AND table_name = ?",
+            "FROM profiling_stats WHERE source = ? AND table_name = ? "
+            "AND column_name != '__row_count__'",
             (source, table),
         ).fetchall()
     for row in rows:
@@ -117,6 +119,30 @@ def _get_profiled_at(
         result: str = row[0]
         return result
     return None
+
+
+def _get_cached_row_counts(project_root: Path) -> dict[tuple[str, str], int]:
+    """Read all cached table-level row counts from SQLite.
+
+    Args:
+        project_root: Dango project root.
+
+    Returns:
+        Mapping of ``{(source, table_name): row_count}`` for every table that
+        has a cached ``__row_count__`` synthetic stat row.
+    """
+    result: dict[tuple[str, str], int] = {}
+    with connect(project_root) as conn:
+        rows = conn.execute(
+            "SELECT source, table_name, stat_value FROM profiling_stats "
+            "WHERE column_name = '__row_count__' AND stat_type = 'value'"
+        ).fetchall()
+    for row in rows:
+        try:
+            result[(row[0], row[1])] = int(row[2])
+        except (TypeError, ValueError):
+            continue
+    return result
 
 
 def _get_row_count(db_path: Path, source: str, table: str) -> int:
@@ -326,6 +352,34 @@ def _classify_model_type(node: dict[str, Any]) -> str:
     return "intermediate"
 
 
+def _model_profiling_key(node: dict[str, Any], kind: str) -> tuple[str, str] | None:
+    """Return the ``(source, table_name)`` SQLite key used by the profiling write path.
+
+    Mirrors :func:`dango.utils.post_sync.profile_table` callers so cached stats
+    and row counts can be read back for any model type:
+    - sources and staging models are keyed by the raw source name,
+    - intermediate/marts models are keyed by their dbt schema.
+
+    Args:
+        node: A manifest model or source node dict.
+        kind: ``"model"`` or ``"source"``.
+
+    Returns:
+        ``(source, table_name)`` tuple or ``None`` if no key applies.
+    """
+    table = node.get("alias") or node.get("name", "")
+    if not table:
+        return None
+    if kind == "source":
+        source = node.get("source_name", "")
+        return (source, table) if source else None
+    schema = node.get("schema", "")
+    if schema == "staging":
+        m = re.match(r"^stg_(.+?)__", table)
+        return (m.group(1), table) if m else None
+    return (schema, table) if schema else None
+
+
 def _get_model_column_schema(
     db_path: Path,
     schema: str,
@@ -382,6 +436,7 @@ def _build_catalog_models(
 
     project_root = get_project_root()
     model_statuses = get_model_statuses(project_root)
+    cached_row_counts = _get_cached_row_counts(project_root)
 
     models: list[dict[str, Any]] = []
     for uid, node in manifest.get("nodes", {}).items():
@@ -395,6 +450,8 @@ def _build_catalog_models(
         tests_failing = sum(1 for t in tests if t["status"] in ("fail", "error"))
 
         status_info = model_statuses.get(uid, {})
+        key = _model_profiling_key(node, "model")
+        row_count = cached_row_counts.get(key) if key else None
 
         models.append(
             {
@@ -413,6 +470,7 @@ def _build_catalog_models(
                 "tags": node.get("tags", []),
                 "last_run": status_info.get("last_run"),
                 "status": status_info.get("status"),
+                "row_count": row_count,
             }
         )
 
@@ -848,6 +906,42 @@ async def refresh_table_profile(
     }
 
 
+@router.post("/api/catalog/profile-all")
+async def profile_all_models(
+    user: User = Depends(require_permission("governance.view")),  # noqa: ARG001
+) -> dict[str, Any]:
+    """Re-profile all raw tables, staging models, and dbt models.
+
+    Populates row counts and column stats in the profiling cache without
+    requiring a sync — covers projects set up via data import and syncs where
+    every source failed.
+
+    Args:
+        user: Authenticated user with ``governance.view`` permission.
+
+    Returns:
+        Dict with the profiling status and the discovered source names.
+    """
+    project_root = get_project_root()
+    db_path = project_root / "data" / "warehouse.duckdb"
+    if not db_path.exists():
+        raise HTTPException(status_code=404, detail="No warehouse database found. Sync data first.")
+
+    raw_tables = await asyncio.to_thread(_get_raw_tables_from_duckdb, db_path)
+    source_names = sorted({rt["source_name"] for rt in raw_tables})
+    if not source_names:
+        raise HTTPException(status_code=404, detail="No tables found to profile.")
+
+    try:
+        await asyncio.to_thread(_run_profiling, project_root, source_names)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500, detail=f"Profiling failed: {type(exc).__name__}"
+        ) from exc
+
+    return {"status": "ok", "sources": source_names}
+
+
 # ---------------------------------------------------------------------------
 # Catalog model endpoints
 # ---------------------------------------------------------------------------
@@ -1030,19 +1124,13 @@ async def get_catalog_model(
     if db_path.exists() and schema and table:
         db_columns = await asyncio.to_thread(_get_model_column_schema, db_path, schema, table)
 
-    # Get profiled_at — for source tables use source_name, for models derive from name
-    source_name = ""
-    if kind == "source":
-        source_name = target_node.get("source_name", "")
-    else:
-        # Derive source from staging model name: stg_{source}__{table}
-        import re
-
-        m = re.match(r"^stg_(.+?)__", table)
-        if m:
-            source_name = m.group(1)
-    if source_name:
-        profiled_at = await asyncio.to_thread(_get_profiled_at, project_root, source_name, table)
+    # Get profiled_at from the profiling cache, keyed identically to the write path
+    cache_key = _model_profiling_key(target_node, kind)
+    if cache_key:
+        cache_source, cache_table = cache_key
+        profiled_at = await asyncio.to_thread(
+            _get_profiled_at, project_root, cache_source, cache_table
+        )
 
     result = _build_model_detail(
         manifest, run_results, target_uid, target_node, kind, db_columns, profiled_at
@@ -1067,8 +1155,11 @@ async def get_catalog_model(
             result["row_count"] = row_count
 
     # Inject cached profiling stats for any table with profiling data
-    if source_name and result.get("columns"):
-        cached_stats = await asyncio.to_thread(_get_cached_stats, project_root, source_name, table)
+    if cache_key and result.get("columns"):
+        cache_source, cache_table = cache_key
+        cached_stats = await asyncio.to_thread(
+            _get_cached_stats, project_root, cache_source, cache_table
+        )
         if cached_stats:
             for col in result["columns"]:
                 col["stats"] = cached_stats.get(col["name"])

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -52,6 +52,11 @@
         <div x-show="!loading && view === 'list'">
             <div class="flex items-center justify-between mb-2">
                 <h2 class="text-xl font-bold text-gray-900">Data Catalog</h2>
+                <button @click="profileAll()" :disabled="profileAllLoading"
+                        class="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 text-sm font-medium transition-colors disabled:opacity-50">
+                    <span x-show="!profileAllLoading">Refresh counts</span>
+                    <span x-show="profileAllLoading" x-cloak>Profiling...</span>
+                </button>
             </div>
             <!-- Summary cards -->
             <template x-if="overview">
@@ -183,6 +188,7 @@
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
                                                 Type<template x-if="sortColumn === 'type'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
                                             </th>
+                                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Rows</th>
                                             <th @click="toggleCatalogSort('description')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
                                                 Description<template x-if="sortColumn === 'description'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
@@ -214,6 +220,8 @@
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     <span class="model-badge" :class="'model-badge-' + item.type" x-text="item.type"></span>
                                                 </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
+                                                    x-text="item.row_count != null ? item.row_count.toLocaleString() : '--'"></td>
                                                 <td class="px-6 py-4 hidden sm:table-cell">
                                                     <div class="desc-truncate text-sm text-gray-500" :title="item.description" x-text="item.description || '--'"></div>
                                                 </td>
@@ -571,7 +579,7 @@ function catalogPage() {
         // Governance state
         piiFindings: [], driftEvents: [], piiOverrides: [],
         // Shared state
-        loading: true, profilingLoading: false, error: null, hasLineage: false, showAllSources: false,
+        loading: true, profilingLoading: false, profileAllLoading: false, error: null, hasLineage: false, showAllSources: false,
         // Guard flag: suppresses pushState during URL restoration and popstate
         // handling to prevent feedback loops (restoreFromUrl → openModel → updateUrl).
         _skipPush: false,
@@ -935,6 +943,29 @@ function catalogPage() {
                 }
             } catch (e) { this.error = 'Failed to refresh profile.'; }
             finally { this.profilingLoading = false; }
+        },
+
+        async profileAll() {
+            this.profileAllLoading = true; this.error = null;
+            try {
+                const res = await fetch('/api/catalog/profile-all', {
+                    method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                });
+                if (res.ok) {
+                    // Reload the model list to pick up the fresh row counts
+                    const modelsRes = await fetch('/api/catalog/models');
+                    if (modelsRes.ok) {
+                        const data = await modelsRes.json();
+                        this.allModels = data.models || [];
+                        this.allSources = data.sources || [];
+                        this.overview = data.overview || null;
+                    }
+                } else {
+                    const data = await res.json().catch(() => null);
+                    this.error = data?.detail || 'Failed to refresh counts.';
+                }
+            } catch (e) { this.error = 'Failed to refresh counts.'; }
+            finally { this.profileAllLoading = false; }
         },
 
         viewInLineage(name, sourceName) {

--- a/tests/integration/test_catalog_integration.py
+++ b/tests/integration/test_catalog_integration.py
@@ -143,6 +143,10 @@ class TestProfileTableIntegration:
         assert "id" in stat_map
         assert stat_map["id"]["null_count"] == "0"
 
+        # Table-level row count is stored as a synthetic __row_count__ stat
+        assert "__row_count__" in stat_map
+        assert stat_map["__row_count__"]["value"] == "5"
+
     def test_zero_row_table(self, tmp_path: Path) -> None:
         """Zero-row table is handled gracefully."""
         _clear_schema_cache()

--- a/tests/unit/test_catalog_models.py
+++ b/tests/unit/test_catalog_models.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
+from dango.auth.audit import AuditEvent
 from dango.auth.models import Role, User
 from dango.exceptions import (
     AuthenticationError,
@@ -21,7 +22,7 @@ from dango.exceptions import (
     DangoError,
     ValidationError,
 )
-from dango.web.routes.catalog import router
+from dango.web.routes.catalog import _model_profiling_key, router
 
 # ---------------------------------------------------------------------------
 # Test infrastructure
@@ -1130,6 +1131,42 @@ class TestRowCountsAndProfileAll:
         for m in models.values():
             assert "row_count" in m
 
+    @patch("dango.web.helpers.get_project_root")
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_cached_row_counts")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_source_list_includes_row_count(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_row_counts: MagicMock,
+        mock_get_root: MagicMock,
+        mock_helpers_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Sources in the list also carry row_count from the profiling cache."""
+        client, _ = _setup_client(tmp_path)
+        mock_get_root.return_value = tmp_path
+        mock_helpers_root.return_value = tmp_path
+        mock_row_counts.return_value = {("shop", "orders"): 50}
+        mock_manifest.return_value = _make_manifest(
+            sources={
+                "source.proj.shop.orders": {
+                    "name": "orders",
+                    "source_name": "shop",
+                    "schema": "raw_shop",
+                },
+            },
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+
+        assert resp.status_code == 200
+        sources = {s["name"]: s for s in resp.json()["sources"]}
+        assert sources["orders"]["row_count"] == 50
+
     @patch("dango.web.routes.catalog.get_project_root")
     @patch("dango.web.routes.catalog._get_cached_stats")
     @patch("dango.web.routes.catalog._get_profiled_at")
@@ -1178,6 +1215,7 @@ class TestRowCountsAndProfileAll:
         assert data["profiled_at"] == "2026-05-01T10:00:00Z"
         assert data["columns"][0]["stats"] == {"null_pct": "0", "distinct_count": "42"}
 
+    @patch("dango.web.routes.catalog.log_auth_event")
     @patch("dango.web.routes.catalog.get_project_root")
     @patch("dango.web.routes.catalog._run_profiling")
     @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
@@ -1186,9 +1224,10 @@ class TestRowCountsAndProfileAll:
         mock_raw_tables: MagicMock,
         mock_run_profiling: MagicMock,
         mock_root: MagicMock,
+        mock_log_auth: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """profile-all discovers raw sources and re-profiles everything."""
+        """profile-all discovers raw sources, re-profiles, and audits the trigger."""
         client, project_root = _setup_client(tmp_path)
         db_dir = tmp_path / "data"
         db_dir.mkdir()
@@ -1208,6 +1247,8 @@ class TestRowCountsAndProfileAll:
         assert data["status"] == "ok"
         assert data["sources"] == ["crm", "shop"]
         mock_run_profiling.assert_called_once_with(project_root, ["crm", "shop"])
+        mock_log_auth.assert_called_once()
+        assert mock_log_auth.call_args[0][0] == AuditEvent.CATALOG_PROFILE_TRIGGERED
 
     @patch("dango.web.routes.catalog.get_project_root")
     def test_profile_all_requires_warehouse(
@@ -1222,3 +1263,62 @@ class TestRowCountsAndProfileAll:
         resp = client.post("/api/catalog/profile-all")
 
         assert resp.status_code == 404
+
+    def test_profile_all_requires_dbt_run_permission(self, tmp_path: Path) -> None:
+        """profile-all requires dbt.run — a viewer gets 403."""
+        client, _ = _setup_client(tmp_path, role=Role.VIEWER)
+
+        resp = client.post("/api/catalog/profile-all")
+
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# S3-QG: profiling cache-key symmetry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModelProfilingKey:
+    """Tests for _model_profiling_key — mirrors the profiling write path."""
+
+    @pytest.mark.parametrize(
+        ("node", "kind", "expected"),
+        [
+            # marts / intermediate models are keyed by their dbt schema
+            (
+                {"schema": "marts", "name": "fct_revenue", "alias": "fct_revenue"},
+                "model",
+                ("marts", "fct_revenue"),
+            ),
+            (
+                {"schema": "intermediate", "name": "int_clean"},
+                "model",
+                ("intermediate", "int_clean"),
+            ),
+            # staging models with stg_{source}__ prefix are keyed by raw source
+            (
+                {"schema": "staging", "name": "stg_google_ads__campaigns"},
+                "model",
+                ("google_ads", "stg_google_ads__campaigns"),
+            ),
+            # staging model without the __ convention is not profiled by the write path
+            ({"schema": "staging", "name": "stg_orders"}, "model", None),
+            # alias is preferred over name (matches _profile_dbt_models)
+            ({"schema": "marts", "name": "foo", "alias": "fct_bar"}, "model", ("marts", "fct_bar")),
+            # model without a schema has no key
+            ({"schema": "", "name": "orphan"}, "model", None),
+            # sources are keyed by source_name
+            ({"name": "orders", "source_name": "shop"}, "source", ("shop", "orders")),
+            # source without a source_name has no key
+            ({"name": "orders", "source_name": ""}, "source", None),
+        ],
+    )
+    def test_key(
+        self,
+        node: dict[str, Any],
+        kind: str,
+        expected: tuple[str, str] | None,
+    ) -> None:
+        """_model_profiling_key produces the (source, table) write-path key."""
+        assert _model_profiling_key(node, kind) == expected

--- a/tests/unit/test_catalog_models.py
+++ b/tests/unit/test_catalog_models.py
@@ -1081,3 +1081,144 @@ class TestSourcesDetail:
         detail_map = {sd["name"]: sd for sd in data["overview"]["sources_detail"]}
         assert detail_map["new_source"]["table_count"] == 0
         assert detail_map["new_source"]["estimated_row_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# S3-QG: row counts in list + profile-all trigger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRowCountsAndProfileAll:
+    """Tests for row counts in the list and the profile-all trigger."""
+
+    @patch("dango.web.helpers.get_project_root")
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_cached_row_counts")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_model_list_includes_row_count(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_row_counts: MagicMock,
+        mock_get_root: MagicMock,
+        mock_helpers_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """List response includes row_count sourced from the profiling cache."""
+        client, _ = _setup_client(tmp_path)
+        mock_get_root.return_value = tmp_path
+        mock_helpers_root.return_value = tmp_path
+        mock_row_counts.return_value = {("marts", "fct_revenue"): 100}
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.stg_orders": {"name": "stg_orders", "schema": "staging"},
+                "model.proj.int_clean": {"name": "int_clean", "schema": "intermediate"},
+                "model.proj.fct_revenue": {"name": "fct_revenue", "schema": "marts"},
+            },
+        )
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+
+        assert resp.status_code == 200
+        models = {m["name"]: m for m in resp.json()["models"]}
+        assert models["fct_revenue"]["row_count"] == 100
+        assert models["stg_orders"]["row_count"] is None
+        assert models["int_clean"]["row_count"] is None
+        for m in models.values():
+            assert "row_count" in m
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_cached_stats")
+    @patch("dango.web.routes.catalog._get_profiled_at")
+    @patch("dango.web.routes.catalog._get_model_column_schema")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_marts_model_reads_cached_stats(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_col_schema: MagicMock,
+        mock_profiled: MagicMock,
+        mock_cached_stats: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Marts models read profiling stats keyed by their dbt schema."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_root.return_value = project_root
+        mock_manifest.return_value = _make_manifest(
+            models={
+                "model.proj.fct_revenue": {
+                    "name": "fct_revenue",
+                    "schema": "marts",
+                    "columns": {"id": {"name": "id", "description": ""}},
+                },
+            },
+        )
+        mock_run_results.return_value = None
+        mock_col_schema.return_value = [
+            {"name": "id", "type": "BIGINT", "nullable": False},
+        ]
+        mock_profiled.return_value = "2026-05-01T10:00:00Z"
+        mock_cached_stats.return_value = {"id": {"null_pct": "0", "distinct_count": "42"}}
+
+        resp = client.get("/api/catalog/models/fct_revenue")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        mock_profiled.assert_called_once_with(project_root, "marts", "fct_revenue")
+        mock_cached_stats.assert_called_once_with(project_root, "marts", "fct_revenue")
+        assert data["profiled_at"] == "2026-05-01T10:00:00Z"
+        assert data["columns"][0]["stats"] == {"null_pct": "0", "distinct_count": "42"}
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._run_profiling")
+    @patch("dango.web.routes.catalog._get_raw_tables_from_duckdb")
+    def test_profile_all_endpoint(
+        self,
+        mock_raw_tables: MagicMock,
+        mock_run_profiling: MagicMock,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """profile-all discovers raw sources and re-profiles everything."""
+        client, project_root = _setup_client(tmp_path)
+        db_dir = tmp_path / "data"
+        db_dir.mkdir()
+        (db_dir / "warehouse.duckdb").touch()
+
+        mock_root.return_value = project_root
+        mock_raw_tables.return_value = [
+            {"schema": "raw_shop", "table": "orders", "source_name": "shop"},
+            {"schema": "raw_shop", "table": "customers", "source_name": "shop"},
+            {"schema": "raw_crm", "table": "contacts", "source_name": "crm"},
+        ]
+
+        resp = client.post("/api/catalog/profile-all")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["sources"] == ["crm", "shop"]
+        mock_run_profiling.assert_called_once_with(project_root, ["crm", "shop"])
+
+    @patch("dango.web.routes.catalog.get_project_root")
+    def test_profile_all_requires_warehouse(
+        self,
+        mock_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """profile-all returns 404 when no warehouse database exists."""
+        client, project_root = _setup_client(tmp_path)
+        mock_root.return_value = project_root
+
+        resp = client.post("/api/catalog/profile-all")
+
+        assert resp.status_code == 404

--- a/tests/unit/test_profiling.py
+++ b/tests/unit/test_profiling.py
@@ -227,6 +227,29 @@ class TestProfileTable:
 
     @patch("dango.utils.post_sync.connect")
     @patch("duckdb.connect")
+    def test_row_count_cached(self, mock_dc, mock_sc, tmp_path):
+        """Table-level row count is stored as a synthetic __row_count__ stat."""
+        _make_warehouse(tmp_path)
+        mock_dc.return_value = _mock_duckdb(
+            [("id", "INTEGER", "NO")],
+            10,
+            {"id": (0, 10, "1", "10", "5.5")},
+            {"id": [("1",)]},
+        )
+        sqlite_conn = _mock_sqlite(mock_sc)
+        profile_table(tmp_path, "shopify", "orders")
+        row_count_inserts = [
+            c.args[1]
+            for c in sqlite_conn.execute.call_args_list
+            if "INSERT" in str(c) and "__row_count__" in str(c)
+        ]
+        assert len(row_count_inserts) == 1
+        # Params tuple: (source, table_name, column_name, stat_type, stat_value, updated_at)
+        assert row_count_inserts[0][2] == "__row_count__"
+        assert row_count_inserts[0][4] == "10"
+
+    @patch("dango.utils.post_sync.connect")
+    @patch("duckdb.connect")
     def test_per_column_error_isolation(self, mock_dc, mock_sc, tmp_path):
         """One column failing does not block profiling of other columns."""
         _make_warehouse(tmp_path)


### PR DESCRIPTION
## Summary
- Add `row_count` to the catalog model list API response, sourced from the profiling cache (single batched SQLite read, no per-model DuckDB queries).
- Fix the profiling cache key read path so intermediate/marts models (keyed by dbt schema) can read their column stats and `profiled_at` from SQLite.
- Store each table's row count in `profiling_stats` as a synthetic `__row_count__` stat during profiling.
- Add `POST /api/catalog/profile-all` to re-profile all raw tables, staging models, and dbt models without requiring a sync (covers imported data and all-sources-failed syncs).
- Add a "Rows" column and "Refresh counts" button to the catalog list UI.

## Verification
- `pytest -x`: 4046 pass, 31 skipped, 0 fail
- `ruff check dango/` and `ruff format --check dango/`: pass
- `mypy dango/web/routes/catalog.py dango/utils/post_sync.py`: no issues
- Beta-1 (coordinating chat): open catalog, click "Refresh counts", confirm models show row counts and marts model detail shows column stats + `profiled_at`