### PR TITLE
1.0.8-D: Unified telemetry control

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -47,6 +47,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/analyze.py` (~97 lines) | `monitor` group + `analyze` alias | `monitor` (group), `monitor_run()`, `analyze()` |
 | `commands/dev.py` (~429 lines) | `dev` group (default run + clean) — branch-based dbt development | `dev` (group), `dev_clean()` |
 | `commands/web.py` (69 lines) | `web` dev server command | `web()` |
+| `commands/telemetry.py` (~250 lines) | `telemetry` group (status, on, off) — unified write-through control for Dango, dbt, dlt, and Metabase telemetry | `telemetry`, `telemetry_status()`, `telemetry_on()`, `telemetry_off()` |
 | **Wizards** | | |
 | `init.py` (1585 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
@@ -136,8 +137,12 @@ dango (top-level group)
 │   ├── accept, drift-report, pii-report, pii-set, pii-list
 ├── notebook (group)            ← commands/notebook.py
 │   ├── new, open              (default invocation lists notebooks)
-└── metabase (group)            ← commands/metabase_cmd.py
-    ├── save, load, refresh
+├── metabase (group)            ← commands/metabase_cmd.py
+│   ├── save, load, refresh
+└── telemetry (group)           ← commands/telemetry.py
+    ├── status
+    ├── on   [--all | --provider dango|dbt|dlt|metabase]
+    └── off  [--all | --provider dango|dbt|dlt|metabase]
 ```
 
 ## Seeds vs CSV Data Source

--- a/dango/cli/commands/dev.py
+++ b/dango/cli/commands/dev.py
@@ -121,7 +121,7 @@ def _run_dev_dbt(project_root: Path, dev_dir: Path, select: str | None) -> int:
     """
     import subprocess
 
-    from dango.transformation import _get_dbt_executable
+    from dango.transformation import _dbt_telemetry_env, _get_dbt_executable
 
     dbt_cmd = _get_dbt_executable()
     dbt_dir = project_root / "dbt"
@@ -133,7 +133,7 @@ def _run_dev_dbt(project_root: Path, dev_dir: Path, select: str | None) -> int:
     console.print(f"[dim]Running: {' '.join(cmd)}[/dim]\n")
 
     try:
-        result = subprocess.run(cmd, cwd=str(dbt_dir), timeout=300)
+        result = subprocess.run(cmd, cwd=str(dbt_dir), timeout=300, env=_dbt_telemetry_env())
         return result.returncode
     except subprocess.TimeoutExpired:
         console.print(

--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -173,10 +173,21 @@ def _set_dbt_telemetry(enabled: bool) -> None:
     Machine-level (~/.dango/), matching Dango's own telemetry identity scope
     (see dango/telemetry.py) — one opt-out covers every project on the
     machine.
+
+    Raises:
+        click.ClickException: If the sentinel file can't be written (e.g.
+            ~/.dango is read-only or otherwise inaccessible) — converted
+            from a raw OSError so `--all` can skip this provider and
+            continue with the rest instead of crashing the whole command,
+            matching the error-handling contract set_metabase_telemetry()
+            uses for every one of its own failure modes.
     """
     sentinel = Path.home() / ".dango" / "dbt_telemetry"
-    sentinel.parent.mkdir(parents=True, exist_ok=True)
-    sentinel.write_text("true" if enabled else "false")
+    try:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text("true" if enabled else "false")
+    except OSError as e:
+        raise click.ClickException(f"Could not write dbt telemetry sentinel: {e}") from e
 
 
 def _set_dlt_telemetry(enabled: bool, project_root: Path | None) -> None:
@@ -185,18 +196,33 @@ def _set_dlt_telemetry(enabled: bool, project_root: Path | None) -> None:
     Writes a native TOML boolean (not a string) to match the value type
     dlt's own `dango telemetry`-equivalent CLI (`dlt telemetry switch`)
     writes — RuntimeConfiguration.dlthub_telemetry is a bool-typed field.
+
+    Raises:
+        click.ClickException: If project_root is None, if the file can't
+            be read/written (OSError — e.g. permissions), or if the
+            existing .dlt/config.toml is malformed
+            (tomlkit.exceptions.TOMLKitError, e.g. from manual editing) —
+            the latter two converted from raw exceptions so `--all` can
+            skip this provider and continue, same contract as dbt above
+            and Metabase's set_metabase_telemetry().
     """
     import tomlkit
+    from tomlkit.exceptions import TOMLKitError
 
     if project_root is None:
         raise click.ClickException("Must be run inside a Dango project for dlt control")
     config_path = project_root / ".dlt" / "config.toml"
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    doc = tomlkit.parse(config_path.read_text()) if config_path.exists() else tomlkit.document()
-    if "runtime" not in doc:
-        doc.add("runtime", tomlkit.table())
-    doc["runtime"]["dlthub_telemetry"] = enabled
-    config_path.write_text(tomlkit.dumps(doc))
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        doc = tomlkit.parse(config_path.read_text()) if config_path.exists() else tomlkit.document()
+        if "runtime" not in doc:
+            doc.add("runtime", tomlkit.table())
+        doc["runtime"]["dlthub_telemetry"] = enabled
+        config_path.write_text(tomlkit.dumps(doc))
+    except OSError as e:
+        raise click.ClickException(f"Could not write .dlt/config.toml: {e}") from e
+    except TOMLKitError as e:
+        raise click.ClickException(f"Could not parse .dlt/config.toml: {e}") from e
 
 
 def _set_metabase_telemetry(enabled: bool, project_root: Path | None) -> None:

--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -73,7 +73,7 @@ def telemetry_status(ctx: click.Context) -> None:
     )
 
     # Metabase
-    mb_on = _get_metabase_telemetry_state()
+    mb_on = _get_metabase_telemetry_state(project_root)
     table.add_row(
         "metabase",
         "[green]on[/green]" if mb_on else "[dim]off[/dim]",
@@ -200,12 +200,15 @@ def _set_dlt_telemetry(enabled: bool, project_root: Path | None) -> None:
 
 
 def _set_metabase_telemetry(enabled: bool, project_root: Path | None) -> None:
-    """Toggle Metabase anonymous tracking via the admin Setting API."""
+    """Toggle Metabase anonymous tracking via the admin Setting API.
+
+    The "is Metabase configured" check lives once, in
+    `set_metabase_telemetry()` itself (dango/visualization/metabase.py) —
+    not duplicated here — since that's the function that actually reads
+    `.dango/metabase.yml`.
+    """
     if project_root is None:
         raise click.ClickException("Must be run inside a Dango project for Metabase control")
-    creds_file = project_root / ".dango" / "metabase.yml"
-    if not creds_file.exists():
-        raise click.ClickException("Metabase not configured. Run dango start first.")
 
     from dango.visualization.metabase import set_metabase_telemetry
 
@@ -237,12 +240,19 @@ def _get_dlt_telemetry_state(project_root: Path | None) -> bool:
         return True
 
 
-def _get_metabase_telemetry_state() -> bool:
-    """Return Metabase's assumed opt-in state.
+def _get_metabase_telemetry_state(project_root: Path | None) -> bool:
+    """Return Metabase's last-known opt-in state.
 
-    Deliberately does not query the live Metabase instance — that would
-    require Metabase to be running and authenticated just to print a status
-    table. Defaults to "on" since that's Metabase's own out-of-the-box
-    default when anon-tracking-enabled has never been explicitly set.
+    Reads the local cache file `set_metabase_telemetry()` writes after each
+    successful live API call (dango/visualization/metabase.py) — this
+    reports the real last-set state without requiring Metabase to be
+    running just to print a status table. If telemetry was never toggled
+    through this command (no cache file, or no project), defaults to "on":
+    that's Metabase's own out-of-the-box default for anon-tracking-enabled.
     """
-    return True
+    if project_root is None:
+        return True
+    state_file = project_root / ".dango" / "metabase_telemetry_state"
+    if not state_file.exists():
+        return True
+    return state_file.read_text().strip() == "true"

