### PR TITLE
fix: PostCSS security update + stale scheduling docs

### DIFF
--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -82,7 +82,7 @@ platform/
 | `scheduling/scheduler.py` | APScheduler wrapper with SQLite persistence, event listeners, retry callback | `SchedulerService` |
 | `scheduling/resilience.py` | Resilience: retry with backoff, timeout via thread kill, cancellation | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `scheduling/history.py` | Execution history tracking for scheduled jobs | `record_start`, `record_completion`, `record_failure`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt` |
+| `scheduling/jobs.py` | Module-level job functions (pickle-safe) | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt`, `run_scheduled_script` |
 | `scheduling/sync_trigger.py` | Subprocess entrypoint for sync operations (progress writing, lock, OAuth) | `run_manual_sync()`, `_write_status()` |
 | `sync_process.py` | Subprocess launch + polling for process-isolated syncs | `launch_sync_subprocess`, `poll_sync_status`, `poll_sync_status_blocking`, `read_sync_status`, `cleanup_sync_status`, `start_sync_status_watcher` |
 | `notifications/webhook.py` | Event types, config models, event filtering, async sender with retry | `WebhookSender`, `WebhookConfig`, `NotificationConfig`, `EventType`, `EventCategory`, `WebhookPayload` |

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -12,7 +12,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | `scheduler.py` (448 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (245 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
-| `jobs.py` (1551 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules and `run_scheduled_script` for SCRIPT schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt`, `run_scheduled_script` |
+| `jobs.py` (1627 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules and `run_scheduled_script` for SCRIPT schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt`, `run_scheduled_script` |
 | `sync_trigger.py` (330 lines) | Subprocess entrypoint for sync operations — progress writing (incl. dbt phase passthrough via progress_callback), lock acquisition, OAuth validation | `run_manual_sync()`, `_write_status()` |
 
 ## Key Conventions

--- a/package-lock.json
+++ b/package-lock.json
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -597,7 +597,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- PostCSS 8.5.10 → 8.5.26: resolves Dependabot alerts #1, #2, #5 (path traversal via sourceMappingURL — build-time only, not exploitable at runtime)
- nanoid 3.3.11 → 3.3.18: side-effect fix for auto-dismissed alerts #3 and #6
- platform/CLAUDE.md: add \`run_scheduled_script\` to scheduling/jobs.py key symbols (was added in 1.0.7 but doc not updated)
- scheduling/CLAUDE.md: jobs.py line count 1551 → 1627 (PRs #428, #429, #431 added ~76 lines)

## Verification
- \`make css-build\`: passes, CSS output unchanged (postcss version bump only)
- \`npm audit\`: 0 vulnerabilities after update

## Regression check
- PostCSS is a devDependency only — no runtime impact
- CSS output verified identical before and after bump