### PR TITLE
1.0.8-B: Egress allowlist CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,13 @@ jobs:
       - name: pytest
         env:
           DANGO_LOG_LEVEL: ERROR
-        run: pytest --tb=short -q
+        # -m "not egress": the egress-marked test needs the spaCy PII model
+        # pre-installed to stay hermetic (see the egress job's dedicated
+        # pre-install step below) — this matrix doesn't have that step, so
+        # running it here would add a live GitHub Releases download
+        # dependency to these required checks for no benefit; the egress
+        # job already covers it.
+        run: pytest --tb=short -q -m "not egress"
 
   security:
     name: Security (pip-audit)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,27 @@ jobs:
       - name: pip-audit
         run: pip-audit --ignore-vuln CVE-2026-32274 --ignore-vuln PYSEC-2026-2120 --ignore-vuln CVE-2026-71491 --ignore-vuln CVE-2026-59894 --ignore-vuln CVE-2026-59893 --ignore-vuln CVE-2026-54284
 
+  egress:
+    name: Egress allowlist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -c constraints.txt -e ".[dev]"
+      - name: Pre-install spaCy PII model
+        # Real download, done here (unguarded) so the guarded test below is
+        # hermetic — spacy.load() succeeds without any network call once this
+        # is installed. Without this step, the live-detection test's PII scan
+        # hook falls through to governance/pii_detector.py's urllib fallback
+        # and either does a slow live download or gets correctly blocked as
+        # an "unexpected host" (it isn't unexpected, it's just not pre-empted).
+        run: python -m spacy download en_core_web_sm
+      - name: Egress allowlist test
+        run: pytest tests/unit/test_egress_allowlist.py -v
+
   llm-checks:
     name: LLM checks
     runs-on: ubuntu-latest

--- a/docs/network-egress.yml
+++ b/docs/network-egress.yml
@@ -1,7 +1,10 @@
 # Dango network egress — all outbound connections made by the stack.
-# Telemetry: controllable via `dango telemetry off --all`
+# Telemetry: each provider has its own opt-out today (see each entry's
+# `control` field). A unified `dango telemetry off --all` command is planned
+# (Session D, not yet merged as of this session) — do not assume it exists.
 # Functional: required for operation, disclosed but not toggleable
-# Verified against installed packages (dbt-core, dlt, marimo source) 2026-08-31.
+# Verified against installed packages (dbt-core 1.11.14, dlt 1.28.1, marimo)
+# 2026-09-01 — re-verified after the dbt-core 1.10->1.11 bump landed on v1.0.8.
 # Metabase's own telemetry endpoint is NOT independently source-verified in this
 # session (Metabase is a Java process, not inspectable from this Python venv) —
 # confirm against Metabase's own telemetry docs before relying on it publicly.
@@ -9,7 +12,13 @@
 telemetry:
   - host: telemetry.getdango.dev
     provider: dango
-    control: "dango telemetry off --provider dango"
+    control: >
+      Today: decline the `dango init` consent prompt (persists "no"), or set
+      DO_NOT_TRACK=1 / DANGO_TELEMETRY=0 / `telemetry: false` in
+      ~/.dango/config.yml (dango/telemetry.py:is_telemetry_enabled) — all
+      three suppress the prompt entirely, no ping is ever sent. A unified
+      `dango telemetry off --provider dango` command is Session D's job
+      (dango/cli/commands/ has no `telemetry.py` yet as of this session).
     sends: "anonymous UUID, version, OS, source type names, weekly heartbeat"
   - host: fishtownanalytics.sinter-collect.com
     provider: dbt-core
@@ -21,7 +30,11 @@ telemetry:
     sends: "command names, hashed pipeline/dataset names, execution times, OS"
   - host: metabase.com
     provider: metabase
-    control: "dango telemetry off --provider metabase (sets allow_tracking=false via API)"
+    control: >
+      Planned: `dango telemetry off --provider metabase` (sets
+      allow_tracking=false via the Metabase admin API) is Session D's job,
+      not yet implemented as of this session — today this requires toggling
+      the setting manually in the Metabase admin UI.
     sends: "anonymous usage statistics"
 
 functional:

--- a/docs/network-egress.yml
+++ b/docs/network-egress.yml
@@ -1,0 +1,58 @@
+# Dango network egress — all outbound connections made by the stack.
+# Telemetry: controllable via `dango telemetry off --all`
+# Functional: required for operation, disclosed but not toggleable
+# Verified against installed packages (dbt-core, dlt, marimo source) 2026-08-31.
+# Metabase's own telemetry endpoint is NOT independently source-verified in this
+# session (Metabase is a Java process, not inspectable from this Python venv) —
+# confirm against Metabase's own telemetry docs before relying on it publicly.
+
+telemetry:
+  - host: telemetry.getdango.dev
+    provider: dango
+    control: "dango telemetry off --provider dango"
+    sends: "anonymous UUID, version, OS, source type names, weekly heartbeat"
+  - host: fishtownanalytics.sinter-collect.com
+    provider: dbt-core
+    control: "DBT_SEND_ANONYMOUS_USAGE_STATS=false or DO_NOT_TRACK=1"
+    sends: "OS, Python version, invocation success/duration, hashed model content (Snowplow)"
+  - host: telemetry.scalevector.ai
+    provider: dlt
+    control: "dlthub_telemetry=false in .dlt/config.toml, or dlt --disable-telemetry"
+    sends: "command names, hashed pipeline/dataset names, execution times, OS"
+  - host: metabase.com
+    provider: metabase
+    control: "dango telemetry off --provider metabase (sets allow_tracking=false via API)"
+    sends: "anonymous usage statistics"
+
+functional:
+  - host: extensions.duckdb.org
+    reason: "DuckDB autoloads extensions on demand"
+    controllable: false
+  - host: hub.getdbt.com
+    reason: "dbt package installation (dbt deps)"
+    controllable: false
+  - host: pypi.org
+    reason: "dango upgrade command"
+    controllable: false
+  - host: registry-1.docker.io
+    reason: "Metabase Docker image pull on first start"
+    controllable: false
+  - host: github.com
+    reason: >
+      Two separate download paths: (1) spaCy PII model wheel on first Presidio use
+      (governance/pii_detector.py, github.com/explosion/spacy-models), (2) Metabase
+      DuckDB driver on `dango init` if not cached (utils/driver.py,
+      github.com/motherduckdb/metabase_duckdb_driver)
+    controllable: false
+  - host: objects.githubusercontent.com
+    reason: "GitHub Releases asset CDN — both github.com download paths above redirect here"
+    controllable: false
+
+notes:
+  - "dbt and dlt telemetry env vars/config are read by their own subprocesses/library
+     calls, not a separate Dango network layer. dango telemetry off --all (Session D)
+     writes these through to each tool's real config."
+  - "Marimo update check host (marimo.io/api/oss/latest-version) is not listed above
+     because it is never contacted in a Dango deployment: Dango always passes
+     --skip-update-check to every Marimo process (dango/notebooks/manager.py:141),
+     verified against marimo's installed source (_cli/cli.py:583, _cli/upgrade.py)."

