### PR TITLE
chore: guard against stale compiled Tailwind CSS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     branches: [v1, main, 'v1.0.*']
 
 jobs:
+  css:
+    name: CSS build (tailwind)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Build CSS
+        run: make css-build
+      - name: Check no drift
+        run: git diff --exit-code dango/web/static/css/tailwind.min.css
+
   lint:
     name: Lint (ruff)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,4 @@ css: css-install
 # Production build (minified, commit the output)
 css-build: css-install
 	npx tailwindcss -i dango/web/static/css/input.css -o dango/web/static/css/tailwind.min.css --minify
+	printf '\n' >> dango/web/static/css/tailwind.min.css


### PR DESCRIPTION
## Summary
- `make css-build` now appends a trailing newline, so it stops tripping `end-of-file-fixer` on every rebuild.
- Add a CI job that rebuilds the CSS from templates/JS and fails on `git diff` drift.

## Why
The compiled `tailwind.min.css` was chronically stale: templates/JS referenced utilities (`rounded-t-lg`, `select-none`, `italic`, `text-blue-500`, etc.) that were missing from the compiled file, silently breaking styles. `web/CLAUDE.md` says "rebuild after template changes" but nothing enforced it. This guard stops that class of bug permanently.

## Verification
- `make css-build` in a clean worktree → `git diff --exit-code` returns 0 (rebuilt CSS matches committed byte-for-byte, trailing newline included).
- Negative test: appended a fake class, `git diff --exit-code` returned 1 (guard catches drift).
- Pre-commit hooks pass (end-of-file-fixer, check-yaml, etc.).