--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -1,0 +1,244 @@
+"""dango/cli/commands/telemetry.py
+
+Unified telemetry control for Dango, dbt, dlt, and Metabase — a single
+command surface that writes through to each provider's own real config
+mechanism (Dango's ~/.dango/telemetry.json, a dbt subprocess env sentinel,
+dlt's .dlt/config.toml, and Metabase's admin Setting API). This controls
+telemetry for the components Dango configures; it does not claim anything
+about network traffic outside those four providers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from dango.cli import console
+
+PROVIDERS = ("dango", "dbt", "dlt", "metabase")
+
+# Providers whose write-through requires an active Dango project (project_root
+# is not None). Used by the --all path to downgrade a missing-project failure
+# to a warning instead of aborting the whole command — dango and dbt are
+# machine-level and always succeed regardless of project context.
+_PROJECT_SCOPED_PROVIDERS = ("dlt", "metabase")
+
+
+@click.group("telemetry")
+def telemetry() -> None:
+    """View and control telemetry for Dango and bundled tools."""
+
+
+@telemetry.command("status")
+@click.pass_context
+def telemetry_status(ctx: click.Context) -> None:
+    """Show telemetry state for all four providers."""
+    from dango.telemetry import is_telemetry_enabled
+
+    project_root = ctx.obj.get("project_root")
+
+    table = Table(title="Telemetry Status", show_header=True, header_style="bold")
+    table.add_column("Provider")
+    table.add_column("State")
+    table.add_column("What it sends")
+    table.add_column("Control")
+
+    # Dango
+    dango_on = is_telemetry_enabled()
+    table.add_row(
+        "dango",
+        "[green]on[/green]" if dango_on else "[dim]off[/dim]",
+        "UUID, version, OS, source type names",
+        "dango telemetry on/off --provider dango",
+    )
+
+    # dbt
+    dbt_on = _get_dbt_telemetry_state()
+    table.add_row(
+        "dbt-core",
+        "[green]on[/green]" if dbt_on else "[dim]off[/dim]",
+        "OS, Python version, invocation success/duration",
+        "dango telemetry on/off --provider dbt",
+    )
+
+    # dlt
+    dlt_on = _get_dlt_telemetry_state(project_root)
+    table.add_row(
+        "dlt",
+        "[green]on[/green]" if dlt_on else "[dim]off[/dim]",
+        "Command names, hashed pipeline names, execution times",
+        "dango telemetry on/off --provider dlt",
+    )
+
+    # Metabase
+    mb_on = _get_metabase_telemetry_state()
+    table.add_row(
+        "metabase",
+        "[green]on[/green]" if mb_on else "[dim]off[/dim]",
+        "Anonymous usage statistics",
+        "dango telemetry on/off --provider metabase",
+    )
+
+    console.print()
+    console.print(table)
+    console.print(
+        "\n[dim]controls telemetry for the components Dango configures — "
+        "full egress docs: docs/network-egress.yml[/dim]\n"
+    )
+
+
+@telemetry.command("off")
+@click.option("--all", "all_providers", is_flag=True, help="Disable all providers")
+@click.option("--provider", type=click.Choice(PROVIDERS), help="Disable specific provider")
+@click.pass_context
+def telemetry_off(ctx: click.Context, all_providers: bool, provider: str | None) -> None:
+    """Disable telemetry for one or all providers."""
+    _run_toggle(ctx, all_providers, provider, enabled=False)
+
+
+@telemetry.command("on")
+@click.option("--all", "all_providers", is_flag=True, help="Enable all providers")
+@click.option("--provider", type=click.Choice(PROVIDERS), help="Enable specific provider")
+@click.pass_context
+def telemetry_on(ctx: click.Context, all_providers: bool, provider: str | None) -> None:
+    """Enable telemetry for one or all providers."""
+    _run_toggle(ctx, all_providers, provider, enabled=True)
+
+
+def _run_toggle(
+    ctx: click.Context, all_providers: bool, provider: str | None, enabled: bool
+) -> None:
+    """Shared implementation for the `on` and `off` subcommands.
+
+    In --all mode, a provider that requires a project (dlt, metabase) and
+    finds none is downgraded to a warning rather than aborting the rest of
+    the run — dango and dbt are machine-level and must still succeed. An
+    explicit --provider request that can't be fulfilled still raises, since
+    that is a single deliberate action rather than a best-effort sweep.
+    """
+    if not all_providers and not provider:
+        raise click.UsageError("Specify --all or --provider PROVIDER")
+
+    project_root = ctx.obj.get("project_root")
+    targets = list(PROVIDERS) if all_providers else [provider]
+    verb = "enabled" if enabled else "disabled"
+
+    for p in targets:
+        if all_providers and p in _PROJECT_SCOPED_PROVIDERS and project_root is None:
+            console.print(f"[yellow]![/yellow] {p}: skipped — not inside a Dango project")
+            continue
+        try:
+            _set_provider(p, enabled=enabled, project_root=project_root)
+        except click.ClickException as exc:
+            if all_providers:
+                console.print(f"[yellow]![/yellow] {p}: skipped — {exc.format_message()}")
+                continue
+            raise
+        console.print(f"[green]✓[/green] {p}: telemetry {verb}")
+
+    console.print()
+
+
+# ── Provider helpers ─────────────────────────────────────────────────────────────
+
+
+def _set_provider(provider: str, enabled: bool, project_root: Path | None) -> None:
+    """Dispatch a single provider's write-through. Raises click.ClickException on failure."""
+    if provider == "dango":
+        from dango.telemetry import set_telemetry_enabled
+
+        set_telemetry_enabled(enabled)
+
+    elif provider == "dbt":
+        _set_dbt_telemetry(enabled)
+
+    elif provider == "dlt":
+        _set_dlt_telemetry(enabled, project_root)
+
+    elif provider == "metabase":
+        _set_metabase_telemetry(enabled, project_root)
+
+
+def _set_dbt_telemetry(enabled: bool) -> None:
+    """Write the dbt telemetry sentinel file, read by `_dbt_telemetry_env()`
+    in transformation/__init__.py to decide whether to inject
+    DBT_SEND_ANONYMOUS_USAGE_STATS=false into the dbt subprocess env.
+
+    Machine-level (~/.dango/), matching Dango's own telemetry identity scope
+    (see dango/telemetry.py) — one opt-out covers every project on the
+    machine.
+    """
+    sentinel = Path.home() / ".dango" / "dbt_telemetry"
+    sentinel.parent.mkdir(parents=True, exist_ok=True)
+    sentinel.write_text("true" if enabled else "false")
+
+
+def _set_dlt_telemetry(enabled: bool, project_root: Path | None) -> None:
+    """Write dlthub_telemetry to .dlt/config.toml under [runtime].
+
+    Writes a native TOML boolean (not a string) to match the value type
+    dlt's own `dango telemetry`-equivalent CLI (`dlt telemetry switch`)
+    writes — RuntimeConfiguration.dlthub_telemetry is a bool-typed field.
+    """
+    import tomlkit
+
+    if project_root is None:
+        raise click.ClickException("Must be run inside a Dango project for dlt control")
+    config_path = project_root / ".dlt" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    doc = tomlkit.parse(config_path.read_text()) if config_path.exists() else tomlkit.document()
+    if "runtime" not in doc:
+        doc.add("runtime", tomlkit.table())
+    doc["runtime"]["dlthub_telemetry"] = enabled
+    config_path.write_text(tomlkit.dumps(doc))
+
+
+def _set_metabase_telemetry(enabled: bool, project_root: Path | None) -> None:
+    """Toggle Metabase anonymous tracking via the admin Setting API."""
+    if project_root is None:
+        raise click.ClickException("Must be run inside a Dango project for Metabase control")
+    creds_file = project_root / ".dango" / "metabase.yml"
+    if not creds_file.exists():
+        raise click.ClickException("Metabase not configured. Run dango start first.")
+
+    from dango.visualization.metabase import set_metabase_telemetry
+
+    set_metabase_telemetry(project_root, enabled)
+
+
+def _get_dbt_telemetry_state() -> bool:
+    """Return dbt's current opt-in state per the sentinel file (default: on)."""
+    sentinel = Path.home() / ".dango" / "dbt_telemetry"
+    if sentinel.exists():
+        return sentinel.read_text().strip() == "true"
+    return True  # default on
+
+
+def _get_dlt_telemetry_state(project_root: Path | None) -> bool:
+    """Return dlt's current opt-in state per .dlt/config.toml (default: on)."""
+    if project_root is None:
+        return True
+    config_path = project_root / ".dlt" / "config.toml"
+    if not config_path.exists():
+        return True
+    try:
+        import tomlkit
+
+        doc = tomlkit.parse(config_path.read_text())
+        val = doc.get("runtime", {}).get("dlthub_telemetry", True)
+        return bool(val)
+    except Exception:
+        return True
+
+
+def _get_metabase_telemetry_state() -> bool:
+    """Return Metabase's assumed opt-in state.
+
+    Deliberately does not query the live Metabase instance — that would
+    require Metabase to be running and authenticated just to print a status
+    table. Defaults to "on" since that's Metabase's own out-of-the-box
+    default when anon-tracking-enabled has never been explicitly set.
+    """
+    return True

--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -118,11 +118,15 @@ def _run_toggle(
     explicit --provider request that can't be fulfilled still raises, since
     that is a single deliberate action rather than a best-effort sweep.
     """
-    if not all_providers and not provider:
+    targets: list[str]
+    if all_providers:
+        targets = list(PROVIDERS)
+    elif provider:
+        targets = [provider]
+    else:
         raise click.UsageError("Specify --all or --provider PROVIDER")
 
     project_root = ctx.obj.get("project_root")
-    targets = list(PROVIDERS) if all_providers else [provider]
     verb = "enabled" if enabled else "disabled"
 
     for p in targets:

--- a/dango/cli/commands/transform.py
+++ b/dango/cli/commands/transform.py
@@ -34,6 +34,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
     """
     import subprocess
 
+    from dango.transformation import _dbt_telemetry_env
     from dango.utils import DbtLock, DbtLockError
     from dango.utils.dbt_status import update_model_status
 
@@ -80,7 +81,7 @@ def run(ctx: click.Context, dbt_args: tuple[str, ...]) -> None:
         _metabase_was_stopped = stop_metabase_for_writes(project_root)
         try:
             # Run dbt command from dbt directory for correct path resolution
-            result = subprocess.run(cmd, cwd=str(dbt_dir))
+            result = subprocess.run(cmd, cwd=str(dbt_dir), env=_dbt_telemetry_env())
         finally:
             if _metabase_was_stopped:
                 start_metabase_after_writes(project_root)
@@ -170,6 +171,7 @@ def docs(ctx: click.Context) -> None:
     import subprocess
 
     from dango.config import ConfigLoader
+    from dango.transformation import _dbt_telemetry_env
 
     from ..utils import require_project_context
 
@@ -196,7 +198,7 @@ def docs(ctx: click.Context) -> None:
         ]
 
         # Run dbt command from dbt directory for correct path resolution
-        result = subprocess.run(cmd, cwd=str(dbt_dir))
+        result = subprocess.run(cmd, cwd=str(dbt_dir), env=_dbt_telemetry_env())
 
         if result.returncode != 0:
             console.print(

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1163,6 +1163,8 @@ on-run-end:
         import subprocess
         import sys
 
+        from dango.transformation import _dbt_telemetry_env
+
         console.print("Generating dbt documentation...")
 
         dbt_dir = self.project_dir / "dbt"
@@ -1191,6 +1193,7 @@ on-run-end:
                 capture_output=True,
                 text=True,
                 timeout=60,
+                env=_dbt_telemetry_env(),
             )
 
             if result.returncode == 0:

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -33,6 +33,7 @@ from dango.cli.commands.seed import seed
 from dango.cli.commands.serve import serve
 from dango.cli.commands.snapshot import snapshot
 from dango.cli.commands.source import source, sync
+from dango.cli.commands.telemetry import telemetry
 from dango.cli.commands.transform import docs, generate, run
 from dango.cli.commands.upgrade import upgrade
 from dango.cli.commands.web import web
@@ -124,6 +125,7 @@ cli.add_command(governance)
 cli.add_command(monitor)
 cli.add_command(snapshot)
 cli.add_command(local_backup_group)
+cli.add_command(telemetry)
 
 
 def main() -> None:

--- a/dango/cli/model_wizard.py
+++ b/dango/cli/model_wizard.py
@@ -516,6 +516,8 @@ class ModelWizard:
         """
         import subprocess
 
+        from dango.transformation import _dbt_telemetry_env
+
         try:
             # Run dbt parse to regenerate manifest
             result = subprocess.run(
@@ -531,6 +533,7 @@ class ModelWizard:
                 capture_output=True,
                 text=True,
                 timeout=30,
+                env=_dbt_telemetry_env(),
             )
 
             if result.returncode == 0:

--- a/dango/cli/validate.py
+++ b/dango/cli/validate.py
@@ -434,6 +434,8 @@ class ProjectValidator:
 
     def _validate_dbt_models(self):
         """Validate dbt models by running dbt parse"""
+        from dango.transformation import _dbt_telemetry_env
+
         dbt_dir = self.project_root / "dbt"
 
         if not dbt_dir.exists():
@@ -447,6 +449,7 @@ class ProjectValidator:
                 capture_output=True,
                 text=True,
                 timeout=60,
+                env=_dbt_telemetry_env(),
             )
 
             if result.returncode == 0:

--- a/dango/platform/local/watcher_runner.py
+++ b/dango/platform/local/watcher_runner.py
@@ -66,6 +66,7 @@ def run_dbt_command(project_root: Path, changed_files: list[Any] | None = None) 
         project_root: Project root path
         changed_files: Optional list of changed file paths for selective runs
     """
+    from dango.transformation import _dbt_telemetry_env
     from dango.utils import DbtLock, DbtLockError
 
     print(f"[FileWatcher] Triggering dbt at {datetime.now().isoformat()}")
@@ -117,6 +118,7 @@ def run_dbt_command(project_root: Path, changed_files: list[Any] | None = None) 
             capture_output=True,
             text=True,
             timeout=3600,  # 1 hour timeout
+            env=_dbt_telemetry_env(),
         )
 
         if result.returncode == 0:

--- a/dango/transformation/CLAUDE.md
+++ b/dango/transformation/CLAUDE.md
@@ -33,6 +33,7 @@ Integrates with dbt for data transformation, including auto-generation of stagin
 - `dango/ingestion/dlt_runner.py` — `DbtModelGenerator`, `run_dbt_models`, `generate_dbt_docs` for post-sync auto-transform
 - `dango/web/app.py` — `run_dbt_models` via API endpoint
 - `dango/platform/watcher_runner.py` — `generate_dbt_docs` for watch-triggered doc generation
+- `_dbt_telemetry_env()` specifically is also imported directly by every other dbt-invoking `subprocess.run` call site outside this module, so the dbt telemetry opt-out (`dango telemetry off --provider dbt`) covers all of them, not just the three functions above: `dango/cli/commands/transform.py` (`dango run`, `dango docs`), `dango/platform/local/watcher_runner.py` (`run_dbt_command`, file-watcher-triggered), `dango/web/routes/dbt.py` (`run_dbt_model_task`, web UI model run), `dango/cli/commands/dev.py` (`_run_dev_dbt`), `dango/cli/init.py` (`_generate_dbt_docs`), `dango/cli/model_wizard.py` (`_regenerate_manifest`), `dango/cli/validate.py` (`_validate_dbt_models`)
 
 ## Testing
 

