### PR TITLE
1.0.7-6: Credential detection — dango doctor

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -17,6 +17,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/platform.py` (1136 lines) | `start`, `stop`, `status` | `start()`, `stop()`, `status()` |
 | `commands/auth.py` (666 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (388 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
+| `commands/doctor.py` (65 lines) | `doctor` command — check credential health for all configured sources | `doctor()` |
 | `commands/oauth.py` (842 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
 | `commands/transform.py` (343 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
 | `commands/upgrade.py` (236 lines) | `upgrade` command — local Dango upgrade via pip + migrations | `upgrade()`, `get_latest_version_cached()` |
@@ -73,6 +74,7 @@ dango (top-level group)
 ├── serve                       ← commands/serve.py
 ├── upgrade                     ← commands/upgrade.py
 ├── cleanup                     ← commands/cleanup.py
+├── doctor                      ← commands/doctor.py
 ├── sync                        ← commands/source.py
 ├── run, docs, generate         ← commands/transform.py
 ├── validate                    ← commands/data.py

--- a/dango/cli/commands/doctor.py
+++ b/dango/cli/commands/doctor.py
@@ -1,0 +1,55 @@
+"""dango/cli/commands/doctor.py
+
+Credential health check: cross-references configured sources against
+available credentials and surfaces missing/expired tokens.
+"""
+
+import click
+
+from dango.cli import console
+
+
+@click.command("doctor")
+@click.pass_context
+def doctor(ctx: click.Context) -> None:
+    """Check credential health for all configured sources."""
+    from rich.table import Table
+
+    from dango.cli.utils import require_project_context
+    from dango.ingestion.credential_health import get_cached_credential_health
+
+    project_root = require_project_context(ctx)
+    results = get_cached_credential_health(project_root)
+
+    if not results:
+        console.print("\n[dim]No sources configured.[/dim]\n")
+        return
+
+    table = Table(title="Credential Health", show_header=True, header_style="bold")
+    table.add_column("Source", style="cyan")
+    table.add_column("Type")
+    table.add_column("Status")
+    table.add_column("Detail")
+
+    status_styles = {
+        "ok": "[green]✓ OK[/green]",
+        "missing": "[red]✗ Missing[/red]",
+        "expired": "[red]✗ Expired[/red]",
+        "expiring_soon": "[yellow]⚠ Expiring soon[/yellow]",
+        "unknown": "[dim]? Unknown[/dim]",
+    }
+
+    for r in results:
+        table.add_row(
+            r["source"], r["type"], status_styles.get(r["status"], r["status"]), r.get("detail", "")
+        )
+
+    console.print()
+    console.print(table)
+
+    issues = [r for r in results if r["status"] != "ok"]
+    if issues:
+        console.print(f"\n[red]{len(issues)} issue(s) found.[/red]")
+        console.print("[dim]Run `dango oauth <source>` to re-authenticate OAuth sources.[/dim]\n")
+    else:
+        console.print("\n[green]All credentials are healthy.[/green]\n")

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -17,6 +17,7 @@ from dango.cli.commands.dashboard import dashboard
 from dango.cli.commands.data import db, validate
 from dango.cli.commands.deploy import deploy
 from dango.cli.commands.dev import dev
+from dango.cli.commands.doctor import doctor
 from dango.cli.commands.governance import governance
 from dango.cli.commands.local_backup import backup_group as local_backup_group
 from dango.cli.commands.metabase_cmd import metabase
@@ -101,6 +102,7 @@ cli.add_command(web)
 cli.add_command(serve)
 cli.add_command(upgrade)
 cli.add_command(cleanup)
+cli.add_command(doctor)
 
 # --- Register command groups ---
 cli.add_command(source)

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -19,6 +19,7 @@ for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see P5-006).
 | `__init__.py` | Public exports | `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata`, `get_source_capabilities` |
 | `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync` (accepts `progress_callback` for dbt phase reporting; imports `SyncTimeoutError` from `dango.exceptions`) |
 | `csv_loader.py` | Multi-format file loading (CSV, JSON, JSONL, Parquet) with metadata tracking and 4 dedup strategies | `CSVLoader`, `SUPPORTED_READ_FUNCTIONS` (imports `CSVSchemaMismatchError` from `dango.exceptions`) |
+| `credential_health.py` | Cross-references configured sources against available credentials (OAuth tokens, API keys, service accounts) | `run_credential_checks()`, `get_cached_credential_health()` (5-minute in-process cache) |
 | `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata`, `get_source_capabilities` |
 | `sources/registry.py` | Central registry of 33 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category`, `get_source_capabilities` |
 | `dlt_sources/` | dlt verified source implementations (27 directories, 105+ files) — helper files are custom Dango code | See "Don't Modify" section for guidelines |

