### PR TITLE
fix: warn sessions that v1.0.7 is active integration branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,9 @@ mypy dango/
 
 ### Git Workflow
 
-All development happens on feature branches off `main`. Never commit directly to `main`.
+**⚠️ Active integration branch: `v1.0.7`** — During the 1.0.7 release cycle all feature branches are created off `v1.0.7` and PRs target `v1.0.7`, NOT `main`. Your session prompt specifies the exact base branch — follow it, not the general pattern below.
+
+All development happens on feature branches. Never commit directly to `main` or the integration branch.
 
 ```bash
 # Start a task


### PR DESCRIPTION
## Summary
Sessions were reading "feature branches off main" in CLAUDE.md and targeting `main` instead of `v1.0.7`, causing PRs #408 and #410 to land in the wrong branch. Adds a prominent warning at the top of the Git Workflow section so sessions follow the session prompt's base branch, not the general rule.

## Change
One paragraph added to `### Git Workflow` in `CLAUDE.md`.

## Verification
- `pytest -x`: not required (doc-only change)
- `ruff check dango/`: not required (doc-only change)