--- a/dango/transformation/CLAUDE.md
+++ b/dango/transformation/CLAUDE.md
@@ -8,7 +8,7 @@ Integrates with dbt for data transformation, including auto-generation of stagin
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `__init__.py` | dbt CLI execution functions | `run_dbt_models`, `run_dbt_snapshots`, `generate_dbt_docs`, `_get_dbt_executable` |
+| `__init__.py` | dbt CLI execution functions | `run_dbt_models`, `run_dbt_snapshots`, `generate_dbt_docs`, `_get_dbt_executable`, `_dbt_telemetry_env` |
 | `generator.py` | Auto-generates dbt staging models from data sources | `DbtModelGenerator`, `generate_staging_models` |
 
 ## Common Tasks
@@ -16,6 +16,7 @@ Integrates with dbt for data transformation, including auto-generation of stagin
 | To... | Modify... | Test with... |
 |-------|-----------|--------------|
 | Change dbt run behavior | `__init__.py` (`run_dbt_models`) | Manual: `dango transform` |
+| Change dbt telemetry opt-out env injection | `__init__.py` (`_dbt_telemetry_env`) | `pytest tests/unit/test_telemetry_unified.py` |
 | Add a new dedup strategy mapping | `generator.py` (`CSV_TO_DBT_STRATEGY_MAP`) | Manual: `dango generate-models` with source using new strategy |
 | Change generated model SQL | `generator.py` + `dango/templates/dbt/staging_model.sql.j2` | Manual: `dango generate-models` and inspect output |
 | Change sources.yml generation | `generator.py` (`generate_sources_yml`) | Manual: `dango generate-models` and inspect `dbt/models/staging/` |

--- a/dango/transformation/__init__.py
+++ b/dango/transformation/__init__.py
@@ -1,4 +1,5 @@
-"""
+"""dango/transformation/__init__.py
+
 Dango Transformation Module
 
 Handles dbt integration and SQL model generation.
@@ -13,6 +14,27 @@ from rich.console import Console
 from dango.exceptions import format_structured_error
 
 console = Console()
+
+
+def _dbt_telemetry_env() -> dict[str, str]:
+    """Return an env dict for the dbt subprocess, with telemetry disabled if opted out.
+
+    Always a complete copy of os.environ ({**os.environ}) — never mutates
+    os.environ in place. The opt-out state comes from the sentinel file
+    dango/cli/commands/telemetry.py writes (~/.dango/dbt_telemetry),
+    machine-level like Dango's own telemetry identity. DBT_SEND_ANONYMOUS_USAGE_STATS
+    is dbt-core's actual documented env var (dbt/cli/params.py); DO_NOT_TRACK
+    is set alongside it as defense in depth, matching the community
+    convention dango/telemetry.py also honors.
+    """
+    import os
+
+    env = {**os.environ}
+    sentinel = Path.home() / ".dango" / "dbt_telemetry"
+    if sentinel.exists() and sentinel.read_text().strip() == "false":
+        env["DBT_SEND_ANONYMOUS_USAGE_STATS"] = "false"
+        env["DO_NOT_TRACK"] = "1"
+    return env
 
 
 def _get_dbt_executable() -> str:
@@ -76,6 +98,7 @@ def run_dbt_models(
             capture_output=True,
             text=True,
             timeout=300,  # 5 minute timeout
+            env=_dbt_telemetry_env(),
         )
 
         output = result.stdout + result.stderr
@@ -161,6 +184,7 @@ def run_dbt_snapshots(
             capture_output=True,
             text=True,
             timeout=300,  # 5 minute timeout
+            env=_dbt_telemetry_env(),
         )
 
         if result.returncode == 0:
@@ -236,6 +260,7 @@ def generate_dbt_docs(project_root: Path) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             timeout=60,
+            env=_dbt_telemetry_env(),
         )
 
         return (result.returncode == 0, result.stdout + result.stderr)

--- a/dango/visualization/CLAUDE.md
+++ b/dango/visualization/CLAUDE.md
@@ -9,7 +9,7 @@ Integrates with Metabase for dashboard provisioning, auto-setup, schema synchron
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports | `provision_dashboard`, `create_pipeline_health_dashboard` |
-| `metabase.py` | Metabase auto-setup, DuckDB connection, schema sync | `MetabaseProvisioner`, `setup_metabase`, `sync_metabase_schema`, `refresh_metabase_connection` |
+| `metabase.py` | Metabase auto-setup, DuckDB connection, schema sync | `MetabaseProvisioner`, `setup_metabase`, `sync_metabase_schema`, `refresh_metabase_connection`, `set_metabase_telemetry` |
 | `dashboard_manager.py` | YAML-based dashboard/question export and import with rollback | `DashboardManager`, `import_dashboards` |
 
 ## Common Tasks

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -1242,6 +1242,16 @@ def set_metabase_telemetry(
             json={"username": email, "password": password},
             timeout=10,
         )
+        if login_response.status_code in (401, 403):
+            # Distinguish "reachable but rejected the credentials" from
+            # "unreachable" *before* raise_for_status() below would
+            # otherwise turn this into a generic requests.HTTPError (a
+            # RequestException subclass) and get mislabeled by the
+            # "is it running?" branch further down — Metabase is running
+            # fine here, the admin password in metabase.yml is just stale.
+            raise click.ClickException(
+                "Metabase login failed — check admin credentials in .dango/metabase.yml"
+            )
         login_response.raise_for_status()
         session_id = login_response.json().get("id")
         if not session_id:

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -1187,7 +1187,7 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
 
 
 def set_metabase_telemetry(
-    project_root: Path, enabled: bool, metabase_url: str = "http://localhost:3000"
+    project_root: Path, enabled: bool, metabase_url: str | None = None
 ) -> None:
     """
     Toggle Metabase's anonymous usage tracking via the admin Setting API.
@@ -1198,14 +1198,23 @@ def set_metabase_telemetry(
     for anonymous tracking (distinct from the one-time "allow_tracking" field
     used only in the /api/setup wizard payload in setup_metabase() above).
 
+    On success, also writes a local last-known-state cache
+    (.dango/metabase_telemetry_state) so `dango telemetry status` can report
+    the real state without making a live API call every time — see
+    dango/cli/commands/telemetry.py's `_get_metabase_telemetry_state()`.
+
     Args:
         project_root: Path to project root
         enabled: True to enable anonymous tracking, False to disable it
-        metabase_url: Metabase URL (default: http://localhost:3000)
+        metabase_url: Metabase URL. If not given, read from the
+            "metabase_url" key in .dango/metabase.yml (same precedent as
+            cli/commands/metabase_cmd.py), falling back to
+            http://localhost:3000 if that key is absent too.
 
     Raises:
         click.ClickException: If Metabase credentials are missing/incomplete,
-            or if the API call fails (e.g. Metabase not running).
+            or if the API call fails (e.g. Metabase not running), or if
+            anything else in the credentials/login/API flow goes wrong.
     """
     import click
 
@@ -1225,9 +1234,11 @@ def set_metabase_telemetry(
                 "Metabase admin credentials missing from .dango/metabase.yml"
             )
 
+        resolved_url = metabase_url or credentials.get("metabase_url", "http://localhost:3000")
+
         session = requests.Session()
         login_response = session.post(
-            f"{metabase_url}/api/session",
+            f"{resolved_url}/api/session",
             json={"username": email, "password": password},
             timeout=10,
         )
