### PR TITLE
1.0.8-A: Upgrade dbt-core 1.11 + Metabase 0.62

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
 
   security:
     name: Security (pip-audit)
-    # Known CVE-2026-32274 in black (dbt-core dep) — revisit when dbt-core supports pydantic v2
+    # Known CVE-2026-32274 in black (dev dep) — dbt-core 1.11 now allows pydantic<3 (was the
+    # original blocker), but black>=26.3.1 needs pathspec>=1.0.0 while dbt-core pins
+    # pathspec<0.13,>=0.9 — still blocked. Revisit when dbt-core relaxes its pathspec pin.
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Dango will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- dbt-core 1.10.22 → 1.11.14, dbt-duckdb 1.10.1 → 1.11.0, Metabase v0.59.1 → v0.62.18, Metabase DuckDB JDBC driver 1.5.3.0 → 1.5.4.0
+
 ## [1.0.7] - 2026-08-27
 
 ### Added

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,10 +8,10 @@ the tested stack and upgrade process.
 | Component | Tested Version | Allowed Range | Source of Truth |
 |-----------|---------------|---------------|-----------------|
 | DuckDB (Python) | 1.5.4 | >=1.5.0,<1.6 | `pyproject.toml` |
-| Metabase JDBC Driver | 1.5.3.0 | pinned | `dango/utils/driver.py` |
-| Metabase | v0.59.1 | pinned | `dango/templates/Dockerfile.metabase` |
-| dbt-core | 1.10.22 | ~=1.10.0 | `pyproject.toml` |
-| dbt-duckdb | 1.10.1 | >=1.10.0,<1.11 | `pyproject.toml` |
+| Metabase JDBC Driver | 1.5.4.0 | pinned | `dango/utils/driver.py` |
+| Metabase | v0.62.18 | pinned | `dango/templates/Dockerfile.metabase` |
+| dbt-core | 1.11.14 | ~=1.11.0 | `pyproject.toml` |
+| dbt-duckdb | 1.11.0 | >=1.11.0,<1.12 | `pyproject.toml` |
 | dlt | 1.28.1 | ~=1.28.0 | `pyproject.toml` |
 
 Tested versions are recorded in `constraints.txt` for reproducible installs.
@@ -31,7 +31,11 @@ Must be changed as a group. A mismatch causes data visibility failures.
 
 Patch upgrades are safe. Minor upgrades need testing.
 
-- **dbt-core** — 1.11 is a breaking release; stay on 1.10.x.
+- **dbt-core** — 1.11 introduced two new opt-in behavior flags
+  (`require_unique_project_resource_names`,
+  `require_ref_searches_node_package_before_root`) that default to `false`;
+  no automatic behavior change. The next real compatibility boundary is
+  1.12, where those two flags flip to `true` by default.
 - **dlt** — generally backwards compatible within a minor series.
 
 ### Tier 3 — Utilities
@@ -59,8 +63,9 @@ within SemVer constraints.
 
 - **DuckDB 1.5.x read-only cannot read 1.4.x files.** Write mode can
   (auto-migrates format), but Metabase connects in read-only mode.
-- **dbt-core 1.11** is a breaking release. Do not upgrade without a
-  dedicated compatibility effort.
+- **dbt-core 1.12** will flip `require_unique_project_resource_names` and
+  `require_ref_searches_node_package_before_root` to `true` by default.
+  Do not upgrade past 1.11.x without a dedicated compatibility effort.
 
 ## Guard Rails
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,10 +4,10 @@
 #
 # Tier 1 — tightly coupled (change as a group)
 duckdb==1.5.4
-dbt-duckdb==1.10.1
+dbt-duckdb==1.11.0
 #
 # Tier 2 — semi-coupled (patch safe, minor needs testing)
-dbt-core==1.10.22
+dbt-core==1.11.14
 dlt==1.28.1
 #
 # Transitive — prevent known breakage

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -598,9 +598,9 @@ Latest 2 versions of:
 | Component | Version | Notes |
 |-----------|---------|-------|
 | DuckDB | {self._get_duckdb_version()} | Embedded analytical database |
-| dbt-core | 1.10.22 | Data transformation framework |
+| dbt-core | 1.11.14 | Data transformation framework |
 | dlt | 1.24.0 | Data ingestion toolkit |
-| Metabase | v0.59.1 | Business intelligence / dashboards |
+| Metabase | v0.62.18 | Business intelligence / dashboards |
 
 ## spaCy (Data Governance)
 

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -599,7 +599,7 @@ Latest 2 versions of:
 |-----------|---------|-------|
 | DuckDB | {self._get_duckdb_version()} | Embedded analytical database |
 | dbt-core | 1.11.14 | Data transformation framework |
-| dlt | 1.24.0 | Data ingestion toolkit |
+| dlt | 1.28.1 | Data ingestion toolkit |
 | Metabase | v0.62.18 | Business intelligence / dashboards |
 
 ## spaCy (Data Governance)

