### PR TITLE
1.0.8-C: Dango opt-in telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2340 | — (metadata-only) |
 | `cli/source_wizard.py` | 2525 | — |
 | `visualization/metabase.py` | 1251 | — |
-| `cli/init.py` | 1559 | — |
+| `cli/init.py` | 1585 | — |
 | `visualization/dashboard_manager.py` | 1117 | — |
 | `cli/commands/platform.py` | 1136 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 902 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2340 | — (metadata-only) |
 | `cli/source_wizard.py` | 2525 | — |
 | `visualization/metabase.py` | 1251 | — |
-| `cli/init.py` | 1549 | — |
+| `cli/init.py` | 1559 | — |
 | `visualization/dashboard_manager.py` | 1117 | — |
 | `cli/commands/platform.py` | 1136 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 902 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2340 | — (metadata-only) |
 | `cli/source_wizard.py` | 2525 | — |
 | `visualization/metabase.py` | 1251 | — |
-| `cli/init.py` | 1538 | — |
+| `cli/init.py` | 1549 | — |
 | `visualization/dashboard_manager.py` | 1117 | — |
 | `cli/commands/platform.py` | 1136 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 902 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/sources/registry.py` | 2340 | — (metadata-only) |
 | `cli/source_wizard.py` | 2525 | — |
 | `visualization/metabase.py` | 1251 | — |
-| `cli/init.py` | 1496 | — |
+| `cli/init.py` | 1538 | — |
 | `visualization/dashboard_manager.py` | 1117 | — |
 | `cli/commands/platform.py` | 1136 | — (extracted from main.py by TASK-005) |
 | `web/routes/auth.py` | 902 | — (split evaluated in DOC-025: exempt, security-critical) |

--- a/dango/CLAUDE.md
+++ b/dango/CLAUDE.md
@@ -10,6 +10,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 |------|---------|----------------------|
 | `__init__.py` | Package metadata: version, author, license | `__version__`, `__author__`, `__license__` |
 | `logging.py` | Structured logging (structlog + stdlib integration) | `configure_logging()`, `get_logger()`, `bind_contextvars`, `clear_contextvars`, `unbind_contextvars` |
+| `telemetry.py` | Opt-in anonymous install telemetry (machine-level UUID in `~/.dango/`) | `is_ci()`, `is_telemetry_enabled()`, `has_recorded_consent()`, `set_telemetry_enabled()`, `ping()` |
 
 ## Common Tasks
 
@@ -30,6 +31,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 - `dango.logging` — `get_logger()` used by `web/routes/`, `web/middleware/`, `web/app.py`, `platform/scheduling/`, `platform/notifications/`, `oauth/web_flow.py`, `utils/log_rotation.py`, `utils/post_sync.py`, `cli/commands/schedule.py`, `cli/commands/remote_env.py`, `governance/`, `analysis/`; `configure_logging()` called by entry points. Note: `notebooks/` uses stdlib `logging` directly, not `dango.logging`.
 - `pyproject.toml` defines `getdango` as the installable package
 - Entry point: `dango.cli.main:cli` (configured in `pyproject.toml`)
+- `dango.telemetry` — `cli/init.py` (`ProjectInitializer._prompt_telemetry_consent()`) is the only caller; stdlib `urllib.request`/`json`/`platform`/`uuid` only, plus lazy `yaml` for the opt-out config file. No new pip dependency.
 
 ## Testing
 
@@ -37,6 +39,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 - **Unit only:** `pytest -m unit`
 - **Integration only:** `pytest -m integration`
 - **Logging tests:** `pytest tests/unit/test_logging.py`
+- **Telemetry tests:** `pytest tests/unit/test_telemetry.py tests/unit/test_cli_init_telemetry.py`
 
 ## Don't Modify
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -48,7 +48,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/dev.py` (~429 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
 | `commands/web.py` (69 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1549 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
+| `init.py` (1559 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2525 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (547 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -48,7 +48,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/dev.py` (~429 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
 | `commands/web.py` (69 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1559 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
+| `init.py` (1585 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2525 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (547 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -48,7 +48,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/dev.py` (~429 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
 | `commands/web.py` (69 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1496 lines) | Project initialization wizard | `ProjectInitializer` |
+| `init.py` (1538 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2525 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (547 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -48,7 +48,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/dev.py` (~429 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
 | `commands/web.py` (69 lines) | `web` dev server command | `web()` |
 | **Wizards** | | |
-| `init.py` (1538 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
+| `init.py` (1549 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
 | `source_wizard.py` (2525 lines) | Source configuration wizard | `add_source()` |
 | `model_wizard.py` (547 lines) | dbt model creation wizard | `add_model()` |

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -10,7 +10,7 @@ from rich.panel import Panel
 
 from dango.config import ConfigLoader, DangoConfig, ProjectContext, SourcesConfig
 
-from .utils import print_error, print_success, safe_confirm
+from .utils import print_error, print_success
 from .wizard import ProjectWizard
 
 console = Console()
@@ -1499,24 +1499,14 @@ on-run-end:
         ``~/.dango/config.yml``) — in all of those cases the user is
         never prompted at all.
 
-        Also a no-op, without persisting anything, when stdin is not a
-        usable TTY: ``safe_confirm()`` would fall back to its default
-        answer without ever displaying the prompt, and persisting that
-        unseen fallback would permanently lock the machine into a
-        consent decision the user never actually saw or made. This
-        includes the case where fd 0 is closed entirely (e.g. a
-        daemonized invocation) rather than merely redirected — CPython
-        sets ``sys.stdin`` to ``None`` in that case, so ``.isatty()``
-        can't even be called; that failure is treated the same as "not
-        a TTY" rather than being allowed to crash `dango init` right
-        after it has already printed its success panel.
+        Also a no-op, without persisting anything, when no real answer
+        can be obtained at all — see `_ask_telemetry_consent` for what
+        that covers and why `safe_confirm()` isn't used here.
 
         Args:
             config: The project's freshly created configuration, used to
                 read configured source *type* names for the install ping.
         """
-        import sys
-
         from dango.telemetry import (
             has_recorded_consent,
             is_ci,
@@ -1527,23 +1517,59 @@ on-run-end:
 
         if is_ci() or has_recorded_consent() or not is_telemetry_enabled():
             return
-        try:
-            is_interactive = sys.stdin is not None and sys.stdin.isatty()
-        except Exception:
-            is_interactive = False
-        if not is_interactive:
-            return
 
         console.print()
-        consent = safe_confirm(
-            "Help improve Dango by sending anonymous usage data "
-            "(no source names, credentials, or data — just install count)?",
-            default=False,
-        )
+        consent = _ask_telemetry_consent()
+        if consent is None:
+            return
         set_telemetry_enabled(consent)
         if consent:
             source_types = [s.type.value for s in config.sources.get_enabled_sources()]
             ping("install", source_types=source_types)
+
+
+def _ask_telemetry_consent() -> bool | None:
+    """Ask the telemetry yes/no question directly, not via `safe_confirm()`.
+
+    Returns the user's real answer, or ``None`` if no real answer could
+    be obtained at all — closed stdin, genuine EOF, or any other failure
+    reading input (e.g. ``sys.stdin`` being ``None`` because fd 0 is
+    closed entirely, as in a daemonized invocation). ``None`` is
+    deliberately distinct from ``False``: the caller persists a real
+    "no" forever, but must never persist an unseen non-answer as if it
+    were one — that would silently and permanently lock the machine
+    into opt-out.
+
+    Deliberately does not pre-check ``sys.stdin.isatty()`` the way an
+    earlier version of this function did: that gate also silently
+    discarded a real answer piped into stdin (e.g. ``echo yes | dango
+    init``), since piped input is never a TTY even when it has genuine
+    data to read. `click.prompt()` only raises on true EOF — when
+    there is really nothing left to read — so relying on that directly
+    (via a broad ``except``, since a closed ``sys.stdin`` raises
+    something other than the ``EOFError``/``click.Abort`` that
+    `safe_confirm()` itself catches) is what actually distinguishes
+    "no real answer" from "a real answer that happens to arrive
+    non-interactively".
+
+    Returns:
+        True or False for a real answer, None if none could be obtained.
+    """
+    import click
+
+    text = (
+        "Help improve Dango by sending anonymous usage data "
+        "(no source names, credentials, or data — just install count)?"
+    )
+    while True:
+        try:
+            result = click.prompt(f"{text} (yes/no)", default="no", show_default=True)
+        except Exception:
+            return None
+        normalised = str(result).lower().strip()
+        if normalised in ("yes", "y", "no", "n"):
+            return normalised in ("yes", "y")
+        click.echo("Please answer yes or no.")
 
 
 def init_project(project_dir: Path, skip_wizard: bool = False, force: bool = False):

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -10,7 +10,7 @@ from rich.panel import Panel
 
 from dango.config import ConfigLoader, DangoConfig, ProjectContext, SourcesConfig
 
-from .utils import print_error, print_success
+from .utils import print_error, print_success, safe_confirm
 from .wizard import ProjectWizard
 
 console = Console()
@@ -138,6 +138,12 @@ class ProjectInitializer:
 
         # Print success message
         self._print_success_message(warnings=warnings, failures=failures, auth_success=auth_success)
+
+        # First-run anonymous telemetry consent (install ping only — no
+        # heartbeat). Skipped for --skip-wizard blank-project creation,
+        # CI environments, and any prior opt-out or stored answer.
+        if not failures and not skip_wizard:
+            self._prompt_telemetry_consent(config)
 
         # Exit with error if critical failures
         if failures:
@@ -1482,6 +1488,41 @@ on-run-end:
             )
 
         console.print()
+
+    def _prompt_telemetry_consent(self, config: DangoConfig) -> None:
+        """Ask for anonymous telemetry consent on first `dango init` run.
+
+        No-op when telemetry is already ruled out by CI detection, a
+        prior stored answer, or an opt-out (``DO_NOT_TRACK``,
+        ``DANGO_TELEMETRY``, or ``telemetry: false`` in
+        ``~/.dango/config.yml``) — in all of those cases the user is
+        never prompted at all.
+
+        Args:
+            config: The project's freshly created configuration, used to
+                read configured source *type* names for the install ping.
+        """
+        from dango.telemetry import (
+            has_recorded_consent,
+            is_ci,
+            is_telemetry_enabled,
+            ping,
+            set_telemetry_enabled,
+        )
+
+        if is_ci() or has_recorded_consent() or not is_telemetry_enabled():
+            return
+
+        console.print()
+        consent = safe_confirm(
+            "Help improve Dango by sending anonymous usage data "
+            "(no source names, credentials, or data — just install count)?",
+            default=False,
+        )
+        set_telemetry_enabled(consent)
+        if consent:
+            source_types = [s.type.value for s in config.sources.sources]
+            ping("install", source_types=source_types)
 
 
 def init_project(project_dir: Path, skip_wizard: bool = False, force: bool = False):

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1500,10 +1500,16 @@ on-run-end:
         never prompted at all.
 
         Also a no-op, without persisting anything, when stdin is not a
-        TTY: ``safe_confirm()`` would fall back to its default answer
-        without ever displaying the prompt, and persisting that
+        usable TTY: ``safe_confirm()`` would fall back to its default
+        answer without ever displaying the prompt, and persisting that
         unseen fallback would permanently lock the machine into a
-        consent decision the user never actually saw or made.
+        consent decision the user never actually saw or made. This
+        includes the case where fd 0 is closed entirely (e.g. a
+        daemonized invocation) rather than merely redirected — CPython
+        sets ``sys.stdin`` to ``None`` in that case, so ``.isatty()``
+        can't even be called; that failure is treated the same as "not
+        a TTY" rather than being allowed to crash `dango init` right
+        after it has already printed its success panel.
 
         Args:
             config: The project's freshly created configuration, used to
@@ -1521,7 +1527,11 @@ on-run-end:
 
         if is_ci() or has_recorded_consent() or not is_telemetry_enabled():
             return
-        if not sys.stdin.isatty():
+        try:
+            is_interactive = sys.stdin is not None and sys.stdin.isatty()
+        except Exception:
+            is_interactive = False
+        if not is_interactive:
             return
 
         console.print()

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -141,8 +141,9 @@ class ProjectInitializer:
 
         # First-run anonymous telemetry consent (install ping only — no
         # heartbeat). Skipped for --skip-wizard blank-project creation,
-        # CI environments, and any prior opt-out or stored answer.
-        if not failures and not skip_wizard:
+        # non-interactive sessions, CI environments, and any prior opt-out
+        # or stored answer.
+        if not skip_wizard:
             self._prompt_telemetry_consent(config)
 
         # Exit with error if critical failures
@@ -1498,10 +1499,18 @@ on-run-end:
         ``~/.dango/config.yml``) — in all of those cases the user is
         never prompted at all.
 
+        Also a no-op, without persisting anything, when stdin is not a
+        TTY: ``safe_confirm()`` would fall back to its default answer
+        without ever displaying the prompt, and persisting that
+        unseen fallback would permanently lock the machine into a
+        consent decision the user never actually saw or made.
+
         Args:
             config: The project's freshly created configuration, used to
                 read configured source *type* names for the install ping.
         """
+        import sys
+
         from dango.telemetry import (
             has_recorded_consent,
             is_ci,
@@ -1512,6 +1521,8 @@ on-run-end:
 
         if is_ci() or has_recorded_consent() or not is_telemetry_enabled():
             return
+        if not sys.stdin.isatty():
+            return
 
         console.print()
         consent = safe_confirm(
@@ -1521,7 +1532,7 @@ on-run-end:
         )
         set_telemetry_enabled(consent)
         if consent:
-            source_types = [s.type.value for s in config.sources.sources]
+            source_types = [s.type.value for s in config.sources.get_enabled_sources()]
             ping("install", source_types=source_types)
 
 

--- a/dango/telemetry.py
+++ b/dango/telemetry.py
@@ -7,10 +7,11 @@ Payload is limited to an anonymous install UUID, Dango version, Python
 version, OS name, and source *type* names (e.g. "postgres", "stripe") —
 never source names, credentials, row counts, schema, or query text.
 
-Fire-and-forget: 2s timeout, silent on ALL failure (network, disk,
-permission, whatever) — telemetry must never raise, never block, and
-never slow down or break any CLI command. Failed pings are never queued
-for retry; a dropped ping is just dropped.
+Fire-and-forget: the network call runs on an un-joined daemon thread with
+a 2s socket timeout, silent on ALL failure (network, disk, permission,
+whatever) — telemetry must never raise, never block, and never slow down
+or break any CLI command. Failed or unfinished pings are never queued for
+retry; a dropped ping is just dropped.
 
 Identity is machine-level (``~/.dango/telemetry.json``), not project-scoped,
 so one consultant with five client projects on one laptop counts as one
@@ -22,6 +23,7 @@ from __future__ import annotations
 import json
 import os
 import platform
+import threading
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -45,6 +47,12 @@ _CI_ENV_VARS = (
     "CODEBUILD_BUILD_ID",
 )
 
+# Matches the community DO_NOT_TRACK convention (consoledonottrack.com) and
+# dbt-core's own DO_NOT_TRACK check (dbt/cli/flags.py) — the exact tool this
+# module's opt-out is meant to be consistent with.
+_TRUTHY_ENV_VALUES = ("1", "t", "true", "y", "yes")
+_FALSY_ENV_VALUES = ("0", "f", "false", "n", "no")
+
 
 def is_ci() -> bool:
     """Detect whether the process is running inside a known CI environment.
@@ -53,27 +61,36 @@ def is_ci() -> bool:
     (``LAUNCH-READINESS.md`` §A1c), so pings must never fire from CI
     regardless of any stored consent.
 
+    A variable set to an explicit falsy value (e.g. ``CI=false``, as some
+    nested build tools set) is not treated as CI, even though it is
+    "present" — only bare presence with a non-falsy value counts.
+
     Returns:
-        True if any recognized CI environment variable is set.
+        True if any recognized CI environment variable indicates CI.
     """
-    return any(os.environ.get(var) for var in _CI_ENV_VARS)
+    for var in _CI_ENV_VARS:
+        value = os.environ.get(var)
+        if value and value.strip().lower() not in _FALSY_ENV_VALUES:
+            return True
+    return False
 
 
 def is_telemetry_enabled() -> bool:
     """Check whether telemetry is enabled, honouring every opt-out signal.
 
     Any one of the following disables telemetry, checked in this order:
-    ``DO_NOT_TRACK=1``, ``DANGO_TELEMETRY=0``, running in CI, ``telemetry:
-    false`` in ``~/.dango/config.yml``, or a previously stored "no" answer
-    in ``~/.dango/telemetry.json``. A missing or corrupt config/identity
-    file is treated as "no opt-out recorded" rather than raising.
+    ``DO_NOT_TRACK`` set to a truthy value, ``DANGO_TELEMETRY`` set to a
+    falsy value, running in CI, ``telemetry: false`` in
+    ``~/.dango/config.yml``, or a previously stored "no" answer in
+    ``~/.dango/telemetry.json``. A missing or corrupt config/identity file
+    is treated as "no opt-out recorded" rather than raising.
 
     Returns:
         True if telemetry may be sent, False if any opt-out applies.
     """
-    if os.environ.get("DO_NOT_TRACK") == "1":
+    if os.environ.get("DO_NOT_TRACK", "").strip().lower() in _TRUTHY_ENV_VALUES:
         return False
-    if os.environ.get("DANGO_TELEMETRY") == "0":
+    if os.environ.get("DANGO_TELEMETRY", "").strip().lower() in _FALSY_ENV_VALUES:
         return False
     if is_ci():
         return False
@@ -184,11 +201,16 @@ def set_telemetry_enabled(enabled: bool) -> None:
 
 
 def ping(event: str, source_types: list[str] | None = None) -> None:
-    """Fire an anonymous telemetry ping. Never raises, never blocks > 2s.
+    """Fire an anonymous telemetry ping. Never raises, never blocks the caller.
 
-    A no-op when telemetry is disabled (see `is_telemetry_enabled`). All
+    A no-op when telemetry is disabled (see `is_telemetry_enabled`). The
+    actual network call runs on a daemon thread that is never joined, so
+    this function returns immediately regardless of network conditions —
+    true fire-and-forget, not just a bounded-timeout blocking call. All
     failures — DNS, timeout, TLS, a non-2xx response, anything — are
-    swallowed silently and never queued for retry.
+    swallowed silently inside that thread and never queued for retry. On a
+    process that exits immediately afterward, the ping may not finish
+    sending; that data loss is an accepted trade-off of never blocking.
 
     Args:
         event: The event name, e.g. ``"install"``.
@@ -199,6 +221,12 @@ def ping(event: str, source_types: list[str] | None = None) -> None:
     if not is_telemetry_enabled():
         return
 
+    thread = threading.Thread(target=_send_ping, args=(event, source_types), daemon=True)
+    thread.start()
+
+
+def _send_ping(event: str, source_types: list[str] | None) -> None:
+    """Build and POST the ping payload. Runs on a background thread; never raises."""
     try:
         import urllib.request
 

--- a/dango/telemetry.py
+++ b/dango/telemetry.py
@@ -1,0 +1,230 @@
+"""dango/telemetry.py
+
+Opt-in anonymous telemetry: a single "install ping" fired once at
+`dango init`. No heartbeat, no scheduler hook — that is future scope.
+
+Payload is limited to an anonymous install UUID, Dango version, Python
+version, OS name, and source *type* names (e.g. "postgres", "stripe") —
+never source names, credentials, row counts, schema, or query text.
+
+Fire-and-forget: 2s timeout, silent on ALL failure (network, disk,
+permission, whatever) — telemetry must never raise, never block, and
+never slow down or break any CLI command. Failed pings are never queued
+for retry; a dropped ping is just dropped.
+
+Identity is machine-level (``~/.dango/telemetry.json``), not project-scoped,
+so one consultant with five client projects on one laptop counts as one
+user rather than five.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+TELEMETRY_ENDPOINT = "https://telemetry.getdango.dev/v1/ping"
+
+_TIMEOUT_SECONDS = 2
+
+_CONFIG_DIR = Path.home() / ".dango"
+_IDENTITY_FILE = _CONFIG_DIR / "telemetry.json"
+_GLOBAL_CONFIG_FILE = _CONFIG_DIR / "config.yml"
+
+_CI_ENV_VARS = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "GITLAB_CI",
+    "JENKINS_URL",
+    "BUILDKITE",
+    "CIRCLECI",
+    "TRAVIS",
+    "CODEBUILD_BUILD_ID",
+)
+
+
+def is_ci() -> bool:
+    """Detect whether the process is running inside a known CI environment.
+
+    CI is the single biggest source of install-count inflation
+    (``LAUNCH-READINESS.md`` §A1c), so pings must never fire from CI
+    regardless of any stored consent.
+
+    Returns:
+        True if any recognized CI environment variable is set.
+    """
+    return any(os.environ.get(var) for var in _CI_ENV_VARS)
+
+
+def is_telemetry_enabled() -> bool:
+    """Check whether telemetry is enabled, honouring every opt-out signal.
+
+    Any one of the following disables telemetry, checked in this order:
+    ``DO_NOT_TRACK=1``, ``DANGO_TELEMETRY=0``, running in CI, ``telemetry:
+    false`` in ``~/.dango/config.yml``, or a previously stored "no" answer
+    in ``~/.dango/telemetry.json``. A missing or corrupt config/identity
+    file is treated as "no opt-out recorded" rather than raising.
+
+    Returns:
+        True if telemetry may be sent, False if any opt-out applies.
+    """
+    if os.environ.get("DO_NOT_TRACK") == "1":
+        return False
+    if os.environ.get("DANGO_TELEMETRY") == "0":
+        return False
+    if is_ci():
+        return False
+
+    if _GLOBAL_CONFIG_FILE.is_file():
+        try:
+            import yaml
+
+            with open(_GLOBAL_CONFIG_FILE) as f:
+                config_data: dict[str, Any] = yaml.safe_load(f) or {}
+            if config_data.get("telemetry") is False:
+                return False
+        except Exception:
+            pass
+
+    if _IDENTITY_FILE.is_file():
+        try:
+            with open(_IDENTITY_FILE) as f:
+                identity_data: dict[str, Any] = json.load(f)
+            if identity_data.get("enabled") is False:
+                return False
+        except Exception:
+            pass
+
+    return True
+
+
+def has_recorded_consent() -> bool:
+    """Check whether the user has already answered the telemetry prompt.
+
+    Returns:
+        True if ``~/.dango/telemetry.json`` already stores an explicit
+        "enabled" answer (from a prior `dango init` run), False otherwise.
+    """
+    try:
+        if _IDENTITY_FILE.is_file():
+            with open(_IDENTITY_FILE) as f:
+                data: dict[str, Any] = json.load(f)
+            return "enabled" in data
+    except Exception:
+        pass
+    return False
+
+
+def _get_or_create_uuid() -> str:
+    """Return the persisted anonymous install UUID, creating it if absent.
+
+    Does a plain read-modify-write with no file lock: this only ever runs
+    once, synchronously, inside `dango init` (never from a background or
+    scheduled process), matching the no-lock precedent already used for
+    ``~/.dango/`` in `dango.config.cloud_credentials` and
+    `dango.platform.local.network`.
+    """
+    try:
+        if _IDENTITY_FILE.is_file():
+            with open(_IDENTITY_FILE) as f:
+                data: dict[str, Any] = json.load(f)
+            existing = data.get("uuid")
+            if existing:
+                return str(existing)
+    except Exception:
+        pass
+
+    new_uuid = str(uuid4())
+    try:
+        _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        existing_data: dict[str, Any] = {}
+        if _IDENTITY_FILE.is_file():
+            try:
+                with open(_IDENTITY_FILE) as f:
+                    existing_data = json.load(f)
+            except Exception:
+                existing_data = {}
+        existing_data["uuid"] = new_uuid
+        with open(_IDENTITY_FILE, "w") as f:
+            json.dump(existing_data, f, indent=2)
+    except Exception:
+        pass
+    return new_uuid
+
+
+def set_telemetry_enabled(enabled: bool) -> None:
+    """Persist the user's telemetry consent answer.
+
+    Called once, right after the `dango init` prompt. Merges with (does
+    not clobber) any existing ``uuid`` key already stored — a plain
+    read-modify-write, same single-process reasoning as
+    `_get_or_create_uuid`. Never raises: a failure to persist just means
+    the prompt reappears on the next `dango init`.
+
+    Args:
+        enabled: The user's answer — True for "yes", False for "no".
+    """
+    try:
+        _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        data: dict[str, Any] = {}
+        if _IDENTITY_FILE.is_file():
+            try:
+                with open(_IDENTITY_FILE) as f:
+                    data = json.load(f)
+            except Exception:
+                data = {}
+        data["enabled"] = enabled
+        with open(_IDENTITY_FILE, "w") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        pass
+
+
+def ping(event: str, source_types: list[str] | None = None) -> None:
+    """Fire an anonymous telemetry ping. Never raises, never blocks > 2s.
+
+    A no-op when telemetry is disabled (see `is_telemetry_enabled`). All
+    failures — DNS, timeout, TLS, a non-2xx response, anything — are
+    swallowed silently and never queued for retry.
+
+    Args:
+        event: The event name, e.g. ``"install"``.
+        source_types: Configured source *type* names only (e.g.
+            ``["postgres", "stripe"]``) — never source names, credentials,
+            or schema content.
+    """
+    if not is_telemetry_enabled():
+        return
+
+    try:
+        import urllib.request
+
+        from dango import __version__
+
+        payload = {
+            "uuid": _get_or_create_uuid(),
+            "event": event,
+            "version": __version__,
+            "os": platform.system(),
+            "python_version": platform.python_version(),
+            "source_types": sorted(set(source_types or [])),
+            "is_ci": False,
+        }
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            TELEMETRY_ENDPOINT,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                # Cloudflare's bot-fight mode (enabled on this endpoint) blocks
+                # requests with no User-Agent — urllib sends none by default.
+                "User-Agent": f"dango-cli/{__version__}",
+            },
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS)
+    except Exception:
+        pass

--- a/dango/telemetry.py
+++ b/dango/telemetry.py
@@ -7,11 +7,17 @@ Payload is limited to an anonymous install UUID, Dango version, Python
 version, OS name, and source *type* names (e.g. "postgres", "stripe") —
 never source names, credentials, row counts, schema, or query text.
 
-Fire-and-forget: the network call runs on an un-joined daemon thread with
-a 2s socket timeout, silent on ALL failure (network, disk, permission,
-whatever) — telemetry must never raise, never block, and never slow down
-or break any CLI command. Failed or unfinished pings are never queued for
-retry; a dropped ping is just dropped.
+Best-effort with a bounded wait: the network call runs on a daemon
+thread, joined with a timeout of `_TIMEOUT_SECONDS`, so `dango init`
+waits at most that long for the ping to actually land before moving on
+— a short-lived CLI process exits so quickly that an un-joined thread
+essentially never gets scheduled before interpreter shutdown kills it
+(verified empirically: without a join, the ping never completes on a
+normal `dango init` exit). Silent on ALL failure (network, disk,
+permission, whatever) — telemetry must never raise or break any CLI
+command, and never waits longer than the timeout regardless of what's
+slow (DNS, connect, read, anything). Failed or unfinished pings are
+never queued for retry; a dropped ping is just dropped.
 
 Identity is machine-level (``~/.dango/telemetry.json``), not project-scoped,
 so one consultant with five client projects on one laptop counts as one
@@ -201,16 +207,20 @@ def set_telemetry_enabled(enabled: bool) -> None:
 
 
 def ping(event: str, source_types: list[str] | None = None) -> None:
-    """Fire an anonymous telemetry ping. Never raises, never blocks the caller.
+    """Fire an anonymous telemetry ping. Never raises, waits at most `_TIMEOUT_SECONDS`.
 
     A no-op when telemetry is disabled (see `is_telemetry_enabled`). The
-    actual network call runs on a daemon thread that is never joined, so
-    this function returns immediately regardless of network conditions —
-    true fire-and-forget, not just a bounded-timeout blocking call. All
-    failures — DNS, timeout, TLS, a non-2xx response, anything — are
-    swallowed silently inside that thread and never queued for retry. On a
-    process that exits immediately afterward, the ping may not finish
-    sending; that data loss is an accepted trade-off of never blocking.
+    actual network call runs on a daemon thread, joined with a timeout —
+    a short-lived CLI process exits so quickly that an un-joined
+    background thread essentially never gets a chance to run before
+    interpreter shutdown kills it (verified empirically), so a bounded
+    wait here is what actually gives the ping a real chance to land, not
+    just a theoretical one. Never waits longer than the timeout even if
+    the thread is still running (DNS hang, slow network, anything) — it
+    is abandoned as a daemon thread at that point, and the caller
+    proceeds immediately. All failures — DNS, timeout, TLS, a non-2xx
+    response, anything — are swallowed silently inside that thread and
+    never queued for retry.
 
     Args:
         event: The event name, e.g. ``"install"``.
@@ -223,6 +233,7 @@ def ping(event: str, source_types: list[str] | None = None) -> None:
 
     thread = threading.Thread(target=_send_ping, args=(event, source_types), daemon=True)
     thread.start()
+    thread.join(timeout=_TIMEOUT_SECONDS)
 
 
 def _send_ping(event: str, source_types: list[str] | None) -> None:
@@ -239,7 +250,11 @@ def _send_ping(event: str, source_types: list[str] | None) -> None:
             "os": platform.system(),
             "python_version": platform.python_version(),
             "source_types": sorted(set(source_types or [])),
-            "is_ci": False,
+            # No is_ci field: ping() already refuses to run at all when
+            # is_ci() is true, so every payload that actually reaches here
+            # would always carry the same fixed False — sending it would
+            # imply per-ping variability that can never exist client-side.
+            # The Worker's schema defaults this column to 0 when absent.
         }
         body = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -196,9 +196,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1496
+    lines: 1538
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen. 1.0.8-C added first-run telemetry consent prompt (+42 lines)."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -196,9 +196,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1549
+    lines: 1559
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen. 1.0.8-C added first-run telemetry consent prompt (+53 lines)."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen. 1.0.8-C added first-run telemetry consent prompt (+63 lines, incl. a closed-stdin safety fix)."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -196,9 +196,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1559
+    lines: 1585
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen. 1.0.8-C added first-run telemetry consent prompt (+63 lines, incl. a closed-stdin safety fix)."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen. 1.0.8-C added first-run telemetry consent prompt (+89 lines total, incl. a closed-stdin safety fix and replacing the isatty() gate with a direct prompt helper that correctly honours piped answers)."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -196,9 +196,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/init.py
-    lines: 1538
+    lines: 1549
     category: exempt
-    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen. 1.0.8-C added first-run telemetry consent prompt (+42 lines)."
+    reason: "Project initialization wizard. Sequential setup flow — splitting adds indirection without benefit. P7-014 added COMPATIBILITY.md + SCALABILITY.md generation (+133 lines). P7-011 added metrics config generation. P8-003 added CI workflow generation. P8-round2 added ICU extension install, auth YAML write, password auto-gen. 1.0.8-C added first-run telemetry consent prompt (+53 lines)."
     review_by: "v1.1"
 
   # Removed: dango/cli/utils.py — now ~130 lines after TASK-006 (utilities moved to proper modules)

--- a/tests/unit/test_cli_init_telemetry.py
+++ b/tests/unit/test_cli_init_telemetry.py
@@ -34,13 +34,14 @@ def _isolated_dango_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def _make_config() -> DangoConfig:
-    """Build a minimal DangoConfig with two fake sources for testing."""
+    """Build a minimal DangoConfig with two enabled sources and one disabled one."""
     return DangoConfig(
         project=ProjectContext(name="Test Project", created_by="tester", purpose="testing"),
         sources=SourcesConfig(
             sources=[
                 DataSource(name="my_csv", type=SourceType.CSV),
                 DataSource(name="my_sheet", type=SourceType.GOOGLE_SHEETS),
+                DataSource(name="paused_source", type=SourceType.STRIPE, enabled=False),
             ]
         ),
     )
@@ -77,15 +78,17 @@ class TestPromptTelemetryConsent:
         mock_confirm.assert_not_called()
 
     def test_prompts_and_persists_yes(self, tmp_path: Path) -> None:
-        """Answering yes persists consent and fires the install ping."""
+        """Answering yes persists consent and fires the install ping with enabled source types only."""
         initializer = ProjectInitializer(tmp_path)
         with (
+            patch("sys.stdin.isatty", return_value=True),
             patch("dango.cli.init.safe_confirm", return_value=True) as mock_confirm,
             patch("dango.telemetry.ping") as mock_ping,
         ):
             initializer._prompt_telemetry_consent(_make_config())
 
         mock_confirm.assert_called_once()
+        # The disabled "paused_source" (stripe) must not appear.
         mock_ping.assert_called_once_with("install", source_types=["csv", "google_sheets"])
         assert telemetry.is_telemetry_enabled() is True
         assert telemetry.has_recorded_consent() is True
@@ -94,6 +97,7 @@ class TestPromptTelemetryConsent:
         """Answering no persists the opt-out and never fires a ping."""
         initializer = ProjectInitializer(tmp_path)
         with (
+            patch("sys.stdin.isatty", return_value=True),
             patch("dango.cli.init.safe_confirm", return_value=False),
             patch("dango.telemetry.ping") as mock_ping,
         ):
@@ -102,6 +106,26 @@ class TestPromptTelemetryConsent:
         mock_ping.assert_not_called()
         assert telemetry.is_telemetry_enabled() is False
         assert telemetry.has_recorded_consent() is True
+
+    def test_skips_and_never_persists_when_not_a_tty(self, tmp_path: Path) -> None:
+        """A non-interactive session (no TTY) is never asked, and nothing is recorded.
+
+        Regression test: previously, safe_confirm()'s non-interactive
+        fallback (default=False) was persisted as if it were a real
+        answer, permanently locking the machine into opt-out without the
+        user ever seeing the prompt.
+        """
+        initializer = ProjectInitializer(tmp_path)
+        with (
+            patch("sys.stdin.isatty", return_value=False),
+            patch("dango.cli.init.safe_confirm") as mock_confirm,
+            patch("dango.telemetry.ping") as mock_ping,
+        ):
+            initializer._prompt_telemetry_consent(_make_config())
+
+        mock_confirm.assert_not_called()
+        mock_ping.assert_not_called()
+        assert telemetry.has_recorded_consent() is False
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cli_init_telemetry.py
+++ b/tests/unit/test_cli_init_telemetry.py
@@ -127,6 +127,42 @@ class TestPromptTelemetryConsent:
         mock_ping.assert_not_called()
         assert telemetry.has_recorded_consent() is False
 
+    def test_skips_without_crashing_when_stdin_is_none(self, tmp_path: Path) -> None:
+        """A closed stdin fd (sys.stdin is None) is treated as non-interactive, not a crash.
+
+        Regression test: CPython sets sys.stdin to None when fd 0 is
+        closed entirely (e.g. a daemonized invocation), rather than
+        merely redirecting it — calling .isatty() on None raises
+        AttributeError, which previously propagated straight up through
+        initialize() right after it had already printed its success
+        panel.
+        """
+        initializer = ProjectInitializer(tmp_path)
+        with (
+            patch("sys.stdin", None),
+            patch("dango.cli.init.safe_confirm") as mock_confirm,
+            patch("dango.telemetry.ping") as mock_ping,
+        ):
+            initializer._prompt_telemetry_consent(_make_config())  # must not raise
+
+        mock_confirm.assert_not_called()
+        mock_ping.assert_not_called()
+        assert telemetry.has_recorded_consent() is False
+
+    def test_skips_without_crashing_when_isatty_raises(self, tmp_path: Path) -> None:
+        """Any other exception from .isatty() (e.g. a closed file object) is also treated as non-interactive."""
+        initializer = ProjectInitializer(tmp_path)
+        with (
+            patch("sys.stdin.isatty", side_effect=ValueError("I/O operation on closed file")),
+            patch("dango.cli.init.safe_confirm") as mock_confirm,
+            patch("dango.telemetry.ping") as mock_ping,
+        ):
+            initializer._prompt_telemetry_consent(_make_config())  # must not raise
+
+        mock_confirm.assert_not_called()
+        mock_ping.assert_not_called()
+        assert telemetry.has_recorded_consent() is False
+
 
 @pytest.mark.unit
 class TestInitializeSkipsPromptWhenSkipWizard:

--- a/tests/unit/test_cli_init_telemetry.py
+++ b/tests/unit/test_cli_init_telemetry.py
@@ -1,18 +1,20 @@
 """tests/unit/test_cli_init_telemetry.py
 
 Tests for the telemetry consent prompt wired into
-ProjectInitializer.initialize() / _prompt_telemetry_consent().
+ProjectInitializer.initialize() / _prompt_telemetry_consent(), and the
+_ask_telemetry_consent() helper it uses instead of safe_confirm().
 """
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 import dango.telemetry as telemetry
-from dango.cli.init import ProjectInitializer
+from dango.cli.init import ProjectInitializer, _ask_telemetry_consent
 from dango.config.models import (
     DangoConfig,
     DataSource,
@@ -48,6 +50,62 @@ def _make_config() -> DangoConfig:
 
 
 @pytest.mark.unit
+class TestAskTelemetryConsent:
+    """Tests for the module-level _ask_telemetry_consent() helper.
+
+    Uses a real (unmocked) sys.stdin swapped for an in-memory stream
+    rather than mocking click.prompt — this proves the function reads
+    genuinely piped data correctly, not just that a mock returns what
+    we told it to.
+    """
+
+    def test_honors_a_real_yes_answer_even_though_stdin_is_not_a_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real 'yes' piped into stdin is read and honoured.
+
+        Regression test: an earlier design pre-checked
+        sys.stdin.isatty() and returned early for ANY non-TTY stdin,
+        silently discarding a real piped answer just because piped
+        input is never a TTY — even though the data was genuinely
+        there to read. This is the exact scenario `echo yes | dango
+        init` hits.
+        """
+        piped_stdin = io.StringIO("yes\n")
+        assert piped_stdin.isatty() is False  # genuinely non-interactive, but has real data
+        monkeypatch.setattr("sys.stdin", piped_stdin)
+        assert _ask_telemetry_consent() is True
+
+    def test_honors_a_real_no_answer_via_pipe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A real 'no' piped into stdin is read and honoured."""
+        monkeypatch.setattr("sys.stdin", io.StringIO("no\n"))
+        assert _ask_telemetry_consent() is False
+
+    def test_returns_none_on_genuine_eof(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty stdin (no data at all) returns None, not a substituted default."""
+        monkeypatch.setattr("sys.stdin", io.StringIO(""))
+        assert _ask_telemetry_consent() is None
+
+    def test_returns_none_when_stdin_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A closed fd 0 (sys.stdin is None) returns None instead of crashing.
+
+        Regression test: CPython sets sys.stdin to None when fd 0 is
+        closed entirely (e.g. a daemonized invocation) rather than
+        merely redirected; input() then raises RuntimeError, which an
+        earlier, narrower except clause did not catch.
+        """
+        monkeypatch.setattr("sys.stdin", None)
+        assert _ask_telemetry_consent() is None
+
+    def test_reprompts_on_invalid_input_then_accepts_valid_answer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unrecognized answer re-prompts instead of guessing or crashing."""
+        monkeypatch.setattr("sys.stdin", io.StringIO("maybe\nyes\n"))
+        assert _ask_telemetry_consent() is True
+
+
+@pytest.mark.unit
 class TestPromptTelemetryConsent:
     """Tests for ProjectInitializer._prompt_telemetry_consent()."""
 
@@ -55,17 +113,17 @@ class TestPromptTelemetryConsent:
         """No prompt fires when running in a detected CI environment."""
         monkeypatch.setenv("CI", "true")
         initializer = ProjectInitializer(tmp_path)
-        with patch("dango.cli.init.safe_confirm") as mock_confirm:
+        with patch("dango.cli.init._ask_telemetry_consent") as mock_ask:
             initializer._prompt_telemetry_consent(_make_config())
-        mock_confirm.assert_not_called()
+        mock_ask.assert_not_called()
 
     def test_skips_when_already_answered(self, tmp_path: Path) -> None:
         """No prompt fires if the user has already answered once before."""
         telemetry.set_telemetry_enabled(True)
         initializer = ProjectInitializer(tmp_path)
-        with patch("dango.cli.init.safe_confirm") as mock_confirm:
+        with patch("dango.cli.init._ask_telemetry_consent") as mock_ask:
             initializer._prompt_telemetry_consent(_make_config())
-        mock_confirm.assert_not_called()
+        mock_ask.assert_not_called()
 
     def test_skips_when_do_not_track_set(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -73,21 +131,20 @@ class TestPromptTelemetryConsent:
         """No prompt fires when DO_NOT_TRACK=1 is set."""
         monkeypatch.setenv("DO_NOT_TRACK", "1")
         initializer = ProjectInitializer(tmp_path)
-        with patch("dango.cli.init.safe_confirm") as mock_confirm:
+        with patch("dango.cli.init._ask_telemetry_consent") as mock_ask:
             initializer._prompt_telemetry_consent(_make_config())
-        mock_confirm.assert_not_called()
+        mock_ask.assert_not_called()
 
     def test_prompts_and_persists_yes(self, tmp_path: Path) -> None:
         """Answering yes persists consent and fires the install ping with enabled source types only."""
         initializer = ProjectInitializer(tmp_path)
         with (
-            patch("sys.stdin.isatty", return_value=True),
-            patch("dango.cli.init.safe_confirm", return_value=True) as mock_confirm,
+            patch("dango.cli.init._ask_telemetry_consent", return_value=True) as mock_ask,
             patch("dango.telemetry.ping") as mock_ping,
         ):
             initializer._prompt_telemetry_consent(_make_config())
 
-        mock_confirm.assert_called_once()
+        mock_ask.assert_called_once()
         # The disabled "paused_source" (stripe) must not appear.
         mock_ping.assert_called_once_with("install", source_types=["csv", "google_sheets"])
         assert telemetry.is_telemetry_enabled() is True
@@ -97,8 +154,7 @@ class TestPromptTelemetryConsent:
         """Answering no persists the opt-out and never fires a ping."""
         initializer = ProjectInitializer(tmp_path)
         with (
-            patch("sys.stdin.isatty", return_value=True),
-            patch("dango.cli.init.safe_confirm", return_value=False),
+            patch("dango.cli.init._ask_telemetry_consent", return_value=False),
             patch("dango.telemetry.ping") as mock_ping,
         ):
             initializer._prompt_telemetry_consent(_make_config())
@@ -107,59 +163,21 @@ class TestPromptTelemetryConsent:
         assert telemetry.is_telemetry_enabled() is False
         assert telemetry.has_recorded_consent() is True
 
-    def test_skips_and_never_persists_when_not_a_tty(self, tmp_path: Path) -> None:
-        """A non-interactive session (no TTY) is never asked, and nothing is recorded.
+    def test_no_real_answer_skips_without_persisting_or_pinging(self, tmp_path: Path) -> None:
+        """When _ask_telemetry_consent() returns None (no real answer obtained), nothing is recorded.
 
-        Regression test: previously, safe_confirm()'s non-interactive
-        fallback (default=False) was persisted as if it were a real
-        answer, permanently locking the machine into opt-out without the
-        user ever seeing the prompt.
+        Regression test: previously, a non-TTY session's unseen fallback
+        answer was persisted as if it were a real "no", permanently
+        locking the machine into opt-out without the user ever seeing
+        the prompt.
         """
         initializer = ProjectInitializer(tmp_path)
         with (
-            patch("sys.stdin.isatty", return_value=False),
-            patch("dango.cli.init.safe_confirm") as mock_confirm,
+            patch("dango.cli.init._ask_telemetry_consent", return_value=None),
             patch("dango.telemetry.ping") as mock_ping,
         ):
             initializer._prompt_telemetry_consent(_make_config())
 
-        mock_confirm.assert_not_called()
-        mock_ping.assert_not_called()
-        assert telemetry.has_recorded_consent() is False
-
-    def test_skips_without_crashing_when_stdin_is_none(self, tmp_path: Path) -> None:
-        """A closed stdin fd (sys.stdin is None) is treated as non-interactive, not a crash.
-
-        Regression test: CPython sets sys.stdin to None when fd 0 is
-        closed entirely (e.g. a daemonized invocation), rather than
-        merely redirecting it — calling .isatty() on None raises
-        AttributeError, which previously propagated straight up through
-        initialize() right after it had already printed its success
-        panel.
-        """
-        initializer = ProjectInitializer(tmp_path)
-        with (
-            patch("sys.stdin", None),
-            patch("dango.cli.init.safe_confirm") as mock_confirm,
-            patch("dango.telemetry.ping") as mock_ping,
-        ):
-            initializer._prompt_telemetry_consent(_make_config())  # must not raise
-
-        mock_confirm.assert_not_called()
-        mock_ping.assert_not_called()
-        assert telemetry.has_recorded_consent() is False
-
-    def test_skips_without_crashing_when_isatty_raises(self, tmp_path: Path) -> None:
-        """Any other exception from .isatty() (e.g. a closed file object) is also treated as non-interactive."""
-        initializer = ProjectInitializer(tmp_path)
-        with (
-            patch("sys.stdin.isatty", side_effect=ValueError("I/O operation on closed file")),
-            patch("dango.cli.init.safe_confirm") as mock_confirm,
-            patch("dango.telemetry.ping") as mock_ping,
-        ):
-            initializer._prompt_telemetry_consent(_make_config())  # must not raise
-
-        mock_confirm.assert_not_called()
         mock_ping.assert_not_called()
         assert telemetry.has_recorded_consent() is False
 

--- a/tests/unit/test_cli_init_telemetry.py
+++ b/tests/unit/test_cli_init_telemetry.py
@@ -1,0 +1,123 @@
+"""tests/unit/test_cli_init_telemetry.py
+
+Tests for the telemetry consent prompt wired into
+ProjectInitializer.initialize() / _prompt_telemetry_consent().
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import dango.telemetry as telemetry
+from dango.cli.init import ProjectInitializer
+from dango.config.models import (
+    DangoConfig,
+    DataSource,
+    ProjectContext,
+    SourcesConfig,
+    SourceType,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_dango_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate telemetry.py's persisted state from the real developer machine."""
+    config_dir = tmp_path / "home" / ".dango"
+    monkeypatch.setattr(telemetry, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(telemetry, "_IDENTITY_FILE", config_dir / "telemetry.json")
+    monkeypatch.setattr(telemetry, "_GLOBAL_CONFIG_FILE", config_dir / "config.yml")
+    for var in ("DO_NOT_TRACK", "DANGO_TELEMETRY", *telemetry._CI_ENV_VARS):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_config() -> DangoConfig:
+    """Build a minimal DangoConfig with two fake sources for testing."""
+    return DangoConfig(
+        project=ProjectContext(name="Test Project", created_by="tester", purpose="testing"),
+        sources=SourcesConfig(
+            sources=[
+                DataSource(name="my_csv", type=SourceType.CSV),
+                DataSource(name="my_sheet", type=SourceType.GOOGLE_SHEETS),
+            ]
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestPromptTelemetryConsent:
+    """Tests for ProjectInitializer._prompt_telemetry_consent()."""
+
+    def test_skips_when_ci(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No prompt fires when running in a detected CI environment."""
+        monkeypatch.setenv("CI", "true")
+        initializer = ProjectInitializer(tmp_path)
+        with patch("dango.cli.init.safe_confirm") as mock_confirm:
+            initializer._prompt_telemetry_consent(_make_config())
+        mock_confirm.assert_not_called()
+
+    def test_skips_when_already_answered(self, tmp_path: Path) -> None:
+        """No prompt fires if the user has already answered once before."""
+        telemetry.set_telemetry_enabled(True)
+        initializer = ProjectInitializer(tmp_path)
+        with patch("dango.cli.init.safe_confirm") as mock_confirm:
+            initializer._prompt_telemetry_consent(_make_config())
+        mock_confirm.assert_not_called()
+
+    def test_skips_when_do_not_track_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No prompt fires when DO_NOT_TRACK=1 is set."""
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        initializer = ProjectInitializer(tmp_path)
+        with patch("dango.cli.init.safe_confirm") as mock_confirm:
+            initializer._prompt_telemetry_consent(_make_config())
+        mock_confirm.assert_not_called()
+
+    def test_prompts_and_persists_yes(self, tmp_path: Path) -> None:
+        """Answering yes persists consent and fires the install ping."""
+        initializer = ProjectInitializer(tmp_path)
+        with (
+            patch("dango.cli.init.safe_confirm", return_value=True) as mock_confirm,
+            patch("dango.telemetry.ping") as mock_ping,
+        ):
+            initializer._prompt_telemetry_consent(_make_config())
+
+        mock_confirm.assert_called_once()
+        mock_ping.assert_called_once_with("install", source_types=["csv", "google_sheets"])
+        assert telemetry.is_telemetry_enabled() is True
+        assert telemetry.has_recorded_consent() is True
+
+    def test_prompts_and_persists_no_skips_ping(self, tmp_path: Path) -> None:
+        """Answering no persists the opt-out and never fires a ping."""
+        initializer = ProjectInitializer(tmp_path)
+        with (
+            patch("dango.cli.init.safe_confirm", return_value=False),
+            patch("dango.telemetry.ping") as mock_ping,
+        ):
+            initializer._prompt_telemetry_consent(_make_config())
+
+        mock_ping.assert_not_called()
+        assert telemetry.is_telemetry_enabled() is False
+        assert telemetry.has_recorded_consent() is True
+
+
+@pytest.mark.unit
+class TestInitializeSkipsPromptWhenSkipWizard:
+    """Covers the skip_wizard gate that lives in initialize(), not the helper."""
+
+    def test_skip_wizard_never_prompts(self, tmp_path: Path) -> None:
+        """A --skip-wizard blank-project init never triggers the telemetry prompt."""
+        project_dir = tmp_path / "proj"
+        initializer = ProjectInitializer(project_dir)
+        with (
+            patch.object(ProjectInitializer, "_prompt_telemetry_consent") as mock_prompt,
+            patch.object(ProjectInitializer, "_setup_metabase", return_value=True),
+            patch.object(ProjectInitializer, "_generate_dbt_docs", return_value=True),
+            patch.object(ProjectInitializer, "_setup_auth", return_value=True),
+        ):
+            initializer.initialize(skip_wizard=True)
+
+        mock_prompt.assert_not_called()

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -190,7 +190,7 @@ class TestSetTelemetryEnabled:
 
 @pytest.mark.unit
 class TestPing:
-    """Tests for telemetry.ping() — spawns a daemon thread, never blocks the caller."""
+    """Tests for telemetry.ping() — spawns a daemon thread, joined with a bounded timeout."""
 
     def test_noop_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """ping() never spawns a thread when telemetry is disabled."""
@@ -199,8 +199,14 @@ class TestPing:
             telemetry.ping("install")
         mock_thread.assert_not_called()
 
-    def test_spawns_daemon_thread_targeting_send_ping(self) -> None:
-        """ping() delegates the real work to a daemon thread running _send_ping."""
+    def test_spawns_daemon_thread_and_joins_with_timeout(self) -> None:
+        """ping() delegates to a daemon thread running _send_ping, then joins it with a timeout.
+
+        Regression test: an un-joined daemon thread was verified
+        empirically to essentially never run at all before a real
+        `dango init` process exits — join() is what actually gives the
+        ping a chance to land.
+        """
         telemetry.set_telemetry_enabled(True)
         with patch("dango.telemetry.threading.Thread") as mock_thread_cls:
             telemetry.ping("install", source_types=["csv"])
@@ -209,19 +215,36 @@ class TestPing:
             target=telemetry._send_ping, args=("install", ["csv"]), daemon=True
         )
         mock_thread_cls.return_value.start.assert_called_once()
+        mock_thread_cls.return_value.join.assert_called_once_with(
+            timeout=telemetry._TIMEOUT_SECONDS
+        )
 
-    def test_never_blocks_even_on_a_slow_send(self) -> None:
-        """ping() returns almost immediately regardless of how long the network call takes.
+    def test_returns_promptly_when_send_finishes_fast(self) -> None:
+        """A fast _send_ping doesn't force ping() to wait out the full timeout.
 
-        Regression test for the original synchronous urlopen() call, which
-        could block `dango init` for up to the full socket timeout.
+        Uses a real (unmocked) thread so the timing is genuine.
         """
         telemetry.set_telemetry_enabled(True)
-        with patch("dango.telemetry._send_ping", side_effect=lambda *a: time.sleep(1)):
+        with patch("dango.telemetry._send_ping", side_effect=lambda *a: time.sleep(0.05)):
             start = time.monotonic()
             telemetry.ping("install")
             elapsed = time.monotonic() - start
         assert elapsed < 0.5
+
+    def test_caps_wait_at_timeout_when_send_is_slow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ping() never waits longer than _TIMEOUT_SECONDS even if the send hangs.
+
+        Without this cap, a hung network call would make `dango init`
+        hang indefinitely; without any join at all (the prior bug), the
+        ping essentially never runs before the process exits.
+        """
+        monkeypatch.setattr(telemetry, "_TIMEOUT_SECONDS", 0.2)
+        telemetry.set_telemetry_enabled(True)
+        with patch("dango.telemetry._send_ping", side_effect=lambda *a: time.sleep(2)):
+            start = time.monotonic()
+            telemetry.ping("install")
+            elapsed = time.monotonic() - start
+        assert 0.15 < elapsed < 1.0
 
     def test_send_ping_silent_on_network_failure(self) -> None:
         """A network failure inside _send_ping never propagates."""
@@ -229,7 +252,13 @@ class TestPing:
             telemetry._send_ping("install", None)  # must not raise
 
     def test_send_ping_payload_shape(self) -> None:
-        """The outgoing payload has exactly the fields the deployed Worker expects."""
+        """The outgoing payload matches the deployed Worker's schema.
+
+        No is_ci field: ping() already refuses to run at all when is_ci()
+        is true, so the field could never carry any information other
+        than a constant False — the Worker's schema defaults it to 0
+        when absent, so omitting it entirely is correct, not a bug.
+        """
         mock_response = Mock()
         with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
             telemetry._send_ping("install", ["postgres", "stripe"])
@@ -244,11 +273,9 @@ class TestPing:
             "os",
             "python_version",
             "source_types",
-            "is_ci",
         }
         assert body["event"] == "install"
         assert body["source_types"] == ["postgres", "stripe"]
-        assert body["is_ci"] is False
         assert request.full_url == telemetry.TELEMETRY_ENDPOINT
         # Cloudflare's bot-fight mode on this endpoint blocks requests with
         # no User-Agent (urllib sends none by default) — regression test

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,207 @@
+"""tests/unit/test_telemetry.py
+
+Tests for dango.telemetry: opt-out precedence, UUID persistence, and
+the outgoing ping payload shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+import dango.telemetry as telemetry
+
+
+@pytest.fixture(autouse=True)
+def _isolated_dango_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect telemetry.py's module-level path constants into tmp_path.
+
+    Patching Path.home() alone would not work here since _CONFIG_DIR,
+    _IDENTITY_FILE, and _GLOBAL_CONFIG_FILE are already bound at import
+    time, so the module attributes are patched directly instead.
+    """
+    config_dir = tmp_path / ".dango"
+    monkeypatch.setattr(telemetry, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(telemetry, "_IDENTITY_FILE", config_dir / "telemetry.json")
+    monkeypatch.setattr(telemetry, "_GLOBAL_CONFIG_FILE", config_dir / "config.yml")
+    for var in ("DO_NOT_TRACK", "DANGO_TELEMETRY", *telemetry._CI_ENV_VARS):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.unit
+class TestIsCi:
+    """Tests for telemetry.is_ci()."""
+
+    def test_false_with_no_env_vars(self) -> None:
+        """No CI env vars set means is_ci() is False."""
+        assert telemetry.is_ci() is False
+
+    @pytest.mark.parametrize("var", telemetry._CI_ENV_VARS)
+    def test_true_when_ci_env_var_set(self, var: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Any recognized CI env var being set makes is_ci() True."""
+        monkeypatch.setenv(var, "1")
+        assert telemetry.is_ci() is True
+
+
+@pytest.mark.unit
+class TestIsTelemetryEnabled:
+    """Tests for telemetry.is_telemetry_enabled()."""
+
+    def test_true_by_default(self) -> None:
+        """No opt-out signal present means telemetry is enabled."""
+        assert telemetry.is_telemetry_enabled() is True
+
+    def test_do_not_track_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DO_NOT_TRACK=1 disables telemetry."""
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        assert telemetry.is_telemetry_enabled() is False
+
+    def test_dango_telemetry_env_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DANGO_TELEMETRY=0 disables telemetry."""
+        monkeypatch.setenv("DANGO_TELEMETRY", "0")
+        assert telemetry.is_telemetry_enabled() is False
+
+    def test_ci_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Running in CI disables telemetry regardless of stored consent."""
+        monkeypatch.setenv("CI", "true")
+        telemetry.set_telemetry_enabled(True)
+        assert telemetry.is_telemetry_enabled() is False
+
+    def test_config_yml_opt_out(self) -> None:
+        """telemetry: false in ~/.dango/config.yml disables telemetry."""
+        telemetry._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        telemetry._GLOBAL_CONFIG_FILE.write_text("telemetry: false\n")
+        assert telemetry.is_telemetry_enabled() is False
+
+    def test_config_yml_opt_in_is_not_required(self) -> None:
+        """Absence of the config.yml key doesn't disable telemetry on its own."""
+        telemetry._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        telemetry._GLOBAL_CONFIG_FILE.write_text("telemetry: true\n")
+        assert telemetry.is_telemetry_enabled() is True
+
+    def test_stored_consent_no_disables(self) -> None:
+        """A stored {"enabled": false} answer disables telemetry."""
+        telemetry.set_telemetry_enabled(False)
+        assert telemetry.is_telemetry_enabled() is False
+
+    def test_stored_consent_yes_enables(self) -> None:
+        """A stored {"enabled": true} answer keeps telemetry enabled."""
+        telemetry.set_telemetry_enabled(True)
+        assert telemetry.is_telemetry_enabled() is True
+
+    def test_corrupt_identity_file_falls_through(self) -> None:
+        """A corrupt telemetry.json is treated as no opt-out, not an error."""
+        telemetry._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        telemetry._IDENTITY_FILE.write_text("not valid json{{{")
+        assert telemetry.is_telemetry_enabled() is True
+
+    def test_corrupt_config_yml_falls_through(self) -> None:
+        """Corrupt YAML in config.yml is treated as no opt-out, not an error."""
+        telemetry._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        telemetry._GLOBAL_CONFIG_FILE.write_text(": : : not valid yaml")
+        assert telemetry.is_telemetry_enabled() is True
+
+
+@pytest.mark.unit
+class TestHasRecordedConsent:
+    """Tests for telemetry.has_recorded_consent()."""
+
+    def test_false_when_no_identity_file(self) -> None:
+        """No telemetry.json means consent has never been recorded."""
+        assert telemetry.has_recorded_consent() is False
+
+    def test_true_after_set_telemetry_enabled(self) -> None:
+        """set_telemetry_enabled() records an answer either way."""
+        telemetry.set_telemetry_enabled(False)
+        assert telemetry.has_recorded_consent() is True
+
+    def test_false_when_uuid_present_but_no_enabled_key(self) -> None:
+        """A UUID alone (no consent answer yet) doesn't count as recorded."""
+        telemetry._get_or_create_uuid()
+        assert telemetry.has_recorded_consent() is False
+
+
+@pytest.mark.unit
+class TestGetOrCreateUuid:
+    """Tests for telemetry._get_or_create_uuid()."""
+
+    def test_persists_across_calls(self) -> None:
+        """The same UUID is returned on every subsequent call."""
+        first = telemetry._get_or_create_uuid()
+        second = telemetry._get_or_create_uuid()
+        assert first == second
+
+    def test_stored_on_disk(self) -> None:
+        """The UUID is written to the machine-level identity file."""
+        generated = telemetry._get_or_create_uuid()
+        data = json.loads(telemetry._IDENTITY_FILE.read_text())
+        assert data["uuid"] == generated
+
+    def test_recovers_from_corrupt_file(self) -> None:
+        """A corrupt telemetry.json doesn't raise — a fresh UUID is generated."""
+        telemetry._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        telemetry._IDENTITY_FILE.write_text("not valid json{{{")
+        result = telemetry._get_or_create_uuid()
+        assert result
+
+
+@pytest.mark.unit
+class TestSetTelemetryEnabled:
+    """Tests for telemetry.set_telemetry_enabled()."""
+
+    def test_merges_without_clobbering_uuid(self) -> None:
+        """Setting consent doesn't erase an already-stored UUID."""
+        existing_uuid = telemetry._get_or_create_uuid()
+        telemetry.set_telemetry_enabled(False)
+        data = json.loads(telemetry._IDENTITY_FILE.read_text())
+        assert data["uuid"] == existing_uuid
+        assert data["enabled"] is False
+
+
+@pytest.mark.unit
+class TestPing:
+    """Tests for telemetry.ping()."""
+
+    def test_noop_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ping() never opens a connection when telemetry is disabled."""
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            telemetry.ping("install")
+        mock_urlopen.assert_not_called()
+
+    def test_silent_on_network_failure(self) -> None:
+        """A network failure inside ping() never propagates."""
+        telemetry.set_telemetry_enabled(True)
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("boom")):
+            telemetry.ping("install")  # must not raise
+
+    def test_sends_expected_payload_shape(self) -> None:
+        """The outgoing payload has exactly the fields the deployed Worker expects."""
+        telemetry.set_telemetry_enabled(True)
+        mock_response = Mock()
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            telemetry.ping("install", source_types=["postgres", "stripe"])
+
+        mock_urlopen.assert_called_once()
+        request = mock_urlopen.call_args[0][0]
+        body = json.loads(request.data.decode("utf-8"))
+        assert set(body.keys()) == {
+            "uuid",
+            "event",
+            "version",
+            "os",
+            "python_version",
+            "source_types",
+            "is_ci",
+        }
+        assert body["event"] == "install"
+        assert body["source_types"] == ["postgres", "stripe"]
+        assert body["is_ci"] is False
+        assert request.full_url == telemetry.TELEMETRY_ENDPOINT
+        # Cloudflare's bot-fight mode on this endpoint blocks requests with
+        # no User-Agent (urllib sends none by default) — regression test
+        # for a live 403 caught during manual verification.
+        assert request.get_header("User-agent")

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -7,6 +7,7 @@ the outgoing ping payload shape.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -41,8 +42,30 @@ class TestIsCi:
 
     @pytest.mark.parametrize("var", telemetry._CI_ENV_VARS)
     def test_true_when_ci_env_var_set(self, var: str, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Any recognized CI env var being set makes is_ci() True."""
+        """Any recognized CI env var being set to a truthy value makes is_ci() True."""
         monkeypatch.setenv(var, "1")
+        assert telemetry.is_ci() is True
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "yes", "t"])
+    def test_true_for_various_truthy_spellings(
+        self, value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Real CI providers set boolean-ish vars to spellings other than '1'."""
+        monkeypatch.setenv("CI", value)
+        assert telemetry.is_ci() is True
+
+    @pytest.mark.parametrize("var", ["CI", "GITHUB_ACTIONS", "CIRCLECI"])
+    @pytest.mark.parametrize("value", ["false", "False", "0", "no", ""])
+    def test_false_when_var_set_to_falsy_value(
+        self, var: str, value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A var explicitly set to a falsy value is not mistaken for CI presence."""
+        monkeypatch.setenv(var, value)
+        assert telemetry.is_ci() is False
+
+    def test_true_for_non_boolean_identifier_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JENKINS_URL/CODEBUILD_BUILD_ID are identifier strings, not booleans — any real value counts."""
+        monkeypatch.setenv("JENKINS_URL", "https://ci.example.com")
         assert telemetry.is_ci() is True
 
 
@@ -54,14 +77,18 @@ class TestIsTelemetryEnabled:
         """No opt-out signal present means telemetry is enabled."""
         assert telemetry.is_telemetry_enabled() is True
 
-    def test_do_not_track_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """DO_NOT_TRACK=1 disables telemetry."""
-        monkeypatch.setenv("DO_NOT_TRACK", "1")
+    @pytest.mark.parametrize("value", ["1", "true", "True", "yes", "t", "Y"])
+    def test_do_not_track_disables(self, value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DO_NOT_TRACK disables telemetry for every spelling dbt-core itself accepts."""
+        monkeypatch.setenv("DO_NOT_TRACK", value)
         assert telemetry.is_telemetry_enabled() is False
 
-    def test_dango_telemetry_env_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """DANGO_TELEMETRY=0 disables telemetry."""
-        monkeypatch.setenv("DANGO_TELEMETRY", "0")
+    @pytest.mark.parametrize("value", ["0", "false", "False", "no", "f"])
+    def test_dango_telemetry_env_disables(
+        self, value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DANGO_TELEMETRY disables telemetry for common falsy spellings, not just '0'."""
+        monkeypatch.setenv("DANGO_TELEMETRY", value)
         assert telemetry.is_telemetry_enabled() is False
 
     def test_ci_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -163,27 +190,49 @@ class TestSetTelemetryEnabled:
 
 @pytest.mark.unit
 class TestPing:
-    """Tests for telemetry.ping()."""
+    """Tests for telemetry.ping() — spawns a daemon thread, never blocks the caller."""
 
     def test_noop_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """ping() never opens a connection when telemetry is disabled."""
+        """ping() never spawns a thread when telemetry is disabled."""
         monkeypatch.setenv("DO_NOT_TRACK", "1")
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("dango.telemetry.threading.Thread") as mock_thread:
             telemetry.ping("install")
-        mock_urlopen.assert_not_called()
+        mock_thread.assert_not_called()
 
-    def test_silent_on_network_failure(self) -> None:
-        """A network failure inside ping() never propagates."""
+    def test_spawns_daemon_thread_targeting_send_ping(self) -> None:
+        """ping() delegates the real work to a daemon thread running _send_ping."""
         telemetry.set_telemetry_enabled(True)
+        with patch("dango.telemetry.threading.Thread") as mock_thread_cls:
+            telemetry.ping("install", source_types=["csv"])
+
+        mock_thread_cls.assert_called_once_with(
+            target=telemetry._send_ping, args=("install", ["csv"]), daemon=True
+        )
+        mock_thread_cls.return_value.start.assert_called_once()
+
+    def test_never_blocks_even_on_a_slow_send(self) -> None:
+        """ping() returns almost immediately regardless of how long the network call takes.
+
+        Regression test for the original synchronous urlopen() call, which
+        could block `dango init` for up to the full socket timeout.
+        """
+        telemetry.set_telemetry_enabled(True)
+        with patch("dango.telemetry._send_ping", side_effect=lambda *a: time.sleep(1)):
+            start = time.monotonic()
+            telemetry.ping("install")
+            elapsed = time.monotonic() - start
+        assert elapsed < 0.5
+
+    def test_send_ping_silent_on_network_failure(self) -> None:
+        """A network failure inside _send_ping never propagates."""
         with patch("urllib.request.urlopen", side_effect=ConnectionError("boom")):
-            telemetry.ping("install")  # must not raise
+            telemetry._send_ping("install", None)  # must not raise
 
-    def test_sends_expected_payload_shape(self) -> None:
+    def test_send_ping_payload_shape(self) -> None:
         """The outgoing payload has exactly the fields the deployed Worker expects."""
-        telemetry.set_telemetry_enabled(True)
         mock_response = Mock()
         with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
-            telemetry.ping("install", source_types=["postgres", "stripe"])
+            telemetry._send_ping("install", ["postgres", "stripe"])
 
         mock_urlopen.assert_called_once()
         request = mock_urlopen.call_args[0][0]


### PR DESCRIPTION
## Summary
- Adds `dango/telemetry.py`: a single opt-in "install ping" fired once at `dango init`, gated behind an explicit consent prompt. No heartbeat/scheduler hook — out of scope for this session.
- `ProjectInitializer._prompt_telemetry_consent()` (`dango/cli/init.py`) wires the prompt in right after the success message prints. Call-site guard is `if not skip_wizard:`; the method itself additionally no-ops (without ever prompting) when `is_ci()`, `has_recorded_consent()`, or `not is_telemetry_enabled()` — i.e. CI detection, a prior stored answer, or any opt-out (`DO_NOT_TRACK`, `DANGO_TELEMETRY`, `telemetry: false` in `~/.dango/config.yml`) all skip silently before ever asking.
- The consent prompt itself is asked via a dedicated `_ask_telemetry_consent()` helper (module-level in `init.py`), not `safe_confirm()` — it calls `click.prompt()` directly and returns `None`, rather than substituting a default, when no real answer could be obtained at all (genuine EOF, or a closed stdin). This distinction matters because the answer gets persisted permanently: a real "no" is persisted, but an unseen non-answer never is. It also means a real answer piped into stdin (e.g. `echo yes | dango init`) is read and honored normally, since it doesn't pre-check `isatty()`.
- Identity is machine-level: anonymous UUID in `~/.dango/telemetry.json`, never project-scoped.
- Opt-out (any one disables): `DO_NOT_TRACK`/`DANGO_TELEMETRY` set to any spelling dbt-core itself accepts (`1/t/true/y/yes` and `0/f/false/n/no`, case-insensitive), `telemetry: false` in `~/.dango/config.yml`, answering "no" at the prompt, or running in CI (checks `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, `BUILDKITE`, `CIRCLECI`, `TRAVIS`, `CODEBUILD_BUILD_ID`).
- Payload: anonymous UUID, event name, Dango version, OS, Python version, and source *type* names (enabled sources only) — never source names, credentials, row counts, schema, or query text.
- `ping()` runs the network call on a daemon thread joined with a `_TIMEOUT_SECONDS` (2s) timeout — bounded wait, not a fully synchronous call, but also not left un-joined (see below for why).
- No new pip dependency — stdlib `urllib.request` only (PyYAML was already a dependency).

### Issues found and fixed across three independent review passes
This PR went through three rounds of independent review (not self-review) between initial implementation and merge-readiness. Each caught something real:

**Round 1** — the original task spec's hook point (`ProjectInitializer.setup_project()` in `commands/project.py`) doesn't exist; wired into `ProjectInitializer.initialize()` instead. `config.sources` corrected to `config.sources.sources`. **Critical bug caught via live-endpoint testing:** Cloudflare's bot-fight mode 403s requests with no `User-Agent` header (urllib sends none by default) — every real ping would have silently failed forever. Fixed by adding `User-Agent: dango-cli/<version>`.

**Round 2** — (a) a non-interactive session's unseen `safe_confirm()` EOF-fallback answer was being persisted as a real "no", permanently locking a machine into opt-out without ever asking; (b) `DO_NOT_TRACK`/`DANGO_TELEMETRY` only matched `"1"`/`"0"` exactly, diverging from dbt-core's own accepted spellings; (c) `is_ci()` misread `CI=false` as CI; (d) `ping()` blocked synchronously; (e) disabled sources leaked into the payload; (f) a `not failures` guard was dead code (removed). A follow-up targeted review then caught that the TTY-check fix for (a) introduced its own unguarded crash when `sys.stdin` is `None` (closed fd) — fixed with a broader exception guard.

**Round 3** — the isatty()-based fix from round 2(a) turned out to be *too* broad: it silently dropped **any** non-TTY stdin, including a pipe with a real answer in it (`echo yes | dango init` got ignored entirely). Fixed by replacing the isatty() pre-check with the `_ask_telemetry_consent()` helper described above. Also found that the un-joined daemon thread from round 2(d)'s fix essentially never got to run at all before a real (undelayed) `dango init` process exit — reproduced directly: 3/3 clean runs wrote zero bytes to `~/.dango/telemetry.json`. Fixed by joining the thread with a timeout. Also removed a dead `is_ci` payload field that could never be anything but `False`.

Every fix above was verified by direct reproduction against the real code (not just trusting the review's claim) both before and after the change — see PR comments for the specific repro commands and outputs.

## Verification
- `pytest -x`: 4271 passed, 30 skipped, 0 failed (full suite — no regressions across all rounds of fixes)
- `pytest tests/unit/test_telemetry.py tests/unit/test_cli_init_telemetry.py -v`: 84/84 passed
- `ruff check` / `ruff format --check` / `mypy dango/telemetry.py dango/cli/init.py`: all clean
- `scripts/validate_headers.py` / `scripts/check_docstrings.py`: all clean
- **Live API verification (current state, re-verified after every round of fixes):**
  - `ping()` called for real (unmocked) against the live endpoint — confirmed `200 {"ok":true}`, `~/.dango/telemetry.json` correctly populated with `{"enabled": true, "uuid": "..."}`
  - A real `"yes\n"` piped into `_prompt_telemetry_consent()` is read and honored end-to-end: prompt text displayed, consent persisted, real ping fires
  - Empty/closed stdin (`< /dev/null`, and `sys.stdin` patched to `None` simulating a closed fd) returns `None` from `_ask_telemetry_consent()` — no prompt, nothing persisted, no crash
  - 3 consecutive real `dango init`-style invocations with **no artificial delay** confirmed the ping's UUID write (and, via an `urlopen` spy, the actual `200` response) now completes before process exit
  - `DO_NOT_TRACK`/`DANGO_TELEMETRY` opt-out confirmed for multiple accepted spellings via unit tests

## Regression check
- `dango init` project creation is unaffected by the telemetry prompt — it fires only after `_print_success_message()`, downstream of all project-creation steps.
- No existing test previously invoked `dango init` end-to-end, so nothing regressed from adding the prompt. The `skip_wizard` gate is covered by `test_skip_wizard_never_prompts`, which runs the real `initialize(skip_wizard=True)` path with only the heavy/unrelated steps (`_setup_metabase`, `_generate_dbt_docs`, `_setup_auth`) mocked.
- Docs kept in sync across all fix rounds: `dango/CLAUDE.md`, `dango/cli/CLAUDE.md` files tables, and `docs/file-exemptions.yml`'s line count for `cli/init.py` (1496 → 1585, with the reasons for each increment documented).

### Known, accepted follow-ups (not fixed in this PR — low severity, flagged by review)
- `_get_or_create_uuid()`/`set_telemetry_enabled()` do an unlocked read-modify-write of `~/.dango/telemetry.json`. Accepted risk: this only runs once per `dango init`, and the only realistic race is two `dango init` invocations landing on the same machine at literally the same instant, which would at worst regenerate a duplicate anonymous UUID — cosmetic, not a correctness bug.
- `_ask_telemetry_consent()` reimplements `safe_confirm()`'s yes/no parsing loop rather than sharing it, since it needs a different return contract (`bool | None` vs `bool`) and broader exception handling. A shared refactor is possible but touches ~25 other `safe_confirm()` call sites for marginal benefit — left as a future cleanup, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UBhTbqnQRga12Q3apJpKw