--- a/docs/network-egress.yml
+++ b/docs/network-egress.yml
@@ -32,7 +32,14 @@ functional:
     reason: "dbt package installation (dbt deps)"
     controllable: false
   - host: pypi.org
-    reason: "dango upgrade command"
+    reason: "dango upgrade command (cli/commands/upgrade.py) — pip resolves package metadata here"
+    controllable: false
+  - host: files.pythonhosted.org
+    reason: >
+      dango upgrade command — pip's actual wheel/sdist download target. pypi.org
+      only resolves metadata; the package file itself is served from this
+      separate PyPI CDN host, same redirect-style pattern as the GitHub Releases
+      entries below.
     controllable: false
   - host: registry-1.docker.io
     reason: "Metabase Docker image pull on first start"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,7 @@ markers = [
     "unit: Unit tests (no external services or network — tmp_path filesystem operations are allowed)",
     "integration: Integration tests (may use temp dirs, real files, DuckDB)",
     "cloud: Cloud integration tests (requires DIGITALOCEAN_TOKEN, on-demand CI)",
+    "egress: Live network-detection tests requiring the spaCy PII model pre-installed (see the egress job in .github/workflows/ci.yml) — excluded from the general test matrix, which doesn't pre-install it",
 ]
 addopts = "--strict-markers"
 log_file = "tests/pytest.log"

--- a/tests/unit/test_egress_allowlist.py
+++ b/tests/unit/test_egress_allowlist.py
@@ -1,7 +1,10 @@
 """tests/unit/test_egress_allowlist.py
 
-CI gate for LAUNCH-READINESS.md §A5: detects hosts Dango's own Python process
-contacts that aren't documented in docs/network-egress.yml.
+Informational CI check for LAUNCH-READINESS.md §A5: detects hosts Dango's own
+Python process contacts that aren't documented in docs/network-egress.yml.
+Not a merge-blocking gate — the `egress` job is deliberately not in required
+status checks (see .github/workflows/ci.yml) — but it does fail loudly and
+visibly on an undisclosed host, which is the detection mechanism §A5 asks for.
 """
 
 from __future__ import annotations
@@ -24,11 +27,18 @@ def _load_egress_doc() -> dict[str, Any]:
     return yaml.safe_load(EGRESS_DOC.read_text())
 
 
+def _normalize_host(host: str) -> str:
+    """Lowercase and strip a trailing root '.' so 'Host.example.com.' and
+    'host.example.com' compare equal — DNS is case-insensitive and a
+    resolver may present either form."""
+    return host.lower().rstrip(".")
+
+
 def _documented_hosts() -> set[str]:
     data = _load_egress_doc()
     hosts = {entry["host"] for entry in data.get("telemetry", [])}
     hosts |= {entry["host"] for entry in data.get("functional", [])}
-    return hosts
+    return {_normalize_host(h) for h in hosts}
 
 
 class _AllowlistGuard:
@@ -53,6 +63,8 @@ class _AllowlistGuard:
     """
 
     def __init__(self, allowed_hosts: set[str]) -> None:
+        # allowed_hosts (from _documented_hosts) is already normalized;
+        # ALWAYS_ALLOWED_HOSTS doesn't need it (no case/dot variation).
         self.allowed_hosts = allowed_hosts | ALWAYS_ALLOWED_HOSTS
         self.blocked_hosts: set[str] = set()
         self._original = socket.getaddrinfo
@@ -65,150 +77,157 @@ class _AllowlistGuard:
         socket.getaddrinfo = self._original  # type: ignore[assignment]
 
     def _patched(self, host: str | None, *args: Any, **kwargs: Any) -> Any:
-        if host is not None and host not in self.allowed_hosts:
+        if host is not None and _normalize_host(host) not in self.allowed_hosts:
             self.blocked_hosts.add(host)
             raise socket.gaierror(socket.EAI_NONAME, f"blocked by egress allowlist test: {host!r}")
         return self._original(host, *args, **kwargs)
 
 
 @pytest.mark.unit
-def test_network_egress_yml_exists() -> None:
-    assert EGRESS_DOC.exists(), "docs/network-egress.yml not found"
-    data = _load_egress_doc()
-    assert "telemetry" in data
-    assert "functional" in data
+class TestNetworkEgressDoc:
+    """Doc-consistency and real-introspection checks — no network, fast."""
 
+    def test_network_egress_yml_exists(self) -> None:
+        assert EGRESS_DOC.exists(), "docs/network-egress.yml not found"
+        data = _load_egress_doc()
+        assert "telemetry" in data
+        assert "functional" in data
 
-@pytest.mark.unit
-def test_network_egress_yml_has_all_known_providers() -> None:
-    data = _load_egress_doc()
-    providers = {entry["provider"] for entry in data["telemetry"]}
-    assert providers == {"dango", "dbt-core", "dlt", "metabase"}
+    def test_network_egress_yml_has_all_known_providers(self) -> None:
+        data = _load_egress_doc()
+        providers = {entry["provider"] for entry in data["telemetry"]}
+        assert providers == {"dango", "dbt-core", "dlt", "metabase"}
 
+    def test_dlt_runtime_configuration_has_telemetry_field(self) -> None:
+        """Real introspection against the installed dlt version, not a
+        hardcoded string comparison. Catches a silent rename of the field
+        docs/network-egress.yml claims controls dlt's telemetry (this is
+        exactly the risk LAUNCH-READINESS.md §A2 calls out: "If dlt renames
+        dlthub_telemetry... a silent failure means you are telling users
+        something false")."""
+        from dlt.common.configuration.specs.runtime_configuration import (
+            RuntimeConfiguration,
+        )
 
