### PR TITLE
fix: stdlib logger kwargs crash /api/sources + staleness test coverage

### DIFF
--- a/dango/web/helpers.py
+++ b/dango/web/helpers.py
@@ -111,7 +111,7 @@ def get_dbt_manifest() -> dict[str, Any] | None:
     try:
         manifest_path = get_project_root() / "dbt" / "target" / "manifest.json"
     except RuntimeError:
-        logger.debug("get_dbt_manifest_skipped", reason="project_root not configured")
+        logger.debug("get_dbt_manifest_skipped: project_root not configured")
         return None
 
     if not manifest_path.exists():
@@ -1052,10 +1052,10 @@ async def get_source_status_data(
                 threshold_hours = _get_staleness_threshold_hours(source_name)
             if threshold_hours is not None and hours_since > threshold_hours:
                 logger.info(
-                    "source_marked_stale",
-                    source=source_name,
-                    hours_since_sync=hours_since,
-                    threshold_hours=threshold_hours,
+                    "source_marked_stale: %s (%.1fh since sync, threshold %.1fh)",
+                    source_name,
+                    hours_since,
+                    threshold_hours,
                 )
                 status = "stale"
 

--- a/tests/unit/test_staleness.py
+++ b/tests/unit/test_staleness.py
@@ -204,14 +204,15 @@ class TestBuildStalenessThresholds:
 class TestGetSourceStatusDataStaleness:
     """Tests for get_source_status_data() with stale sources (QG-005)."""
 
-    def test_staleness_branch_no_logger_crash(self):
-        import asyncio
-
+    def test_staleness_branch_no_logger_crash(self, caplog):
         """When source is stale, logger.info is called without stdlib TypeError.
 
         Before fix, this would crash with:
         TypeError: Logger._log() got an unexpected keyword argument 'source'
         """
+        import asyncio
+        import logging
+
         source = {
             "name": "my_source",
             "type": "google_ads",
@@ -220,6 +221,7 @@ class TestGetSourceStatusDataStaleness:
 
         # Mock all the helpers called by get_source_status_data()
         with (
+            caplog.at_level(logging.INFO, logger="dango.web.helpers"),
             patch(
                 "dango.web.helpers.get_source_tables_info",
                 return_value={"total_rows": 100, "has_multiple_tables": False, "tables": []},
@@ -254,3 +256,8 @@ class TestGetSourceStatusDataStaleness:
 
             # Should return stale status without crashing
             assert result.status == "stale"
+            # Verify log message was written correctly
+            assert "source_marked_stale" in caplog.text
+            assert "my_source" in caplog.text
+            assert "50.0h" in caplog.text  # hours_since formatted to 1 decimal
+            assert "24.0h" in caplog.text  # threshold formatted to 1 decimal

--- a/tests/unit/test_staleness.py
+++ b/tests/unit/test_staleness.py
@@ -199,3 +199,58 @@ class TestBuildStalenessThresholds:
 
             result = build_staleness_thresholds()
             assert "src_b" not in result  # not in any schedule
+
+
+class TestGetSourceStatusDataStaleness:
+    """Tests for get_source_status_data() with stale sources (QG-005)."""
+
+    def test_staleness_branch_no_logger_crash(self):
+        import asyncio
+
+        """When source is stale, logger.info is called without stdlib TypeError.
+
+        Before fix, this would crash with:
+        TypeError: Logger._log() got an unexpected keyword argument 'source'
+        """
+        source = {
+            "name": "my_source",
+            "type": "google_ads",
+            "enabled": True,
+        }
+
+        # Mock all the helpers called by get_source_status_data()
+        with (
+            patch(
+                "dango.web.helpers.get_source_tables_info",
+                return_value={"total_rows": 100, "has_multiple_tables": False, "tables": []},
+            ),
+            patch("dango.web.helpers.get_last_sync_time", return_value="2026-08-18T00:00:00"),
+            patch("dango.web.helpers.get_last_sync_status", return_value="success"),
+            patch(
+                "dango.web.helpers.load_sync_history",
+                return_value=[
+                    {
+                        "rows_processed": 100,
+                        "duration_seconds": 5,
+                        "status": "success",
+                        "full_refresh": False,
+                    }
+                ],
+            ),
+            patch("dango.web.helpers.get_source_freshness", return_value={"hours_since_sync": 50}),
+            # Lazy imports from registry
+            patch("dango.ingestion.sources.registry.get_source_capabilities", return_value=None),
+            patch("dango.ingestion.sources.registry.get_source_metadata", return_value=None),
+        ):
+            from dango.web.helpers import get_source_status_data
+
+            # With hours_since_sync=50 and threshold=24, this triggers the staleness branch
+            result = asyncio.run(
+                get_source_status_data(
+                    source,
+                    staleness_thresholds={"my_source": 24.0},
+                )
+            )
+
+            # Should return stale status without crashing
+            assert result.status == "stale"


### PR DESCRIPTION
Fix two stdlib logger calls in helpers.py that rejected structlog-style kwargs. Add unit test for staleness branch.