### PR TITLE
fix: write history entries for cancelled/timed-out/failed script runs

### DIFF
--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -1481,6 +1481,20 @@ def run_scheduled_script(
 
     except JobTimeoutError:
         elapsed = time.monotonic() - t0
+        if script_path:
+            _write_script_logs(
+                project_root,
+                script_path,
+                schedule_name,
+                stdout="",
+                stderr="",
+                exit_code=-1,
+                duration_seconds=elapsed,
+                status="timeout",
+                run_id=run_id,
+                started_at=started_at,
+                error="Job timed out (APScheduler limit)",
+            )
         log_activity(project_root, "error", script_label, "Scheduled script timed out")
         _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
         _log_execution_event(
@@ -1508,6 +1522,20 @@ def run_scheduled_script(
 
     except JobCancelledError:
         elapsed = time.monotonic() - t0
+        if script_path:
+            _write_script_logs(
+                project_root,
+                script_path,
+                schedule_name,
+                stdout="",
+                stderr="",
+                exit_code=-1,
+                duration_seconds=elapsed,
+                status="cancelled",
+                run_id=run_id,
+                started_at=started_at,
+                error="Script run was cancelled",
+            )
         log_activity(project_root, "warning", script_label, "Scheduled script cancelled")
         _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")
         _log_execution_event(
@@ -1536,6 +1564,20 @@ def run_scheduled_script(
     except Exception as exc:  # noqa: BLE001
         elapsed = time.monotonic() - t0
         error_msg = str(exc)
+        if script_path:
+            _write_script_logs(
+                project_root,
+                script_path,
+                schedule_name,
+                stdout="",
+                stderr="",
+                exit_code=-1,
+                duration_seconds=elapsed,
+                status="failed",
+                run_id=run_id,
+                started_at=started_at,
+                error=error_msg,
+            )
         log_activity(
             project_root,
             "error",

--- a/dango/platform/scheduling/jobs.py
+++ b/dango/platform/scheduling/jobs.py
@@ -1479,7 +1479,12 @@ def run_scheduled_script(
                 duration_seconds=round(elapsed, 2),
             )
 
-    except JobTimeoutError:
+    # Not reachable via SCRIPT schedules today (they aren't wrapped in
+    # run_with_resilience(), unlike run_scheduled_sync/run_scheduled_dbt), so this
+    # branch only fires if a future caller starts injecting JobTimeoutError. Kept
+    # for parity with the sync/dbt handlers so history writing doesn't have to be
+    # re-added later.
+    except JobTimeoutError as exc:
         elapsed = time.monotonic() - t0
         if script_path:
             _write_script_logs(
@@ -1493,7 +1498,7 @@ def run_scheduled_script(
                 status="timeout",
                 run_id=run_id,
                 started_at=started_at,
-                error="Job timed out (APScheduler limit)",
+                error=str(exc) or "Job timed out (APScheduler limit)",
             )
         log_activity(project_root, "error", script_label, "Scheduled script timed out")
         _try_finish_record(project_root, schedule_name, record_id, "record_timeout")
@@ -1520,7 +1525,7 @@ def run_scheduled_script(
             duration_seconds=elapsed,
         )
 
-    except JobCancelledError:
+    except JobCancelledError as exc:
         elapsed = time.monotonic() - t0
         if script_path:
             _write_script_logs(
@@ -1534,7 +1539,7 @@ def run_scheduled_script(
                 status="cancelled",
                 run_id=run_id,
                 started_at=started_at,
-                error="Script run was cancelled",
+                error=str(exc) or "Script run was cancelled",
             )
         log_activity(project_root, "warning", script_label, "Scheduled script cancelled")
         _try_finish_record(project_root, schedule_name, record_id, "record_cancellation")

--- a/tests/unit/test_script_exception_history.py
+++ b/tests/unit/test_script_exception_history.py
@@ -1,0 +1,143 @@
+"""tests/unit/test_script_exception_history.py
+
+Tests that cancelled, timed-out, and pre-launch-failed script runs write
+history entries to the .jsonl file so the Scripts UI can show them.
+"""
+
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+def _run_id():
+    return str(uuid.uuid4())
+
+
+def _make_kwargs(tmp_path):
+    return {"project_root": str(tmp_path)}
+
+
+def _history_file(tmp_path, script_path):
+    safe_name = script_path.replace("/", "__").replace("\\", "__")
+    return tmp_path / ".dango" / "logs" / "scripts" / f"{safe_name}.jsonl"
+
+
+@pytest.mark.unit
+class TestScriptExceptionHistory:
+    """run_scheduled_script writes history entries for non-happy-path outcomes."""
+
+    def _setup_valid_script(self, tmp_path, content="print('hello')"):
+        """Create a valid scripts/ directory and script file."""
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        script = scripts_dir / "my_script.py"
+        script.write_text(content)
+        return "my_script.py"
+
+    @patch("dango.platform.scheduling.jobs._scheduler_service", None)
+    def test_cancelled_run_writes_history(self, tmp_path):
+        """JobCancelledError path writes a 'cancelled' history entry."""
+        from dango.exceptions import JobCancelledError
+        from dango.platform.scheduling.jobs import run_scheduled_script
+
+        script_path = self._setup_valid_script(tmp_path)
+
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch("dango.utils.activity_log.log_activity"),
+            patch("dango.platform.scheduling.jobs._broadcast"),
+            patch("dango.platform.scheduling.jobs._notify"),
+            patch("dango.platform.scheduling.jobs._try_record_start", return_value=1),
+            patch("dango.platform.scheduling.jobs._try_finish_record"),
+            patch("dango.platform.scheduling.jobs._log_execution_event"),
+            patch("dango.platform.notifications.webhook.WebhookSender"),
+            patch("dango.platform.notifications.webhook.load_notification_config"),
+        ):
+            mock_popen.side_effect = JobCancelledError("cancelled")
+
+            run_scheduled_script(
+                "test_schedule",
+                script_path=script_path,
+                **_make_kwargs(tmp_path),
+            )
+
+        hist = _history_file(tmp_path, script_path)
+        assert hist.exists(), "No .jsonl written for cancelled run"
+        entry = json.loads(hist.read_text().strip())
+        assert entry["status"] == "cancelled"
+        assert entry["script_name"] == script_path
+        assert entry["error"] == "Script run was cancelled"
+        assert entry["exit_code"] == -1
+        assert "run_id" in entry
+        assert "started_at" in entry
+
+    @patch("dango.platform.scheduling.jobs._scheduler_service", None)
+    def test_pre_launch_exception_writes_history(self, tmp_path):
+        """Exception before subprocess launches writes a 'failed' history entry."""
+        from dango.platform.scheduling.jobs import run_scheduled_script
+
+        script_path = self._setup_valid_script(tmp_path)
+
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch("dango.utils.activity_log.log_activity"),
+            patch("dango.platform.scheduling.jobs._broadcast"),
+            patch("dango.platform.scheduling.jobs._notify"),
+            patch("dango.platform.scheduling.jobs._try_record_start", return_value=1),
+            patch("dango.platform.scheduling.jobs._try_finish_record"),
+            patch("dango.platform.scheduling.jobs._log_execution_event"),
+            patch("dango.platform.notifications.webhook.WebhookSender"),
+            patch("dango.platform.notifications.webhook.load_notification_config"),
+        ):
+            mock_popen.side_effect = OSError("Permission denied")
+
+            run_scheduled_script(
+                "test_schedule",
+                script_path=script_path,
+                **_make_kwargs(tmp_path),
+            )
+
+        hist = _history_file(tmp_path, script_path)
+        assert hist.exists(), "No .jsonl written for pre-launch failed run"
+        entry = json.loads(hist.read_text().strip())
+        assert entry["status"] == "failed"
+        assert "Permission denied" in entry["error"]
+        assert entry["exit_code"] == -1
+        assert "run_id" in entry
+
+    @patch("dango.platform.scheduling.jobs._scheduler_service", None)
+    def test_job_timeout_writes_history(self, tmp_path):
+        """JobTimeoutError path writes a 'timeout' history entry."""
+        from dango.exceptions import JobTimeoutError
+        from dango.platform.scheduling.jobs import run_scheduled_script
+
+        script_path = self._setup_valid_script(tmp_path)
+
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch("dango.utils.activity_log.log_activity"),
+            patch("dango.platform.scheduling.jobs._broadcast"),
+            patch("dango.platform.scheduling.jobs._notify"),
+            patch("dango.platform.scheduling.jobs._try_record_start", return_value=1),
+            patch("dango.platform.scheduling.jobs._try_finish_record"),
+            patch("dango.platform.scheduling.jobs._log_execution_event"),
+            patch("dango.platform.notifications.webhook.WebhookSender"),
+            patch("dango.platform.notifications.webhook.load_notification_config"),
+        ):
+            mock_popen.side_effect = JobTimeoutError("timed out")
+
+            run_scheduled_script(
+                "test_schedule",
+                script_path=script_path,
+                **_make_kwargs(tmp_path),
+            )
+
+        hist = _history_file(tmp_path, script_path)
+        assert hist.exists(), "No .jsonl written for timed-out run"
+        entry = json.loads(hist.read_text().strip())
+        assert entry["status"] == "timeout"
+        assert "timed out" in entry["error"].lower()
+        assert entry["exit_code"] == -1
+        assert "run_id" in entry

--- a/tests/unit/test_script_exception_history.py
+++ b/tests/unit/test_script_exception_history.py
@@ -38,11 +38,21 @@ class TestScriptExceptionHistory:
 
     @patch("dango.platform.scheduling.jobs._scheduler_service", None)
     def test_cancelled_run_writes_history(self, tmp_path):
-        """JobCancelledError path writes a 'cancelled' history entry."""
+        """JobCancelledError path writes a 'cancelled' history entry.
+
+        The exception is injected via ``Popen.side_effect`` rather than the
+        actual pre-launch ``is_cancelled()`` check (jobs.py) for test
+        convenience — either way it's uncaught until the ``except
+        JobCancelledError`` handler, so this still exercises the real handler.
+        The message mirrors production's raise site so the assertion checks
+        that the handler preserves the real exception detail, not a
+        hardcoded placeholder.
+        """
         from dango.exceptions import JobCancelledError
         from dango.platform.scheduling.jobs import run_scheduled_script
 
         script_path = self._setup_valid_script(tmp_path)
+        cancel_message = "Script cancelled before launch for test_schedule"
 
         with (
             patch("subprocess.Popen") as mock_popen,
@@ -55,7 +65,7 @@ class TestScriptExceptionHistory:
             patch("dango.platform.notifications.webhook.WebhookSender"),
             patch("dango.platform.notifications.webhook.load_notification_config"),
         ):
-            mock_popen.side_effect = JobCancelledError("cancelled")
+            mock_popen.side_effect = JobCancelledError(cancel_message)
 
             run_scheduled_script(
                 "test_schedule",
@@ -68,7 +78,7 @@ class TestScriptExceptionHistory:
         entry = json.loads(hist.read_text().strip())
         assert entry["status"] == "cancelled"
         assert entry["script_name"] == script_path
-        assert entry["error"] == "Script run was cancelled"
+        assert entry["error"] == cancel_message
         assert entry["exit_code"] == -1
         assert "run_id" in entry
         assert "started_at" in entry
@@ -109,7 +119,16 @@ class TestScriptExceptionHistory:
 
     @patch("dango.platform.scheduling.jobs._scheduler_service", None)
     def test_job_timeout_writes_history(self, tmp_path):
-        """JobTimeoutError path writes a 'timeout' history entry."""
+        """JobTimeoutError handler writes a 'timeout' history entry.
+
+        NOTE: run_scheduled_script is not currently wrapped in
+        run_with_resilience() (unlike run_scheduled_sync/run_scheduled_dbt),
+        so nothing raises JobTimeoutError for SCRIPT schedules in production
+        today — this test validates the handler's own logic in isolation
+        (defensive parity with the sync/dbt handlers), not a reachable
+        production trigger. See the comment above the except block in
+        jobs.py.
+        """
         from dango.exceptions import JobTimeoutError
         from dango.platform.scheduling.jobs import run_scheduled_script
 


### PR DESCRIPTION
## Summary
- Fix cancelled and pre-launch-failed script runs showing no history in Scripts UI
- Scripts scheduling is new in 1.0.7 — these are new bugs, not pre-existing gaps
- Three outer except blocks in run_scheduled_script() never called _write_script_logs():
  except JobTimeoutError, except JobCancelledError, except Exception
- Fix: add _write_script_logs() call to each, using run_id/started_at already in scope,
  binding the real exception (`as exc`) so the recorded error detail is accurate

## Note on except JobTimeoutError
Self-review (see PR comment below) found that SCRIPT schedules are not currently
wrapped in `run_with_resilience()` and never get a `_timeout_minutes` kwarg (unlike
SYNC/dbt schedules), so nothing raises `JobTimeoutError` in `run_scheduled_script`'s
call chain today — actual script timeouts are already handled by the pre-existing
`subprocess.TimeoutExpired` branch (which had its own `_write_script_logs` call
from PR #428). The `except JobTimeoutError` history-write is kept for parity with
the sync/dbt handlers and as future-proofing, but is not fixing a currently-reachable
gap. Commented in the code and reworded the corresponding test's docstring so this
isn't misleading to future readers.

## Verification
- `pytest -x`: 4197 pass, 0 fail, 30 skipped
- `pytest tests/unit/test_script_exception_history.py -x -v`: 3 pass
- `ruff check dango/`: passed
- `ruff format --check dango/`: passed

## Regression check
- run_scheduled_sync() and run_scheduled_dbt() handlers not touched (verified via grep — exactly 5 _write_script_logs call sites total: 2 pre-existing from PR #428 + 3 new)
- _write_script_logs() signature unchanged
- All additions guarded by `if script_path:` — no change to functions missing a script
- _write_script_logs() never raises (top-level try/except) — no new failure modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFWGJfbediMp2C7E28Zqin