@@ -1237,19 +1248,30 @@ def set_metabase_telemetry(
             raise click.ClickException("Metabase login did not return a session id")
 
         response = session.put(
-            f"{metabase_url}/api/setting/anon-tracking-enabled",
+            f"{resolved_url}/api/setting/anon-tracking-enabled",
             headers={"X-Metabase-Session": session_id},
             json={"value": enabled},
             timeout=10,
         )
         response.raise_for_status()
 
+        state_file = project_root / ".dango" / "metabase_telemetry_state"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text("true" if enabled else "false")
+
     except click.ClickException:
         raise
     except requests.exceptions.RequestException as e:
         raise click.ClickException(
-            f"Could not reach Metabase at {metabase_url} — is it running? ({e})"
+            f"Could not reach Metabase at {resolved_url} — is it running? ({e})"
         ) from e
+    except Exception as e:
+        # Broad fallback: credentials-load/login/API flow can also fail on
+        # yaml.YAMLError (malformed metabase.yml) or a non-JSON 200 login
+        # response (login_response.json() raising ValueError), neither of
+        # which is a RequestException. Convert to the same clean-error
+        # contract this function promises for every other failure mode.
+        raise click.ClickException(f"Failed to set Metabase telemetry: {e}") from e
 
 
 def refresh_metabase_connection(

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -1186,6 +1186,72 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
         return False
 
 
+def set_metabase_telemetry(
+    project_root: Path, enabled: bool, metabase_url: str = "http://localhost:3000"
+) -> None:
+    """
+    Toggle Metabase's anonymous usage tracking via the admin Setting API.
+
+    Loads admin credentials from .dango/metabase.yml (same pattern as
+    sync_metabase_schema), logs in, then calls
+    PUT /api/setting/anon-tracking-enabled — Metabase's runtime setting key
+    for anonymous tracking (distinct from the one-time "allow_tracking" field
+    used only in the /api/setup wizard payload in setup_metabase() above).
+
+    Args:
+        project_root: Path to project root
+        enabled: True to enable anonymous tracking, False to disable it
+        metabase_url: Metabase URL (default: http://localhost:3000)
+
+    Raises:
+        click.ClickException: If Metabase credentials are missing/incomplete,
+            or if the API call fails (e.g. Metabase not running).
+    """
+    import click
+
+    credentials_file = project_root / ".dango" / "metabase.yml"
+    if not credentials_file.exists():
+        raise click.ClickException("Metabase not configured. Run dango start first.")
+
+    try:
+        with open(credentials_file) as f:
+            credentials = yaml.safe_load(f) or {}
+
+        admin = credentials.get("admin", {})
+        email = admin.get("email")
+        password = admin.get("password")
+        if not email or not password:
+            raise click.ClickException(
+                "Metabase admin credentials missing from .dango/metabase.yml"
+            )
+
+        session = requests.Session()
+        login_response = session.post(
+            f"{metabase_url}/api/session",
+            json={"username": email, "password": password},
+            timeout=10,
+        )
+        login_response.raise_for_status()
+        session_id = login_response.json().get("id")
+        if not session_id:
+            raise click.ClickException("Metabase login did not return a session id")
+
+        response = session.put(
+            f"{metabase_url}/api/setting/anon-tracking-enabled",
+            headers={"X-Metabase-Session": session_id},
+            json={"value": enabled},
+            timeout=10,
+        )
+        response.raise_for_status()
+
+    except click.ClickException:
+        raise
+    except requests.exceptions.RequestException as e:
+        raise click.ClickException(
+            f"Could not reach Metabase at {metabase_url} — is it running? ({e})"
+        ) from e
+
+
 def refresh_metabase_connection(
     project_root: Path, metabase_url: str = "http://localhost:3000"
 ) -> tuple[bool, str | None]:

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -1255,9 +1255,28 @@ def set_metabase_telemetry(
         )
         response.raise_for_status()
 
-        state_file = project_root / ".dango" / "metabase_telemetry_state"
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text("true" if enabled else "false")
+        # The real API call above already succeeded — enabled is now the
+        # actual live Metabase state. A failure writing the local status
+        # cache (disk full, permissions, read-only filesystem) is a
+        # "dango telemetry status may show a stale value" problem, not a
+        # "this command failed" problem, so it's caught and logged here,
+        # inside its own try, rather than left to fall into the broad
+        # `except Exception` below — that would misreport a successful
+        # toggle as a failure just because a secondary, best-effort write
+        # didn't land.
+        try:
+            state_file = project_root / ".dango" / "metabase_telemetry_state"
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text("true" if enabled else "false")
+        except Exception:
+            logger.warning(
+                "Metabase telemetry set to %s via API, but failed to write "
+                "local status cache at %s — `dango telemetry status` may "
+                "show a stale value until the next successful toggle.",
+                enabled,
+                project_root / ".dango" / "metabase_telemetry_state",
+                exc_info=True,
+            )
 
     except click.ClickException:
         raise

--- a/dango/web/routes/dbt.py
+++ b/dango/web/routes/dbt.py
@@ -128,6 +128,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
         logger.warning(f"Could not acquire dbt lock for {model_name}: {e}")
         return
 
+    from dango.transformation import _dbt_telemetry_env
     from dango.utils.activity_log import log_activity
 
     log_activity(project_root, "info", f"dbt:{model_name}", f"dbt run started: {model_name}")
@@ -181,6 +182,7 @@ async def run_dbt_model_task(model_name: str, cascade: bool) -> None:
             capture_output=True,
             text=True,
             timeout=300,  # 5 minute timeout
+            env=_dbt_telemetry_env(),
         )
 
         duration = time.time() - start_time

--- a/docs/network-egress.yml
+++ b/docs/network-egress.yml
@@ -1,7 +1,11 @@
 # Dango network egress — all outbound connections made by the stack.
-# Telemetry: each provider has its own opt-out today (see each entry's
-# `control` field). A unified `dango telemetry off --all` command is planned
-# (Session D, not yet merged as of this session) — do not assume it exists.
+# Telemetry: each provider has its own opt-out (see each entry's `control`
+# field). `dango telemetry status/on/off [--all|--provider X]`
+# (dango/cli/commands/telemetry.py, added in Session D) controls telemetry
+# for the components Dango configures — Dango, dbt, dlt, and Metabase — by
+# writing through to each provider's own real config mechanism below. It
+# does not affect, and makes no claim about, the `functional` hosts further
+# down this file.
 # Functional: required for operation, disclosed but not toggleable
 # Verified against installed packages (dbt-core 1.11.14, dlt 1.28.1, marimo)
 # 2026-09-01 — re-verified after the dbt-core 1.10->1.11 bump landed on v1.0.8.
@@ -13,13 +17,13 @@ telemetry:
   - host: telemetry.getdango.dev
     provider: dango
     control: >
-      Today: decline the `dango init` consent prompt (persists "no"), or set
-      DO_NOT_TRACK=1 / DANGO_TELEMETRY=0 / `telemetry: false` in
-      ~/.dango/config.yml (dango/telemetry.py:is_telemetry_enabled) — all
-      three suppress the prompt entirely, no ping is ever sent. A unified
-      `dango telemetry off --provider dango` command is Session D's job
-      (dango/cli/commands/ has no `telemetry.py` yet as of this session).
-    sends: "anonymous UUID, version, OS, source type names, weekly heartbeat"
+      `dango telemetry off --provider dango` (or `--all`), which persists
+      the same "no" answer as declining the `dango init` consent prompt
+      (dango/telemetry.py:set_telemetry_enabled). DO_NOT_TRACK=1 /
+      DANGO_TELEMETRY=0 / `telemetry: false` in ~/.dango/config.yml also
+      still suppress every ping without touching stored state
+      (dango/telemetry.py:is_telemetry_enabled).
+    sends: "anonymous UUID, version, OS, source type names — single install ping, no heartbeat"
   - host: fishtownanalytics.sinter-collect.com
     provider: dbt-core
     control: "DBT_SEND_ANONYMOUS_USAGE_STATS=false or DO_NOT_TRACK=1"
@@ -31,10 +35,15 @@ telemetry:
   - host: metabase.com
     provider: metabase
     control: >
-      Planned: `dango telemetry off --provider metabase` (sets
-      allow_tracking=false via the Metabase admin API) is Session D's job,
-      not yet implemented as of this session — today this requires toggling
-      the setting manually in the Metabase admin UI.
+      `dango telemetry off --provider metabase` (or `--all`), which calls
+      PUT /api/setting/anon-tracking-enabled via the Metabase admin API
+      (visualization/metabase.py:set_metabase_telemetry). This is Metabase's
+      runtime setting key for anonymous tracking — distinct from the
+      one-time `allow_tracking` field Dango already sets to false in the
+      /api/setup payload when it provisions a fresh Metabase instance
+      (visualization/metabase.py:setup_metabase), so tracking is off by
+      default on new installs even before this command is ever run.
+      Manually toggling the setting in the Metabase admin UI still works too.
     sends: "anonymous usage statistics"
 
 functional:
@@ -70,8 +79,17 @@ functional:
 
 notes:
   - "dbt and dlt telemetry env vars/config are read by their own subprocesses/library
-     calls, not a separate Dango network layer. dango telemetry off --all (Session D)
-     writes these through to each tool's real config."
+     calls, not a separate Dango network layer. dango telemetry off --all writes
+     these through to each tool's real config (dango/cli/commands/telemetry.py)."
+  - "dlt's write-through (dlthub_telemetry=false in .dlt/config.toml) has not been
+     observed to change real dlt network behavior — Session B verified empirically,
+     for the CSV-source sync path only, that dlt's telemetry runtime never
+     initializes at all for Dango's direct-library usage (RunContext.runtime_config
+     is never touched), so there was nothing live to flip. The write-through is kept
+     anyway: it matches dlt's own documented opt-out mechanism and takes effect if a
+     different source type or a future dlt/dango version does touch that code path.
+     This remains an open question, not a confirmed no-op — see
+     tests/unit/test_egress_allowlist.py's docstring for the full empirical detail."
   - "Marimo update check host (marimo.io/api/oss/latest-version) is not listed above
      because it is never contacted in a Dango deployment: Dango always passes
      --skip-update-check to every Marimo process (dango/notebooks/manager.py:141),

--- a/tests/unit/test_telemetry_unified.py
+++ b/tests/unit/test_telemetry_unified.py
@@ -1,0 +1,206 @@
+"""tests/unit/test_telemetry_unified.py
+
+Tests for dango.cli.commands.telemetry (unified `dango telemetry`
+status/on/off) and the dbt subprocess telemetry-env helper it drives in
+dango.transformation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import dango.telemetry as dango_telemetry
+from dango.cli.main import cli
+from dango.transformation import _dbt_telemetry_env
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect Path.home() (used by the dbt sentinel file and dango.telemetry's
+    module-level path constants) into tmp_path, and clear opt-out env vars so
+    tests are hermetic regardless of the host machine's real ~/.dango state.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    config_dir = tmp_path / ".dango"
+    monkeypatch.setattr(dango_telemetry, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(dango_telemetry, "_IDENTITY_FILE", config_dir / "telemetry.json")
+    monkeypatch.setattr(dango_telemetry, "_GLOBAL_CONFIG_FILE", config_dir / "config.yml")
+    for var in ("DO_NOT_TRACK", "DANGO_TELEMETRY", *dango_telemetry._CI_ENV_VARS):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.unit
+class TestDbtTelemetryEnv:
+    """_dbt_telemetry_env() — the helper wired into all three dbt subprocess.run calls."""
+
+    def test_dbt_env_includes_opt_out(self, tmp_path: Path) -> None:
+        """When the sentinel file says 'false', the env carries the real
+        dbt-core opt-out var (DBT_SEND_ANONYMOUS_USAGE_STATS — verified
+        against installed dbt-core in test_egress_allowlist.py) plus
+        DO_NOT_TRACK as defense in depth."""
+        sentinel = tmp_path / ".dango" / "dbt_telemetry"
+        sentinel.parent.mkdir(parents=True)
+        sentinel.write_text("false")
+
+        env = _dbt_telemetry_env()
+
+        assert env["DBT_SEND_ANONYMOUS_USAGE_STATS"] == "false"
+        assert env["DO_NOT_TRACK"] == "1"
+
+    def test_dbt_env_default_clean(self, tmp_path: Path) -> None:
+        """When no sentinel file exists, the env is an unmodified copy of
+        os.environ — no telemetry opt-out vars injected."""
+        env = _dbt_telemetry_env()
+
+        assert "DBT_SEND_ANONYMOUS_USAGE_STATS" not in env
+        assert "DO_NOT_TRACK" not in env
+
+    def test_dbt_env_is_a_copy_not_the_real_environ(self, tmp_path: Path) -> None:
+        """Regression risk from the task spec: never mutate os.environ in place."""
+        import os
+
+        sentinel = tmp_path / ".dango" / "dbt_telemetry"
+        sentinel.parent.mkdir(parents=True)
+        sentinel.write_text("false")
+
+        env = _dbt_telemetry_env()
+
+        assert env is not os.environ
+        assert "DBT_SEND_ANONYMOUS_USAGE_STATS" not in os.environ
+        assert "DO_NOT_TRACK" not in os.environ
+
+
+@pytest.mark.unit
+class TestDltWriteThrough:
+    """_set_dlt_telemetry / _get_dlt_telemetry_state — .dlt/config.toml write-through."""
+
+    def test_dlt_write_through(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _set_dlt_telemetry
+
+        _set_dlt_telemetry(False, tmp_path)
+
+        config_path = tmp_path / ".dlt" / "config.toml"
+        assert config_path.exists()
+        content = config_path.read_text()
+        assert "dlthub_telemetry" in content
+        # Written as a native TOML boolean (unquoted), matching the type of
+        # dlt's own dlthub_telemetry field (RuntimeConfiguration.dlthub_telemetry: bool)
+        # and the value type dlt's own CLI writes via WritableConfigValue(..., bool, ...).
+        assert "false" in content
+        assert '"false"' not in content
+
+    def test_dlt_read_state_off(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_dlt_telemetry_state, _set_dlt_telemetry
+
+        _set_dlt_telemetry(False, tmp_path)
+
+        assert _get_dlt_telemetry_state(tmp_path) is False
+
+    def test_dlt_read_state_default_on(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_dlt_telemetry_state
+
+        assert _get_dlt_telemetry_state(tmp_path) is True
+
+    def test_dlt_round_trip_on(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_dlt_telemetry_state, _set_dlt_telemetry
+
+        _set_dlt_telemetry(False, tmp_path)
+        _set_dlt_telemetry(True, tmp_path)
+
+        assert _get_dlt_telemetry_state(tmp_path) is True
+
+
+@pytest.mark.unit
+class TestTelemetryStatusCommand:
+    def test_telemetry_status_runs(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["telemetry", "status"])
+
+        assert result.exit_code == 0, result.output
+        assert "dango" in result.output
+        assert "dbt-core" in result.output
+        assert "dlt" in result.output
+        assert "metabase" in result.output
+        # The absolute wording constraint (D-telemetry-unified.md): never
+        # claim "nothing leaves your machine".
+        assert "nothing leaves your machine" not in result.output.lower()
+
+
+@pytest.mark.unit
+class TestTelemetryOffAllOutsideProject:
+    """Regression risk + acceptance criterion: `--all` outside a project must
+    succeed for dango+dbt and warn (not crash) for dlt+metabase."""
+
+    def test_off_all_outside_project_warns_not_crashes(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["telemetry", "off", "--all"])
+
+        assert result.exit_code == 0, result.output
+        assert "dango: telemetry disabled" in result.output
+        assert "dbt: telemetry disabled" in result.output
+        assert "dlt" in result.output and "skipped" in result.output
+        assert "metabase" in result.output and "skipped" in result.output
+
+    def test_off_provider_dlt_outside_project_raises(self, tmp_path: Path) -> None:
+        """A single explicit --provider request outside a project is a hard
+        error, not a silent skip — this is a deliberate action, not a sweep."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["telemetry", "off", "--provider", "dlt"])
+
+        assert result.exit_code != 0
+        assert "Dango project" in result.output
+
+
+@pytest.mark.unit
+class TestMetabaseTelemetry:
+    """set_metabase_telemetry — request-level behavior, mocked (no live Metabase)."""
+
+    def test_set_metabase_telemetry_calls_correct_endpoint(self, tmp_path: Path) -> None:
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False, metabase_url="http://localhost:3000")
+
+        put_args = mock_session.put.call_args
+        assert put_args.args[0] == "http://localhost:3000/api/setting/anon-tracking-enabled"
+        assert put_args.kwargs["json"] == {"value": False}
+        assert put_args.kwargs["headers"]["X-Metabase-Session"] == "sess-123"
+
+    def test_set_metabase_telemetry_wraps_connection_failure(self, tmp_path: Path) -> None:
+        """Regression risk from the task spec: must not raise a raw requests
+        exception if Metabase is not running — surface a helpful ClickException."""
+        import click
+        import requests
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        with patch(
+            "dango.visualization.metabase.requests.Session",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ):
+            with pytest.raises(click.ClickException):
+                set_metabase_telemetry(tmp_path, False)

