### PR TITLE
1.0.7-15: Fix service account validation returning valid=True on missing google-auth

### DIFF
--- a/dango/oauth/service_account.py
+++ b/dango/oauth/service_account.py
@@ -217,8 +217,8 @@ def validate_google_service_account(credential: OAuthCredential) -> TokenValidat
         return TokenValidationResult(
             source_type=credential.source_type,
             provider=credential.provider,
-            valid=True,
-            message="google-auth not installed (can't verify service account)",
+            valid=False,
+            message="google-auth not installed. Run: pip install google-auth",
             error_code="google_auth_missing",
             account_info=credential.account_info,
         )

--- a/tests/unit/test_oauth_validation.py
+++ b/tests/unit/test_oauth_validation.py
@@ -578,3 +578,63 @@ class TestValidateAllTokens:
 
         results = validate_all_tokens(tmp_path)
         assert results == []
+
+
+@pytest.mark.unit
+class TestValidateGoogleServiceAccount:
+    """Tests for validate_google_service_account() in oauth/service_account.py."""
+
+    def _make_service_account_credential(self):
+        return make_oauth_credential(
+            source_type="google_sheets",
+            provider="google_service_account",
+            identifier="test@test-project.iam.gserviceaccount.com",
+            account_info="test@test-project.iam.gserviceaccount.com",
+            credentials={
+                "type": "service_account",
+                "project_id": "test-project",
+                "private_key_id": "key-id",
+                "private_key": (
+                    "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n"
+                    "-----END RSA PRIVATE KEY-----\n"
+                ),
+                "client_email": "test@test-project.iam.gserviceaccount.com",
+                "client_id": "123456789",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            },
+        )
+
+    def test_google_auth_missing_returns_invalid(self):
+        from dango.oauth.service_account import validate_google_service_account
+
+        credential = self._make_service_account_credential()
+        with patch.dict(
+            "sys.modules",
+            {
+                "google.auth.transport.requests": None,
+                "google.oauth2.service_account": None,
+            },
+        ):
+            result = validate_google_service_account(credential)
+
+        assert result.valid is False
+        assert result.error_code == "google_auth_missing"
+        assert "google-auth not installed" in result.message
+        assert result.source_type == "google_sheets"
+        assert result.provider == "google_service_account"
+
+    def test_google_auth_missing_message_includes_install_hint(self):
+        from dango.oauth.service_account import validate_google_service_account
+
+        credential = self._make_service_account_credential()
+        with patch.dict(
+            "sys.modules",
+            {
+                "google.auth.transport.requests": None,
+                "google.oauth2.service_account": None,
+            },
+        ):
+            result = validate_google_service_account(credential)
+
+        assert "pip install google-auth" in result.message


### PR DESCRIPTION
## Summary
`validate_google_service_account()` was returning `valid=True` when google-auth wasn't installed, masking a missing dependency until sync time. This fix aligns it with the sibling function `verify_service_account_key()`, which already returns `valid=False` with a helpful install hint on the same condition.

The change surfaces the missing dependency at health-check time instead of sync time, giving users earlier feedback.

## Changes
- **dango/oauth/service_account.py**: Change ImportError handler to return `valid=False` with message "google-auth not installed. Run: pip install google-auth"
- **tests/unit/test_oauth_validation.py**: Add `TestValidateGoogleServiceAccount` class with two tests verifying the new behavior

## Test Results
- New unit tests: PASSED (2/2)
- Existing oauth validation tests: PASSED (35/35)
- Full test suite: PASSED (4196/4196, 30 skipped)

## Verification
```bash
pytest tests/unit/test_oauth_validation.py::TestValidateGoogleServiceAccount -v
# Result: 2 passed

pytest -x
# Result: 4196 passed, 30 skipped, 64 warnings
```

No regressions in existing functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDJbB7yUJbKTcT9ncWpkdY