-@pytest.mark.unit
-def test_dlt_runtime_configuration_has_telemetry_field() -> None:
-    """Real introspection against the installed dlt version, not a hardcoded
-    string comparison. Catches a silent rename of the field
-    docs/network-egress.yml claims controls dlt's telemetry (this is exactly
-    the risk LAUNCH-READINESS.md §A2 calls out: "If dlt renames
-    dlthub_telemetry... a silent failure means you are telling users
-    something false")."""
-    from dlt.common.configuration.specs.runtime_configuration import (
-        RuntimeConfiguration,
-    )
+        fields = RuntimeConfiguration.__dataclass_fields__
+        assert "dlthub_telemetry" in fields, (
+            "dlt renamed its telemetry opt-out field — update "
+            "docs/network-egress.yml and the write-through in the telemetry command"
+        )
 
-    fields = RuntimeConfiguration.__dataclass_fields__
-    assert "dlthub_telemetry" in fields, (
-        "dlt renamed its telemetry opt-out field — update "
-        "docs/network-egress.yml and the write-through in the telemetry command"
-    )
+    def test_dbt_send_anonymous_usage_stats_envvar_name(self) -> None:
+        """Real check against the installed dbt-core source, not memory.
+        Catches a silent rename of the env var docs/network-egress.yml
+        documents as dbt's telemetry opt-out control."""
+        from dbt.cli import params as dbt_params
 
-
-@pytest.mark.unit
-def test_dbt_send_anonymous_usage_stats_envvar_name() -> None:
-    """Real check against the installed dbt-core source, not memory. Catches
-    a silent rename of the env var docs/network-egress.yml documents as
-    dbt's telemetry opt-out control."""
-    from dbt.cli import params as dbt_params
-
-    source = inspect.getsource(dbt_params)
-    assert "DBT_SEND_ANONYMOUS_USAGE_STATS" in source, (
-        "dbt-core's telemetry opt-out env var name changed — update "
-        "docs/network-egress.yml and the write-through in the telemetry command"
-    )
+        source = inspect.getsource(dbt_params)
+        assert "DBT_SEND_ANONYMOUS_USAGE_STATS" in source, (
+            "dbt-core's telemetry opt-out env var name changed — update "
+            "docs/network-egress.yml and the write-through in the telemetry command"
+        )
 
 
 @pytest.mark.unit
 @pytest.mark.egress
