### PR TITLE
1.0.7-1: Model wizard table selection + CTE scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/users.py` | 540 | — (admin user CRUD + invite) |
 | `platform/local/watcher.py` | 524 | — |
 | `cli/commands/schedule.py` | 914 | — (schedule wizard + time customization) |
-| `cli/model_wizard.py` | 507 | — |
+| `cli/model_wizard.py` | 547 | — |
 | `cli/commands/remote_backup.py` | 521 | — (R2-D10: --from-local flag) |
 | `platform/cloud/scheduled_backup.py` | 606 | — (server-side scheduled backup) |
 | `governance/schema_drift.py` | 654 | — (R9-D: breaking drift protection + accept flow) |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -50,7 +50,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `init.py` (1496 lines) | Project initialization wizard | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2525 lines) | Source configuration wizard | `add_source()` |
-| `model_wizard.py` (507 lines) | dbt model creation wizard | `add_model()` |
+| `model_wizard.py` (547 lines) | dbt model creation wizard | `add_model()` |
 | **Helpers** | | |
 | `utils.py` (164 lines) | Display helpers + project context | `require_project_context()` |
 | `validate.py` (787 lines) | Project validation logic | `validate_project()` |

--- a/dango/cli/model_wizard.py
+++ b/dango/cli/model_wizard.py
@@ -289,6 +289,81 @@ class ModelWizard:
 
         return None
 
+    def _get_available_tables(self, layer_filter: str | None = None) -> list[dict[str, str]]:
+        """Return existing dbt models grouped by layer, for upstream selection.
+
+        Each entry: {"name": "stg_stripe_customers", "layer": "staging", "source": "stripe"}.
+        "source" is only populated for staging tables (derived from the stg_<source>_ prefix).
+        """
+        tables: list[dict[str, str]] = []
+
+        def scan_dir(d: Path, layer: str) -> None:
+            """Scan directory for SQL model files."""
+            if not d.exists():
+                return
+            for f in sorted(d.glob("*.sql")):
+                name = f.stem
+                source = ""
+                if layer == "staging" and name.startswith("stg_"):
+                    parts = name.split("_")
+                    source = parts[1] if len(parts) > 2 else ""
+                tables.append({"name": name, "layer": layer, "source": source})
+
+        if layer_filter is None or layer_filter == "staging":
+            scan_dir(self.models_dir / "staging", "staging")
+        if layer_filter is None or layer_filter == "intermediate":
+            scan_dir(self.models_dir / "intermediate", "intermediate")
+        if layer_filter is None or layer_filter == "marts":
+            scan_dir(self.models_dir / "marts", "marts")
+        return tables
+
+    def _ask_upstream_tables(self, model_layer: str) -> list[str]:
+        """Interactive loop: ask user to pick upstream tables one at a time.
+
+        Returns selected table names in pick order (empty = skip → placeholder SQL).
+        Intermediate models only see staging tables; marts models see all layers.
+        """
+        from rich.prompt import Confirm
+
+        layer_filter = "staging" if model_layer == "intermediate" else None
+        tables = self._get_available_tables(layer_filter=layer_filter)
+        if not tables:
+            return []
+
+        selected: list[str] = []
+
+        while True:
+            remaining = [t for t in tables if t["name"] not in selected]
+            if not remaining:
+                break
+
+            choices = [("(skip — generate placeholder instead)", "__skip__")]
+            for t in remaining:
+                label = t["name"]
+                if t["source"]:
+                    label += f" ({t['layer']}/{t['source']})"
+                else:
+                    label += f" ({t['layer']})"
+                choices.append((label, t["name"]))
+
+            questions = [
+                inquirer.List("table", message="Select an upstream table", choices=choices)
+            ]
+            answers = inquirer.prompt(questions)
+            if not answers:
+                break  # Ctrl-C
+
+            result = answers.get("table")
+            if result == "__skip__":
+                break
+
+            selected.append(result)
+
+            if not Confirm.ask("Add another table?", default=False):
+                break
+
+        return selected
+
     def _create_model_file(
         self, layer: str, name: str, description: str, materialization: str
     ) -> Path | None:
@@ -336,9 +411,16 @@ class ModelWizard:
             )
             return None
 
+        # Ask user to select upstream tables
+        upstream_tables = self._ask_upstream_tables(layer)
+
         # Generate SQL content
         sql_content = self._generate_sql_template(
-            layer=layer, name=name, description=description, materialization=materialization
+            layer=layer,
+            name=name,
+            description=description,
+            materialization=materialization,
+            upstream_tables=upstream_tables,
         )
 
         # Write file
@@ -348,7 +430,12 @@ class ModelWizard:
         return model_path
 
     def _generate_sql_template(
-        self, layer: str, name: str, description: str, materialization: str
+        self,
+        layer: str,
+        name: str,
+        description: str,
+        materialization: str,
+        upstream_tables: list[str] | None = None,
     ) -> str:
         """
         Generate SQL template content with comprehensive documentation
@@ -383,80 +470,26 @@ class ModelWizard:
         lines.append(") }}")
         lines.append("")
 
-        # Comprehensive reference guide
-        lines.append("-- " + "=" * 76)
-        lines.append("-- HOW TO REFERENCE TABLES IN dbt")
-        lines.append("-- " + "=" * 76)
-        lines.append("--")
-        lines.append("-- 1. STAGING MODELS (auto-generated, in staging schema)")
-        lines.append("--    {# {{ ref('stg_source_name') }} #}")
-        lines.append("--    Example: FROM {# {{ ref('stg_stripe_customers') }} #}")
-        lines.append("--")
-        lines.append("--    These are auto-generated from your data sources.")
-        lines.append("--    List available: dango models list")
-        lines.append("--")
-        lines.append("-- 2. INTERMEDIATE MODELS (in intermediate schema)")
-        lines.append("--    {# {{ ref('int_model_name') }} #}")
-        lines.append("--    Example: FROM {# {{ ref('int_customer_orders') }} #}")
-        lines.append("--")
-        lines.append("--    These are building blocks you create for reusable logic.")
-        lines.append("--")
-        lines.append("-- 3. MARTS MODELS (in marts schema, no prefix)")
-        lines.append("--    {# {{ ref('model_name') }} #}")
-        lines.append("--    Example: FROM {# {{ ref('customer_revenue') }} #}")
-        lines.append("--")
-        lines.append("--    These are final business tables for reporting/dashboards.")
-        lines.append("--")
-        lines.append("-- 4. EXTERNAL CSV DATA (dbt seeds)")
-        lines.append("--    {# {{ ref('seed_name') }} #}")
-        lines.append("--    1. Add the file:   dango seed add path/to/data.csv")
-        lines.append("--    2. Reference it:   {# {{ ref('data') }} #}")
-        lines.append(
-            "--    (Do NOT use read_csv_auto('/absolute/path') — it breaks on other machines/cloud.)"
-        )
-        lines.append("--")
-        lines.append("-- " + "=" * 76)
-        lines.append("-- COMMON PATTERNS")
-        lines.append("-- " + "=" * 76)
-        lines.append("--")
-        lines.append("-- PATTERN 1: Simple transformation (intermediate layer)")
-        lines.append("-- SELECT")
-        lines.append("--     customer_id,")
-        lines.append("--     UPPER(customer_name) AS customer_name,")
-        lines.append("--     total_orders")
-        lines.append("-- FROM {# {{ ref('stg_customers') }} #}")
-        lines.append("--")
-        lines.append("-- PATTERN 2: Join multiple tables (intermediate or marts layer)")
-        lines.append("-- SELECT")
-        lines.append("--     c.customer_id,")
-        lines.append("--     c.customer_name,")
-        lines.append("--     COUNT(o.order_id) AS order_count,")
-        lines.append("--     SUM(o.amount) AS total_revenue")
-        lines.append("-- FROM {# {{ ref('stg_customers') }} #} c")
-        lines.append("-- LEFT JOIN {# {{ ref('stg_orders') }} #} o")
-        lines.append("--     ON c.customer_id = o.customer_id")
-        lines.append("-- GROUP BY 1, 2")
-        lines.append("--")
-        lines.append("-- PATTERN 3: Build on intermediate models (marts layer)")
-        lines.append("-- SELECT")
-        lines.append("--     co.customer_id,")
-        lines.append("--     co.customer_name,")
-        lines.append("--     co.order_count,")
-        lines.append("--     cr.total_revenue,")
-        lines.append("--     cr.avg_order_value")
-        lines.append("-- FROM {# {{ ref('int_customer_orders') }} #} co")
-        lines.append("-- LEFT JOIN {# {{ ref('int_customer_revenue') }} #} cr")
-        lines.append("--     ON co.customer_id = cr.customer_id")
-        lines.append("--")
-        lines.append("-- " + "=" * 76)
-        lines.append("-- YOUR SQL STARTS HERE")
-        lines.append("-- " + "=" * 76)
-        lines.append("")
-        lines.append("-- Replace this placeholder query with your actual transformation")
-        lines.append("SELECT 1 as placeholder")
-        lines.append("    -- Example transformations:")
-        lines.append("    -- SELECT * FROM {{ ref('stg_customers') }}")
-        lines.append("    -- SELECT * FROM {{ ref('int_customer_orders') }}")
+        if upstream_tables:
+            lines.append("")
+            for i, table in enumerate(upstream_tables):
+                parts = table.split("_")
+                alias = parts[-1] if len(parts) > 1 else table
+                comma = "," if i < len(upstream_tables) - 1 else ""
+                lines.append(f"WITH {alias} AS (" if i == 0 else f"{alias} AS (")
+                lines.append(f"    SELECT * FROM {{{{ ref('{table}') }}}}")
+                lines.append(f"){comma}")
+            lines.append("")
+            lines.append("SELECT")
+            lines.append("    -- TODO: Define your transformation here")
+            first_alias = upstream_tables[0].split("_")[-1]
+            lines.append(f"    {first_alias}.*")
+            lines.append(f"FROM {first_alias}")
+        else:
+            lines.append("")
+            lines.append("SELECT")
+            lines.append("    -- TODO: Define your transformation here")
+            lines.append("    1 AS placeholder")
 
         return "\n".join(lines) + "\n"
 

--- a/dango/cli/model_wizard.py
+++ b/dango/cli/model_wizard.py
@@ -472,9 +472,18 @@ class ModelWizard:
 
         if upstream_tables:
             lines.append("")
-            for i, table in enumerate(upstream_tables):
+            # Derive aliases, handling collisions
+            aliases: list[str] = []
+            for table in upstream_tables:
                 parts = table.split("_")
                 alias = parts[-1] if len(parts) > 1 else table
+                # Fall back to full table name if alias already used
+                if alias in aliases:
+                    alias = table
+                aliases.append(alias)
+
+            # Generate CTE block with resolved aliases
+            for i, (table, alias) in enumerate(zip(upstream_tables, aliases, strict=True)):
                 comma = "," if i < len(upstream_tables) - 1 else ""
                 lines.append(f"WITH {alias} AS (" if i == 0 else f"{alias} AS (")
                 lines.append(f"    SELECT * FROM {{{{ ref('{table}') }}}}")
@@ -482,9 +491,8 @@ class ModelWizard:
             lines.append("")
             lines.append("SELECT")
             lines.append("    -- TODO: Define your transformation here")
-            first_alias = upstream_tables[0].split("_")[-1]
-            lines.append(f"    {first_alias}.*")
-            lines.append(f"FROM {first_alias}")
+            lines.append(f"    {aliases[0]}.*")
+            lines.append(f"FROM {aliases[0]}")
         else:
             lines.append("")
             lines.append("SELECT")

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -234,9 +234,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/model_wizard.py
-    lines: 507
+    lines: 547
     category: exempt
-    reason: "Interactive dbt model creation wizard. Sequential prompting, stable."
+    reason: "Interactive dbt model creation wizard. Sequential prompting, stable. 1.0.7-1: Added table selection + CTE scaffold generation."
     review_by: "v1.1"
 
 # Removed: dango/platform/network.py — now 486 lines, within limit (TASK-088)

--- a/tests/unit/test_model_wizard.py
+++ b/tests/unit/test_model_wizard.py
@@ -1,0 +1,215 @@
+"""tests/unit/test_model_wizard.py
+
+Tests for dbt model wizard.
+"""
+
+import pytest
+
+from dango.cli.model_wizard import ModelWizard
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    """Create a minimal valid project structure for ModelWizard"""
+    dango_dir = tmp_path / ".dango"
+    dango_dir.mkdir()
+    (dango_dir / "project.yml").write_text(
+        "project:\n  name: test\n  created_by: test\n  purpose: test project\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def project_with_models(project_root):
+    """Create a project with sample dbt models"""
+    models_dir = project_root / "dbt" / "models"
+
+    # Create staging models
+    staging_dir = models_dir / "staging"
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    (staging_dir / "stg_stripe_customers.sql").write_text("SELECT 1")
+    (staging_dir / "stg_stripe_orders.sql").write_text("SELECT 1")
+    (staging_dir / "stg_github_repos.sql").write_text("SELECT 1")
+
+    # Create intermediate models
+    intermediate_dir = models_dir / "intermediate"
+    intermediate_dir.mkdir(parents=True, exist_ok=True)
+    (intermediate_dir / "int_customer_summary.sql").write_text("SELECT 1")
+
+    # Create marts models
+    marts_dir = models_dir / "marts"
+    marts_dir.mkdir(parents=True, exist_ok=True)
+    (marts_dir / "customers.sql").write_text("SELECT 1")
+
+    return project_root
+
+
+def test_generate_sql_template_with_upstream_tables(project_root):
+    """Test SQL generation with multiple upstream tables"""
+    wizard = ModelWizard(project_root)
+
+    sql = wizard._generate_sql_template(
+        layer="intermediate",
+        name="int_test.sql",
+        description="Test model",
+        materialization="table",
+        upstream_tables=["stg_stripe_customers", "stg_stripe_orders"],
+    )
+
+    # Check header
+    assert "-- int_test" in sql
+    assert "-- Test model" in sql
+
+    # Check config block
+    assert "{{ config(" in sql
+    assert "materialized='table'" in sql
+    assert "schema='intermediate'" in sql
+
+    # Check CTE structure
+    assert "WITH customers AS (" in sql
+    assert "orders AS (" in sql
+    assert "{{ ref('stg_stripe_customers') }}" in sql
+    assert "{{ ref('stg_stripe_orders') }}" in sql
+
+    # Check final SELECT
+    assert "SELECT" in sql
+    assert "customers.*" in sql
+    assert "FROM customers" in sql
+
+    # Ensure no placeholder
+    assert "1 AS placeholder" not in sql
+
+
+def test_generate_sql_template_no_upstream_tables_none(project_root):
+    """Test SQL generation with upstream_tables=None produces placeholder"""
+    wizard = ModelWizard(project_root)
+
+    sql = wizard._generate_sql_template(
+        layer="marts",
+        name="customer_revenue.sql",
+        description="",
+        materialization="table",
+        upstream_tables=None,
+    )
+
+    # Check placeholder is present
+    assert "1 AS placeholder" in sql
+
+    # Check no CTE structure
+    assert "WITH" not in sql
+    assert "{{ ref(" not in sql
+
+
+def test_generate_sql_template_no_upstream_tables_empty_list(project_root):
+    """Test SQL generation with empty upstream_tables list produces placeholder"""
+    wizard = ModelWizard(project_root)
+
+    sql = wizard._generate_sql_template(
+        layer="intermediate",
+        name="int_test.sql",
+        description="",
+        materialization="table",
+        upstream_tables=[],
+    )
+
+    # Check placeholder is present
+    assert "1 AS placeholder" in sql
+
+    # Check no CTE structure
+    assert "WITH" not in sql
+    assert "{{ ref(" not in sql
+
+
+def test_get_available_tables_empty_project(project_root):
+    """Test _get_available_tables returns empty list for project with no models"""
+    wizard = ModelWizard(project_root)
+    tables = wizard._get_available_tables()
+
+    assert tables == []
+
+
+def test_get_available_tables_populates_source(project_with_models):
+    """Test _get_available_tables correctly extracts source name for staging tables"""
+    wizard = ModelWizard(project_with_models)
+    tables = wizard._get_available_tables(layer_filter="staging")
+
+    assert len(tables) == 3
+
+    # Find stg_stripe_customers
+    stripe_customers = next(t for t in tables if t["name"] == "stg_stripe_customers")
+    assert stripe_customers["layer"] == "staging"
+    assert stripe_customers["source"] == "stripe"
+
+    # Find stg_github_repos
+    github_repos = next(t for t in tables if t["name"] == "stg_github_repos")
+    assert github_repos["layer"] == "staging"
+    assert github_repos["source"] == "github"
+
+
+def test_get_available_tables_all_layers(project_with_models):
+    """Test _get_available_tables returns models from all layers when no filter"""
+    wizard = ModelWizard(project_with_models)
+    tables = wizard._get_available_tables()
+
+    # Should have: 3 staging + 1 intermediate + 1 marts = 5 total
+    assert len(tables) == 5
+
+    layers = [t["layer"] for t in tables]
+    assert "staging" in layers
+    assert "intermediate" in layers
+    assert "marts" in layers
+
+
+def test_get_available_tables_layer_filter_staging(project_with_models):
+    """Test _get_available_tables respects layer_filter for staging"""
+    wizard = ModelWizard(project_with_models)
+    tables = wizard._get_available_tables(layer_filter="staging")
+
+    assert len(tables) == 3
+    assert all(t["layer"] == "staging" for t in tables)
+
+
+def test_get_available_tables_layer_filter_intermediate(project_with_models):
+    """Test _get_available_tables respects layer_filter for intermediate"""
+    wizard = ModelWizard(project_with_models)
+    tables = wizard._get_available_tables(layer_filter="intermediate")
+
+    assert len(tables) == 1
+    assert tables[0]["name"] == "int_customer_summary"
+    assert tables[0]["layer"] == "intermediate"
+
+
+def test_alias_derivation_single_table(project_root):
+    """Test that table name alias is correctly extracted from last component"""
+    wizard = ModelWizard(project_root)
+
+    sql = wizard._generate_sql_template(
+        layer="intermediate",
+        name="int_test.sql",
+        description="",
+        materialization="table",
+        upstream_tables=["stg_stripe_customers"],
+    )
+
+    # Verify the alias "customers" appears in the WITH clause
+    assert "WITH customers AS (" in sql
+    assert "FROM customers" in sql
+
+
+def test_alias_derivation_multiple_tables(project_root):
+    """Test that aliases are correctly extracted for multiple tables"""
+    wizard = ModelWizard(project_root)
+
+    sql = wizard._generate_sql_template(
+        layer="intermediate",
+        name="int_test.sql",
+        description="",
+        materialization="table",
+        upstream_tables=["stg_stripe_customers", "stg_stripe_orders"],
+    )
+
+    # Both aliases should be present
+    assert "WITH customers AS (" in sql
+    assert "orders AS (" in sql
+    # First one should be first alias reference
+    assert "FROM customers" in sql

--- a/tests/unit/test_model_wizard.py
+++ b/tests/unit/test_model_wizard.py
@@ -213,3 +213,27 @@ def test_alias_derivation_multiple_tables(project_root):
     assert "orders AS (" in sql
     # First one should be first alias reference
     assert "FROM customers" in sql
+
+
+def test_alias_collision_resolution(project_root):
+    """Test that colliding aliases fall back to full table name"""
+    wizard = ModelWizard(project_root)
+
+    # Both tables end with "customers" — would collide
+    sql = wizard._generate_sql_template(
+        layer="intermediate",
+        name="int_test.sql",
+        description="",
+        materialization="table",
+        upstream_tables=["stg_stripe_customers", "stg_hubspot_customers"],
+    )
+
+    # First should use derived alias (customers from stripe)
+    assert "WITH customers AS (" in sql
+    # Second should fall back to full name (collision detected)
+    assert "stg_hubspot_customers AS (" in sql
+    # Both refs should be present
+    assert "{{ ref('stg_stripe_customers') }}" in sql
+    assert "{{ ref('stg_hubspot_customers') }}" in sql
+    # First alias used in final SELECT
+    assert "FROM customers" in sql


### PR DESCRIPTION
## Summary

Adds interactive upstream table selection to `dango model add` command with automatic CTE scaffold generation:
- Intermediate models limited to staging layer; marts models see all layers
- Looping single-select prompt (never checkbox) for table selection
- Generated CTE scaffold with alias extraction from table names
- Fallback to placeholder SQL when no tables selected
- All CTEs reference upstream via `{{ ref() }}`

## Changes

**dango/cli/model_wizard.py** (507→547 lines)
- `_get_available_tables()` — discovers staging/intermediate/marts models
- `_ask_upstream_tables()` — looping single-select prompt
- Updated `_generate_sql_template()` to generate CTEs instead of 60-line reference guide
- Updated `_create_model_file()` to call table selection

**tests/unit/test_model_wizard.py** (new, 212 lines)
- 10 tests covering CTE scaffold generation, table discovery, layer filtering, alias derivation

**Documentation**
- Updated model_wizard.py line count (507→547) in 3 files:
  - docs/file-exemptions.yml
  - dango/cli/CLAUDE.md  
  - CLAUDE.md (workspace)

## Test Plan

- [x] pytest tests/unit/test_model_wizard.py — 10/10 pass
- [x] ruff check — all pass
- [x] ruff format — clean
- [x] Pre-commit hooks — all pass
- [ ] Manual test on beta-1 (coordinating chat)

## Verification

```bash
# Unit tests
pytest tests/unit/test_model_wizard.py -v
# 10 tests: CTE scaffold (2 with/without tables, 1 empty list), 
# table discovery (empty project, with models, all layers, layer filters),
# alias derivation (single and multiple tables)

# Code quality
ruff check dango/cli/model_wizard.py tests/unit/test_model_wizard.py
ruff format --check dango/cli/model_wizard.py tests/unit/test_model_wizard.py
```

Manual testing deferred to coordinating chat (beta-1 verification workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myfp1v1S8UKqXEnZ2iTuq4