### PR TITLE
feat: seed profiling in catalog + Scripts before Schedules in nav

### DIFF
--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -602,11 +602,11 @@ def _profile_dbt_models(project_root: Path) -> None:
         logger.warning("profiling_dbt_json_error", exc_info=True)
         return
 
-    # Collect unique_ids of successful models
+    # Collect unique_ids of successful models and seeds
     successful_ids = [
         r["unique_id"]
         for r in run_results.get("results", [])
-        if r.get("unique_id", "").startswith("model.") and r.get("status") == "success"
+        if r.get("unique_id", "").startswith(("model.", "seed.")) and r.get("status") == "success"
     ]
 
     nodes = manifest.get("nodes", {})

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -14,7 +14,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `__init__.py` | Public exports | `app` module |
 | `middleware/auth.py` | Session/API key auth + CSRF check on every request (~324 lines) | `AuthMiddleware`, `is_secure_request()`, `COOKIE_NAME` |
 | `middleware/rate_limit.py` | Rate limiting (login 10/min, API 200/min, localhost exempt, ~235 lines) | `RateLimitMiddleware` |
-| `templates/base.html` | Shared Jinja2 layout: head (compiled Tailwind CSS), header, nav bar (9-item flat: Overview/Sources/Models/Schedules/Catalog/Query/Dashboards/Notebooks/Scripts + gear dropdown), responsive hamburger menu, footer, script blocks | Blocks: `title`, `subtitle_attrs`, `header_right`, `nav`, `content`, `footer`, `scripts` |
+| `templates/base.html` | Shared Jinja2 layout: head (compiled Tailwind CSS), header, nav bar (9-item flat: Overview/Sources/Models/Scripts/Schedules/Catalog/Query/Dashboards/Notebooks + gear dropdown), responsive hamburger menu, footer, script blocks | Blocks: `title`, `subtitle_attrs`, `header_right`, `nav`, `content`, `footer`, `scripts` |
 | `templates/error.html` | HTML error page (extends `base.html`) — status code, title, message, back/home links | Rendered by `dango_error_handler()` for browser 401/403 requests |
 | `templates/dashboard.html` | Overview page (extends `base.html`) — health widget, service cards, activity log | Loads `app.js` |
 | `templates/sources.html` | Sources page (extends `base.html`) — source table, sync controls, upload/detail modals | Loads `app.js` |

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -371,6 +371,9 @@ def _model_profiling_key(node: dict[str, Any], kind: str) -> tuple[str, str] | N
     table = node.get("alias") or node.get("name", "")
     if not table:
         return None
+    if kind == "seed":
+        schema = node.get("schema", "main")
+        return (schema, table) if table else None
     if kind == "source":
         source = node.get("source_name", "")
         return (source, table) if source else None
@@ -475,9 +478,38 @@ def _build_catalog_models(
             }
         )
 
-    # Sort: type order (staging → intermediate → marts), then name
-    type_order = {"staging": 0, "intermediate": 1, "marts": 2}
+    # Sort: type order (staging → intermediate → marts → seed), then name
+    type_order = {"staging": 0, "intermediate": 1, "marts": 2, "seed": 3}
     models.sort(key=lambda m: (type_order.get(m["type"], 1), m["name"].lower()))
+
+    # Seeds — resource_type == "seed" nodes from manifest
+    for uid, node in manifest.get("nodes", {}).items():
+        if node.get("resource_type") != "seed":
+            continue
+        columns = node.get("columns", {})
+        cols_documented = sum(1 for c in columns.values() if c.get("description"))
+        key = _model_profiling_key(node, "seed")
+        row_count = cached_row_counts.get(key) if key else None
+        models.append(
+            {
+                "unique_id": uid,
+                "name": node.get("name", ""),
+                "type": "seed",
+                "schema": node.get("schema", ""),
+                "materialization": "table",
+                "description": node.get("description", ""),
+                "test_count": 0,
+                "tests_passing": 0,
+                "tests_warning": 0,
+                "tests_failing": 0,
+                "columns_total": len(columns),
+                "columns_documented": cols_documented,
+                "tags": node.get("tags", []),
+                "last_run": None,
+                "status": None,
+                "row_count": row_count,
+            }
+        )
 
     sources: list[dict[str, Any]] = []
     for uid, src in manifest.get("sources", {}).items():

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -478,10 +478,6 @@ def _build_catalog_models(
             }
         )
 