--- a/tests/unit/test_telemetry_unified.py
+++ b/tests/unit/test_telemetry_unified.py
@@ -285,6 +285,42 @@ class TestMetabaseTelemetry:
 
         assert state_file.read_text().strip() == "true"
 
+    def test_set_metabase_telemetry_cache_write_failure_does_not_raise(
+        self, tmp_path: Path
+    ) -> None:
+        """The failure-ordering bug found in review: if the real Metabase API
+        call already succeeded, a failure writing the secondary local status
+        cache must NOT be reported as a command failure — it's a "status may
+        be stale" problem, not an "operation failed" problem. Forces a real
+        write failure (state-file path collides with an existing directory,
+        so write_text() raises IsADirectoryError) rather than mocking the
+        exception, so this exercises the actual except-block wiring."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+        # Pre-create the cache path AS A DIRECTORY so write_text() fails.
+        (creds_dir / "metabase_telemetry_state").mkdir()
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            # Must return normally — no exception — even though the cache
+            # write underneath will fail.
+            set_metabase_telemetry(tmp_path, False)
+
+        # The real API call still happened correctly.
+        assert mock_session.put.call_args.args[0] == (
+            "http://localhost:3000/api/setting/anon-tracking-enabled"
+        )
+        assert mock_session.put.call_args.kwargs["json"] == {"value": False}
+
     def test_set_metabase_telemetry_wraps_malformed_yaml(self, tmp_path: Path) -> None:
         """Review fix #4: a broad except Exception fallback converts anything
         else in the credentials/login/API flow (e.g. yaml.YAMLError from a

--- a/tests/unit/test_telemetry_unified.py
+++ b/tests/unit/test_telemetry_unified.py
@@ -1,14 +1,16 @@
 """tests/unit/test_telemetry_unified.py
 
 Tests for dango.cli.commands.telemetry (unified `dango telemetry`
-status/on/off) and the dbt subprocess telemetry-env helper it drives in
-dango.transformation.
+status/on/off) covering the dbt and dlt providers, the dbt subprocess
+telemetry-env helper in dango.transformation, and the top-level status/
+--all CLI behavior. Metabase-specific tests live in
+tests/unit/test_telemetry_unified_metabase.py (split out to stay under the
+500-line file-size limit — see scripts/check_file_sizes.py).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -113,6 +115,61 @@ class TestDltWriteThrough:
 
         assert _get_dlt_telemetry_state(tmp_path) is True
 
+    def test_dlt_malformed_existing_toml_raises_click_exception(self, tmp_path: Path) -> None:
+        """Review fix #1: a hand-corrupted .dlt/config.toml must raise
+        click.ClickException (so --all can skip and continue), not a raw
+        tomlkit.exceptions.TOMLKitError."""
+        import click
+
+        from dango.cli.commands.telemetry import _set_dlt_telemetry
+
+        config_path = tmp_path / ".dlt" / "config.toml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("[runtime\ndlthub_telemetry = true\n")  # missing ']'
+
+        with pytest.raises(click.ClickException):
+            _set_dlt_telemetry(False, tmp_path)
+
+    def test_dlt_write_failure_raises_click_exception_not_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Review fix #1: a real OSError writing .dlt/config.toml (disk
+        full, permissions) must surface as click.ClickException."""
+        import click
+
+        from dango.cli.commands.telemetry import _set_dlt_telemetry
+
+        def _raise_oserror(self: Path, *args: object, **kwargs: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "write_text", _raise_oserror)
+
+        with pytest.raises(click.ClickException):
+            _set_dlt_telemetry(False, tmp_path)
+
+
+@pytest.mark.unit
+class TestDbtSentinelErrorHandling:
+    """Review fix #1: _set_dbt_telemetry() must convert a raw OSError into
+    click.ClickException, matching the contract every other provider's
+    write-through follows — otherwise `dango telemetry off --all` crashes
+    outright instead of skipping dbt and continuing with the rest."""
+
+    def test_write_failure_raises_click_exception_not_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import click
+
+        from dango.cli.commands.telemetry import _set_dbt_telemetry
+
+        def _raise_oserror(self: Path, *args: object, **kwargs: object) -> None:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "write_text", _raise_oserror)
+
+        with pytest.raises(click.ClickException):
+            _set_dbt_telemetry(False)
+
 
 @pytest.mark.unit
 class TestTelemetryStatusCommand:
@@ -156,288 +213,6 @@ class TestTelemetryOffAllOutsideProject:
 
         assert result.exit_code != 0
         assert "Dango project" in result.output
-
-
-@pytest.mark.unit
-class TestMetabaseTelemetry:
-    """set_metabase_telemetry — request-level behavior, mocked (no live Metabase)."""
-
-    def test_set_metabase_telemetry_calls_correct_endpoint(self, tmp_path: Path) -> None:
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-        )
-
-        mock_session = MagicMock()
-        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
-        mock_session.post.return_value.raise_for_status.return_value = None
-        mock_session.put.return_value.raise_for_status.return_value = None
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            set_metabase_telemetry(tmp_path, False, metabase_url="http://localhost:3000")
-
-        put_args = mock_session.put.call_args
-        assert put_args.args[0] == "http://localhost:3000/api/setting/anon-tracking-enabled"
-        assert put_args.kwargs["json"] == {"value": False}
-        assert put_args.kwargs["headers"]["X-Metabase-Session"] == "sess-123"
-
-    def test_set_metabase_telemetry_wraps_connection_failure(self, tmp_path: Path) -> None:
-        """Regression risk from the task spec: must not raise a raw requests
-        exception if Metabase is not running — surface a helpful ClickException."""
-        import click
-        import requests
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-        )
-
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        with patch(
-            "dango.visualization.metabase.requests.Session",
-            side_effect=requests.exceptions.ConnectionError("refused"),
-        ):
-            with pytest.raises(click.ClickException):
-                set_metabase_telemetry(tmp_path, False)
-
-    def test_set_metabase_telemetry_reads_stored_metabase_url(self, tmp_path: Path) -> None:
-        """Review fix #3: when metabase_url isn't passed explicitly, read it
-        from the "metabase_url" key in .dango/metabase.yml (matching the
-        precedent in cli/commands/metabase_cmd.py:343), instead of always
-        hardcoding localhost:3000."""
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-            "metabase_url: http://metabase.internal:9000\n"
-        )
-
-        mock_session = MagicMock()
-        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
-        mock_session.post.return_value.raise_for_status.return_value = None
-        mock_session.put.return_value.raise_for_status.return_value = None
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            set_metabase_telemetry(tmp_path, False)
-
-        post_url = mock_session.post.call_args.args[0]
-        put_url = mock_session.put.call_args.args[0]
-        assert post_url == "http://metabase.internal:9000/api/session"
-        assert put_url == "http://metabase.internal:9000/api/setting/anon-tracking-enabled"
-
-    def test_set_metabase_telemetry_falls_back_to_localhost_when_url_key_absent(
-        self, tmp_path: Path
-    ) -> None:
-        """No "metabase_url" key in metabase.yml and no explicit override ->
-        still falls back to the documented default, doesn't crash."""
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-        )
-
-        mock_session = MagicMock()
-        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
-        mock_session.post.return_value.raise_for_status.return_value = None
-        mock_session.put.return_value.raise_for_status.return_value = None
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            set_metabase_telemetry(tmp_path, False)
-
-        assert mock_session.put.call_args.args[0] == (
-            "http://localhost:3000/api/setting/anon-tracking-enabled"
-        )
-
-    def test_set_metabase_telemetry_writes_state_cache_on_success(self, tmp_path: Path) -> None:
-        """Review fix #2: a successful call writes a local last-known-state
-        cache that _get_metabase_telemetry_state() reads, instead of status
-        being hardcoded."""
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-        )
-
-        mock_session = MagicMock()
-        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
-        mock_session.post.return_value.raise_for_status.return_value = None
-        mock_session.put.return_value.raise_for_status.return_value = None
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            set_metabase_telemetry(tmp_path, False)
-
-        state_file = tmp_path / ".dango" / "metabase_telemetry_state"
-        assert state_file.read_text().strip() == "false"
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            set_metabase_telemetry(tmp_path, True)
-
-        assert state_file.read_text().strip() == "true"
-
-    def test_set_metabase_telemetry_cache_write_failure_does_not_raise(
-        self, tmp_path: Path
-    ) -> None:
-        """The failure-ordering bug found in review: if the real Metabase API
-        call already succeeded, a failure writing the secondary local status
-        cache must NOT be reported as a command failure — it's a "status may
-        be stale" problem, not an "operation failed" problem. Forces a real
-        write failure (state-file path collides with an existing directory,
-        so write_text() raises IsADirectoryError) rather than mocking the
-        exception, so this exercises the actual except-block wiring."""
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-        )
-        # Pre-create the cache path AS A DIRECTORY so write_text() fails.
-        (creds_dir / "metabase_telemetry_state").mkdir()
-
-        mock_session = MagicMock()
-        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
-        mock_session.post.return_value.raise_for_status.return_value = None
-        mock_session.put.return_value.raise_for_status.return_value = None
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            # Must return normally — no exception — even though the cache
-            # write underneath will fail.
-            set_metabase_telemetry(tmp_path, False)
-
-        # The real API call still happened correctly.
-        assert mock_session.put.call_args.args[0] == (
-            "http://localhost:3000/api/setting/anon-tracking-enabled"
-        )
-        assert mock_session.put.call_args.kwargs["json"] == {"value": False}
-
-    def test_set_metabase_telemetry_wraps_malformed_yaml(self, tmp_path: Path) -> None:
-        """Review fix #4: a broad except Exception fallback converts anything
-        else in the credentials/login/API flow (e.g. yaml.YAMLError from a
-        hand-edited metabase.yml) into the same clean click.ClickException
-        contract, instead of letting a raw traceback through."""
-        import click
-
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        # Invalid YAML (unbalanced flow mapping) -> yaml.safe_load raises YAMLError.
-        (creds_dir / "metabase.yml").write_text("admin: [email: broken\n")
-
-        with pytest.raises(click.ClickException):
-            set_metabase_telemetry(tmp_path, False)
-
-    def test_set_metabase_telemetry_wraps_non_json_login_response(self, tmp_path: Path) -> None:
-        """Same broad-except contract for a 200 login response with a
-        non-JSON body (login_response.json() raising ValueError)."""
-        import click
-
-        from dango.visualization.metabase import set_metabase_telemetry
-
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-        )
-
-        mock_session = MagicMock()
-        mock_session.post.return_value.raise_for_status.return_value = None
-        mock_session.post.return_value.json.side_effect = ValueError("not JSON")
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            with pytest.raises(click.ClickException):
-                set_metabase_telemetry(tmp_path, False)
-
-
-@pytest.mark.unit
-class TestMetabaseTelemetryStatus:
-    """_get_metabase_telemetry_state — review fix #2: status must reflect the
-    real last-set state (via the cache file), not a hardcoded True."""
-
-    def test_defaults_true_when_no_project(self) -> None:
-        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
-
-        assert _get_metabase_telemetry_state(None) is True
-
-    def test_defaults_true_when_no_cache_file(self, tmp_path: Path) -> None:
-        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
-
-        assert _get_metabase_telemetry_state(tmp_path) is True
-
-    def test_reads_off_from_cache_file(self, tmp_path: Path) -> None:
-        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
-
-        state_dir = tmp_path / ".dango"
-        state_dir.mkdir()
-        (state_dir / "metabase_telemetry_state").write_text("false")
-
-        assert _get_metabase_telemetry_state(tmp_path) is False
-
-    def test_reads_on_from_cache_file(self, tmp_path: Path) -> None:
-        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
-
-        state_dir = tmp_path / ".dango"
-        state_dir.mkdir()
-        (state_dir / "metabase_telemetry_state").write_text("true")
-
-        assert _get_metabase_telemetry_state(tmp_path) is True
-
-    def test_status_reflects_real_toggle_end_to_end(self, tmp_path: Path) -> None:
-        """The specific bug three review angles independently flagged: status
-        must change after a real successful `telemetry off --provider
-        metabase` call, not stay stuck on "on" forever."""
-        creds_dir = tmp_path / ".dango"
-        creds_dir.mkdir()
-        (creds_dir / "metabase.yml").write_text(
-            "admin:\n  email: admin@example.com\n  password: secret123\n"
-        )
-
-        mock_session = MagicMock()
-        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
-        mock_session.post.return_value.raise_for_status.return_value = None
-        mock_session.put.return_value.raise_for_status.return_value = None
-
-        from dango.cli.commands.telemetry import (
-            _get_metabase_telemetry_state,
-            _set_metabase_telemetry,
-        )
-
-        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
-            assert _get_metabase_telemetry_state(tmp_path) is True
-            _set_metabase_telemetry(False, tmp_path)
-            assert _get_metabase_telemetry_state(tmp_path) is False
-
-
-@pytest.mark.unit
-class TestMetabaseNotConfiguredCheckSingleSource:
-    """Review fix #10: the duplicate `creds_file.exists()` check was removed
-    from telemetry.py's wrapper — the single remaining check, in
-    metabase.py's set_metabase_telemetry(), must still surface the same
-    user-facing error end-to-end."""
-
-    def test_off_provider_metabase_not_configured_inside_project(self, tmp_path: Path) -> None:
-        project_dir = tmp_path / "project"
-        (project_dir / ".dango").mkdir(parents=True)
-        (project_dir / ".dango" / "project.yml").write_text("name: test\n")
-        # Deliberately no .dango/metabase.yml.
-
-        runner = CliRunner()
-        with runner.isolated_filesystem(temp_dir=project_dir):
-            result = runner.invoke(cli, ["telemetry", "off", "--provider", "metabase"])
-
-        assert result.exit_code != 0
-        assert "Metabase not configured" in result.output
 
 
 @pytest.mark.unit

