### PR TITLE
Fix DbtLock unlink race condition (S3-QG-I)

### DIFF
--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -53,53 +53,14 @@ def run_pending_migrations(project_root: Path) -> dict[str, Any]:
 
 
 def cleanup_stale_dbt_lock(project_root: Path) -> bool:
-    """Remove stale dbt lock if the holding process is dead.
+    """No-op: stale locks clean themselves up via kernel flock auto-release.
 
-    Called during startup to proactively clean up locks from crashed processes.
-    Returns True if a stale lock was cleaned up, False otherwise.
-    Never raises.
+    Kept for backwards compatibility. Callers check the return value only to
+    print a warning — returning False always is safe.
 
-    Note: DbtLock._cleanup_stale_lock() has similar logic invoked lazily on
-    acquire().  This function exists separately because startup.py follows the
-    never-display / never-raise contract and cannot instantiate DbtLock (which
-    creates directories as a side effect).
+    Note: DbtLock._cleanup_stale_lock() follows the same no-op pattern.
     """
-    import json
-    import logging
-
-    logger = logging.getLogger(__name__)
-
-    try:
-        import psutil
-
-        lock_info_path = project_root / ".dango" / "state" / "dbt.lock.json"
-        if not lock_info_path.exists():
-            return False
-
-        with open(lock_info_path) as f:
-            lock_info = json.load(f)
-
-        pid = lock_info.get("pid")
-        if pid is None:
-            return False
-
-        if psutil.pid_exists(pid):
-            return False
-
-        # Process is dead — clean up stale lock files
-        lock_file_path = project_root / ".dango" / "state" / "dbt.lock"
-        lock_file_path.unlink(missing_ok=True)
-        lock_info_path.unlink(missing_ok=True)
-
-        logger.warning(
-            "Removed stale dbt lock (PID %d: %s — %s)",
-            pid,
-            lock_info.get("source", "unknown"),
-            lock_info.get("operation", "unknown"),
-        )
-        return True
-    except Exception:
-        return False
+    return False
 
 
 def ensure_dbt_schemas(project_root: Path) -> None:

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -28,7 +28,13 @@ else:
 
 class DbtLock:
     """
-    File-based lock for dbt operations.
+    File-based lock for dbt operations using fcntl.flock() on Unix.
+
+    **Design note:** flock() locks inodes, not file paths. Stale locks are
+    auto-released by the kernel when the holding process exits. Lock files are
+    never unlinked — this prevents a race condition where unlink() + open("w")
+    creates a new inode, allowing multiple processes to hold "the lock" on
+    different inodes simultaneously (see S3-QG-I).
 
     Usage:
         with DbtLock(project_root, source="cli", operation="dbt run"):
@@ -181,7 +187,15 @@ class DbtLock:
                 raise DbtLockError(message, lock_info=lock_info) from None
 
     def release(self) -> None:
-        """Release the lock."""
+        """Release the lock.
+
+        Note: Lock files are intentionally NOT deleted. Deleting the file after
+        acquiring the lock creates a race condition (S3-QG-I): if the file is
+        unlinked while a process holds the lock, the next open() creates a new
+        inode, allowing multiple processes to hold "the lock" on different
+        inodes. The kernel auto-releases flock when the fd is closed or the
+        process exits, so deletion is unnecessary and harmful.
+        """
         if not self._acquired:
             return
 

--- a/dango/utils/dbt_lock.py
+++ b/dango/utils/dbt_lock.py
@@ -15,8 +15,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any
 
-import psutil
-
 from dango.exceptions import DbtLockError
 
 logger = logging.getLogger(__name__)
@@ -72,14 +70,6 @@ class DbtLock:
         self._lock_file: IO[str] | None = None
         self._acquired = False
 
-    def _is_process_running(self, pid: int) -> bool:
-        """Check if a process with the given PID is running."""
-        try:
-            process = psutil.Process(pid)
-            return bool(process.is_running())
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            return False
-
     def _read_lock_info(self) -> dict[str, Any] | None:
         """Read lock information from the lock info file."""
         if not self.lock_info_path.exists():
@@ -115,35 +105,13 @@ class DbtLock:
 
     def _cleanup_stale_lock(self) -> bool:
         """
-        Clean up stale lock if the holding process no longer exists.
+        No-op: stale locks clean themselves up via kernel flock auto-release.
 
-        Returns:
-            True if a stale lock was cleaned up, False otherwise
+        Kept for API compatibility with acquire() call site.
+        Returns False always (no cleanup performed).
 
         See also: startup.cleanup_stale_dbt_lock() for the proactive startup variant.
         """
-        lock_info = self._read_lock_info()
-        if not lock_info:
-            return False
-
-        pid = lock_info.get("pid")
-        if pid and not self._is_process_running(pid):
-            # Process is dead, clean up the lock
-            try:
-                if self.lock_file_path.exists():
-                    self.lock_file_path.unlink()
-                if self.lock_info_path.exists():
-                    self.lock_info_path.unlink()
-                logger.warning(
-                    "Removed stale dbt lock (PID %d: %s — %s)",
-                    pid,
-                    lock_info.get("source", "unknown"),
-                    lock_info.get("operation", "unknown"),
-                )
-                return True
-            except OSError:  # noqa: BLE001
-                pass
-
         return False
 
     def acquire(self, timeout: float = 300) -> bool:
@@ -232,12 +200,6 @@ class DbtLock:
 
                 self._lock_file.close()
                 self._lock_file = None
-
-            # Clean up lock files
-            if self.lock_file_path.exists():
-                self.lock_file_path.unlink()
-            if self.lock_info_path.exists():
-                self.lock_info_path.unlink()
 
             self._acquired = False
         except OSError:  # noqa: BLE001

--- a/tests/unit/test_dbt_lock_stale.py
+++ b/tests/unit/test_dbt_lock_stale.py
@@ -7,7 +7,6 @@ import importlib
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -55,8 +54,7 @@ class TestCleanupStaleDbtLock:
 
     def test_lock_from_running_pid_preserved(self, tmp_path: Path) -> None:
         _write_stale_lock(tmp_path, pid=12345)
-        with patch("psutil.pid_exists", return_value=True):
-            result = cleanup_stale_dbt_lock(tmp_path)
+        result = cleanup_stale_dbt_lock(tmp_path)
         assert result is False
         assert (tmp_path / ".dango" / "state" / "dbt.lock").exists()
         assert (tmp_path / ".dango" / "state" / "dbt.lock.json").exists()

--- a/tests/unit/test_dbt_lock_stale.py
+++ b/tests/unit/test_dbt_lock_stale.py
@@ -43,11 +43,11 @@ def _write_stale_lock(project_root: Path, pid: int) -> None:
 class TestCleanupStaleDbtLock:
     def test_stale_lock_from_dead_pid_removed(self, tmp_path: Path) -> None:
         _write_stale_lock(tmp_path, pid=99999)
-        with patch("psutil.pid_exists", return_value=False):
-            result = cleanup_stale_dbt_lock(tmp_path)
-        assert result is True
-        assert not (tmp_path / ".dango" / "state" / "dbt.lock").exists()
-        assert not (tmp_path / ".dango" / "state" / "dbt.lock.json").exists()
+        result = cleanup_stale_dbt_lock(tmp_path)
+        assert result is False
+        # Cleanup is now a no-op; stale files persist (auto-released by kernel)
+        assert (tmp_path / ".dango" / "state" / "dbt.lock").exists()
+        assert (tmp_path / ".dango" / "state" / "dbt.lock.json").exists()
 
     def test_no_lock_files_returns_false(self, tmp_path: Path) -> None:
         result = cleanup_stale_dbt_lock(tmp_path)
@@ -73,15 +73,18 @@ class TestCleanupStaleDbtLock:
 @pytest.mark.unit
 class TestDbtLockCleanupStaleIntegration:
     def test_acquire_succeeds_after_stale_lock_cleanup(self, tmp_path: Path) -> None:
-        """DbtLock.acquire() succeeds when stale lock files exist from a dead process."""
+        """DbtLock.acquire() succeeds when stale lock files exist.
+
+        Stale locks are auto-released by the kernel (flock) when the holding
+        process exits. _cleanup_stale_lock() is a no-op; the test verifies that
+        acquire still works in the presence of stale files.
+        """
         _write_stale_lock(tmp_path, pid=99999)
 
-        _mod = sys.modules["dango.utils.dbt_lock"]
-        with patch.object(_mod.DbtLock, "_is_process_running", return_value=False):
-            lock = DbtLock(tmp_path, source="test", operation="test op")
-            acquired = lock.acquire(timeout=0)
-            assert acquired is True
-            lock.release()
+        lock = DbtLock(tmp_path, source="test", operation="test op")
+        acquired = lock.acquire(timeout=0)
+        assert acquired is True
+        lock.release()
 
     def test_acquire_blocked_by_running_pid(self, tmp_path: Path) -> None:
         """DbtLock.acquire() raises DbtLockError when lock is held by running process."""
@@ -157,19 +160,15 @@ class TestDbtLockCleanupLogging:
     def test_cleanup_stale_lock_logs_warning(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """_cleanup_stale_lock() logs a warning when removing stale files."""
+        """_cleanup_stale_lock() is now a no-op and does not log."""
         _write_stale_lock(tmp_path, pid=99999)
 
         _mod = sys.modules["dango.utils.dbt_lock"]
         import logging
 
-        with (
-            caplog.at_level(logging.WARNING, logger="dango.utils.dbt_lock"),
-            patch.object(_mod.DbtLock, "_is_process_running", return_value=False),
-        ):
+        with caplog.at_level(logging.WARNING, logger="dango.utils.dbt_lock"):
             lock = DbtLock(tmp_path, source="test", operation="test op")
             cleaned = lock._cleanup_stale_lock()
 
-        assert cleaned is True
-        assert "Removed stale dbt lock" in caplog.text
-        assert "99999" in caplog.text
+        assert cleaned is False
+        assert "Removed stale dbt lock" not in caplog.text


### PR DESCRIPTION
Fixes concurrent DuckDB write-lock conflicts by removing flock unlink race. Stale locks self-clean via kernel auto-release.