-    # Sort: type order (staging → intermediate → marts → seed), then name
-    type_order = {"staging": 0, "intermediate": 1, "marts": 2, "seed": 3}
-    models.sort(key=lambda m: (type_order.get(m["type"], 1), m["name"].lower()))
-
     # Seeds — resource_type == "seed" nodes from manifest
     for uid, node in manifest.get("nodes", {}).items():
         if node.get("resource_type") != "seed":
@@ -510,6 +506,10 @@ def _build_catalog_models(
                 "row_count": row_count,
             }
         )
+
+    # Sort: type order (staging → intermediate → marts → seed), then name
+    type_order = {"staging": 0, "intermediate": 1, "marts": 2, "seed": 3}
+    models.sort(key=lambda m: (type_order.get(m["type"], 1), m["name"].lower()))
 
     sources: list[dict[str, Any]] = []
     for uid, src in manifest.get("sources", {}).items():

--- a/dango/web/routes/catalog.py
+++ b/dango/web/routes/catalog.py
@@ -359,11 +359,12 @@ def _model_profiling_key(node: dict[str, Any], kind: str) -> tuple[str, str] | N
     Mirrors :func:`dango.utils.post_sync.profile_table` callers so cached stats
     and row counts can be read back for any model type:
     - sources and staging models are keyed by the raw source name,
-    - intermediate/marts models are keyed by their dbt schema.
+    - intermediate/marts models are keyed by their dbt schema,
+    - seeds are keyed by their dbt schema (always "main" by default).
 
     Args:
-        node: A manifest model or source node dict.
-        kind: ``"model"`` or ``"source"``.
+        node: A manifest model, source, or seed node dict.
+        kind: ``"model"``, ``"source"``, or ``"seed"``.
 
     Returns:
         ``(source, table_name)`` tuple or ``None`` if no key applies.
@@ -478,7 +479,9 @@ def _build_catalog_models(
             }
         )
 
-    # Seeds — resource_type == "seed" nodes from manifest
+    # Seeds — resource_type == "seed" nodes from manifest.
+    # Note: seeds don't have dbt tests (test_count=0, always) or status tracking.
+    # Row counts are populated from profiling cache if available.
     for uid, node in manifest.get("nodes", {}).items():
         if node.get("resource_type") != "seed":
             continue
@@ -494,14 +497,14 @@ def _build_catalog_models(
                 "schema": node.get("schema", ""),
                 "materialization": "table",
                 "description": node.get("description", ""),
-                "test_count": 0,
+                "test_count": 0,  # Seeds don't have dbt tests
                 "tests_passing": 0,
                 "tests_warning": 0,
                 "tests_failing": 0,
                 "columns_total": len(columns),
                 "columns_documented": cols_documented,
                 "tags": node.get("tags", []),
-                "last_run": None,
+                "last_run": None,  # Seeds don't have execution status
                 "status": None,
                 "row_count": row_count,
             }

--- a/dango/web/templates/base.html
+++ b/dango/web/templates/base.html
@@ -56,11 +56,11 @@
                     <a href="/models" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'models' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
                         Models
                     </a>
-                    <a href="/schedules" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'schedules' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
-                        Schedules
-                    </a>
                     <a href="/scripts" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'scripts' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
                         Scripts
+                    </a>
+                    <a href="/schedules" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'schedules' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
+                        Schedules
                     </a>
                     <a href="/catalog" class="px-2 py-2 rounded-md text-xs font-medium {% if current_page == 'catalog' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white transition-colors">
                         Catalog
@@ -130,8 +130,8 @@
                 <a href="/" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'overview' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Overview</a>
                 <a href="/sources" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'sources' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Sources</a>
                 <a href="/models" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'models' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Models</a>
-                <a href="/schedules" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'schedules' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Schedules</a>
                 <a href="/scripts" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'scripts' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Scripts</a>
