### PR TITLE
backport: cherry-pick PR #408 UI consistency onto v1.0.7

### DIFF
--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -52,6 +52,68 @@ let modelSortDirection = localStorage.getItem('dango-models-sort-direction') || 
 let modelFilterText = localStorage.getItem('dango-models-filter') || '';
 
 /**
+ * Shared table sort utility for Alpine.js components. Returns properties
+ * and methods to spread into a component's data object.
+ *
+ * config: {
+ *   storageKey: string,          // localStorage key (single JSON object)
+ *   defaultSortField: string,    // initial sort field
+ *   defaultSortDir: 'asc'|'desc',
+ *   filterFields: string[],      // item fields to match against filterText
+ * }
+ */
+function createTableSorter(config) {
+    const stored = JSON.parse(localStorage.getItem(config.storageKey) || '{}');
+    return {
+        sortField: stored.sortField || config.defaultSortField,
+        sortDir: stored.sortDir || config.defaultSortDir,
+        filterText: '',
+
+        toggleSort(field) {
+            if (this.sortField === field) {
+                if (this.sortDir === 'asc') this.sortDir = 'desc';
+                else { this.sortField = config.defaultSortField; this.sortDir = 'asc'; }
+            } else {
+                this.sortField = field;
+                this.sortDir = 'asc';
+            }
+            localStorage.setItem(config.storageKey, JSON.stringify({
+                sortField: this.sortField,
+                sortDir: this.sortDir,
+            }));
+        },
+
+        sortArrow(field) {
+            if (this.sortField !== field) return '';
+            return this.sortDir === 'asc' ? ' ▲' : ' ▼';
+        },
+
+        matchesFilter(item) {
+            if (!this.filterText) return true;
+            const q = this.filterText.toLowerCase();
+            return config.filterFields.some(f => {
+                const val = (item[f] || '').toString().toLowerCase();
+                return val.includes(q);
+            });
+        },
+
+        applySort(items) {
+            return [...items].sort((a, b) => {
+                const av = (a[this.sortField] ?? '');
+                const bv = (b[this.sortField] ?? '');
+                if (av == null && bv == null) return 0;
+                if (av == null) return 1;
+                if (bv == null) return -1;
+                const cmp = typeof av === 'number'
+                    ? av - bv
+                    : String(av).toLowerCase().localeCompare(String(bv).toLowerCase());
+                return this.sortDir === 'asc' ? cmp : -cmp;
+            });
+        },
+    };
+}
+
+/**
  * Format a file size in bytes to a human-readable string (B/KB/MB/GB).
  * @param {number} bytes - Size in bytes
  * @returns {string} Formatted size string

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -72,17 +72,19 @@ function createTableSorter(config) {
     if (!stored.sortField) {
         const oldFieldKey = config.storageKey.replace('-sort', '-sort-column');
         const oldDirKey = config.storageKey.replace('-sort', '-sort-direction');
+        const oldFilterKey = config.storageKey.replace('-sort', '-filter');
         const oldField = localStorage.getItem(oldFieldKey);
         const oldDir = localStorage.getItem(oldDirKey);
         if (oldField) {
             stored.sortField = oldField;
             stored.sortDir = oldDir || config.defaultSortDir;
-            // Clean up old keys
-            localStorage.removeItem(oldFieldKey);
-            localStorage.removeItem(oldDirKey);
             // Save in new format
             localStorage.setItem(config.storageKey, JSON.stringify(stored));
         }
+        // Clean up all old keys (sort column, sort direction, filter)
+        localStorage.removeItem(oldFieldKey);
+        localStorage.removeItem(oldDirKey);
+        localStorage.removeItem(oldFilterKey);
     }
 
     return {

--- a/dango/web/static/js/app.js
+++ b/dango/web/static/js/app.js
@@ -61,12 +61,33 @@ let modelFilterText = localStorage.getItem('dango-models-filter') || '';
  *   defaultSortDir: 'asc'|'desc',
  *   filterFields: string[],      // item fields to match against filterText
  * }
+ *
+ * Migration: Automatically migrates old two-key format (column + direction)
+ * to new single-key JSON format for seamless upgrades.
  */
 function createTableSorter(config) {
-    const stored = JSON.parse(localStorage.getItem(config.storageKey) || '{}');
+    let stored = JSON.parse(localStorage.getItem(config.storageKey) || '{}');
+
+    // Migrate from old two-key format to new single-key format
+    if (!stored.sortField) {
+        const oldFieldKey = config.storageKey.replace('-sort', '-sort-column');
+        const oldDirKey = config.storageKey.replace('-sort', '-sort-direction');
+        const oldField = localStorage.getItem(oldFieldKey);
+        const oldDir = localStorage.getItem(oldDirKey);
+        if (oldField) {
+            stored.sortField = oldField;
+            stored.sortDir = oldDir || config.defaultSortDir;
+            // Clean up old keys
+            localStorage.removeItem(oldFieldKey);
+            localStorage.removeItem(oldDirKey);
+            // Save in new format
+            localStorage.setItem(config.storageKey, JSON.stringify(stored));
+        }
+    }
+
     return {
-        sortField: stored.sortField || config.defaultSortField,
-        sortDir: stored.sortDir || config.defaultSortDir,
+        sortField: stored.sortField ?? config.defaultSortField,
+        sortDir: stored.sortDir ?? config.defaultSortDir,
         filterText: '',
 
         toggleSort(field) {
@@ -92,22 +113,8 @@ function createTableSorter(config) {
             if (!this.filterText) return true;
             const q = this.filterText.toLowerCase();
             return config.filterFields.some(f => {
-                const val = (item[f] || '').toString().toLowerCase();
+                const val = (item[f] ?? '').toString().toLowerCase();
                 return val.includes(q);
-            });
-        },
-
-        applySort(items) {
-            return [...items].sort((a, b) => {
-                const av = (a[this.sortField] ?? '');
-                const bv = (b[this.sortField] ?? '');
-                if (av == null && bv == null) return 0;
-                if (av == null) return 1;
-                if (bv == null) return -1;
-                const cmp = typeof av === 'number'
-                    ? av - bv
-                    : String(av).toLowerCase().localeCompare(String(bv).toLowerCase());
-                return this.sortDir === 'asc' ? cmp : -cmp;
             });
         },
     };

--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -180,34 +180,34 @@
                                 <table class="min-w-full divide-y divide-gray-200">
                                     <thead class="bg-gray-50">
                                         <tr>
-                                            <th @click="toggleCatalogSort('name')"
+                                            <th @click="toggleSort('name')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
-                                                Name<template x-if="sortColumn === 'name'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                                Name<span x-text="sortArrow('name')"></span>
                                             </th>
-                                            <th @click="toggleCatalogSort('type')"
+                                            <th @click="toggleSort('type')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
-                                                Type<template x-if="sortColumn === 'type'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                                Type<span x-text="sortArrow('type')"></span>
                                             </th>
                                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">Rows</th>
-                                            <th @click="toggleCatalogSort('description')"
+                                            <th @click="toggleSort('description')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
-                                                Description<template x-if="sortColumn === 'description'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                                Description<span x-text="sortArrow('description')"></span>
                                             </th>
-                                            <th @click="toggleCatalogSort('tests')"
+                                            <th @click="toggleSort('tests')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden md:table-cell">
-                                                Tests<template x-if="sortColumn === 'tests'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                                Tests<span x-text="sortArrow('tests')"></span>
                                             </th>
-                                            <th @click="toggleCatalogSort('last_updated')"
+                                            <th @click="toggleSort('last_updated')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden md:table-cell">
-                                                Last Updated<template x-if="sortColumn === 'last_updated'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                                Last Updated<span x-text="sortArrow('last_updated')"></span>
                                             </th>
-                                            <th @click="toggleCatalogSort('documented')"
+                                            <th @click="toggleSort('documented')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden md:table-cell">
-                                                Documented<template x-if="sortColumn === 'documented'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                                Documented<span x-text="sortArrow('documented')"></span>
                                             </th>
-                                            <th @click="toggleCatalogSort('tags')"
+                                            <th @click="toggleSort('tags')"
                                                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden lg:table-cell">
-                                                Tags<template x-if="sortColumn === 'tags'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                                                Tags<span x-text="sortArrow('tags')"></span>
                                             </th>
                                         </tr>
                                     </thead>
@@ -583,9 +583,6 @@ function catalogPage() {
         // Guard flag: suppresses pushState during URL restoration and popstate
         // handling to prevent feedback loops (restoreFromUrl → openModel → updateUrl).
         _skipPush: false,
-        // Sort state
-        sortColumn: localStorage.getItem('dango-catalog-sort-column') || 'name',
-        sortDirection: localStorage.getItem('dango-catalog-sort-direction') || 'asc',
         // Tab config
         tabs: [
             { key: 'all', label: 'All' },
@@ -598,6 +595,14 @@ function catalogPage() {
 
         metabaseDatabaseId: null,
         metabaseTableMap: {},
+
+        // Sort state
+        ...createTableSorter({
+            storageKey: 'dango-catalog-sort',
+            defaultSortField: 'name',
+            defaultSortDir: 'asc',
+            filterFields: [],
+        }),
 
         metabaseQueryUrl() {
             if (!this.selectedModel?.schema || !this.selectedModel?.name || !this.metabaseDatabaseId) return '/metabase/';
@@ -766,9 +771,9 @@ function catalogPage() {
 
         get sortedFilteredItems() {
             let items = this.filteredItems;
-            if (this.sortColumn && this.sortDirection && this.sortDirection !== 'none') {
-                const dir = this.sortDirection === 'desc' ? -1 : 1;
-                const col = this.sortColumn;
+            if (this.sortField && this.sortDir && this.sortDir !== 'none') {
+                const dir = this.sortDir === 'desc' ? -1 : 1;
+                const col = this.sortField;
                 items = [...items].sort((a, b) => {
                     const va = this._resolveCatalogField(a, col);
                     const vb = this._resolveCatalogField(b, col);
@@ -795,19 +800,6 @@ function catalogPage() {
                 case 'tags': return (item.tags && item.tags.length > 0) ? item.tags[0] : '';
                 default: return undefined;
             }
-        },
-
-        toggleCatalogSort(col) {
-            if (this.sortColumn === col) {
-                if (this.sortDirection === 'asc') this.sortDirection = 'desc';
-                else if (this.sortDirection === 'desc') { this.sortColumn = 'name'; this.sortDirection = 'asc'; }
-                else this.sortDirection = 'asc';
-            } else {
-                this.sortColumn = col;
-                this.sortDirection = 'asc';
-            }
-            localStorage.setItem('dango-catalog-sort-column', this.sortColumn || '');
-            localStorage.setItem('dango-catalog-sort-direction', this.sortDirection || '');
         },
 
         tabCount(key) {

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -37,28 +37,28 @@
                     <tr>
                         <th @click="toggleSort('name')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
-                            Name<template x-if="sortColumn === 'name'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Name<span x-text="sortArrow('name')"></span>
                         </th>
                         <th @click="toggleSort('type')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
-                            Type<template x-if="sortColumn === 'type'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Type<span x-text="sortArrow('type')"></span>
                         </th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">Sources</th>
                         <th @click="toggleSort('cron')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
-                            Cron<template x-if="sortColumn === 'cron'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Cron<span x-text="sortArrow('cron')"></span>
                         </th>
                         <th @click="toggleSort('next_run')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden lg:table-cell">
-                            Next Run<template x-if="sortColumn === 'next_run'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Next Run<span x-text="sortArrow('next_run')"></span>
                         </th>
                         <th @click="toggleSort('status')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
-                            Status<template x-if="sortColumn === 'status'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Status<span x-text="sortArrow('status')"></span>
                         </th>
                         <th @click="toggleSort('enabled')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
-                            Enabled<template x-if="sortColumn === 'enabled'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Enabled<span x-text="sortArrow('enabled')"></span>
                         </th>
                         <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
@@ -320,9 +320,12 @@ function schedulesPage() {
         pollInterval: null,
 
         // Sort/filter state
-        sortColumn: localStorage.getItem('dango-schedules-sort-column') || 'name',
-        sortDirection: localStorage.getItem('dango-schedules-sort-direction') || 'asc',
-        filterText: localStorage.getItem('dango-schedules-filter') || '',
+        ...createTableSorter({
+            storageKey: 'dango-schedules-sort',
+            defaultSortField: 'name',
+            defaultSortDir: 'asc',
+            filterFields: ['name', 'type', 'cron'],
+        }),
 
         async init() {
             await Promise.all([
@@ -331,25 +334,15 @@ function schedulesPage() {
                 this.loadNotifConfig()
             ]);
             this.connectWebSocket();
-            this.$watch('filterText', val => {
-                localStorage.setItem('dango-schedules-filter', val || '');
-            });
         },
 
         // --- Sort/filter ---
         get sortedSchedules() {
-            let items = this.filterText
-                ? this.schedules.filter(s => {
-                    const q = this.filterText.toLowerCase();
-                    return (s.name && s.name.toLowerCase().includes(q))
-                        || (s.type && s.type.toLowerCase().includes(q))
-                        || (s.cron && s.cron.toLowerCase().includes(q));
-                  })
-                : [...this.schedules];
+            let items = this.schedules.filter(s => this.matchesFilter(s));
 
-            if (this.sortColumn && this.sortDirection && this.sortDirection !== 'none') {
-                const dir = this.sortDirection === 'desc' ? -1 : 1;
-                const col = this.sortColumn;
+            if (this.sortField) {
+                const dir = this.sortDir === 'desc' ? -1 : 1;
+                const col = this.sortField;
                 items.sort((a, b) => {
                     const va = this._resolveScheduleField(a, col);
                     const vb = this._resolveScheduleField(b, col);
@@ -381,19 +374,6 @@ function schedulesPage() {
                 case 'enabled': return sched.enabled ? 1 : 0;
                 default: return undefined;
             }
-        },
-
-        toggleSort(col) {
-            if (this.sortColumn === col) {
-                if (this.sortDirection === 'asc') this.sortDirection = 'desc';
-                else if (this.sortDirection === 'desc') { this.sortColumn = 'name'; this.sortDirection = 'asc'; }
-                else this.sortDirection = 'asc';
-            } else {
-                this.sortColumn = col;
-                this.sortDirection = 'asc';
-            }
-            localStorage.setItem('dango-schedules-sort-column', this.sortColumn || '');
-            localStorage.setItem('dango-schedules-sort-direction', this.sortDirection || '');
         },
 
         // --- Data loading ---

--- a/dango/web/templates/scripts.html
+++ b/dango/web/templates/scripts.html
@@ -35,21 +35,21 @@
             <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
                     <tr>
-                        <th @click="toggleScriptSort('name')"
+                        <th @click="toggleSort('name')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
-                            Script<template x-if="sortColumn === 'name'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Script<span x-text="sortArrow('name')"></span>
                         </th>
-                        <th @click="toggleScriptSort('last_run')"
+                        <th @click="toggleSort('last_run')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
-                            Last Run<template x-if="sortColumn === 'last_run'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Last Run<span x-text="sortArrow('last_run')"></span>
                         </th>
-                        <th @click="toggleScriptSort('status')"
+                        <th @click="toggleSort('status')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700">
-                            Status<template x-if="sortColumn === 'status'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Status<span x-text="sortArrow('status')"></span>
                         </th>
-                        <th @click="toggleScriptSort('schedule')"
+                        <th @click="toggleSort('schedule')"
                             class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:text-gray-700 hidden sm:table-cell">
-                            Schedule<template x-if="sortColumn === 'schedule'"><span x-text="sortDirection === 'asc' ? ' ▲' : ' ▼'"></span></template>
+                            Schedule<span x-text="sortArrow('schedule')"></span>
                         </th>
                         <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
@@ -174,30 +174,25 @@ function scriptsPage() {
         reconnectInterval: null,
 
         // Sort/filter state
-        sortColumn: localStorage.getItem('dango-scripts-sort-column') || 'name',
-        sortDirection: localStorage.getItem('dango-scripts-sort-direction') || 'asc',
-        filterText: localStorage.getItem('dango-scripts-filter') || '',
+        ...createTableSorter({
+            storageKey: 'dango-scripts-sort',
+            defaultSortField: 'name',
+            defaultSortDir: 'asc',
+            filterFields: ['name'],
+        }),
 
         async init() {
             await this.loadScripts();
             this.connectWebSocket();
-            this.$watch('filterText', val => {
-                localStorage.setItem('dango-scripts-filter', val || '');
-            });
         },
 
         // --- Sort/filter ---
         get sortedScripts() {
-            let items = this.filterText
-                ? this.scripts.filter(s => {
-                    const q = this.filterText.toLowerCase();
-                    return (s.name && s.name.toLowerCase().includes(q));
-                  })
-                : [...this.scripts];
+            let items = this.scripts.filter(s => this.matchesFilter(s));
 
-            if (this.sortColumn && this.sortDirection && this.sortDirection !== 'none') {
-                const dir = this.sortDirection === 'desc' ? -1 : 1;
-                const col = this.sortColumn;
+            if (this.sortField) {
+                const dir = this.sortDir === 'desc' ? -1 : 1;
+                const col = this.sortField;
                 items.sort((a, b) => {
                     const va = this._resolveScriptField(a, col);
                     const vb = this._resolveScriptField(b, col);
@@ -227,19 +222,6 @@ function scriptsPage() {
                 case 'schedule': return null;
                 default: return undefined;
             }
-        },
-
-        toggleScriptSort(col) {
-            if (this.sortColumn === col) {
-                if (this.sortDirection === 'asc') this.sortDirection = 'desc';
-                else if (this.sortDirection === 'desc') { this.sortColumn = 'name'; this.sortDirection = 'asc'; }
-                else this.sortDirection = 'asc';
-            } else {
-                this.sortColumn = col;
-                this.sortDirection = 'asc';
-            }
-            localStorage.setItem('dango-scripts-sort-column', this.sortColumn || '');
-            localStorage.setItem('dango-scripts-sort-direction', this.sortDirection || '');
         },
 
         // --- Data loading ---


### PR DESCRIPTION
PR #408 (createTableSorter) was accidentally merged to main instead of v1.0.7. Cherry-picks the 3 commits so session 8 (catalog extraction) has the changes it depends on.