--- a/tests/unit/test_telemetry_unified.py
+++ b/tests/unit/test_telemetry_unified.py
@@ -204,3 +204,246 @@ class TestMetabaseTelemetry:
         ):
             with pytest.raises(click.ClickException):
                 set_metabase_telemetry(tmp_path, False)
+
+    def test_set_metabase_telemetry_reads_stored_metabase_url(self, tmp_path: Path) -> None:
+        """Review fix #3: when metabase_url isn't passed explicitly, read it
+        from the "metabase_url" key in .dango/metabase.yml (matching the
+        precedent in cli/commands/metabase_cmd.py:343), instead of always
+        hardcoding localhost:3000."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+            "metabase_url: http://metabase.internal:9000\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False)
+
+        post_url = mock_session.post.call_args.args[0]
+        put_url = mock_session.put.call_args.args[0]
+        assert post_url == "http://metabase.internal:9000/api/session"
+        assert put_url == "http://metabase.internal:9000/api/setting/anon-tracking-enabled"
+
+    def test_set_metabase_telemetry_falls_back_to_localhost_when_url_key_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """No "metabase_url" key in metabase.yml and no explicit override ->
+        still falls back to the documented default, doesn't crash."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False)
+
+        assert mock_session.put.call_args.args[0] == (
+            "http://localhost:3000/api/setting/anon-tracking-enabled"
+        )
+
+    def test_set_metabase_telemetry_writes_state_cache_on_success(self, tmp_path: Path) -> None:
+        """Review fix #2: a successful call writes a local last-known-state
+        cache that _get_metabase_telemetry_state() reads, instead of status
+        being hardcoded."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False)
+
+        state_file = tmp_path / ".dango" / "metabase_telemetry_state"
+        assert state_file.read_text().strip() == "false"
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, True)
+
+        assert state_file.read_text().strip() == "true"
+
+    def test_set_metabase_telemetry_wraps_malformed_yaml(self, tmp_path: Path) -> None:
+        """Review fix #4: a broad except Exception fallback converts anything
+        else in the credentials/login/API flow (e.g. yaml.YAMLError from a
+        hand-edited metabase.yml) into the same clean click.ClickException
+        contract, instead of letting a raw traceback through."""
+        import click
+
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        # Invalid YAML (unbalanced flow mapping) -> yaml.safe_load raises YAMLError.
+        (creds_dir / "metabase.yml").write_text("admin: [email: broken\n")
+
+        with pytest.raises(click.ClickException):
+            set_metabase_telemetry(tmp_path, False)
+
+    def test_set_metabase_telemetry_wraps_non_json_login_response(self, tmp_path: Path) -> None:
+        """Same broad-except contract for a 200 login response with a
+        non-JSON body (login_response.json() raising ValueError)."""
+        import click
+
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.post.return_value.json.side_effect = ValueError("not JSON")
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            with pytest.raises(click.ClickException):
+                set_metabase_telemetry(tmp_path, False)
+
+
+@pytest.mark.unit
+class TestMetabaseTelemetryStatus:
+    """_get_metabase_telemetry_state — review fix #2: status must reflect the
+    real last-set state (via the cache file), not a hardcoded True."""
+
+    def test_defaults_true_when_no_project(self) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        assert _get_metabase_telemetry_state(None) is True
+
+    def test_defaults_true_when_no_cache_file(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        assert _get_metabase_telemetry_state(tmp_path) is True
+
+    def test_reads_off_from_cache_file(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        state_dir = tmp_path / ".dango"
+        state_dir.mkdir()
+        (state_dir / "metabase_telemetry_state").write_text("false")
+
+        assert _get_metabase_telemetry_state(tmp_path) is False
+
+    def test_reads_on_from_cache_file(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        state_dir = tmp_path / ".dango"
+        state_dir.mkdir()
+        (state_dir / "metabase_telemetry_state").write_text("true")
+
+        assert _get_metabase_telemetry_state(tmp_path) is True
+
+    def test_status_reflects_real_toggle_end_to_end(self, tmp_path: Path) -> None:
+        """The specific bug three review angles independently flagged: status
+        must change after a real successful `telemetry off --provider
+        metabase` call, not stay stuck on "on" forever."""
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        from dango.cli.commands.telemetry import (
+            _get_metabase_telemetry_state,
+            _set_metabase_telemetry,
+        )
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            assert _get_metabase_telemetry_state(tmp_path) is True
+            _set_metabase_telemetry(False, tmp_path)
+            assert _get_metabase_telemetry_state(tmp_path) is False
+
+
+@pytest.mark.unit
+class TestMetabaseNotConfiguredCheckSingleSource:
+    """Review fix #10: the duplicate `creds_file.exists()` check was removed
+    from telemetry.py's wrapper — the single remaining check, in
+    metabase.py's set_metabase_telemetry(), must still surface the same
+    user-facing error end-to-end."""
+
+    def test_off_provider_metabase_not_configured_inside_project(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        (project_dir / ".dango").mkdir(parents=True)
+        (project_dir / ".dango" / "project.yml").write_text("name: test\n")
+        # Deliberately no .dango/metabase.yml.
+
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=project_dir):
+            result = runner.invoke(cli, ["telemetry", "off", "--provider", "metabase"])
+
+        assert result.exit_code != 0
+        assert "Metabase not configured" in result.output
+
+
+@pytest.mark.unit
+class TestDbtTelemetryEnvWiredEverywhere:
+    """Review finding #1 (the blocking one): _dbt_telemetry_env() must be
+    wired into every real dbt-invoking subprocess.run call, not just the
+    three functions in transformation/__init__.py. Regression guard against
+    a future dbt call site silently bypassing the opt-out — asserts the
+    literal `env=_dbt_telemetry_env()` wiring is present at each known call
+    site's source line, rather than re-deriving the list by grep (which
+    would just re-check itself)."""
+
+    _EXPECTED_SITES: tuple[tuple[str, str], ...] = (
+        ("dango/transformation/__init__.py", "run_dbt_models"),
+        ("dango/transformation/__init__.py", "run_dbt_snapshots"),
+        ("dango/transformation/__init__.py", "generate_dbt_docs"),
+        ("dango/cli/commands/transform.py", "def run("),
+        ("dango/cli/commands/transform.py", "def docs("),
+        ("dango/platform/local/watcher_runner.py", "def run_dbt_command("),
+        ("dango/web/routes/dbt.py", "def run_dbt_model_task("),
+        ("dango/cli/commands/dev.py", "def _run_dev_dbt("),
+        ("dango/cli/init.py", "def _generate_dbt_docs("),
+        ("dango/cli/model_wizard.py", "def _regenerate_manifest("),
+        ("dango/cli/validate.py", "def _validate_dbt_models("),
+    )
+
+    def test_every_known_dbt_subprocess_site_passes_env(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        for rel_path, anchor in self._EXPECTED_SITES:
+            source = (repo_root / rel_path).read_text()
+            assert anchor in source, f"{rel_path}: expected anchor {anchor!r} not found"
+            start = source.index(anchor)
+            # The function body containing this anchor must reach a
+            # subprocess.run(...) call that passes env=_dbt_telemetry_env()
+            # before the next top-level def/class (a rough but effective
+            # "same function" boundary for these small, single-call functions).
+            next_def = source.find("\ndef ", start + 1)
+            next_top_level = source.find("\n\ndef ", start + 1)
+            end = min(x for x in (next_def, next_top_level, len(source)) if x != -1)
+            body = source[start:end]
+            assert "env=_dbt_telemetry_env()" in body, (
+                f"{rel_path} ({anchor}): subprocess.run call in this function "
+                f"does not pass env=_dbt_telemetry_env() — dbt telemetry "
+                f"opt-out would silently not apply here"
+            )

--- a/tests/unit/test_telemetry_unified_metabase.py
+++ b/tests/unit/test_telemetry_unified_metabase.py
@@ -1,0 +1,345 @@
+"""tests/unit/test_telemetry_unified_metabase.py
+
+Metabase-specific tests for the unified `dango telemetry` command
+(dango.visualization.metabase.set_metabase_telemetry and
+dango.cli.commands.telemetry's Metabase provider helpers). Split out of
+tests/unit/test_telemetry_unified.py to stay under the 500-line file-size
+limit (scripts/check_file_sizes.py) — dbt/dlt and top-level CLI tests
+remain there.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import dango.telemetry as dango_telemetry
+from dango.cli.main import cli
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect Path.home() and dango.telemetry's module-level path
+    constants into tmp_path, and clear opt-out env vars, so tests are
+    hermetic regardless of the host machine's real ~/.dango state.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    config_dir = tmp_path / ".dango"
+    monkeypatch.setattr(dango_telemetry, "_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(dango_telemetry, "_IDENTITY_FILE", config_dir / "telemetry.json")
+    monkeypatch.setattr(dango_telemetry, "_GLOBAL_CONFIG_FILE", config_dir / "config.yml")
+    for var in ("DO_NOT_TRACK", "DANGO_TELEMETRY", *dango_telemetry._CI_ENV_VARS):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.unit
+class TestMetabaseTelemetry:
+    """set_metabase_telemetry — request-level behavior, mocked (no live Metabase)."""
+
+    def test_set_metabase_telemetry_calls_correct_endpoint(self, tmp_path: Path) -> None:
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False, metabase_url="http://localhost:3000")
+
+        put_args = mock_session.put.call_args
+        assert put_args.args[0] == "http://localhost:3000/api/setting/anon-tracking-enabled"
+        assert put_args.kwargs["json"] == {"value": False}
+        assert put_args.kwargs["headers"]["X-Metabase-Session"] == "sess-123"
+
+    def test_set_metabase_telemetry_wraps_connection_failure(self, tmp_path: Path) -> None:
+        """Regression risk from the task spec: must not raise a raw requests
+        exception if Metabase is not running — surface a helpful ClickException."""
+        import click
+        import requests
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        with patch(
+            "dango.visualization.metabase.requests.Session",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ):
+            with pytest.raises(click.ClickException):
+                set_metabase_telemetry(tmp_path, False)
+
+    def test_set_metabase_telemetry_login_401_gives_credentials_message(
+        self, tmp_path: Path
+    ) -> None:
+        """Review fix #2: a 401/403 on login (stale admin password) must NOT
+        be mislabeled "is it running?" — Metabase is reachable and running
+        fine, the credentials are just wrong. HTTPError from
+        raise_for_status() is a RequestException subclass, so without the
+        explicit status-code check this fell into the generic
+        "is it running?" branch."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: stale-password\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.status_code = 401
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            with pytest.raises(Exception) as exc_info:
+                set_metabase_telemetry(tmp_path, False)
+
+        message = str(exc_info.value)
+        assert "credentials" in message.lower()
+        assert "is it running" not in message.lower()
+
+    def test_set_metabase_telemetry_reads_stored_metabase_url(self, tmp_path: Path) -> None:
+        """Review fix #3: when metabase_url isn't passed explicitly, read it
+        from the "metabase_url" key in .dango/metabase.yml (matching the
+        precedent in cli/commands/metabase_cmd.py:343), instead of always
+        hardcoding localhost:3000."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+            "metabase_url: http://metabase.internal:9000\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False)
+
+        post_url = mock_session.post.call_args.args[0]
+        put_url = mock_session.put.call_args.args[0]
+        assert post_url == "http://metabase.internal:9000/api/session"
+        assert put_url == "http://metabase.internal:9000/api/setting/anon-tracking-enabled"
+
+    def test_set_metabase_telemetry_falls_back_to_localhost_when_url_key_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """No "metabase_url" key in metabase.yml and no explicit override ->
+        still falls back to the documented default, doesn't crash."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False)
+
+        assert mock_session.put.call_args.args[0] == (
+            "http://localhost:3000/api/setting/anon-tracking-enabled"
+        )
+
+    def test_set_metabase_telemetry_writes_state_cache_on_success(self, tmp_path: Path) -> None:
+        """Review fix #2: a successful call writes a local last-known-state
+        cache that _get_metabase_telemetry_state() reads, instead of status
+        being hardcoded."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, False)
+
+        state_file = tmp_path / ".dango" / "metabase_telemetry_state"
+        assert state_file.read_text().strip() == "false"
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            set_metabase_telemetry(tmp_path, True)
+
+        assert state_file.read_text().strip() == "true"
+
+    def test_set_metabase_telemetry_cache_write_failure_does_not_raise(
+        self, tmp_path: Path
+    ) -> None:
+        """The failure-ordering bug found in review: if the real Metabase API
+        call already succeeded, a failure writing the secondary local status
+        cache must NOT be reported as a command failure — it's a "status may
+        be stale" problem, not an "operation failed" problem. Forces a real
+        write failure (state-file path collides with an existing directory,
+        so write_text() raises IsADirectoryError) rather than mocking the
+        exception, so this exercises the actual except-block wiring."""
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+        # Pre-create the cache path AS A DIRECTORY so write_text() fails.
+        (creds_dir / "metabase_telemetry_state").mkdir()
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            # Must return normally — no exception — even though the cache
+            # write underneath will fail.
+            set_metabase_telemetry(tmp_path, False)
+
+        # The real API call still happened correctly.
+        assert mock_session.put.call_args.args[0] == (
+            "http://localhost:3000/api/setting/anon-tracking-enabled"
+        )
+        assert mock_session.put.call_args.kwargs["json"] == {"value": False}
+
+    def test_set_metabase_telemetry_wraps_malformed_yaml(self, tmp_path: Path) -> None:
+        """Review fix #4: a broad except Exception fallback converts anything
+        else in the credentials/login/API flow (e.g. yaml.YAMLError from a
+        hand-edited metabase.yml) into the same clean click.ClickException
+        contract, instead of letting a raw traceback through."""
+        import click
+
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        # Invalid YAML (unbalanced flow mapping) -> yaml.safe_load raises YAMLError.
+        (creds_dir / "metabase.yml").write_text("admin: [email: broken\n")
+
+        with pytest.raises(click.ClickException):
+            set_metabase_telemetry(tmp_path, False)
+
+    def test_set_metabase_telemetry_wraps_non_json_login_response(self, tmp_path: Path) -> None:
+        """Same broad-except contract for a 200 login response with a
+        non-JSON body (login_response.json() raising ValueError)."""
+        import click
+
+        from dango.visualization.metabase import set_metabase_telemetry
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.post.return_value.json.side_effect = ValueError("not JSON")
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            with pytest.raises(click.ClickException):
+                set_metabase_telemetry(tmp_path, False)
+
+
+@pytest.mark.unit
+class TestMetabaseTelemetryStatus:
+    """_get_metabase_telemetry_state — review fix #2: status must reflect the
+    real last-set state (via the cache file), not a hardcoded True."""
+
+    def test_defaults_true_when_no_project(self) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        assert _get_metabase_telemetry_state(None) is True
+
+    def test_defaults_true_when_no_cache_file(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        assert _get_metabase_telemetry_state(tmp_path) is True
+
+    def test_reads_off_from_cache_file(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        state_dir = tmp_path / ".dango"
+        state_dir.mkdir()
+        (state_dir / "metabase_telemetry_state").write_text("false")
+
+        assert _get_metabase_telemetry_state(tmp_path) is False
+
+    def test_reads_on_from_cache_file(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_metabase_telemetry_state
+
+        state_dir = tmp_path / ".dango"
+        state_dir.mkdir()
+        (state_dir / "metabase_telemetry_state").write_text("true")
+
+        assert _get_metabase_telemetry_state(tmp_path) is True
+
+    def test_status_reflects_real_toggle_end_to_end(self, tmp_path: Path) -> None:
+        """The specific bug three review angles independently flagged: status
+        must change after a real successful `telemetry off --provider
+        metabase` call, not stay stuck on "on" forever."""
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            "admin:\n  email: admin@example.com\n  password: secret123\n"
+        )
+
+        mock_session = MagicMock()
+        mock_session.post.return_value.json.return_value = {"id": "sess-123"}
+        mock_session.post.return_value.raise_for_status.return_value = None
+        mock_session.put.return_value.raise_for_status.return_value = None
+
+        from dango.cli.commands.telemetry import (
+            _get_metabase_telemetry_state,
+            _set_metabase_telemetry,
+        )
+
+        with patch("dango.visualization.metabase.requests.Session", return_value=mock_session):
+            assert _get_metabase_telemetry_state(tmp_path) is True
+            _set_metabase_telemetry(False, tmp_path)
+            assert _get_metabase_telemetry_state(tmp_path) is False
+
+
+@pytest.mark.unit
+class TestMetabaseNotConfiguredCheckSingleSource:
+    """Review fix #10: the duplicate `creds_file.exists()` check was removed
+    from telemetry.py's wrapper — the single remaining check, in
+    metabase.py's set_metabase_telemetry(), must still surface the same
+    user-facing error end-to-end."""
+
+    def test_off_provider_metabase_not_configured_inside_project(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project"
+        (project_dir / ".dango").mkdir(parents=True)
+        (project_dir / ".dango" / "project.yml").write_text("name: test\n")
+        # Deliberately no .dango/metabase.yml.
+
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=project_dir):
+            result = runner.invoke(cli, ["telemetry", "off", "--provider", "metabase"])
+
+        assert result.exit_code != 0
+        assert "Metabase not configured" in result.output


### PR DESCRIPTION
## Summary
- Add `dango telemetry` command group (`status` / `on` / `off`)
- Unified control: `--all` (or `--provider X`) controls Dango + dbt + dlt + Metabase in one command, writing through to each provider's own real config mechanism
- dbt: injects `DBT_SEND_ANONYMOUS_USAGE_STATS=false` + `DO_NOT_TRACK=1` into the subprocess env at **every** real dbt-invoking `subprocess.run` call site in the codebase (10 total — see "Independent review" below for how this list grew from 3 to 10)
- dlt: writes `dlthub_telemetry = false` (native TOML boolean) to `.dlt/config.toml`
- Metabase: calls `PUT /api/setting/anon-tracking-enabled` via `set_metabase_telemetry()` in `visualization/metabase.py`, reading the real `metabase_url` from `.dango/metabase.yml` and caching last-known state locally so `dango telemetry status` reflects reality
- Dango: delegates to `dango.telemetry` from Session C
- Updates `docs/network-egress.yml`'s `dango`/`metabase` `control` fields (previously placeholder text written before this session existed) to describe the real commands, and fixes a wrong field name (`allow_tracking` is the one-time `/api/setup` wizard field, not the runtime setting key)

**Wording:** every user-facing string says "controls telemetry for the components Dango configures" — never "nothing leaves your machine" (per task spec).

## Scope note: no web UI in this PR
The task file's title/Background mention a web settings page, but its Required Changes / Tests / Acceptance Criteria never actually specify any web route, template, or endpoint. Confirmed with the coordinating chat that this is a gap in how the task was originally scoped, not something to paper over — this PR is CLI-only. A follow-up task will cover the web settings page.

## Independent review — findings and how they were resolved
An independent multi-angle review (line-by-line diff scan, removed-behavior audit, cross-file call-site tracing, reuse/simplification/altitude passes) was run against this PR before merge, with every finding verified against the live worktree rather than trusted on report alone. Results, categorized:

**Fixed in this PR (blocking/high-severity):**
1. **dbt telemetry write-through only covered 3 of ~10 real dbt subprocess call sites.** The original PR wired `_dbt_telemetry_env()` into `run_dbt_models`/`run_dbt_snapshots`/`generate_dbt_docs` only. Two independent finder angles each found this from different directions; I personally verified all 7 additional sites by reading each one. Now wired into all of them: `cli/commands/transform.py` (`dango run`, `dango docs` — the primary user-facing dbt commands), `platform/local/watcher_runner.py` (file-watcher auto-triggered dbt run — previously silent since it's unattended), `web/routes/dbt.py` (web UI model-run endpoint), `cli/commands/dev.py` (`dango dev`), `cli/init.py` (`dango init`'s doc generation), `cli/model_wizard.py` (`dango model add/remove`), `cli/validate.py` (`dango validate`). This was the one that actually broke the "unified control" claim for most real dbt invocations — now fixed.
2. **`_get_metabase_telemetry_state()` was hardcoded `True`**, so `dango telemetry status` never reflected a real successful toggle. Fixed: `set_metabase_telemetry()` now writes a local last-known-state cache (`.dango/metabase_telemetry_state`) after every successful live API call; status reads that cache instead of guessing, with no live API call needed just to print status.
3. **`set_metabase_telemetry()` hardcoded `metabase_url="http://localhost:3000"`**, ignoring the real URL stored in `.dango/metabase.yml`. Fixed to read `credentials.get("metabase_url", "http://localhost:3000")`, matching the existing precedent in `cli/commands/metabase_cmd.py:343`.
4. **Uncaught exceptions in `set_metabase_telemetry()`** — only `click.ClickException`/`requests.exceptions.RequestException` were caught, so a malformed `metabase.yml` (`yaml.YAMLError`) or a non-JSON login response produced a raw traceback. Added a broad `except Exception` fallback converting anything else in the credentials/login/API flow to the same clean `click.ClickException` contract.
10. **Duplicate `creds_file.exists()` check** between `telemetry.py`'s wrapper and `metabase.py`'s `set_metabase_telemetry()` (byte-identical error message in both places — dead code in the first). Removed from `telemetry.py`'s wrapper; kept in `set_metabase_telemetry()` itself, since that's the function that actually reads the credentials file.

**Accepted trade-off — documented, not changed:**
5. `dango telemetry on --provider dbt` doesn't clear ambient `DO_NOT_TRACK`/`DBT_SEND_ANONYMOUS_USAGE_STATS` if the parent shell already exports them, so status can say "on" while dbt subprocesses still inherit an ambient opt-out. This is treated as correct behavior, not a bug: respecting an explicit ambient `DO_NOT_TRACK` (a user's own privacy signal, set outside Dango entirely) takes precedence over a Dango-level "on" the same way it takes precedence everywhere else in this codebase (`dango/telemetry.py`'s own `is_telemetry_enabled()` gives `DO_NOT_TRACK` the same override priority). Silently overriding a user's explicit ambient opt-out to force telemetry back on would be the wrong default for a privacy-focused command.
7. `.dlt/config.toml` read/write is hand-rolled with `tomlkit` in `telemetry.py` instead of reusing `CredentialManager.load_config()`/`save_config()` in `dango/config/credentials.py`, which already owns this file. Not changed here: the task spec this PR implements explicitly directed the tomlkit approach (matching dlt's own value-type behavior, verified against the installed dlt package), so this wasn't something introduced by choice — it's a legitimate follow-up (`CredentialManager.save_config()` uses the `toml` library, which does still serialize native booleans correctly, but loses `tomlkit`'s comment-preservation) rather than a defect in this PR.
8. Manual `project_root is None` checks in `telemetry.py` duplicate the codebase-wide `require_project_context()` helper. Not changed here: the `--all` flow deliberately treats a missing project as a soft skip-and-continue for dlt/metabase rather than a hard abort (see the acceptance criterion this implements), and `require_project_context()` always raises immediately — it can't be swapped in at the point this check lives without restructuring the soft-skip behavior it's specifically there to support.

**Deferred as follow-up tech debt (tracked in `ROADMAP.md` by the coordinating chat, not touched in this PR):**
6. Metabase auth flow (load creds → session → login → header) now duplicated three times across `setup_metabase()`, `sync_metabase_schema()`, and `set_metabase_telemetry()`, each with different error-handling conventions.
9. Bespoke `~/.dango/dbt_telemetry` plain-text sentinel file duplicates the existing `~/.dango/config.yml` machine-level config mechanism `dango/telemetry.py` already reads/writes — no other precedent for a bare sentinel file under `~/.dango/`.

## Corrections made vs. the task file's pseudocode
Grepped every path/class/function name against the live `v1.0.8` branch before implementing; found and fixed:
1. `dango.cli.utils.get_project_root_or_abort` doesn't exist (and was unused in the pseudocode anyway) — dropped.
2. `dango.config.helpers.load_config` import in the Metabase helper was unused — dropped.
3. **dbt env var name was wrong**: pseudocode used `DBT_ENGINE_SEND_ANONYMOUS_USAGE_STATS`; the real dbt-core var (verified against installed dbt-core 1.11.14 source and Session B's own `test_dbt_send_anonymous_usage_stats_envvar_name`) is `DBT_SEND_ANONYMOUS_USAGE_STATS`.
4. `MetabaseClient` class doesn't exist. The real class is `MetabaseProvisioner`, with no `from_project`/`set_setting`. Implemented `set_metabase_telemetry()` as a module-level function instead, matching the existing `sync_metabase_schema()` pattern.
5. dlt's `dlthub_telemetry` field is `bool`-typed, and dlt's own CLI writes a native TOML boolean — fixed from the pseudocode's string form.
6. **Acceptance-criteria bug**: the pseudocode's `--all` loop would abort entirely on the first project-scoped provider instead of warning and continuing. Fixed with per-provider error handling.
7. `docs/network-egress.yml`'s Metabase `control` field said `allow_tracking=false` — that's the one-time `/api/setup` wizard field name, not the runtime setting key (`anon-tracking-enabled`, confirmed against Metabase's public API docs). Fixed the doc wording.
8. Added try/except around the Metabase HTTP calls so a stopped Metabase raises a clean `ClickException`, not a raw `requests` exception (later broadened further — see review finding #4 above).

No lint/type/test check was resolved by adding to an exemption or skip mechanism — all corrections above are real fixes, not workarounds.

## Open question — left undisturbed, not resolved
Session B's egress test found that dlt's telemetry runtime never actually initializes for Dango's CSV-source sync path (`RunContext.runtime_config` is never touched), so there was nothing live to flip in that specific path. This PR's `dlthub_telemetry=false` write-through is correct and safe regardless — it matches dlt's own documented opt-out mechanism and takes effect if/when dlt's telemetry path ever does initialize. This PR does **not** claim the write-through has been observed to change real dlt network behavior — that remains an open question, documented as such in `docs/network-egress.yml`'s `notes` section.

## Verification
- `pytest -x`: 4300 passed, 30 skipped, 0 failed (full suite; +12 tests over the previous round)
- `pytest tests/unit/test_telemetry_unified.py -v`: 24 passed (12 original + 12 new, covering all 5 review fixes plus a structural regression guard asserting every known dbt subprocess call site passes `env=_dbt_telemetry_env()`)
- `mypy dango/`: Success, no issues found in 233 source files
- `ruff check dango/` / `ruff format --check dango/`: clean
- `python3 scripts/validate_headers.py` / `check_docstrings.py` on all changed files: clean
- Session B's egress tests, both classes: `pytest tests/unit/test_egress_allowlist.py -m "not egress"` (4 passed) and `-m egress` (1 passed) — both still pass
- **Live CLI runs**, isolated via `HOME=` override (never touched the real machine's `~/.dango/`):
  ```
  $ dango telemetry off --all   # outside a project
  ✓ dango: telemetry disabled
  ✓ dbt: telemetry disabled
  ! dlt: skipped — not inside a Dango project
  ! metabase: skipped — not inside a Dango project

  $ dango telemetry off --all   # inside a minimal project, Metabase not configured
  ✓ dango: telemetry disabled
  ✓ dbt: telemetry disabled
  ✓ dlt: telemetry disabled
  ! metabase: skipped — Metabase not configured. Run dango start first.

  $ cat .dlt/config.toml
  [runtime]
  dlthub_telemetry = false

  $ dango telemetry status   # no metabase.yml, no cache file — clean default, no crash
  metabase │ on │ Anonymous usage statistics │ dango telemetry on/off --provider metabase
  ```
  Metabase's live API call path is covered by mocked unit tests only — no running Metabase in this worktree session per the "don't test on shared projects" rule.

## Regression check
- dbt subprocess env verified: `_dbt_telemetry_env()` returns `{**os.environ}` copy, never mutates `os.environ` in place (explicit test: `test_dbt_env_is_a_copy_not_the_real_environ`)
- Metabase call confirmed graceful on connection failure, malformed YAML, and non-JSON login response (all convert to `click.ClickException`, never a raw traceback)
- `--all` outside a project succeeds for dango+dbt, warns (not crashes) for dlt+metabase — verified both by unit test and live CLI run above
- `dango telemetry status` now reflects a real Metabase toggle end-to-end (previously always showed "on") — verified by `test_status_reflects_real_toggle_end_to_end`


## Second narrower review pass — findings and fixes
A follow-up review scoped specifically to the changes above (the Metabase state-cache write/read, the 8 newly-wired dbt call sites, and the new `except Exception` handler) — not a full re-audit — found and fixed two more real issues:

1. **`_set_dbt_telemetry()`/`_set_dlt_telemetry()` raised unwrapped `OSError`/`tomlkit.exceptions.TOMLKitError`** instead of `click.ClickException`, breaking the `--all` graceful-degradation contract every other provider follows (a read-only `~/.dango`, or a hand-corrupted `.dlt/config.toml`, would crash the whole `--all` command instead of skipping that provider). Both now wrap their filesystem/tomlkit operations and convert to `click.ClickException`.
2. **A Metabase login 401/403 (stale admin password) was mislabeled "Could not reach Metabase — is it running?"** since `requests.HTTPError` is a `RequestException` subclass. Metabase is running fine in this case — the credentials are wrong. Now checked explicitly on the login response status code, with a distinct "check admin credentials in .dango/metabase.yml" message.

Also proactively found and fixed, ahead of that review pass, by re-reading the previous round's own fix: the Metabase state-cache write (`.dango/metabase_telemetry_state`) landed inside the same `try` as the real API call, so a failure writing that *secondary* cache file (disk full, permissions) would report a *successful* telemetry toggle as a command failure. Fixed: the cache write is now wrapped in its own try/except that logs a warning and returns normally on failure — real API success is never reported as failure due to the secondary write.

`tests/unit/test_telemetry_unified.py` grew to 568 lines during this round, tripping the 500-line file-size-check pre-commit hook. Split along its existing class boundaries into `test_telemetry_unified.py` (dbt/dlt + top-level CLI tests) and a new `test_telemetry_unified_metabase.py` (all Metabase-specific tests) — not exempted, since this is new code from this PR, not legacy debt.

## Final verification (after all review rounds)
- `pytest -x`: 4305 passed, 30 skipped, 0 failed
- `pytest tests/unit/test_telemetry_unified.py tests/unit/test_telemetry_unified_metabase.py -v`: 29 passed
- `mypy dango/`: Success, no issues found in 233 source files
- `ruff check` / `ruff format --check`: clean
- header/docstring/file-size checks: clean
- Session B's egress tests (both classes): still pass
