### PR TITLE
fix: add missing app.js to schedules, scripts, catalog templates

### DIFF
--- a/dango/web/templates/catalog.html
+++ b/dango/web/templates/catalog.html
@@ -557,6 +557,7 @@
 </main>
 {% endblock %}
 {% block scripts %}
+<script src="{{ static_url('js/app.js') }}"></script>
 <script>
 function catalogPage() {
     return {

--- a/dango/web/templates/schedules.html
+++ b/dango/web/templates/schedules.html
@@ -287,6 +287,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="{{ static_url('js/app.js') }}"></script>
 <script>
 function schedulesPage() {
     const headers = {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'};

--- a/dango/web/templates/scripts.html
+++ b/dango/web/templates/scripts.html
@@ -154,6 +154,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="{{ static_url('js/app.js') }}"></script>
 <script>
 function scriptsPage() {
     const headers = {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'};


### PR DESCRIPTION
## Summary

- PR #408 moved `createTableSorter()` to `app.js` but forgot to add the `<script src=\"app.js\">` tag to the three templates that call it
- Schedules, Scripts, and Catalog pages broke entirely with `ReferenceError: createTableSorter is not defined`
- Fix: add `<script src="{{ static_url('js/app.js') }}"></script>` to `{% block scripts %}` in all three templates

## Affected templates

- `dango/web/templates/schedules.html` — calls `createTableSorter()` in `schedulesPage()`
- `dango/web/templates/scripts.html` — calls `createTableSorter()` in `scriptsPage()`
- `dango/web/templates/catalog.html` — calls `createTableSorter()` in `catalogPage()`

## Verification

- `pytest -x`: passes (no unit tests for this — template rendering)
- `ruff check dango/`: clean
- Confirmed fix: pages load data correctly after adding the script tag

## Regression check

- Sources and Models pages unaffected (already loaded `app.js` correctly)
- No JS logic changes — purely a missing `<script>` tag