### PR TITLE
fix: add InquirerPy to declared dependencies (release blocker)

### DIFF
--- a/dango/cli/commands/oauth.py
+++ b/dango/cli/commands/oauth.py
@@ -20,7 +20,7 @@ def _try_service_account_auth(source_type: str, project_root: Path) -> bool:
     """
     import json
 
-    from InquirerPy import inquirer  # type: ignore[import-not-found]
+    from InquirerPy import inquirer  # type: ignore[import-untyped]
 
     from dango.oauth.service_account import (
         save_service_account_credential,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,8 @@ exclude = ["dango/ingestion/dlt_sources/"]
 module = [
     "inquirer",
     "inquirer.*",
+    "InquirerPy",
+    "InquirerPy.*",
     "googleapiclient",
     "googleapiclient.*",
     "boto3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "watchdog>=5.0.0",
     "rich>=13.7.0",
     "inquirer>=3.4.0",
+    "InquirerPy>=0.3.4",              # used by oauth.py wizards (google_sheets, google_analytics)
     "requests>=2.33.0",           # CVE-2026-25645 fixed in 2.33.0
     "httpx>=0.27.0,<1.0",            # httpx 1.0 removes TimeoutException
     "idna>=3.15",                     # CVE fix — transitive via httpx/requests/anyio


### PR DESCRIPTION
## Summary
- `oauth.py` imports `from InquirerPy import inquirer` for the `google_sheets` and `google_analytics` OAuth wizards
- `InquirerPy` was never declared in `pyproject.toml` — only `inquirer` (a different package) was listed
- Any fresh install of `getdango` omits `InquirerPy`, causing `dango oauth google_sheets` and `dango oauth google_analytics` to fail immediately with `No module named 'InquirerPy'`
- Discovered during 1.0.7 manual verification on beta-1

## Verification
- `dango oauth google_sheets` now shows OAuth vs Service Account prompt correctly after fix
- `pytest tests/unit/test_web_imports.py tests/unit/test_scheduler.py -x -q`: 61 passed

## Regression check
- `InquirerPy 0.3.4` is the version currently installed in the dev venv — pinning to `>=0.3.4`
- `inquirer>=3.4.0` remains — other CLI commands use it directly; both packages coexist fine