--- a/dango/ingestion/credential_health.py
+++ b/dango/ingestion/credential_health.py
@@ -6,12 +6,15 @@ tokens, API-key env vars) and reports missing/expired/expiring issues.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Any
 
-_cache: tuple[list[dict[str, Any]], float] | None = None
+logger = logging.getLogger(__name__)
+
+_cache: dict[str, tuple[list[dict[str, Any]], float]] = {}
 _CACHE_TTL = 300  # 5 minutes
 
 
@@ -96,7 +99,13 @@ def run_credential_checks(project_root: Path) -> list[dict[str, Any]]:
                             "detail": cred.account_info or "",
                         }
                     )
-            except Exception:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001
+                logger.debug(
+                    "Failed to validate token for %s: %s",
+                    source_type,
+                    e,
+                    exc_info=True,
+                )
                 results.append(
                     {
                         "source": source_name,
@@ -139,18 +148,35 @@ def run_credential_checks(project_root: Path) -> list[dict[str, Any]]:
             )
 
         elif auth_type == AuthType.SERVICE_ACCOUNT:
-            # Best-effort: can't verify the specific per-source TOML section without
-            # parsing each source's secrets_toml_template. Existence check only.
-            found = secrets_file.exists() and secrets_file.stat().st_size > 0
+            # Check if secrets.toml exists and contains the source-specific section
+            found = False
+            detail = ""
+            if secrets_file.exists() and secrets_file.stat().st_size > 0:
+                try:
+                    import toml
+
+                    secrets = toml.load(secrets_file)
+                    # Service account credentials should be under sources.{source_type}
+                    source_secrets = secrets.get("sources", {}).get(source_type, {})
+                    found = bool(source_secrets)
+                    if not found:
+                        detail = f"No [sources.{source_type}] section in .dlt/secrets.toml"
+                except Exception as e:  # noqa: BLE001
+                    logger.debug(
+                        "Failed to parse secrets.toml for %s: %s",
+                        source_type,
+                        e,
+                    )
+                    detail = "Failed to parse .dlt/secrets.toml"
+            else:
+                detail = "No .dlt/secrets.toml found — add service-account credentials there"
             results.append(
                 {
                     "source": source_name,
                     "type": source_type,
                     "auth_type": "service_account",
                     "status": "ok" if found else "missing",
-                    "detail": ""
-                    if found
-                    else "No .dlt/secrets.toml found — add service-account credentials there",
+                    "detail": detail,
                 }
             )
 
@@ -159,7 +185,7 @@ def run_credential_checks(project_root: Path) -> list[dict[str, Any]]:
                 {
                     "source": source_name,
                     "type": source_type,
-                    "auth_type": auth_type.value if hasattr(auth_type, "value") else str(auth_type),
+                    "auth_type": auth_type.value,
                     "status": "ok",
                     "detail": "",
                 }
@@ -169,11 +195,15 @@ def run_credential_checks(project_root: Path) -> list[dict[str, Any]]:
 
 
 def get_cached_credential_health(project_root: Path) -> list[dict[str, Any]]:
-    """Return cached results or run a fresh check (5-minute TTL, in-process only)."""
+    """Return cached results or run a fresh check (5-minute TTL, in-process only).
+
+    Cache is scoped per project_root to handle multi-project scenarios.
+    """
     global _cache
+    cache_key = str(project_root.resolve())
     now = time.monotonic()
-    if _cache is not None and (now - _cache[1]) < _CACHE_TTL:
-        return _cache[0]
+    if cache_key in _cache and (now - _cache[cache_key][1]) < _CACHE_TTL:
+        return _cache[cache_key][0]
     results = run_credential_checks(project_root)
-    _cache = (results, now)
+    _cache[cache_key] = (results, now)
     return results

--- a/dango/ingestion/credential_health.py
+++ b/dango/ingestion/credential_health.py
@@ -1,0 +1,179 @@
+"""dango/ingestion/credential_health.py
+
+Cross-references configured sources against available credentials (OAuth
+tokens, API-key env vars) and reports missing/expired/expiring issues.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+_cache: tuple[list[dict[str, Any]], float] | None = None
+_CACHE_TTL = 300  # 5 minutes
+
+
+def run_credential_checks(project_root: Path) -> list[dict[str, Any]]:
+    """Check all configured sources for credential health.
+
+    Returns list of dicts:
+      {"source": str, "type": str, "auth_type": str,
+       "status": "ok"|"missing"|"expired"|"expiring_soon"|"unknown",
+       "detail": str}
+    """
+    from dango.config.helpers import get_config
+    from dango.ingestion.sources.registry import AuthType, get_source_metadata
+    from dango.oauth.storage import OAuthStorage
+    from dango.oauth.validation import validate_token
+
+    results: list[dict[str, Any]] = []
+    config = get_config(project_root)
+    sources = config.sources.sources  # SourcesConfig.sources — list[DataSource]
+    if not sources:
+        return results
+
+    oauth_storage = OAuthStorage(project_root)
+    env_file = project_root / ".env"
+    dot_env = {}
+    if env_file.exists():
+        from dotenv import dotenv_values
+
+        dot_env = dotenv_values(env_file)
+
+    secrets_file = project_root / ".dlt" / "secrets.toml"
+
+    for source in sources:
+        source_type = source.type.value
+        source_name = source.name
+        registry_entry = get_source_metadata(source_type) or {}
+        auth_type = registry_entry.get("auth_type", AuthType.NONE)
+
+        if auth_type == AuthType.OAUTH:
+            cred = oauth_storage.get(source_type)
+            if cred is None:
+                results.append(
+                    {
+                        "source": source_name,
+                        "type": source_type,
+                        "auth_type": "oauth",
+                        "status": "missing",
+                        "detail": f"No OAuth credential found. Run 'dango oauth {source_type}'",
+                    }
+                )
+                continue
+            try:
+                vr = validate_token(cred)
+                if not vr.valid:
+                    results.append(
+                        {
+                            "source": source_name,
+                            "type": source_type,
+                            "auth_type": "oauth",
+                            "status": "expired",
+                            "detail": vr.message,
+                        }
+                    )
+                elif cred.is_expiring_soon(days=7):
+                    days = cred.days_until_expiry()
+                    results.append(
+                        {
+                            "source": source_name,
+                            "type": source_type,
+                            "auth_type": "oauth",
+                            "status": "expiring_soon",
+                            "detail": f"Expires in {days} day(s)",
+                        }
+                    )
+                else:
+                    results.append(
+                        {
+                            "source": source_name,
+                            "type": source_type,
+                            "auth_type": "oauth",
+                            "status": "ok",
+                            "detail": cred.account_info or "",
+                        }
+                    )
+            except Exception:  # noqa: BLE001
+                results.append(
+                    {
+                        "source": source_name,
+                        "type": source_type,
+                        "auth_type": "oauth",
+                        "status": "unknown",
+                        "detail": "Failed to validate token",
+                    }
+                )
+
+        elif auth_type in (AuthType.API_KEY, AuthType.BASIC):
+            params = registry_entry.get("required_params", []) + registry_entry.get(
+                "optional_params", []
+            )
+            secret_params = [p for p in params if p.get("type") == "secret" and p.get("env_var")]
+            if not secret_params:
+                results.append(
+                    {
+                        "source": source_name,
+                        "type": source_type,
+                        "auth_type": auth_type.value,
+                        "status": "ok",
+                        "detail": "",
+                    }
+                )
+                continue
+            missing = [
+                p["env_var"]
+                for p in secret_params
+                if not os.environ.get(p["env_var"]) and p["env_var"] not in dot_env
+            ]
+            results.append(
+                {
+                    "source": source_name,
+                    "type": source_type,
+                    "auth_type": auth_type.value,
+                    "status": "ok" if not missing else "missing",
+                    "detail": "" if not missing else f"Missing: {', '.join(missing)}",
+                }
+            )
+
+        elif auth_type == AuthType.SERVICE_ACCOUNT:
+            # Best-effort: can't verify the specific per-source TOML section without
+            # parsing each source's secrets_toml_template. Existence check only.
+            found = secrets_file.exists() and secrets_file.stat().st_size > 0
+            results.append(
+                {
+                    "source": source_name,
+                    "type": source_type,
+                    "auth_type": "service_account",
+                    "status": "ok" if found else "missing",
+                    "detail": ""
+                    if found
+                    else "No .dlt/secrets.toml found — add service-account credentials there",
+                }
+            )
+
+        else:
+            results.append(
+                {
+                    "source": source_name,
+                    "type": source_type,
+                    "auth_type": auth_type.value if hasattr(auth_type, "value") else str(auth_type),
+                    "status": "ok",
+                    "detail": "",
+                }
+            )
+
+    return results
+
+
+def get_cached_credential_health(project_root: Path) -> list[dict[str, Any]]:
+    """Return cached results or run a fresh check (5-minute TTL, in-process only)."""
+    global _cache
+    now = time.monotonic()
+    if _cache is not None and (now - _cache[1]) < _CACHE_TTL:
+        return _cache[0]
+    results = run_credential_checks(project_root)
+    _cache = (results, now)
+    return results

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -31,7 +31,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/auth.py` | Login/logout, password change, OAuth flows, invite accept, API key CRUD (~901 lines) | `_bridge_metabase_session()`, `_set_session_cookie()` |
 | `routes/auth_2fa.py` | TOTP 2FA setup/verify/disable/recovery (~340 lines) | — |
 | `routes/users.py` | Admin user CRUD: create, edit, deactivate, delete, unlock, invite (531 lines) | — |
-| `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` (incl. DuckDB capacity gauge, OAuth token health, component disk breakdown, cloud resource metrics, backup staleness, deployment info), `/api/deployments/history` (admin-only) | — |
+| `routes/health.py` | `/api/status`, `/api/watcher/status`, `/api/health/platform` (incl. DuckDB capacity gauge, OAuth token health, credential health, component disk breakdown, cloud resource metrics, backup staleness, deployment info), `/api/deployments/history` (admin-only) | — |
 | `routes/config.py` | `/api/config`, `/api/metabase-config` | — |
 | `routes/sources.py` | `/api/sources`, `/api/sources/{name}/details` | — |
 | `routes/sync.py` | `/api/sources/{name}/sync`, `/api/sync/trigger` (remote), `/api/sync/status/{id}` + subprocess-based `run_sync_task()` (~370 lines) | `run_sync_task()` |

--- a/dango/web/routes/health.py
+++ b/dango/web/routes/health.py
@@ -253,6 +253,26 @@ async def get_platform_health() -> dict[str, Any]:
         logger.warning("Failed to check OAuth token health", exc_info=True)
     result["oauth_health"] = oauth_health
 
+    # Credential health (dango doctor checks)
+    try:
+        from dango.ingestion.credential_health import get_cached_credential_health
+
+        cred_results = get_cached_credential_health(project_root)
+        cred_issues = [r for r in cred_results if r["status"] != "ok"]
+        credential_health: dict[str, Any] = {
+            "status": "ok" if not cred_issues else "warning",
+            "issues": cred_issues,
+            "total_sources": len(cred_results),
+        }
+        if cred_issues:
+            warnings.append(
+                f"{len(cred_issues)} source(s) with credential issues — run `dango doctor`"
+            )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to check credential health", exc_info=True)
+        credential_health = {"status": "unknown", "issues": [], "total_sources": 0}
+    result["credential_health"] = credential_health
+
     if critical_issues:
         result["status"] = "critical"
     elif warnings:

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -505,6 +505,12 @@ exemptions:
     reason: "S3-1 added 5 tests for monthly retention tier, archive cleanup, and secrets exclusion/inclusion in local archive."
     review_by: "v1.1"
 
+  - file: tests/unit/test_credential_health.py
+    lines: 523
+    category: exempt
+    reason: "1.0.7-6: 14 tests covering credential health checks across all auth types (OAuth, API key, service account, none) with cache scoping and multi-project isolation. Tests also verify exception handling and TOML parsing for service accounts."
+    review_by: "v1.1"
+
 # Vendored files (in dlt_sources/, not subject to dango standards, always skipped by check script)
 vendored:
   - file: dango/ingestion/dlt_sources/mongodb/helpers.py

--- a/tests/unit/test_credential_health.py
+++ b/tests/unit/test_credential_health.py
@@ -30,9 +30,9 @@ def reset_cache() -> None:
     """Reset the credential health cache before each test."""
     import dango.ingestion.credential_health as ch
 
-    ch._cache = None
+    ch._cache = {}
     yield
-    ch._cache = None
+    ch._cache = {}
 
 
 def test_no_sources(mock_project_root: Path) -> None:
@@ -316,9 +316,14 @@ def test_service_account_present(mock_project_root: Path) -> None:
         patch("dango.config.helpers.get_config") as mock_get_config,
         patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
     ):
-        # Create secrets.toml file
+        # Create secrets.toml file with source-specific section
         secrets_file = mock_project_root / ".dlt" / "secrets.toml"
-        secrets_file.write_text("[sources]\n")
+        secrets_file.write_text(
+            "[sources.gcs]\n"
+            'type = "service_account"\n'
+            'project_id = "my-project"\n'
+            'private_key_id = "key123"\n'
+        )
 
         # Setup config
         mock_source = Mock()
@@ -385,15 +390,100 @@ def test_cache_returns_stale_results(mock_project_root: Path) -> None:
         assert mock_run.call_count == 1  # No additional call
         assert result1 == result2
 
-        # Simulate cache expiry
+        # Simulate cache expiry by manipulating the timestamp
         import time
 
-        ch._cache = (result1, time.monotonic() - 400)  # Older than 300s TTL
+        cache_key = str(mock_project_root.resolve())
+        ch._cache[cache_key] = (result1, time.monotonic() - 400)  # Older than 300s TTL
 
         # Third call after TTL
         result3 = get_cached_credential_health(mock_project_root)
         assert mock_run.call_count == 2  # Cache expired, new call made
         assert len(result3) == 1
+
+
+def test_cache_scoped_by_project_root(tmp_path: Path) -> None:
+    """Test that cache entries are separate per project_root."""
+
+    # Create two different project roots
+    project1 = tmp_path / "project1"
+    project2 = tmp_path / "project2"
+    project1.mkdir()
+    project2.mkdir()
+    (project1 / ".dlt").mkdir()
+    (project2 / ".dlt").mkdir()
+
+    with patch("dango.ingestion.credential_health.run_credential_checks") as mock_run:
+        # Setup different results for each project
+        def side_effect(root: Path) -> list[dict]:
+            if root == project1:
+                return [
+                    {
+                        "source": "proj1_source",
+                        "type": "csv",
+                        "auth_type": "none",
+                        "status": "ok",
+                        "detail": "",
+                    }
+                ]
+            else:
+                return [
+                    {
+                        "source": "proj2_source",
+                        "type": "csv",
+                        "auth_type": "none",
+                        "status": "ok",
+                        "detail": "",
+                    }
+                ]
+
+        mock_run.side_effect = side_effect
+
+        # Call for project1
+        result1 = get_cached_credential_health(project1)
+        assert result1[0]["source"] == "proj1_source"
+        assert mock_run.call_count == 1
+
+        # Call for project2 - should NOT use project1's cache
+        result2 = get_cached_credential_health(project2)
+        assert result2[0]["source"] == "proj2_source"
+        assert mock_run.call_count == 2  # New call, not cached from project1
+
+        # Call for project1 again - should use cached result
+        result3 = get_cached_credential_health(project1)
+        assert result3[0]["source"] == "proj1_source"
+        assert mock_run.call_count == 2  # No new call
+
+
+def test_service_account_toml_section_missing(mock_project_root: Path) -> None:
+    """Test service account source when secrets.toml exists but lacks source section."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+    ):
+        # Create secrets.toml with content but no source-specific section
+        secrets_file = mock_project_root / ".dlt" / "secrets.toml"
+        secrets_file.write_text("[sources]\n")
+
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_gcs"
+        mock_source.type.value = "gcs"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.SERVICE_ACCOUNT}
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_gcs"
+        assert results[0]["status"] == "missing"
+        assert "gcs" in results[0]["detail"]
 
 
 def test_validation_exception_handling(mock_project_root: Path) -> None:

--- a/tests/unit/test_credential_health.py
+++ b/tests/unit/test_credential_health.py
@@ -1,0 +1,433 @@
+"""tests/unit/test_credential_health.py
+
+Tests for dango.ingestion.credential_health module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dango.ingestion.credential_health import (
+    get_cached_credential_health,
+    run_credential_checks,
+)
+
+
+@pytest.fixture
+def mock_project_root(tmp_path: Path) -> Path:
+    """Create a temporary project root."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / ".dlt").mkdir()
+    return project_root
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> None:
+    """Reset the credential health cache before each test."""
+    import dango.ingestion.credential_health as ch
+
+    ch._cache = None
+    yield
+    ch._cache = None
+
+
+def test_no_sources(mock_project_root: Path) -> None:
+    """Test with no sources configured."""
+    with patch("dango.config.helpers.get_config") as mock_get_config:
+        mock_config = Mock()
+        mock_config.sources.sources = []
+        mock_get_config.return_value = mock_config
+
+        results = run_credential_checks(mock_project_root)
+
+        assert results == []
+
+
+def test_missing_oauth_credential(mock_project_root: Path) -> None:
+    """Test OAuth source with missing credential."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+        patch("dango.oauth.storage.OAuthStorage") as mock_storage_class,
+    ):
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_google_sheets"
+        mock_source.type.value = "google_sheets"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.OAUTH}
+
+        # Setup storage - no credential
+        mock_storage = Mock()
+        mock_storage.get.return_value = None
+        mock_storage_class.return_value = mock_storage
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_google_sheets"
+        assert results[0]["status"] == "missing"
+        assert "dango oauth" in results[0]["detail"]
+
+
+def test_valid_oauth_credential(mock_project_root: Path) -> None:
+    """Test OAuth source with valid credential."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+        patch("dango.oauth.storage.OAuthStorage") as mock_storage_class,
+        patch("dango.oauth.validation.validate_token") as mock_validate,
+    ):
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_google_sheets"
+        mock_source.type.value = "google_sheets"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.OAUTH}
+
+        # Setup credential
+        mock_cred = Mock()
+        mock_cred.account_info = "user@example.com"
+        mock_cred.is_expiring_soon.return_value = False
+
+        # Setup storage
+        mock_storage = Mock()
+        mock_storage.get.return_value = mock_cred
+        mock_storage_class.return_value = mock_storage
+
+        # Setup validation
+        mock_result = Mock()
+        mock_result.valid = True
+        mock_validate.return_value = mock_result
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_google_sheets"
+        assert results[0]["status"] == "ok"
+        assert results[0]["detail"] == "user@example.com"
+
+
+def test_expired_oauth_credential(mock_project_root: Path) -> None:
+    """Test OAuth source with expired credential."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+        patch("dango.oauth.storage.OAuthStorage") as mock_storage_class,
+        patch("dango.oauth.validation.validate_token") as mock_validate,
+    ):
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_google_sheets"
+        mock_source.type.value = "google_sheets"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.OAUTH}
+
+        # Setup credential
+        mock_cred = Mock()
+        mock_storage = Mock()
+        mock_storage.get.return_value = mock_cred
+        mock_storage_class.return_value = mock_storage
+
+        # Setup validation - expired
+        mock_result = Mock()
+        mock_result.valid = False
+        mock_result.message = "Token expired"
+        mock_validate.return_value = mock_result
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_google_sheets"
+        assert results[0]["status"] == "expired"
+        assert results[0]["detail"] == "Token expired"
+
+
+def test_expiring_soon_oauth_credential(mock_project_root: Path) -> None:
+    """Test OAuth source with credential expiring soon."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+        patch("dango.oauth.storage.OAuthStorage") as mock_storage_class,
+        patch("dango.oauth.validation.validate_token") as mock_validate,
+    ):
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_google_sheets"
+        mock_source.type.value = "google_sheets"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.OAUTH}
+
+        # Setup credential
+        mock_cred = Mock()
+        mock_cred.account_info = "user@example.com"
+        mock_cred.is_expiring_soon.return_value = True
+        mock_cred.days_until_expiry.return_value = 3
+
+        # Setup storage
+        mock_storage = Mock()
+        mock_storage.get.return_value = mock_cred
+        mock_storage_class.return_value = mock_storage
+
+        # Setup validation
+        mock_result = Mock()
+        mock_result.valid = True
+        mock_validate.return_value = mock_result
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_google_sheets"
+        assert results[0]["status"] == "expiring_soon"
+        assert "3 day" in results[0]["detail"]
+
+
+def test_api_key_present(mock_project_root: Path) -> None:
+    """Test API key source with credential present in .env."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+    ):
+        # Create .env file
+        env_file = mock_project_root / ".env"
+        env_file.write_text("STRIPE_API_KEY=sk_test_123456\n")
+
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_stripe"
+        mock_source.type.value = "stripe"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {
+            "auth_type": AuthType.API_KEY,
+            "required_params": [
+                {"name": "stripe_api_key", "type": "secret", "env_var": "STRIPE_API_KEY"}
+            ],
+            "optional_params": [],
+        }
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_stripe"
+        assert results[0]["status"] == "ok"
+
+
+def test_api_key_missing(mock_project_root: Path) -> None:
+    """Test API key source with credential missing."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+    ):
+        # No .env file created
+
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_stripe"
+        mock_source.type.value = "stripe"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {
+            "auth_type": AuthType.API_KEY,
+            "required_params": [
+                {"name": "stripe_api_key", "type": "secret", "env_var": "STRIPE_API_KEY"}
+            ],
+            "optional_params": [],
+        }
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_stripe"
+        assert results[0]["status"] == "missing"
+        assert "STRIPE_API_KEY" in results[0]["detail"]
+
+
+def test_service_account_missing(mock_project_root: Path) -> None:
+    """Test service account source with missing secrets.toml."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+    ):
+        # No secrets.toml file created
+
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_gcs"
+        mock_source.type.value = "gcs"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.SERVICE_ACCOUNT}
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_gcs"
+        assert results[0]["status"] == "missing"
+        assert "secrets.toml" in results[0]["detail"]
+
+
+def test_service_account_present(mock_project_root: Path) -> None:
+    """Test service account source with secrets.toml present."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+    ):
+        # Create secrets.toml file
+        secrets_file = mock_project_root / ".dlt" / "secrets.toml"
+        secrets_file.write_text("[sources]\n")
+
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_gcs"
+        mock_source.type.value = "gcs"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.SERVICE_ACCOUNT}
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_gcs"
+        assert results[0]["status"] == "ok"
+
+
+def test_no_auth_source(mock_project_root: Path) -> None:
+    """Test source that doesn't require authentication."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+    ):
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_csv"
+        mock_source.type.value = "csv"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.NONE}
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["source"] == "my_csv"
+        assert results[0]["status"] == "ok"
+
+
+def test_cache_returns_stale_results(mock_project_root: Path) -> None:
+    """Test that cache returns results within TTL without re-checking."""
+    import dango.ingestion.credential_health as ch
+
+    with patch("dango.ingestion.credential_health.run_credential_checks") as mock_run:
+        mock_run.return_value = [
+            {"source": "test", "type": "csv", "auth_type": "none", "status": "ok", "detail": ""}
+        ]
+
+        # First call
+        result1 = get_cached_credential_health(mock_project_root)
+        assert mock_run.call_count == 1
+        assert len(result1) == 1
+
+        # Second call within TTL
+        result2 = get_cached_credential_health(mock_project_root)
+        assert mock_run.call_count == 1  # No additional call
+        assert result1 == result2
+
+        # Simulate cache expiry
+        import time
+
+        ch._cache = (result1, time.monotonic() - 400)  # Older than 300s TTL
+
+        # Third call after TTL
+        result3 = get_cached_credential_health(mock_project_root)
+        assert mock_run.call_count == 2  # Cache expired, new call made
+        assert len(result3) == 1
+
+
+def test_validation_exception_handling(mock_project_root: Path) -> None:
+    """Test that validation exceptions are caught and reported as unknown."""
+    with (
+        patch("dango.config.helpers.get_config") as mock_get_config,
+        patch("dango.ingestion.sources.registry.get_source_metadata") as mock_get_metadata,
+        patch("dango.oauth.storage.OAuthStorage") as mock_storage_class,
+        patch("dango.oauth.validation.validate_token") as mock_validate,
+    ):
+        # Setup config
+        mock_source = Mock()
+        mock_source.name = "my_google_sheets"
+        mock_source.type.value = "google_sheets"
+        mock_config = Mock()
+        mock_config.sources.sources = [mock_source]
+        mock_get_config.return_value = mock_config
+
+        # Setup registry
+        from dango.ingestion.sources.registry import AuthType
+
+        mock_get_metadata.return_value = {"auth_type": AuthType.OAUTH}
+
+        # Setup credential
+        mock_cred = Mock()
+        mock_storage = Mock()
+        mock_storage.get.return_value = mock_cred
+        mock_storage_class.return_value = mock_storage
+
+        # Setup validation to raise exception
+        mock_validate.side_effect = RuntimeError("Network error")
+
+        results = run_credential_checks(mock_project_root)
+
+        assert len(results) == 1
+        assert results[0]["status"] == "unknown"
+        assert "Failed to validate" in results[0]["detail"]


### PR DESCRIPTION
## Summary
- Add `dango doctor` CLI command — checks all configured sources for credential health
- Core check logic lives in `dango/ingestion/credential_health.py` (Level 1) so both the CLI command and `/api/health/platform` can use it without violating the module layering rule
- OAuth sources: checks token validity/expiry via oauth/validation.py + OAuthCredential.is_expiring_soon()
- API-key/basic-auth sources: checks required secret env vars exist in .env/os.environ (no live calls)
- Service-account sources: validates [sources.SOURCE_NAME] section exists in .dlt/secrets.toml
- 5-minute in-process result cache (not persisted to disk), scoped per project_root
- /api/health/platform response now includes a credential_health section, contributing to warnings

## Verification
- `pytest -x`: 14/14 credential health tests pass, 4117 total tests pass, 30 skipped
- Manual testing (scratch project, not beta-1):
  - Missing OAuth credential → ✗ Missing with actionable message
  - Valid OAuth credential → ✓ OK with account info from live validation
  - Expired/expiring-soon OAuth credentials → handled correctly
  - Missing API key env var → ✗ Missing with env var name
  - Service account missing section → ✗ Missing with specific section name
- `/api/health/platform` includes credential_health with status and issues list
- Credential issues contribute to warnings and affect overall platform health status

## Quality Improvements in Final Commit
- Fixed global cache to be scoped by project_root (prevents stale data in multi-project scenarios)
- Enhanced service account validation to parse TOML and check for source-specific section
- Added exception logging for OAuth validation failures (debug level with full traceback)
- Removed redundant hasattr check (auth_type is always from AuthType enum)
- Added 2 new tests: test_cache_scoped_by_project_root, test_service_account_toml_section_missing
- Test file added to exemptions list (523 lines, justified by 14 comprehensive tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnhXbQDPeVfhxNvLtXfkna