### PR TITLE
Add scripts, catalog, and backup to README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,19 @@ For detailed installation instructions, see the [documentation](https://docs.get
 
 - **33 data sources** — Stripe, Google Sheets, Google Analytics, Shopify, PostgreSQL, MySQL, CSV, REST APIs, and more
 - **Auto-generated dbt models** — staging models created automatically when you add a source
-- **Web dashboard** — monitor syncs, browse your data catalog, manage sources
+- **Data catalog** — browse tables, columns, and profiling stats; view dbt lineage and test results
+- **Web dashboard** — monitor syncs, manage sources, and view platform health
 - **Metabase integration** — dashboards and SQL queries, auto-configured and ready to use
+- **Scripts** — schedule custom Python scripts alongside your syncs; runs on a schedule with access to your warehouse
 - **Cloud deployment** — deploy to DigitalOcean or any server with `dango deploy`
 - **Authentication** — admin login, user management, 2FA, API keys
 - **Schema drift detection** — get alerted when source schemas change
 - **PII scanning** — detect personally identifiable information across your tables
 - **Notebooks** — Marimo notebooks connected to your DuckDB warehouse
 - **Monitoring** — metric tracking with trend detection and drill-downs
-- **Scheduled syncs** — cron-based scheduling with retry and timeout handling
+- **Scheduled syncs** — cron-based scheduling with queued execution, retry, and timeout handling
 - **Webhooks** — Slack notifications for sync results and alerts
+- **Local backup** — `dango backup` lists and restores local project backups
 - **File watcher** — auto-sync when CSV files change on disk
 
 ## Screenshots


### PR DESCRIPTION
## Summary
- Add **Data catalog** as a dedicated feature (pulled from Web dashboard description)
- Add **Scripts** (scheduled Python jobs against the warehouse)
- Add **Local backup** (`dango backup` / `dango backup restore`)
- Update **Scheduled syncs** to mention queued execution as a reliability improvement
- Trim **Web dashboard** description to remove data catalog mention (now its own bullet)

## Context
Dango is preparing for launch announcements. The README Features list predates several shipped capabilities and undersells one existing feature. This ensures the features list is accurate before launch.

## Verification
- Markdown format: bullet list with **bold** headings and descriptions; consistent with existing style
- Command names verified against `dango/dango/cli/commands/local_backup.py`