### PR TITLE
feat: scripts cloud sync + path validation + starter template

### DIFF
--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -63,13 +63,17 @@ _SCRIPT_TEMPLATE = '''\
 Dango script — runs as a subprocess (scheduled or via Run Now in the Scripts tab).
 """
 import os
+from pathlib import Path
 
 import duckdb
 
-project_root = os.environ["DANGO_PROJECT_ROOT"]
-db_path = os.path.join(project_root, "data", "warehouse.duckdb")
+# Support both scheduled runs (DANGO_PROJECT_ROOT set) and manual runs
+_env_root = os.environ.get("DANGO_PROJECT_ROOT")
+project_root = Path(_env_root) if _env_root else Path(__file__).resolve().parent.parent
 
-conn = duckdb.connect(db_path, read_only=True)
+db_path = project_root / "data" / "warehouse.duckdb"
+
+conn = duckdb.connect(str(db_path), read_only=True)
 # TODO: add your queries here
 # Example:
 # rows = conn.sql("SELECT * FROM marts.my_table LIMIT 10").fetchall()

--- a/dango/cli/commands/schedule.py
+++ b/dango/cli/commands/schedule.py
@@ -57,6 +57,25 @@ _DAY_CHOICES = [
     ("Sunday", 0),
 ]
 
+_SCRIPT_TEMPLATE = '''\
+"""scripts/{script_name}.py
+
+Dango script — runs as a subprocess (scheduled or via Run Now in the Scripts tab).
+"""
+import os
+
+import duckdb
+
+project_root = os.environ["DANGO_PROJECT_ROOT"]
+db_path = os.path.join(project_root, "data", "warehouse.duckdb")
+
+conn = duckdb.connect(db_path, read_only=True)
+# TODO: add your queries here
+# Example:
+# rows = conn.sql("SELECT * FROM marts.my_table LIMIT 10").fetchall()
+conn.close()
+'''
+
 
 def _load_schedules_yaml(project_root: Path) -> dict[str, Any]:
     """Load raw YAML from ``.dango/schedules.yml``, or empty dict if missing."""
@@ -747,23 +766,54 @@ def schedule_add(ctx: click.Context) -> None:
         script_choices: list[tuple[str, str]] = [(s["name"], s["path"]) for s in scripts]
 
         if not script_choices:
-            console.print(
-                "[red]No Python scripts found in scripts/ directory.[/red] Add a .py file first."
-            )
-            return
-
-        answers = inquirer.prompt(
-            [
-                inquirer.List(
-                    "script_path",
-                    message="Select a script to run",
-                    choices=[label for label, _ in script_choices],
+            if safe_confirm(
+                "No Python scripts found in scripts/ directory. Create a starter script?",
+                default=True,
+            ):
+                name_answers = inquirer.prompt(
+                    [
+                        inquirer.Text(
+                            "script_name",
+                            message="Script filename",
+                            default="my_report.py",
+                            validate=lambda _, x: (
+                                x.endswith(".py")
+                                and x not in ("__init__.py",)
+                                and not x.startswith((".", "_"))
+                            ),
+                        )
+                    ]
                 )
-            ]
-        )
-        if answers is None:
-            return
-        script_path = answers["script_path"]
+                if name_answers is None:
+                    return
+                script_name = name_answers["script_name"]
+                scripts_dir_path = project_root / "scripts"
+                scripts_dir_path.mkdir(parents=True, exist_ok=True)
+                script_full = scripts_dir_path / script_name
+                if script_full.exists():
+                    console.print(f"[red]scripts/{script_name} already exists.[/red]")
+                    return
+                script_full.write_text(_SCRIPT_TEMPLATE.format(script_name=Path(script_name).stem))
+                console.print(f"[green]✓ Created scripts/{script_name}[/green]")
+                script_path = script_name
+            else:
+                console.print(
+                    "[red]No Python scripts found in scripts/ directory.[/red] Add a .py file first."
+                )
+                return
+        else:
+            answers = inquirer.prompt(
+                [
+                    inquirer.List(
+                        "script_path",
+                        message="Select a script to run",
+                        choices=[label for label, _ in script_choices],
+                    )
+                ]
+            )
+            if answers is None:
+                return
+            script_path = answers["script_path"]
 
         # Timeout prompt
         answers = inquirer.prompt(

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -575,11 +575,11 @@ class ProjectValidator:
         bad_patterns = [
             (re.compile(r"Path\.home\(\)"), "Path.home() — use DANGO_PROJECT_ROOT env var instead"),
             (
-                re.compile(r"/Users/[A-Za-z]"),
+                re.compile(r"/Users/\S"),
                 "hardcoded /Users/... path — use DANGO_PROJECT_ROOT env var",
             ),
             (
-                re.compile(r"/home/[A-Za-z]"),
+                re.compile(r"/home/\S"),
                 "hardcoded /home/... path — use DANGO_PROJECT_ROOT env var",
             ),
             (

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -70,6 +70,7 @@ class ProjectValidator:
         self._check_env_vars()
         self._check_dbt_setup()
         self._check_model_sql_portability()
+        self._check_script_paths()
         self._check_database()
         self._check_dependencies()
         self._check_permissions()
@@ -564,6 +565,47 @@ class ProjectValidator:
                         "Use 'dango seed add <file>' and {{ ref('seed_name') }} instead.",
                     )
                 )
+
+    def _check_script_paths(self):
+        """Warn if any script hardcodes an absolute path instead of DANGO_PROJECT_ROOT."""
+        scripts_dir = self.project_root / "scripts"
+        if not scripts_dir.exists():
+            return
+
+        bad_patterns = [
+            (re.compile(r"Path\.home\(\)"), "Path.home() — use DANGO_PROJECT_ROOT env var instead"),
+            (
+                re.compile(r"/Users/[A-Za-z]"),
+                "hardcoded /Users/... path — use DANGO_PROJECT_ROOT env var",
+            ),
+            (
+                re.compile(r"/home/[A-Za-z]"),
+                "hardcoded /home/... path — use DANGO_PROJECT_ROOT env var",
+            ),
+            (
+                re.compile(r'Path\(["\'][/~]'),
+                "hardcoded absolute path in Path() — use DANGO_PROJECT_ROOT env var",
+            ),
+        ]
+
+        for script in sorted(scripts_dir.rglob("*.py")):
+            if script.name == "__init__.py" or script.name.startswith((".", "_")):
+                continue
+            try:
+                content = script.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            for pattern, message in bad_patterns:
+                if pattern.search(content):
+                    rel = script.relative_to(scripts_dir)
+                    self.results.append(
+                        ValidationResult(
+                            f"scripts: {rel}",
+                            "warn",
+                            f'{message}. Fix: PROJECT_ROOT = os.environ["DANGO_PROJECT_ROOT"]',
+                        )
+                    )
+                    break
 
     def _check_database(self):
         """Check if DuckDB database exists and is accessible"""

--- a/dango/platform/cloud/file_sync.py
+++ b/dango/platform/cloud/file_sync.py
@@ -21,7 +21,8 @@ File sync scope
 ---------------
 Synced: ``.dango/sources.yml``, ``.dango/schedules.yml``,
 ``dbt/models/``, ``dbt/macros/``, ``dbt/dbt_project.yml``,
-``dbt/packages.yml``, ``metabase/`` (dashboard exports).
+``dbt/packages.yml``, ``metabase/`` (dashboard exports),
+``custom_sources/``, ``scripts/`` (custom Python scripts).
 
 Never synced: ``.env``, ``.dlt/secrets.toml``, ``*.duckdb``,
 ``metabase.db``, ``dbt/profiles.yml``, ``dbt/target/``, ``__pycache__/``,
@@ -86,7 +87,7 @@ SYNC_DBT_DIRS: list[str] = ["dbt/models", "dbt/macros", "dbt/seeds"]
 
 #: Additional directories to sync via rsync (with ``--delete``).
 #: Unlike dbt dirs, these are not part of the change-detection logic.
-SYNC_EXTRA_DIRS: list[str] = ["metabase", "custom_sources"]
+SYNC_EXTRA_DIRS: list[str] = ["metabase", "custom_sources", "scripts"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_schedule.py
+++ b/tests/unit/test_cli_schedule.py
@@ -691,6 +691,114 @@ class TestScheduleAdd:
         # Should exit cleanly without error
         assert result.exit_code == 0
 
+    @patch("dango.cli.commands.schedule.safe_confirm")
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_script_schedule_creates_template_on_confirm(
+        self, mock_root: MagicMock, mock_prompt: MagicMock, mock_confirm: MagicMock, tmp_path: Path
+    ) -> None:
+        """Script schedule with template creation when user confirms."""
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(project_root, {"schedules": []})
+
+        # User confirms template creation
+        mock_confirm.return_value = True
+        # Prompts: name, type, script_name, timeout, frequency, timezone
+        mock_prompt.side_effect = [
+            {"name": "daily_report"},
+            {"type": "Script (custom Python)"},
+            {"script_name": "daily_report.py"},
+            {"timeout_minutes": "30"},
+            {"frequency": "Daily"},
+            {"hour": "9"},
+            {"minute": "0"},
+            {"timezone": "UTC"},
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "add"])
+        plain = _strip_ansi(result.output)
+        assert "added" in plain
+        assert "Created scripts/daily_report.py" in plain
+
+        # Check schedule was created
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        assert len(data["schedules"]) == 1
+        assert data["schedules"][0]["name"] == "daily_report"
+        assert data["schedules"][0]["type"] == "script"
+
+        # Check template file was created
+        script_path = project_root / "scripts" / "daily_report.py"
+        assert script_path.exists()
+        content = script_path.read_text()
+        assert "DANGO_PROJECT_ROOT" in content
+        assert "duckdb.connect" in content
+
+    @patch("dango.cli.commands.schedule.safe_confirm")
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_script_schedule_declines_template(
+        self, mock_root: MagicMock, mock_prompt: MagicMock, mock_confirm: MagicMock, tmp_path: Path
+    ) -> None:
+        """Script schedule creation cancelled when user declines template."""
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(project_root, {"schedules": []})
+
+        # User declines template creation (safe_confirm returns False)
+        # This means we should get to the safe_confirm after selecting script type
+        mock_confirm.return_value = False
+        # Setup prompts: name, type only (then safe_confirm is called)
+        mock_prompt.side_effect = [
+            {"name": "declined_sched"},
+            {"type": "Script (custom Python)"},
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "add"])
+        plain = _strip_ansi(result.output)
+        assert "No Python scripts found" in plain
+        assert result.exit_code == 0
+
+        # No schedule was created
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        assert len(data.get("schedules", [])) == 0
+
+    @patch("inquirer.prompt")
+    @patch("dango.cli.utils.find_project_root")
+    def test_add_script_schedule_with_existing_scripts(
+        self, mock_root: MagicMock, mock_prompt: MagicMock, tmp_path: Path
+    ) -> None:
+        """Script schedule with existing scripts skips template prompt."""
+        project_root = _setup_project(tmp_path)
+        mock_root.return_value = project_root
+        _write_schedules_yaml(project_root, {"schedules": []})
+        (project_root / "scripts").mkdir()
+        (project_root / "scripts" / "report.py").write_text("# existing script")
+
+        # No safe_confirm call — goes straight to script selection
+        # Prompts: name, type, script_path, timeout, frequency, timezone
+        mock_prompt.side_effect = [
+            {"name": "script_sched"},
+            {"type": "Script (custom Python)"},
+            {"script_path": "report.py"},
+            {"timeout_minutes": "30"},
+            {"frequency": "Daily"},
+            {"hour": "9"},
+            {"minute": "0"},
+            {"timezone": "UTC"},
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "add"])
+        plain = _strip_ansi(result.output)
+        assert "added" in plain
+
+        # Check schedule was created
+        data = yaml.safe_load((project_root / ".dango" / "schedules.yml").read_text())
+        assert data["schedules"][0]["type"] == "script"
+
 
 @pytest.mark.unit
 class TestGetLocalTimezone:

--- a/tests/unit/test_file_sync.py
+++ b/tests/unit/test_file_sync.py
@@ -12,6 +12,7 @@ import pytest
 from dango.platform.cloud.file_sync import (
     REMOTE_PROJECT_DIR,
     SYNC_CONFIG_FILES,
+    SYNC_EXTRA_DIRS,
     SyncResult,
     _build_rsync_ssh_arg,
     _compute_local_hashes,
@@ -87,6 +88,10 @@ class TestSyncConfigFiles:
         assert "docker-compose.yml" in local_paths
         assert "Dockerfile.metabase" in local_paths
         assert "entrypoint.sh" in local_paths
+
+    def test_scripts_in_sync_extra_dirs(self):
+        """scripts/ directory is synced via rsync (1.0.7-11)."""
+        assert "scripts" in SYNC_EXTRA_DIRS
 
 
 @pytest.mark.unit
@@ -374,6 +379,28 @@ class TestSyncProjectFiles:
         assert "--delete" in cmd_list
         assert any("metabase" in str(arg) for arg in cmd_list)
         assert "metabase/" in result.synced_files
+
+    @patch("dango.platform.cloud.file_sync.shutil.which", return_value="/usr/bin/rsync")
+    @patch("dango.platform.cloud.file_sync.subprocess.run")
+    def test_rsync_syncs_scripts_dir(self, mock_run, mock_which, tmp_path):
+        """SYNC_EXTRA_DIRS: scripts/ is rsynced when present."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ssh = _make_ssh_mock(first_deploy=True)
+        project = _make_project(tmp_path)
+        # Create scripts directory
+        (project / "scripts").mkdir(parents=True)
+        (project / "scripts" / "daily_report.py").write_text("# daily report script")
+
+        result = sync_project_files(ssh, project, remote_host="10.0.0.1")
+
+        # rsync should be called 3 times: models, macros, scripts
+        assert mock_run.call_count == 3
+        last_call = mock_run.call_args_list[-1]
+        cmd_list = last_call[0][0]
+        assert cmd_list[0] == "rsync"
+        assert "--delete" in cmd_list
+        assert any("scripts" in str(arg) for arg in cmd_list)
+        assert "scripts/" in result.synced_files
 
     @patch("dango.platform.cloud.file_sync.shutil.which", return_value=None)
     def test_rsync_not_installed(self, mock_which, tmp_path):

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -60,3 +60,95 @@ class TestModelSqlPortability:
         v._check_model_sql_portability()
 
         assert v.results == []
+
+
+@pytest.mark.unit
+class TestScriptPaths:
+    def _validator(self, tmp_path):
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(parents=True)
+        return ProjectValidator(tmp_path), scripts_dir
+
+    def test_clean_script_no_warnings(self, tmp_path):
+        """Script using DANGO_PROJECT_ROOT env var should not warn."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "clean.py").write_text(
+            'import os\nproject_root = os.environ["DANGO_PROJECT_ROOT"]\n'
+        )
+
+        v._check_script_paths()
+
+        assert not any(r.name.startswith("scripts:") for r in v.results)
+
+    def test_flags_path_home(self, tmp_path):
+        """Script using Path.home() should warn."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "home.py").write_text("from pathlib import Path\ndir = Path.home()\n")
+
+        v._check_script_paths()
+
+        assert any(r.status == "warn" and "home.py" in r.name for r in v.results)
+
+    def test_flags_hardcoded_users_path(self, tmp_path):
+        """Script with hardcoded /Users/... path should warn."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "local.py").write_text("path = '/Users/aaronteoh/project/data.csv'\n")
+
+        v._check_script_paths()
+
+        assert any(r.status == "warn" and "local.py" in r.name for r in v.results)
+
+    def test_flags_hardcoded_home_path(self, tmp_path):
+        """Script with hardcoded /home/... path should warn."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "linux.py").write_text("path = '/home/user/project/data.csv'\n")
+
+        v._check_script_paths()
+
+        assert any(r.status == "warn" and "linux.py" in r.name for r in v.results)
+
+    def test_flags_path_absolute_call(self, tmp_path):
+        """Script with Path('/absolute/path') should warn."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "pathabs.py").write_text(
+            'from pathlib import Path\ndir = Path("/home/data")\n'
+        )
+
+        v._check_script_paths()
+
+        assert any(r.status == "warn" and "pathabs.py" in r.name for r in v.results)
+
+    def test_no_scripts_dir(self, tmp_path):
+        """No scripts/ dir should produce no results."""
+        v = ProjectValidator(tmp_path)
+
+        v._check_script_paths()
+
+        assert not any(r.name.startswith("scripts:") for r in v.results)
+
+    def test_skips_init_file(self, tmp_path):
+        """__init__.py should be skipped."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "__init__.py").write_text("path = '/Users/foo/bar'\n")
+
+        v._check_script_paths()
+
+        assert not any(r.name.startswith("scripts:") for r in v.results)
+
+    def test_skips_dotfiles(self, tmp_path):
+        """Dotfiles should be skipped."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / ".hidden.py").write_text("path = '/Users/foo/bar'\n")
+
+        v._check_script_paths()
+
+        assert not any(r.name.startswith("scripts:") for r in v.results)
+
+    def test_skips_underscore_prefix(self, tmp_path):
+        """Files starting with _ should be skipped."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "_private.py").write_text("path = '/Users/foo/bar'\n")
+
+        v._check_script_paths()
+
+        assert not any(r.name.startswith("scripts:") for r in v.results)

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -107,6 +107,24 @@ class TestScriptPaths:
 
         assert any(r.status == "warn" and "linux.py" in r.name for r in v.results)
 
+    def test_flags_single_letter_username(self, tmp_path):
+        """Script with single-letter username (/Users/a, /home/j) should warn."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "single.py").write_text("path = '/Users/a/project' # or '/home/j/data'\n")
+
+        v._check_script_paths()
+
+        assert any(r.status == "warn" and "single.py" in r.name for r in v.results)
+
+    def test_flags_numeric_username(self, tmp_path):
+        """Script with numeric username (/Users/123, /home/42) should warn."""
+        v, scripts_dir = self._validator(tmp_path)
+        (scripts_dir / "numeric.py").write_text("path = '/home/123/project/data'\n")
+
+        v._check_script_paths()
+
+        assert any(r.status == "warn" and "numeric.py" in r.name for r in v.results)
+
     def test_flags_path_absolute_call(self, tmp_path):
         """Script with Path('/absolute/path') should warn."""
         v, scripts_dir = self._validator(tmp_path)


### PR DESCRIPTION
## Summary

Closes three related gaps in the Scripts feature (1.0.7-11):

1. **Cloud sync:** Add `scripts/` to `SYNC_EXTRA_DIRS` in `file_sync.py` — scripts are now synced to cloud via rsync (matching metabase/ + custom_sources/ pattern). Activates `deployer.py` step 5c (pip install `scripts/requirements.txt` on remote).

2. **Path validation:** New `_check_script_paths()` in `dango validate` warns if scripts hardcode absolute paths (`Path.home()`, `/Users/...`, `/home/...`, `Path('/absolute/path')`) instead of `DANGO_PROJECT_ROOT` env var. Guides users to portable pattern. Skips `__init__.py`, dotfiles, and `_`-prefixed files (matches scripts tab discovery).

3. **Starter template:** `dango schedule add` (script type) now offers to create a starter script when none exist. Pre-filled with correct `DANGO_PROJECT_ROOT` + read-only DuckDB access pattern from docs. User can accept (creates file + schedule), decline (wizard exits), or proceed with existing scripts.

## Verification

- `pytest -x`: 14 new tests, all pass (file_sync, validate, cli_schedule)
- `ruff check`: all checks pass
- `ruff format`: all files formatted
- No breaking changes to existing behavior

## Testing

**Unit tests added:**
- `test_file_sync.py::TestSyncConfigFiles::test_scripts_in_sync_extra_dirs`
- `test_file_sync.py::TestSyncProjectFiles::test_rsync_syncs_scripts_dir`
- `test_validate.py::TestScriptPaths` (9 cases: clean/Path.home/hardcoded paths/no-dir/skip rules)
- `test_cli_schedule.py::TestScheduleAdd` (3 script-specific: create/decline/existing)

Per project rules: no testing on beta-1 (coordinating chat verifies sequentially).

## Notes

- All changes follow real code patterns verified via grep/read (not design doc assumptions)
- Docs repo changes deferred to separate PR (separate base branch)
- No CLAUDE.md updates (existing files, standards apply incrementally per project rules)

🤖 Generated with Claude Code