-def test_dango_init_source_sync_only_contacts_allowlisted_hosts(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Runs a real dango init (--skip-wizard) -> CSV source -> sync workflow
-    with DNS resolution blocked for any host outside docs/network-egress.yml.
-    This is detection, not documentation: it fails if an undisclosed host is
-    contacted, it does not just check the doc is self-consistent.
+class TestLiveEgressDetection:
+    """Live network-detection test — its own class because it carries the
+    extra `egress` marker the doc-consistency tests above don't need
+    (STANDARDS.md §7: markers apply at the class level)."""
 
-    Scope: catches egress from Dango's own Python process only.
-    - dbt runs as a real subprocess during dango init (`dbt docs generate`,
-      cli/init.py:1153-1225, unconditional — dbt docs generation is treated
-      as CRITICAL and rolls back init on failure) and inside run_sync when
-      skip_dbt=False — its own DNS/socket calls happen in a separate process
-      and are invisible to this monkeypatch. skip_dbt=True below avoids also
-      running it during sync, since running it here adds latency for zero
-      detection coverage. dbt-core's anonymous usage stats are on by default
-      (dbt/tracking.py) and, being a real subprocess call this monkeypatch
-      can't see, would otherwise fire a real ping to
-      fishtownanalytics.sinter-collect.com on every run of this test via the
-      init step above — DBT_SEND_ANONYMOUS_USAGE_STATS/DO_NOT_TRACK below
-      disable that. This is an env var, not subprocess network interception
-      (still out of scope) — it doesn't let this test see dbt's egress, it
-      just stops the init step from producing an actual telemetry send as an
-      unintended side effect of writing a telemetry-detection test.
-    - dlt itself runs in-process (imported directly in dlt_runner.py, not
-      subprocess'd) — it IS covered by this test, unlike dbt.
-    - `dango start`/`dango serve` are excluded entirely: they require a
-      running Docker daemon to launch Metabase (cli/commands/platform.py:
-      464-495), which would make this job slow and Docker-availability
-      flaky for no additional Python-process detection coverage — their
-      egress (Metabase container, localhost health polling) is separately
-      documented/functional.
+    def test_dango_init_source_sync_only_contacts_allowlisted_hosts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Runs a real dango init (--skip-wizard) -> CSV source -> sync
+        workflow with DNS resolution blocked for any host outside
+        docs/network-egress.yml. This is detection, not documentation: it
+        fails if an undisclosed host is contacted, it does not just check
+        the doc is self-consistent.
 
-    Marked `egress` (in addition to `unit`) and excluded from the general
-    `test` CI job matrix (`-m "not egress"`, .github/workflows/ci.yml) — that
-    job's 3-way Python-version matrix doesn't run the `egress` job's spaCy
-    pre-install step, so without this exclusion the test would fall through
-    to governance/pii_detector.py's live model-download path three times per
-    CI run, adding real network dependency to the *required* Test (Python
-    3.10)/(3.12) checks for no detection benefit (the dedicated `egress` job
-    already covers this test hermetically).
-    """
-    from dango.cli.init import init_project
-    from dango.config.models import SourceType
-    from dango.ingestion import run_sync
-    from dango.utils.driver import METABASE_DUCKDB_DRIVER_VERSION
-    from tests.factories.config_factories import (
-        make_csv_source_config,
-        make_data_source,
-    )
+        Scope: catches egress from Dango's own Python process only.
+        - dbt runs as a real subprocess during dango init (`dbt docs
+          generate`, cli/init.py:1153-1225, unconditional — dbt docs
+          generation is treated as CRITICAL and rolls back init on failure)
+          and inside run_sync when skip_dbt=False — its own DNS/socket calls
+          happen in a separate process and are invisible to this
+          monkeypatch. skip_dbt=True below avoids also running it during
+          sync, since running it here adds latency for zero detection
+          coverage. dbt-core's anonymous usage stats are on by default
+          (dbt/tracking.py) and, being a real subprocess call this
+          monkeypatch can't see, would otherwise fire a real ping to
+          fishtownanalytics.sinter-collect.com on every run of this test via
+          the init step above — DBT_SEND_ANONYMOUS_USAGE_STATS/DO_NOT_TRACK
+          below disable that. This is an env var, not subprocess network
+          interception (still out of scope) — it doesn't let this test see
+          dbt's egress, it just stops the init step from producing an actual
+          telemetry send as an unintended side effect of writing a
+          telemetry-detection test.
+        - dlt itself runs in-process (imported directly in dlt_runner.py,
+          not subprocess'd) — it IS covered by this test, unlike dbt.
+        - `dango start`/`dango serve` are excluded entirely: they require a
+          running Docker daemon to launch Metabase (cli/commands/platform.py:
+          464-495), which would make this job slow and Docker-availability
+          flaky for no additional Python-process detection coverage — their
+          egress (Metabase container, localhost health polling) is
+          separately documented/functional.
 
-    monkeypatch.setenv("DBT_SEND_ANONYMOUS_USAGE_STATS", "false")
-    monkeypatch.setenv("DO_NOT_TRACK", "1")
-
-    # Pre-seed the Metabase DuckDB driver so init's download step
-    # (cli/init.py:_setup_metabase, utils/driver.py:driver_needs_update) is a
-    # no-op. This test asserts against *undocumented* hosts; it does not
-    # verify the documented github.com download path is reachable —
-    # depending on live GitHub Releases availability would make an
-    # informational CI job flaky for zero detection benefit.
-    plugins_dir = tmp_path / "metabase-plugins"
-    plugins_dir.mkdir(parents=True, exist_ok=True)
-    (plugins_dir / "duckdb.metabase-driver.jar").write_bytes(b"test-driver-stub")
-    (plugins_dir / ".driver-version").write_text(METABASE_DUCKDB_DRIVER_VERSION + "\n")
-
-    allowed = _documented_hosts()
-    guard = _AllowlistGuard(allowed)
-
-    with guard:
-        init_project(tmp_path, skip_wizard=True)
-
-        data_dir = tmp_path / "data" / "test_csv"
-        data_dir.mkdir(parents=True, exist_ok=True)
-        (data_dir / "test.csv").write_text("id,value\n1,a\n2,b\n")
-
-        source = make_data_source(
-            SourceType.CSV,
-            name="test_csv",
-            csv=make_csv_source_config(directory=str(data_dir)),
+        Marked `egress` (in addition to `unit`) and excluded from the
+        general `test` CI job matrix (`-m "not egress"`,
+        .github/workflows/ci.yml) — that job's 3-way Python-version matrix
+        doesn't run the `egress` job's spaCy pre-install step, so without
+        this exclusion the test would fall through to
+        governance/pii_detector.py's live model-download path three times
+        per CI run, adding real network dependency to the *required* Test
+        (Python 3.10)/(3.12) checks for no detection benefit (the dedicated
+        `egress` job already covers this test hermetically).
+        """
+        from dango.cli.init import init_project
+        from dango.config.models import SourceType
+        from dango.ingestion import run_sync
+        from dango.utils.driver import METABASE_DUCKDB_DRIVER_VERSION
+        from tests.factories.config_factories import (
+            make_csv_source_config,
+            make_data_source,
         )
 
-        result = run_sync(tmp_path, [source], skip_dbt=True)
+        monkeypatch.setenv("DBT_SEND_ANONYMOUS_USAGE_STATS", "false")
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
 
-    assert guard.blocked_hosts == set(), (
-        f"Undocumented host(s) contacted during dango init/source/sync: "
-        f"{guard.blocked_hosts}. If this is expected, add it to "
-        f"docs/network-egress.yml (telemetry or functional section) with an "
-        f"honest reason. Do not loosen this test to make it pass."
-    )
-    assert result["failed_sources"] == [], f"sync failed: {result['failed_sources']}"
+        # Pre-seed the Metabase DuckDB driver so init's download step
+        # (cli/init.py:_setup_metabase, utils/driver.py:driver_needs_update)
+        # is a no-op. This test asserts against *undocumented* hosts; it
+        # does not verify the documented github.com download path is
+        # reachable — depending on live GitHub Releases availability would
+        # make an informational CI job flaky for zero detection benefit.
+        plugins_dir = tmp_path / "metabase-plugins"
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+        (plugins_dir / "duckdb.metabase-driver.jar").write_bytes(b"test-driver-stub")
+        (plugins_dir / ".driver-version").write_text(METABASE_DUCKDB_DRIVER_VERSION + "\n")
+
+        allowed = _documented_hosts()
+        guard = _AllowlistGuard(allowed)
+
+        with guard:
+            init_project(tmp_path, skip_wizard=True)
+
+            data_dir = tmp_path / "data" / "test_csv"
+            data_dir.mkdir(parents=True, exist_ok=True)
+            (data_dir / "test.csv").write_text("id,value\n1,a\n2,b\n")
+
+            source = make_data_source(
+                SourceType.CSV,
+                name="test_csv",
+                csv=make_csv_source_config(directory=str(data_dir)),
+            )
+
+            result = run_sync(tmp_path, [source], skip_dbt=True)
+
+        assert guard.blocked_hosts == set(), (
+            f"Undocumented host(s) contacted during dango init/source/sync: "
+            f"{guard.blocked_hosts}. If this is expected, add it to "
+            f"docs/network-egress.yml (telemetry or functional section) with "
+            f"an honest reason. Do not loosen this test to make it pass."
+        )
+        assert result["failed_sources"] == [], f"sync failed: {result['failed_sources']}"

--- a/tests/unit/test_egress_allowlist.py
+++ b/tests/unit/test_egress_allowlist.py
@@ -252,6 +252,19 @@ class TestLiveEgressDetection:
         monkeypatch.setenv("DBT_SEND_ANONYMOUS_USAGE_STATS", "false")
         monkeypatch.setenv("DO_NOT_TRACK", "1")
 
+        # DO_NOT_TRACK also now does double duty: cli/init.py's
+        # _prompt_telemetry_consent() (Dango's own opt-in telemetry, added
+        # after this test was first written) is called unconditionally
+        # inside initialize() -- not gated by skip_wizard -- and would
+        # otherwise call click.prompt() interactively. is_ci() short-circuits
+        # it on real CI (GITHUB_ACTIONS=true), but a contributor running this
+        # test locally, on a machine that has never run a real `dango init`
+        # (so has_recorded_consent() is False), would hit a live interactive
+        # prompt without this. is_telemetry_enabled() (dango/telemetry.py)
+        # honors DO_NOT_TRACK the same way dbt does, so the env var above
+        # already covers this -- confirmed empirically (no hang, no prompt)
+        # after dbt-core 1.11/dango-telemetry landed on v1.0.8 post-branch.
+
         # Pre-seed the Metabase DuckDB driver so init's download step
         # (cli/init.py:_setup_metabase, utils/driver.py:driver_needs_update)
         # is a no-op. This test asserts against *undocumented* hosts; it

--- a/tests/unit/test_egress_allowlist.py
+++ b/tests/unit/test_egress_allowlist.py
@@ -120,8 +120,10 @@ def test_dbt_send_anonymous_usage_stats_envvar_name() -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.egress
 def test_dango_init_source_sync_only_contacts_allowlisted_hosts(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Runs a real dango init (--skip-wizard) -> CSV source -> sync workflow
     with DNS resolution blocked for any host outside docs/network-egress.yml.
@@ -130,10 +132,20 @@ def test_dango_init_source_sync_only_contacts_allowlisted_hosts(
 
     Scope: catches egress from Dango's own Python process only.
     - dbt runs as a real subprocess during dango init (`dbt docs generate`,
-      cli/init.py:1153-1225) and inside run_sync when skip_dbt=False — its
-      own DNS/socket calls happen in a separate process and are invisible to
-      this monkeypatch. skip_dbt=True below avoids also running it during
-      sync, since running it here adds latency for zero detection coverage.
+      cli/init.py:1153-1225, unconditional — dbt docs generation is treated
+      as CRITICAL and rolls back init on failure) and inside run_sync when
+      skip_dbt=False — its own DNS/socket calls happen in a separate process
+      and are invisible to this monkeypatch. skip_dbt=True below avoids also
+      running it during sync, since running it here adds latency for zero
+      detection coverage. dbt-core's anonymous usage stats are on by default
+      (dbt/tracking.py) and, being a real subprocess call this monkeypatch
+      can't see, would otherwise fire a real ping to
+      fishtownanalytics.sinter-collect.com on every run of this test via the
+      init step above — DBT_SEND_ANONYMOUS_USAGE_STATS/DO_NOT_TRACK below
+      disable that. This is an env var, not subprocess network interception
+      (still out of scope) — it doesn't let this test see dbt's egress, it
+      just stops the init step from producing an actual telemetry send as an
+      unintended side effect of writing a telemetry-detection test.
     - dlt itself runs in-process (imported directly in dlt_runner.py, not
       subprocess'd) — it IS covered by this test, unlike dbt.
     - `dango start`/`dango serve` are excluded entirely: they require a
@@ -142,6 +154,15 @@ def test_dango_init_source_sync_only_contacts_allowlisted_hosts(
       flaky for no additional Python-process detection coverage — their
       egress (Metabase container, localhost health polling) is separately
       documented/functional.
+
+    Marked `egress` (in addition to `unit`) and excluded from the general
+    `test` CI job matrix (`-m "not egress"`, .github/workflows/ci.yml) — that
+    job's 3-way Python-version matrix doesn't run the `egress` job's spaCy
+    pre-install step, so without this exclusion the test would fall through
+    to governance/pii_detector.py's live model-download path three times per
+    CI run, adding real network dependency to the *required* Test (Python
+    3.10)/(3.12) checks for no detection benefit (the dedicated `egress` job
+    already covers this test hermetically).
     """
     from dango.cli.init import init_project
     from dango.config.models import SourceType
@@ -151,6 +172,9 @@ def test_dango_init_source_sync_only_contacts_allowlisted_hosts(
         make_csv_source_config,
         make_data_source,
     )
+
+    monkeypatch.setenv("DBT_SEND_ANONYMOUS_USAGE_STATS", "false")
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
 
     # Pre-seed the Metabase DuckDB driver so init's download step
     # (cli/init.py:_setup_metabase, utils/driver.py:driver_needs_update) is a

--- a/tests/unit/test_egress_allowlist.py
+++ b/tests/unit/test_egress_allowlist.py
@@ -36,8 +36,15 @@ def _normalize_host(host: str) -> str:
 
 def _documented_hosts() -> set[str]:
     data = _load_egress_doc()
-    hosts = {entry["host"] for entry in data.get("telemetry", [])}
-    hosts |= {entry["host"] for entry in data.get("functional", [])}
+    hosts: set[str] = set()
+    for section in ("telemetry", "functional"):
+        for i, entry in enumerate(data.get(section, [])):
+            host = entry.get("host")
+            assert host, (
+                f"docs/network-egress.yml: entry {i} in '{section}' is missing "
+                f"a 'host' key: {entry!r}"
+            )
+            hosts.add(host)
     return {_normalize_host(h) for h in hosts}
 
 
@@ -77,9 +84,19 @@ class _AllowlistGuard:
         socket.getaddrinfo = self._original  # type: ignore[assignment]
 
     def _patched(self, host: str | None, *args: Any, **kwargs: Any) -> Any:
-        if host is not None and _normalize_host(host) not in self.allowed_hosts:
-            self.blocked_hosts.add(host)
-            raise socket.gaierror(socket.EAI_NONAME, f"blocked by egress allowlist test: {host!r}")
+        if host is None:
+            return self._original(host, *args, **kwargs)
+        normalized = _normalize_host(host)
+        if normalized not in self.allowed_hosts:
+            # Store the normalized form: this is what gets surfaced in the
+            # final assertion message, and it should match exactly what
+            # someone would type into docs/network-egress.yml, not a
+            # case/trailing-dot variant that looks like a different host.
+            self.blocked_hosts.add(normalized)
+            raise socket.gaierror(
+                socket.EAI_NONAME,
+                f"blocked by egress allowlist test: {host!r} (normalized: {normalized!r})",
+            )
         return self._original(host, *args, **kwargs)
 
 
@@ -95,7 +112,14 @@ class TestNetworkEgressDoc:
 
     def test_network_egress_yml_has_all_known_providers(self) -> None:
         data = _load_egress_doc()
-        providers = {entry["provider"] for entry in data["telemetry"]}
+        providers: set[str] = set()
+        for i, entry in enumerate(data["telemetry"]):
+            provider = entry.get("provider")
+            assert provider, (
+                f"docs/network-egress.yml: telemetry entry {i} is missing a "
+                f"'provider' key: {entry!r}"
+            )
+            providers.add(provider)
         assert providers == {"dango", "dbt-core", "dlt", "metabase"}
 
     def test_dlt_runtime_configuration_has_telemetry_field(self) -> None:
@@ -165,7 +189,31 @@ class TestLiveEgressDetection:
           telemetry send as an unintended side effect of writing a
           telemetry-detection test.
         - dlt itself runs in-process (imported directly in dlt_runner.py,
-          not subprocess'd) — it IS covered by this test, unlike dbt.
+          not subprocess'd) — its DNS calls happen on this thread and are
+          visible to _AllowlistGuard, unlike dbt's. But dlt's own telemetry
+          is dispatched fire-and-forget on a background thread pool
+          (dlt/common/runtime/anon_tracker.py: `_THREAD_POOL.thread_pool.
+          submit(_future_send)`, never joined by the caller) — a send queued
+          there could execute after this `with` block exits and
+          _AllowlistGuard restores the real socket.getaddrinfo, racing past
+          detection. `stop_telemetry()` below forces a synchronous flush
+          (`disable_anon_tracker()` -> `ManagedThreadPool.stop(wait=True)`,
+          which blocks on `ThreadPoolExecutor.shutdown(wait=True)`) so any
+          queued send is forced to happen, and be checked against the
+          allowlist, deterministically inside the guard.
+          Verified empirically for the CSV-source path this test drives:
+          `dlt.common.runtime.telemetry.is_telemetry_started()` and
+          `dlt.common.runtime.anon_tracker._ANON_TRACKER_ENDPOINT` both stay
+          unset through a full run_sync() call here — dlt's runtime-config
+          lazy-init (dlt/common/runtime/run_context.py:
+          `RunContext.runtime_config` property) is apparently never touched
+          by this code path, so there is currently no live telemetry event
+          for stop_telemetry() to flush. It's kept anyway as defense in
+          depth — a different source type, or a future dlt/dango version,
+          could touch that property and start telemetry, and this test
+          shouldn't silently stop covering dlt the day that happens. Do not
+          read "dlt IS covered" as "dlt telemetry was observed firing here";
+          it wasn't, in this specific run.
         - `dango start`/`dango serve` are excluded entirely: they require a
           running Docker daemon to launch Metabase (cli/commands/platform.py:
           464-495), which would make this job slow and Docker-availability
@@ -182,7 +230,16 @@ class TestLiveEgressDetection:
         per CI run, adding real network dependency to the *required* Test
         (Python 3.10)/(3.12) checks for no detection benefit (the dedicated
         `egress` job already covers this test hermetically).
+
+        Local reproduction: run `python -m spacy download en_core_web_sm`
+        once first (matches the CI `egress` job's pre-install step) — the
+        post-sync PII-scan hook isn't gated by skip_dbt (post_sync.py:381,
+        unconditional), so without the model already installed this test
+        falls through to governance/pii_detector.py's live download path
+        instead of a clean skip.
         """
+        from dlt.common.runtime.telemetry import stop_telemetry
+
         from dango.cli.init import init_project
         from dango.config.models import SourceType
         from dango.ingestion import run_sync
@@ -223,6 +280,11 @@ class TestLiveEgressDetection:
             )
 
             result = run_sync(tmp_path, [source], skip_dbt=True)
+
+            # Force dlt's background telemetry thread pool to drain before
+            # the guard exits — see the docstring above. Safe to call even
+            # if no telemetry was actually queued (no-op then).
+            stop_telemetry()
 
         assert guard.blocked_hosts == set(), (
             f"Undocumented host(s) contacted during dango init/source/sync: "

--- a/tests/unit/test_egress_allowlist.py
+++ b/tests/unit/test_egress_allowlist.py
@@ -1,0 +1,190 @@
+"""tests/unit/test_egress_allowlist.py
+
+CI gate for LAUNCH-READINESS.md §A5: detects hosts Dango's own Python process
+contacts that aren't documented in docs/network-egress.yml.
+"""
+
+from __future__ import annotations
+
+import inspect
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EGRESS_DOC = REPO_ROOT / "docs" / "network-egress.yml"
+
+ALWAYS_ALLOWED_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def _load_egress_doc() -> dict[str, Any]:
+    return yaml.safe_load(EGRESS_DOC.read_text())
+
+
+def _documented_hosts() -> set[str]:
+    data = _load_egress_doc()
+    hosts = {entry["host"] for entry in data.get("telemetry", [])}
+    hosts |= {entry["host"] for entry in data.get("functional", [])}
+    return hosts
+
+
+class _AllowlistGuard:
+    """Monkeypatches socket.getaddrinfo to block DNS resolution of any hostname
+    not in *allowed_hosts*, and records what it blocked.
+
+    getaddrinfo (not socket.connect) is the patch point: it still has the
+    original hostname string before resolution to an IP. requests, urllib3,
+    urllib.request, and httpx all route through it for hostname lookups.
+
+    Blocked hosts are recorded on self.blocked_hosts rather than relied upon
+    via a raised exception reaching the test: dango/utils/post_sync.py's
+    dispatch_post_sync_hooks (lines 378-387) wraps each hook in a bare
+    ``except Exception`` and only logs a hook name, so an exception raised
+    from inside a hook (e.g. the PII-scan hook attempting a blocked host)
+    never propagates to the caller. Asserting on self.blocked_hosts after
+    the `with` block survives that swallowing.
+
+    Caveat: a C extension doing its own libc DNS resolution (bypassing
+    Python's socket module) would not be caught. Not a concern for the
+    workflow this test drives — no DuckDB extensions (e.g. httpfs) load.
+    """
+
+    def __init__(self, allowed_hosts: set[str]) -> None:
+        self.allowed_hosts = allowed_hosts | ALWAYS_ALLOWED_HOSTS
+        self.blocked_hosts: set[str] = set()
+        self._original = socket.getaddrinfo
+
+    def __enter__(self) -> _AllowlistGuard:
+        socket.getaddrinfo = self._patched  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        socket.getaddrinfo = self._original  # type: ignore[assignment]
+
+    def _patched(self, host: str | None, *args: Any, **kwargs: Any) -> Any:
+        if host is not None and host not in self.allowed_hosts:
+            self.blocked_hosts.add(host)
+            raise socket.gaierror(socket.EAI_NONAME, f"blocked by egress allowlist test: {host!r}")
+        return self._original(host, *args, **kwargs)
+
+
+@pytest.mark.unit
+def test_network_egress_yml_exists() -> None:
+    assert EGRESS_DOC.exists(), "docs/network-egress.yml not found"
+    data = _load_egress_doc()
+    assert "telemetry" in data
+    assert "functional" in data
+
+
+@pytest.mark.unit
+def test_network_egress_yml_has_all_known_providers() -> None:
+    data = _load_egress_doc()
+    providers = {entry["provider"] for entry in data["telemetry"]}
+    assert providers == {"dango", "dbt-core", "dlt", "metabase"}
+
+
+@pytest.mark.unit
+def test_dlt_runtime_configuration_has_telemetry_field() -> None:
+    """Real introspection against the installed dlt version, not a hardcoded
+    string comparison. Catches a silent rename of the field
+    docs/network-egress.yml claims controls dlt's telemetry (this is exactly
+    the risk LAUNCH-READINESS.md §A2 calls out: "If dlt renames
+    dlthub_telemetry... a silent failure means you are telling users
+    something false")."""
+    from dlt.common.configuration.specs.runtime_configuration import (
+        RuntimeConfiguration,
+    )
+
+    fields = RuntimeConfiguration.__dataclass_fields__
+    assert "dlthub_telemetry" in fields, (
+        "dlt renamed its telemetry opt-out field — update "
+        "docs/network-egress.yml and the write-through in the telemetry command"
+    )
+
+
+@pytest.mark.unit
+def test_dbt_send_anonymous_usage_stats_envvar_name() -> None:
+    """Real check against the installed dbt-core source, not memory. Catches
+    a silent rename of the env var docs/network-egress.yml documents as
+    dbt's telemetry opt-out control."""
+    from dbt.cli import params as dbt_params
+
+    source = inspect.getsource(dbt_params)
+    assert "DBT_SEND_ANONYMOUS_USAGE_STATS" in source, (
+        "dbt-core's telemetry opt-out env var name changed — update "
+        "docs/network-egress.yml and the write-through in the telemetry command"
+    )
+
+
+@pytest.mark.unit
+def test_dango_init_source_sync_only_contacts_allowlisted_hosts(
+    tmp_path: Path,
+) -> None:
+    """Runs a real dango init (--skip-wizard) -> CSV source -> sync workflow
+    with DNS resolution blocked for any host outside docs/network-egress.yml.
+    This is detection, not documentation: it fails if an undisclosed host is
+    contacted, it does not just check the doc is self-consistent.
+
+    Scope: catches egress from Dango's own Python process only.
+    - dbt runs as a real subprocess during dango init (`dbt docs generate`,
+      cli/init.py:1153-1225) and inside run_sync when skip_dbt=False — its
+      own DNS/socket calls happen in a separate process and are invisible to
+      this monkeypatch. skip_dbt=True below avoids also running it during
+      sync, since running it here adds latency for zero detection coverage.
+    - dlt itself runs in-process (imported directly in dlt_runner.py, not
+      subprocess'd) — it IS covered by this test, unlike dbt.
+    - `dango start`/`dango serve` are excluded entirely: they require a
+      running Docker daemon to launch Metabase (cli/commands/platform.py:
+      464-495), which would make this job slow and Docker-availability
+      flaky for no additional Python-process detection coverage — their
+      egress (Metabase container, localhost health polling) is separately
+      documented/functional.
+    """
+    from dango.cli.init import init_project
+    from dango.config.models import SourceType
+    from dango.ingestion import run_sync
+    from dango.utils.driver import METABASE_DUCKDB_DRIVER_VERSION
+    from tests.factories.config_factories import (
+        make_csv_source_config,
+        make_data_source,
+    )
+
+    # Pre-seed the Metabase DuckDB driver so init's download step
+    # (cli/init.py:_setup_metabase, utils/driver.py:driver_needs_update) is a
+    # no-op. This test asserts against *undocumented* hosts; it does not
+    # verify the documented github.com download path is reachable —
+    # depending on live GitHub Releases availability would make an
+    # informational CI job flaky for zero detection benefit.
+    plugins_dir = tmp_path / "metabase-plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    (plugins_dir / "duckdb.metabase-driver.jar").write_bytes(b"test-driver-stub")
+    (plugins_dir / ".driver-version").write_text(METABASE_DUCKDB_DRIVER_VERSION + "\n")
+
+    allowed = _documented_hosts()
+    guard = _AllowlistGuard(allowed)
+
+    with guard:
+        init_project(tmp_path, skip_wizard=True)
+
+        data_dir = tmp_path / "data" / "test_csv"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "test.csv").write_text("id,value\n1,a\n2,b\n")
+
+        source = make_data_source(
+            SourceType.CSV,
+            name="test_csv",
+            csv=make_csv_source_config(directory=str(data_dir)),
+        )
+
+        result = run_sync(tmp_path, [source], skip_dbt=True)
+
+    assert guard.blocked_hosts == set(), (
+        f"Undocumented host(s) contacted during dango init/source/sync: "
+        f"{guard.blocked_hosts}. If this is expected, add it to "
+        f"docs/network-egress.yml (telemetry or functional section) with an "
+        f"honest reason. Do not loosen this test to make it pass."
+    )
+    assert result["failed_sources"] == [], f"sync failed: {result['failed_sources']}"


### PR DESCRIPTION
## Summary
- Add `docs/network-egress.yml` — enumerated, source-verified list of hosts the Dango
  stack contacts (telemetry hosts and env vars corrected against the actual installed
  dbt-core/dlt packages, not vendor docs — see corrections below)
- Add `egress` job to `.github/workflows/ci.yml` — live-detection test, not just a
  documentation-consistency check: patches Python-layer DNS resolution and runs a real
  `dango init` -> CSV source -> sync workflow inside it, failing on any undocumented host
- Marimo's "no telemetry" claim verified against installed marimo source in this
  session (previously asserted but unverified — `LAUNCH-READINESS.md` §A5 flagged this
  gap explicitly)
- Tests are class-wrapped (`TestNetworkEgressDoc`, `TestLiveEgressDetection`) with
  markers applied at the class level per `STANDARDS.md` §7; the live-detection test
  gets its own class since it needs an extra `egress` marker the doc-consistency tests
  don't
- Host comparisons are case/trailing-dot normalized; doc entries are read with `.get()`
  and a clear assertion message instead of raw `entry["host"]` indexing, so a future
  typo'd YAML key fails with a pointer to the problem, not a bare `KeyError`

### Corrections made against an earlier draft of this spec (verified via `dango/venv`, not vendor docs)
| Claim | Verified reality | Source |
|---|---|---|
| dbt telemetry host: `firehose.us-east-1.amazonaws.com` | `fishtownanalytics.sinter-collect.com` | `dbt/tracking.py:35` |
| dbt opt-out env var: `DBT_ENGINE_SEND_ANONYMOUS_USAGE_STATS` | `DBT_SEND_ANONYMOUS_USAGE_STATS` (no `ENGINE_`) | `dbt/cli/params.py:569` |
| dlt telemetry host: `dlthub.com` | `telemetry.scalevector.ai` | `dlt/common/configuration/specs/runtime_configuration.py:19` |

Also documents two real `github.com` download paths found by tracing the actual code
(not previously written down anywhere): the Metabase DuckDB driver download on
`dango init` (`cli/init.py:_setup_metabase`) and the spaCy PII model download inside
post-sync hooks (`governance/pii_detector.py`) — both redirect through
`objects.githubusercontent.com`, now also documented.

### dlt telemetry coverage — verified empirically, corrected from an earlier overclaim
An earlier version of this PR's test docstring stated dlt telemetry "IS covered by
this test" because dlt runs in-process. That's incomplete in two ways, both now fixed:
1. dlt dispatches telemetry fire-and-forget on an unjoined background thread
   (`dlt/common/runtime/anon_tracker.py`) — a queued send's DNS resolution could
   execute after the guard exits, racing past detection. Fixed by calling
   `dlt.common.runtime.telemetry.stop_telemetry()` before the guard exits, which
   blocks (`ThreadPoolExecutor.shutdown(wait=True)`) until any pending send completes.
2. More fundamentally: I checked at runtime, and for the CSV-source path this test
   actually drives, dlt's telemetry runtime never initializes at all —
   `is_telemetry_started()` and `_ANON_TRACKER_ENDPOINT` both stay unset through a
   full `run_sync()` call. `stop_telemetry()` is a safe no-op today; it's kept as
   defense in depth for a different source type or future dlt/dango version that does
   touch dlt's runtime-config lazy-init. The docstring now says this explicitly instead
   of implying dlt telemetry was observed firing.

## Verification
- `pytest -x` (no `-m` filter, matches local dev): 4202 pass, 30 skipped, 0 fail
- `pytest --tb=short -q -m "not egress"` (matches the CI `test` job exactly):
  4201 pass, 30 skipped, 1 deselected, 0 fail
- `pytest tests/unit/test_egress_allowlist.py -v`: 5 pass, 0 fail
- `ruff check dango/ tests/`: all checks passed
- `ruff format --check dango/ tests/`: all files formatted
- `mypy tests/unit/test_egress_allowlist.py`: no issues
- The live-detection test (`test_dango_init_source_sync_only_contacts_allowlisted_hosts`)
  runs a real `dango init --skip-wizard` + CSV source + `run_sync(skip_dbt=True)` inside
  a `socket.getaddrinfo` monkeypatch that blocks any hostname outside
  `docs/network-egress.yml` — passed with zero undocumented hosts contacted
- Positive-control check (not part of the test suite, run manually to prove the
  detection mechanism actually works rather than trusting it): deliberately excluded
  `telemetry.scalevector.ai` from the allowed set and re-ran the same workflow —
  correctly caught and reported as blocked

## Regression check
- CI job name is `Egress allowlist`. **Corrected verification method**: an earlier
  push checked this only against `main`'s branch protection
  (`gh api repos/getdango/dango/branches/main/protection`). PR #438 targets `v1.0.8`,
  which has no classic branch protection at all (`gh api
  repos/getdango/dango/branches/v1.0.8/protection` → 404) — the actual gate is a
  separate ruleset, "Protect version branches" (id 12778188,
  `gh api repos/getdango/dango/rulesets/12778188`), whose `required_status_checks` are
  identical: `Lint (ruff)`, `Type check (mypy)`, `Test (Python 3.10)`,
  `Test (Python 3.12)`, no `Egress allowlist`. Conclusion unchanged, verification method
  now correct.
- Added as a job inside the existing single `ci.yml` (repo convention), not a new
  workflow file
- No subprocess-level network interception attempted (dbt subprocess egress is
  explicitly out of scope — a parent-process monkeypatch can't see a child process's
  own socket calls); dlt itself runs in-process and its DNS calls are visible to the
  guard when it makes any (see "dlt telemetry coverage" above for what that does and
  doesn't currently mean in practice)
- Full test suite passes unchanged with the CI-matching filter (4201/4201 with
  `-m "not egress"`, pre-existing 30 skips unaffected)
- Local reproduction note: the post-sync PII-scan hook isn't gated by `skip_dbt`
  (`post_sync.py:381`, unconditional) — run `python -m spacy download en_core_web_sm`
  once before running the `egress`-marked test locally (matches the CI `egress` job's
  pre-install step), or it falls through to a live model download instead of a clean
  skip

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Er5nVqaH2DsnhCh58NTLXU