+                <a href="/schedules" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'schedules' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Schedules</a>
                 <a href="/catalog" class="block px-3 py-2 rounded-md text-base font-medium {% if current_page == 'catalog' %}text-white bg-gray-900{% else %}text-gray-300{% endif %} hover:bg-gray-700 hover:text-white">Catalog</a>
                 <a href="/metabase/question#{{ query_hash }}" target="_blank" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Query</a>
                 <a href="/metabase" target="_blank" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white">Dashboards</a>

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -593,6 +593,7 @@ function catalogPage() {
             { key: 'staging', label: 'Staging' },
             { key: 'intermediate', label: 'Intermediate' },
             { key: 'marts', label: 'Marts' },
+            { key: 'seed', label: 'Seeds' },
         ],
 
         metabaseDatabaseId: null,

--- a/tests/integration/test_catalog_integration.py
+++ b/tests/integration/test_catalog_integration.py
@@ -202,6 +202,85 @@ class TestRunProfilingIntegration:
 
 
 @pytest.mark.integration
+class TestSeedProfilingIntegration:
+    """Integration tests for seed profiling via post_sync pipeline."""
+
+    def test_seeds_profiled_by_profile_dbt_models(self, tmp_path: Path) -> None:
+        """Seeds in main schema are profiled by _profile_dbt_models."""
+        _clear_schema_cache()
+        db_path = tmp_path / "data" / "warehouse.duckdb"
+        db_path.parent.mkdir(parents=True)
+
+        # Create seed table in main schema (main schema exists by default)
+        conn = duckdb.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE main.sti_constituents (
+                ticker VARCHAR,
+                name VARCHAR,
+                sector VARCHAR
+            )
+        """)
+        conn.execute("""
+            INSERT INTO main.sti_constituents VALUES
+            ('DBS', 'DBS Group', 'Financials'),
+            ('UOB', 'UOB Group', 'Financials'),
+            ('OCBC', 'OCBC Bank', 'Financials')
+        """)
+        conn.close()
+
+        # Create manifest with seed node
+        manifest = {
+            "nodes": {
+                "seed.proj.sti_constituents": {
+                    "resource_type": "seed",
+                    "name": "sti_constituents",
+                    "schema": "main",
+                    "description": "Singapore stock constituents",
+                    "columns": {
+                        "ticker": {"description": "Stock ticker"},
+                        "name": {"description": "Company name"},
+                        "sector": {"description": "Sector"},
+                    },
+                    "tags": [],
+                },
+            },
+            "sources": {},
+        }
+        manifest_dir = tmp_path / "dbt" / "target"
+        manifest_dir.mkdir(parents=True)
+        manifest_path = manifest_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        # Create run_results.json showing seed executed successfully
+        run_results = {
+            "results": [
+                {
+                    "unique_id": "seed.proj.sti_constituents",
+                    "status": "success",
+                }
+            ]
+        }
+        run_results_path = manifest_dir / "run_results.json"
+        run_results_path.write_text(json.dumps(run_results), encoding="utf-8")
+
+        # Import _profile_dbt_models here to test the profiling filter
+        from dango.utils.post_sync import _profile_dbt_models
+
+        _profile_dbt_models(tmp_path)
+
+        # Verify seed was profiled
+        with connect(tmp_path) as conn:
+            row_count_row = conn.execute(
+                "SELECT stat_value FROM profiling_stats "
+                "WHERE source = 'main' AND table_name = 'sti_constituents' "
+                "AND column_name = '__row_count__'"
+            ).fetchone()
+
+        assert row_count_row is not None, "Seed row count should be cached"
+        assert int(row_count_row[0]) == 3
+
+
+@pytest.mark.integration
 class TestProfilingPerformance:
     """Performance test for profiling a larger table."""
 

--- a/tests/unit/test_catalog_models.py
+++ b/tests/unit/test_catalog_models.py
@@ -248,6 +248,80 @@ class TestListCatalogModels:
     @patch("dango.web.routes.catalog.get_project_root")
     @patch("dango.web.routes.catalog._get_run_results")
     @patch("dango.web.routes.catalog.get_dbt_manifest")
+    def test_seeds_appear_in_models_list(
+        self,
+        mock_manifest: MagicMock,
+        mock_run_results: MagicMock,
+        mock_get_root: MagicMock,
+        mock_helpers_root: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Seeds appear in models list with type='seed' and zero tests."""
+        client, _ = _setup_client(tmp_path)
+        mock_get_root.return_value = tmp_path
+        mock_helpers_root.return_value = tmp_path
+
+        manifest = _make_manifest(
+            models={
+                "model.proj.fct_revenue": {
+                    "name": "fct_revenue",
+                    "schema": "marts",
+                },
+            },
+        )
+        # Manually add seed nodes (not models)
+        manifest["nodes"]["seed.proj.sti_constituents"] = {
+            "resource_type": "seed",
+            "name": "sti_constituents",
+            "schema": "main",
+            "description": "Stock ticker constituents",
+            "columns": {
+                "ticker": {"description": "Ticker symbol"},
+            },
+            "tags": [],
+        }
+        manifest["nodes"]["seed.proj.geo_targets"] = {
+            "resource_type": "seed",
+            "name": "geo_targets",
+            "schema": "main",
+            "description": "",
+            "columns": {},
+            "tags": ["data"],
+        }
+        mock_manifest.return_value = manifest
+        mock_run_results.return_value = None
+
+        resp = client.get("/api/catalog/models")
+        data = resp.json()
+
+        # Check seeds are included
+        assert len(data["models"]) == 3  # 1 model + 2 seeds
+        seed_map = {m["name"]: m for m in data["models"] if m["type"] == "seed"}
+        assert len(seed_map) == 2
+        assert "sti_constituents" in seed_map
+        assert "geo_targets" in seed_map
+
+        # Check seed properties
+        sti_seed = seed_map["sti_constituents"]
+        assert sti_seed["schema"] == "main"
+        assert sti_seed["materialization"] == "table"
+        assert sti_seed["test_count"] == 0
+        assert sti_seed["tests_passing"] == 0
+        assert sti_seed["columns_total"] == 1
+        assert sti_seed["columns_documented"] == 1
+        assert sti_seed["last_run"] is None
+        assert sti_seed["status"] is None
+
+        # Check seed with no columns/description
+        geo_seed = seed_map["geo_targets"]
+        assert geo_seed["columns_total"] == 0
+        assert geo_seed["columns_documented"] == 0
+        assert geo_seed["tags"] == ["data"]
+
+    @patch("dango.web.helpers.get_project_root")
+    @patch("dango.web.routes.catalog.get_project_root")
+    @patch("dango.web.routes.catalog._get_run_results")
+    @patch("dango.web.routes.catalog.get_dbt_manifest")
     def test_test_counts_from_run_results(
         self,
         mock_manifest: MagicMock,
@@ -1312,6 +1386,22 @@ class TestModelProfilingKey:
             ({"name": "orders", "source_name": "shop"}, "source", ("shop", "orders")),
             # source without a source_name has no key
             ({"name": "orders", "source_name": ""}, "source", None),
+            # seeds are keyed by their schema (default "main")
+            ({"name": "sti_constituents", "schema": "main"}, "seed", ("main", "sti_constituents")),
+            # seed with explicit schema
+            (
+                {"name": "clr_constituents", "schema": "custom_schema"},
+                "seed",
+                ("custom_schema", "clr_constituents"),
+            ),
+            # seed without schema defaults to "main"
+            ({"name": "geo_targets"}, "seed", ("main", "geo_targets")),
+            # seed with alias is preferred over name
+            (
+                {"name": "foo", "alias": "sti_constituents", "schema": "main"},
+                "seed",
+                ("main", "sti_constituents"),
+            ),
         ],
     )
     def test_key(


### PR DESCRIPTION
## Summary

- Seeds (sti_constituents, clr_constituents, geo_targets) now appear in catalog with profiling stats and row counts
- Nav bar: Scripts now comes before Schedules (logical flow: Scripts → Schedules since scripts can have schedules)

## Changes

**catalog.py:**
- Added seed branch to _model_profiling_key() — seeds keyed by main schema
- Extended _build_catalog_models() to include seed.* nodes in the models list  
- Updated type_order to place seeds last (staging=0, intermediate=1, marts=2, seed=3)

**post_sync.py:**
- Changed _profile_dbt_models() filter from startswith("model.") to startswith(("model.", "seed."))

**catalog.html:**
- Added Seeds tab to tabs array (all tabs: All, Sources, Staging, Intermediate, Marts, Seeds)

**base.html:**
- Desktop nav: moved Scripts before Schedules
- Mobile nav: moved Scripts before Schedules

**web/CLAUDE.md:**
- Updated nav bar description to reflect new order: Scripts before Schedules

## Verification

- pytest -x: 4069 pass, 30 skip
- ruff check: all pass  
- ruff format: all formatted