### PR TITLE
fix: model wizard duplicate CTE alias on double collision

### DIFF
--- a/dango/cli/model_wizard.py
+++ b/dango/cli/model_wizard.py
@@ -480,6 +480,12 @@ class ModelWizard:
                 # Fall back to full table name if alias already used
                 if alias in aliases:
                     alias = table
+                # If fallback also collides, add numeric suffix
+                if alias in aliases:
+                    i = 2
+                    while f"{alias}_{i}" in aliases:
+                        i += 1
+                    alias = f"{alias}_{i}"
                 aliases.append(alias)
 
             # Generate CTE block with resolved aliases

--- a/tests/unit/test_model_wizard.py
+++ b/tests/unit/test_model_wizard.py
@@ -237,3 +237,23 @@ def test_alias_collision_resolution(project_root):
     assert "{{ ref('stg_hubspot_customers') }}" in sql
     # First alias used in final SELECT
     assert "FROM customers" in sql
+
+
+def test_alias_double_collision_resolution(project_root):
+    """Test that alias collision is handled even when fallback also collides."""
+    wizard = ModelWizard(project_root)
+
+    sql = wizard._generate_sql_template(
+        layer="intermediate",
+        name="int_test.sql",
+        description="",
+        materialization="table",
+        upstream_tables=["stg_stripe_customers", "customers"],
+    )
+
+    assert "WITH customers AS (" in sql
+    assert "customers_2 AS (" in sql
+    assert "{{ ref('stg_stripe_customers') }}" in sql
+    assert "{{ ref('customers') }}" in sql
+    assert sql.count("WITH customers AS (") == 1
+    assert sql.count("customers_2 AS (") == 1


### PR DESCRIPTION
## Summary
- Fix model wizard generating duplicate CTE names when full table name collides with an already-used alias (double collision case not handled by PR #414)
- Example: `["stg_stripe_customers", "customers"]` previously generated two CTEs both named `"customers"` → invalid SQL
- Fix: add numeric suffix (`customers_2`, `customers_3`, …) when fallback also collides

## Changes
- `dango/cli/model_wizard.py`: Added second collision check with numeric suffix generation (lines 484-487)
- `tests/unit/test_model_wizard.py`: Added `test_alias_double_collision_resolution` test case

## Verification
- `pytest -x`: 4199 pass, 30 skip
- `test_alias_double_collision_resolution`: new test covers the double collision case
- `test_alias_collision_resolution` (PR #414 case): passes unchanged ✓
- All other alias tests: pass unchanged ✓
- Full test suite: all green

## Regression check
- Single collision case (stg_stripe_customers, stg_hubspot_customers) — no numeric suffix needed, falls back to full table name as before
- No collisions case — new code path never triggers
- All existing tests pass unchanged