--- a/dango/templates/Dockerfile.metabase
+++ b/dango/templates/Dockerfile.metabase
@@ -7,7 +7,7 @@
 FROM eclipse-temurin:21-jre-jammy
 
 # Metabase version (requires Java 21 as of v0.52+)
-ENV MB_VERSION=v0.59.1
+ENV MB_VERSION=v0.62.18
 
 # Install Metabase
 USER root

--- a/dango/utils/driver.py
+++ b/dango/utils/driver.py
@@ -15,12 +15,12 @@ DRIVER_VERSION_FILE = ".driver-version"
 
 # Rule: Python DuckDB major.minor MUST match driver's bundled DuckDB major.minor.
 # DuckDB 1.5.x read-only mode CANNOT read files created by 1.4.x.
-# Current alignment: Python DuckDB 1.5.x, driver 1.5.3.0, Metabase v0.59.1
+# Current alignment: Python DuckDB 1.5.x, driver 1.5.4.0, Metabase v0.62.18
 #
 # When upgrading: check https://github.com/motherduckdb/metabase_duckdb_driver/releases
 # for the driver that targets your Metabase version. The driver's bundled DuckDB must
 # share the same major.minor as the Python DuckDB version.
-METABASE_DUCKDB_DRIVER_VERSION = "1.5.3.0"
+METABASE_DUCKDB_DRIVER_VERSION = "1.5.4.0"
 
 METABASE_DUCKDB_DRIVER_URL = (
     "https://github.com/motherduckdb/metabase_duckdb_driver/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
     # DuckDB Python + Metabase JDBC driver must share the same DuckDB
     # major.minor. Read-only mode CANNOT cross versions.
     "duckdb>=1.5.0,<1.6",         # Tier 1 — must match driver (driver.py)
-    "dbt-duckdb>=1.10.0,<1.11",   # Tier 1 — must match dbt-core
+    "dbt-duckdb>=1.11.0,<1.12",   # Tier 1 — must match dbt-core
     # ── Tier 2: semi-coupled (patch safe, minor needs testing) ────────────
-    "dbt-core~=1.10.0",           # Tier 2 — 1.11 is breaking
+    "dbt-core~=1.11.0",           # Tier 2 — 1.12 flips two flags to default true
     "dlt[duckdb]~=1.28.0",        # Tier 2 — latest stable
 
     # Framework and utilities - flexible versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,8 @@ dependencies = [
 dev = [
     "pytest>=9.0.3",              # CVE-2025-71176 fixed in 9.0.3
     "pytest-cov>=5.0.0",
-    "black>=24.0.0",  # CVE-2026-32274 in <26.3.1; bump blocked by dbt-core pydantic<2 conflict
+    "black>=24.0.0",  # CVE-2026-32274 in <26.3.1; dbt-core 1.11 now allows pydantic<3 (unblocked),
+    # but black>=26.3.1 needs pathspec>=1.0.0 while dbt-core pins pathspec<0.13,>=0.9 (still blocked)
     "ruff>=0.6.0",
     "mypy>=1.11.0",
     "types-PyYAML>=6.0.0",

--- a/tests/integration/test_metabase_duckdb.py
+++ b/tests/integration/test_metabase_duckdb.py
@@ -185,7 +185,7 @@ class TestMetabaseReadsPythonDuckdbData:
                 "MB_DB_TYPE=h2",
                 "-e",
                 "MB_DB_FILE=/metabase-data/metabase.db",
-                "metabase/metabase:v0.59.1",
+                "metabase/metabase:v0.62.18",
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

Dependency-upgrade PR, no application code logic changes. Bumps four coupled
versions verified against live sources on 2026-08-31:

- dbt-core `~=1.10.0` (1.10.22) → `~=1.11.0` (resolves to `1.11.14`, latest stable patch)
- dbt-duckdb `>=1.10.0,<1.11` (1.10.1) → `>=1.11.0,<1.12` (`1.11.0` — the only
  version that exists in the 1.11.x series on PyPI, so it's an exact pin)
- Metabase app v0.59.1 → v0.62.18 (latest v0.62.x GitHub release, published 2026-08-26)
- Metabase DuckDB JDBC driver 1.5.3.0 → 1.5.4.0 (release explicitly titled
  "Metabase 62 + DuckDB 1.5.4" — targets the new Metabase line while keeping
  the *same* bundled DuckDB 1.5.4, which is not changing)

**Out of scope, unchanged:** DuckDB Python (`>=1.5.0,<1.6`, tested 1.5.4), dlt (1.28.1).

## Regression risk

The original task brief for this PR claimed dbt-core 1.11 "enables
`skip_nodes_if_on_run_start_fails` and `state_modified_compare_more_unrendered_values`
by default." **That claim was wrong** and was corrected before implementation:
those two flags are unrelated, pre-existing flags that stay `false` in 1.11 and
only default to `true` in dbt-core 1.12 (out of scope for this PR).

The actual new flags introduced in dbt-core 1.11 are
`require_unique_project_resource_names` and
`require_ref_searches_node_package_before_root` — **both default to `false`**,
so no automatic behavior change occurs from this bump. Verified against
https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.11.
Confirmed via repo-wide grep that neither the old (wrong) nor new (correct)
flag names appear anywhere in this codebase, and that no `flags:` block is
emitted by the generated `dbt_project.yml` template
(`dango/cli/init.py::ProjectInitializer._create_dbt_project`, lines
~1032-1099). No flags block has been added preemptively — the real
compatibility boundary to watch is dbt-core 1.12, where these two flags flip
to `true` by default. `VERSIONS.md` updated to reflect this.

`constraints.txt` was hand-edited (lines 7 and 10 only) — not regenerated via
`pip freeze`, which would have destroyed its curated Tier 1 / Tier 2 /
transitive-CVE-floor structure.

## Post-review fixes (commit cabfb3f)

An independent code review caught two issues in the original PR, both fixed:

- `dango/cli/init.py` line 602's generated end-user README table had a stale
  `dlt | 1.24.0` entry (real version per `constraints.txt` is 1.28.1). The
  original PR description said this was intentionally left untouched — it
  has since been fixed to `1.28.1` in commit cabfb3f, since two of the three
  rows in that same table were already being edited by this PR.
- The `black` CVE-2026-32274 comment (`pyproject.toml:98`,
  `.github/workflows/ci.yml:73`) cited a stale blocker ("dbt-core
  pydantic<2 conflict") that this PR's own dbt-core bump actually resolves.
  Attempted the black version bump to confirm — it surfaced a different,
  still-live conflict instead (`black>=26.3.1` needs `pathspec>=1.0.0`,
  dbt-core pins `pathspec<0.13`). Reverted the bump, corrected both comments
  to document the real current blocker. See PR comment for full detail.

## CHANGELOG.md

Added a new `## [Unreleased]` section — this repo has no prior `[Unreleased]`
or `[1.0.8]` heading (`v1.0.7` → `v1.0.8` has no CHANGELOG commits yet;
historically each version section was added in one shot by a release-bump
commit). Flagging this choice in case the coordinating chat prefers a
different convention for 1.0.8.

## Verification

- `pip install -e ".[dev]"` resolved cleanly, no transitive-dependency
  conflicts (dbt-core minor bumps have caused friction here before — see the
  `black` CVE comment at `pyproject.toml:98` — but this one resolved clean)
- `dbt --version` → Core: 1.11.14, duckdb plugin: 1.11.0
- `pip install -c constraints.txt -e ".[dev]"` → no-op resolution, confirms
  the pin is internally consistent and matches how CI installs
- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: 231 files already formatted
- `pytest -m unit`: **3950 passed, 6 skipped, 0 failed**
- `pytest -x tests/integration/test_metabase_duckdb.py -v`: 3/4 passed. The
  4th (`TestMetabaseReadsPythonDuckdbData::test_metabase_sees_tables`, gated
  behind `DANGO_RUN_DOCKER_TESTS=1`) failed locally with
  `AccessDeniedException: /metabase-data` during Metabase's H2 DB
  initialization. **Root-caused, not a regression**: reproduced the exact
  container setup manually against the *old* `metabase/metabase:v0.59.1`
  image and got the identical `AccessDeniedException` — this is a
  pre-existing local Docker environment limitation on this sandbox (likely a
  bind-mount permission/UID issue), not something introduced by the version
  bump. **Correction**: CI does NOT set `DANGO_RUN_DOCKER_TESTS`, so this
  sub-test is skipped in CI too — it has not been validated anywhere against
  the new Metabase v0.62.18 image + driver 1.5.4.0. This PR's
  driver-major.minor alignment logic (`TestDuckdbVersionMatchesDriver`)
  already passed locally, but the live REST API surface
  (`visualization/metabase.py`, `auth/metabase_bridge.py`,
  `visualization/dashboard_manager.py`, `auth/metabase_sync.py`) has not
  been exercised against v0.62.18 by any automated check. This is a specific,
  concrete ask for the beta-1 pass below, not just a nice-to-have.
- `scripts/check_version_alignment.py`: ran automatically as a pre-commit
  hook (`DuckDB version alignment check`) — passed, since it only compares
  DuckDB Python vs. driver major.minor (both unchanged at `1.5.x`)

Per workspace convention, this PR does NOT touch `tests/beta-1/` — the
coordinating chat handles live beta-1 verification after this PR is open.
Two specific asks for that pass, both un-validated by any automated check
in this PR:
1. Run `dango transform` (not just `dango start`) — `dango/transformation/`
   has no dedicated unit tests, so this is the first live signal on the
   dbt-core 1.11 bump specifically.
2. Open a live Metabase dashboard / view — the REST-API-calling modules
   (metabase.py, metabase_bridge.py, dashboard_manager.py, metabase_sync.py)
   received zero code changes for this 3-minor-version Metabase bump, and
   the one test that would catch an API-shape regression is skipped both
   locally and in CI (see Verification above).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01W5NLafVsewv3pJCWNdprBh
