### PR TITLE
1.0.8-E: MCP server — scaffold + read tools + setup

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -27,6 +27,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/model.py` (258 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/seed.py` (135 lines) | `seed` group (`add`, `list`) — dbt seed CSV management | `seed` |
 | `commands/dashboard.py` (153 lines) | `dashboard` group (`provision`) | `dashboard` |
+| `commands/mcp_server.py` (~470 lines) | `mcp` group + `run` command; FastMCP stdio server with 8 read-only tools (list_sources, get_table_schema, get_catalog, get_lineage, list_models, get_model_sql, query, get_sync_history) | `mcp_group`, `mcp`, `mcp_run()` |
+| `commands/mcp_setup.py` (~120 lines) | `mcp setup` / `mcp status` subcommands (registers onto `mcp_group` from mcp_server.py) — detects/configures Claude Code, Cursor, Windsurf | `mcp_setup()`, `mcp_status()` |
 | `commands/remote.py` (702 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~205 lines) | `serve` production foreground server with `--workers` option. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
@@ -99,6 +101,9 @@ dango (top-level group)
 │   ├── add, list
 ├── dashboard (group)           ← commands/dashboard.py
 │   ├── provision
+├── mcp (group)                 ← commands/mcp_server.py
+│   ├── run                     ← commands/mcp_server.py (FastMCP stdio server)
+│   └── setup, status           ← commands/mcp_setup.py
 ├── migrate (group)             ← commands/migrate.py
 │   ├── status, run
 ├── remote (group)              ← commands/remote.py
@@ -165,7 +170,8 @@ dango (top-level group)
 - **Lazy imports:** All command functions use `from dango.xxx import ...` inside the function body, not at module level. This prevents circular imports and speeds up CLI startup.
 - **Shared console:** All command modules import `console` from `dango.cli` for Rich terminal output.
 - **Project root via context:** `ctx.obj["project_root"]` is set by the top-level `cli` group in `main.py` (via `dango.config.helpers.find_project_root`).
-- **Cross-file command registration:** `remote_auth.py`, `remote_mgmt.py`, `remote_ops.py`, `remote_env.py`, `remote_backup.py`, `remote_repair.py`, and `remote_sync.py` import `remote` from `remote.py` and register commands via `@remote.command()` / `@remote.group()`. Registration is triggered by bottom-of-file imports in `remote.py`.
+- **Cross-file command registration:** `remote_auth.py`, `remote_mgmt.py`, `remote_ops.py`, `remote_env.py`, `remote_backup.py`, `remote_repair.py`, and `remote_sync.py` import `remote` from `remote.py` and register commands via `@remote.command()` / `@remote.group()`. Registration is triggered by bottom-of-file imports in `remote.py`. Same pattern for `mcp`: `mcp_setup.py` imports `mcp_group` from `mcp_server.py` and registers `setup`/`status` via `@mcp_group.command()`; triggered by a bottom-of-file import in `mcp_server.py`. Split out of a single file to stay under the 500-line file-size check.
+- **MCP tool functions are plain functions, not wrapped:** `@mcp.tool()` (fastmcp) returns the original function unchanged — call `mcp_server.list_sources()` etc. directly in tests, no `.fn` unwrapping needed. All `dango.*` imports inside MCP tool bodies must stay lazy (never at module top level) — the server communicates over stdio and any stray stdout write corrupts the JSON-RPC protocol.
 - **Two SSH users:** `root` for system ops (backup, rollback, domain, server setup) via `load_cloud_config_with_ssh()` in `cli/utils.py`. `dango` for project file ops (.env, .dlt/secrets.toml) via `_ssh_connect_or_fail()` in `remote.py`.
 
 ### Key conventions

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -27,8 +27,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/model.py` (258 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/seed.py` (135 lines) | `seed` group (`add`, `list`) — dbt seed CSV management | `seed` |
 | `commands/dashboard.py` (153 lines) | `dashboard` group (`provision`) | `dashboard` |
-| `commands/mcp_server.py` (~470 lines) | `mcp` group + `run` command; FastMCP stdio server with 8 read-only tools (list_sources, get_table_schema, get_catalog, get_lineage, list_models, get_model_sql, query, get_sync_history) | `mcp_group`, `mcp`, `mcp_run()` |
-| `commands/mcp_setup.py` (~120 lines) | `mcp setup` / `mcp status` subcommands (registers onto `mcp_group` from mcp_server.py) — detects/configures Claude Code, Cursor, Windsurf | `mcp_setup()`, `mcp_status()` |
+| `commands/mcp_server.py` (~420 lines) | `mcp` group + `run` command; FastMCP stdio server with 8 read-only tools (list_sources, get_table_schema, get_catalog, get_lineage, list_models, get_model_sql, query, get_sync_history) | `mcp_group`, `mcp`, `mcp_run()` |
+| `commands/mcp_setup.py` (~145 lines) | `mcp setup` / `mcp status` subcommands (registers onto `mcp_group` from mcp_server.py) — detects/configures Claude Code, Cursor, Windsurf | `mcp_setup()`, `mcp_status()` |
+| `commands/mcp_helpers.py` (~120 lines) | Plain-function helpers for the MCP read tools (project root, SELECT-only SQL validation, retry-on-lock DuckDB connect, blocking query execution) — split out of mcp_server.py, not a Click module | `_get_project_root()`, `_validate_select_only()`, `_connect_readonly_with_retry()`, `_execute_query_sync()` |
 | `commands/remote.py` (702 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~205 lines) | `serve` production foreground server with `--workers` option. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
@@ -102,7 +103,7 @@ dango (top-level group)
 ├── dashboard (group)           ← commands/dashboard.py
 │   ├── provision
 ├── mcp (group)                 ← commands/mcp_server.py
-│   ├── run                     ← commands/mcp_server.py (FastMCP stdio server)
+│   ├── run                     ← commands/mcp_server.py (FastMCP stdio server; helpers in commands/mcp_helpers.py)
 │   └── setup, status           ← commands/mcp_setup.py
 ├── migrate (group)             ← commands/migrate.py
 │   ├── status, run
@@ -170,8 +171,8 @@ dango (top-level group)
 - **Lazy imports:** All command functions use `from dango.xxx import ...` inside the function body, not at module level. This prevents circular imports and speeds up CLI startup.
 - **Shared console:** All command modules import `console` from `dango.cli` for Rich terminal output.
 - **Project root via context:** `ctx.obj["project_root"]` is set by the top-level `cli` group in `main.py` (via `dango.config.helpers.find_project_root`).
-- **Cross-file command registration:** `remote_auth.py`, `remote_mgmt.py`, `remote_ops.py`, `remote_env.py`, `remote_backup.py`, `remote_repair.py`, and `remote_sync.py` import `remote` from `remote.py` and register commands via `@remote.command()` / `@remote.group()`. Registration is triggered by bottom-of-file imports in `remote.py`. Same pattern for `mcp`: `mcp_setup.py` imports `mcp_group` from `mcp_server.py` and registers `setup`/`status` via `@mcp_group.command()`; triggered by a bottom-of-file import in `mcp_server.py`. Split out of a single file to stay under the 500-line file-size check.
-- **MCP tool functions are plain functions, not wrapped:** `@mcp.tool()` (fastmcp) returns the original function unchanged — call `mcp_server.list_sources()` etc. directly in tests, no `.fn` unwrapping needed. All `dango.*` imports inside MCP tool bodies must stay lazy (never at module top level) — the server communicates over stdio and any stray stdout write corrupts the JSON-RPC protocol.
+- **Cross-file command registration:** `remote_auth.py`, `remote_mgmt.py`, `remote_ops.py`, `remote_env.py`, `remote_backup.py`, `remote_repair.py`, and `remote_sync.py` import `remote` from `remote.py` and register commands via `@remote.command()` / `@remote.group()`. Registration is triggered by bottom-of-file imports in `remote.py`. Same pattern for `mcp`: `mcp_setup.py` imports `mcp_group` from `mcp_server.py` and registers `setup`/`status` via `@mcp_group.command()`; triggered by a bottom-of-file import in `mcp_server.py`. `mcp_helpers.py` is a *different* kind of split — plain functions, no Click decorators, imported normally at the top of `mcp_server.py` (not bottom-of-file, no registration side effect involved). Both splits exist to stay under the 500-line file-size check.
+- **MCP tool functions are plain functions, not wrapped:** `@mcp.tool()` (fastmcp) returns the original function unchanged — call `mcp_server.get_table_schema()` etc. directly in tests, no `.fn` unwrapping needed. All `dango.*` imports inside MCP tool bodies must stay lazy (never at module top level) — the server communicates over stdio and any stray stdout write corrupts the JSON-RPC protocol. `list_sources` and `query` are `async def` tools (fastmcp supports both sync and async tools natively) — call them with `await` under `@pytest.mark.anyio`, matching the pattern in `test_rate_limit_proxy.py`. Prefer `async def` over a sync tool doing `asyncio.run()` internally: the latter only works because fastmcp currently dispatches sync tools to a worker thread by default (`run_in_thread=True`, undocumented in our code) — an `async def` tool awaits directly on fastmcp's own loop with no such dependency.
 - **Two SSH users:** `root` for system ops (backup, rollback, domain, server setup) via `load_cloud_config_with_ssh()` in `cli/utils.py`. `dango` for project file ops (.env, .dlt/secrets.toml) via `_ssh_connect_or_fail()` in `remote.py`.
 
 ### Key conventions

--- a/dango/cli/commands/mcp_helpers.py
+++ b/dango/cli/commands/mcp_helpers.py
@@ -11,6 +11,17 @@ imports only" rule for that file: this module itself does zero dango.*
 imports at its own top level (stdlib only below) — find_project_root,
 duckdb, and sqlglot are all imported lazily inside the function bodies here,
 same discipline as before the split. Importing *this* module is inert.
+
+Patchability note: mcp_server.py does `from mcp_helpers import _get_project_root,
+_validate_select_only, ...`, which re-binds those names into mcp_server's own
+module namespace. Patching `mcp_server._get_project_root` etc. in a test
+works correctly for any *mcp_server.py* function that calls it, because a
+bare-name lookup at call time resolves against the caller's own module
+globals. It would NOT work for a call made from *within this file* (a
+function defined here calling another function defined here resolves
+against mcp_helpers's globals, not mcp_server's re-exported copy) — which is
+exactly why _execute_query_on_connection below takes an already-open
+connection instead of calling _connect_readonly_with_retry itself.
 """
 
 from __future__ import annotations
@@ -100,17 +111,39 @@ def _connect_readonly_with_retry(db_path: Path) -> Any:
     raise last_exc
 
 
-def _execute_query_sync(db_path: Path, sql: str, row_limit: int) -> dict[str, Any]:
-    """Blocking DuckDB query execution. Run via asyncio.to_thread from query()."""
-    conn = _connect_readonly_with_retry(db_path)
+def _get_query_timeout_seconds(project_root: Path) -> float:
+    """Read api.query_timeout_seconds from project.yml, mirroring
+    web/routes/query.py's `_get_api_config` so the MCP `query()` tool honors
+    the same per-project configured timeout, not just the same hardcoded
+    default. Falls back to 30s (ApiConfig's own default) if unset/unreadable.
+    """
     try:
-        rel = conn.execute(sql)
-        columns = [d[0] for d in rel.description]
-        raw_rows = rel.fetchmany(row_limit + 1)
-        truncated = len(raw_rows) > row_limit
-        rows = [list(r) for r in raw_rows[:row_limit]]
-    finally:
-        conn.close()
+        from dango.config.helpers import load_config
+
+        config = load_config(project_root)
+        return config.api.query_timeout_seconds
+    except Exception:
+        return 30
+
+
+def _execute_query_on_connection(conn: Any, sql: str, row_limit: int) -> dict[str, Any]:
+    """Blocking DuckDB query execution against an *already-open* connection.
+
+    Run via asyncio.to_thread from query(). Deliberately does not create or
+    close the connection itself, and does not call _connect_readonly_with_retry
+    — the caller (query()) owns the connection's full lifecycle (create,
+    conn.interrupt() on timeout, close) so it can cancel an in-flight query
+    from the awaiting coroutine while this function is still running in a
+    worker thread. Keeping connection creation out of this function also
+    means it's callable from mcp_server.py's own namespace-resolved
+    _connect_readonly_with_retry when needed, rather than only the copy in
+    this module's globals — see the module docstring's patchability note.
+    """
+    rel = conn.execute(sql)
+    columns = [d[0] for d in rel.description]
+    raw_rows = rel.fetchmany(row_limit + 1)
+    truncated = len(raw_rows) > row_limit
+    rows = [list(r) for r in raw_rows[:row_limit]]
     return {
         "columns": columns,
         "rows": rows,

--- a/dango/cli/commands/mcp_helpers.py
+++ b/dango/cli/commands/mcp_helpers.py
@@ -1,0 +1,119 @@
+"""dango/cli/commands/mcp_helpers.py
+
+Shared helpers for the MCP server's read tools (dango/cli/commands/mcp_server.py).
+Split out purely to keep mcp_server.py under the file-size check — these are
+plain functions, not Click-registered commands, so there's no cross-file
+command-registration pattern involved (unlike mcp_setup.py), just a normal
+helper extraction.
+
+Safe to import at mcp_server.py's module top level despite the "lazy Dango
+imports only" rule for that file: this module itself does zero dango.*
+imports at its own top level (stdlib only below) — find_project_root,
+duckdb, and sqlglot are all imported lazily inside the function bodies here,
+same discipline as before the split. Importing *this* module is inert.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def _get_project_root() -> Path:
+    """Get project root for MCP tools. Raises RuntimeError if not in a project."""
+    from dango.config.helpers import find_project_root
+
+    try:
+        return find_project_root()
+    except Exception:
+        raise RuntimeError(
+            "Not inside a Dango project. cd into your project directory first."
+        ) from None
+
+
+def _infer_layer(model_name: str) -> str:
+    if model_name.startswith("stg_"):
+        return "staging"
+    if model_name.startswith("int_"):
+        return "intermediate"
+    if model_name.startswith("fct_") or model_name.startswith("dim_"):
+        return "marts"
+    return "other"
+
+
+def _validate_select_only(sql: str) -> None:
+    """Validate that *sql* is a single SELECT (or WITH ... SELECT) statement.
+
+    Uses sqlglot for AST-level validation when available (mirrors
+    dango/web/routes/query.py's `_validate_sql`), falling back to a keyword +
+    multi-statement heuristic otherwise. Raises ValueError on rejection.
+    """
+    if not sql.strip():
+        raise ValueError("SQL query is empty")
+
+    try:
+        import sqlglot
+        import sqlglot.expressions as exp
+    except ImportError:
+        first_keyword = sql.strip().split()[0].upper()
+        if first_keyword not in ("SELECT", "WITH"):
+            raise ValueError("Only SELECT queries are allowed") from None
+        stripped = sql.strip().rstrip(";").strip()
+        if ";" in stripped:
+            raise ValueError("Multiple SQL statements are not allowed") from None
+        return
+
+    try:
+        statements = [s for s in sqlglot.parse(sql, dialect="duckdb") if s is not None]
+    except Exception as e:
+        raise ValueError(f"Invalid SQL syntax: {e}") from None
+
+    if len(statements) == 0:
+        raise ValueError("Empty SQL statement")
+    if len(statements) > 1:
+        raise ValueError("Multiple SQL statements are not allowed")
+    if not isinstance(statements[0], exp.Select):
+        raise ValueError(f"Only SELECT queries are allowed, got {type(statements[0]).__name__}")
+
+
+def _connect_readonly_with_retry(db_path: Path) -> Any:
+    """Open a read-only DuckDB connection, retrying briefly on IOException.
+
+    DuckDB is single-writer (see VAL-003 finding); a concurrent sync can
+    transiently hold the write lock even though read-only connections are
+    normally allowed alongside a writer. Mirrors the retry in
+    dango/web/routes/query.py's `_execute_query`.
+    """
+    import time
+
+    import duckdb
+
+    last_exc: Exception | None = None
+    for attempt in range(3):
+        try:
+            return duckdb.connect(str(db_path), read_only=True)
+        except duckdb.IOException as e:
+            last_exc = e
+            if attempt < 2:
+                time.sleep(0.1 * (2**attempt))
+    assert last_exc is not None
+    raise last_exc
+
+
+def _execute_query_sync(db_path: Path, sql: str, row_limit: int) -> dict[str, Any]:
+    """Blocking DuckDB query execution. Run via asyncio.to_thread from query()."""
+    conn = _connect_readonly_with_retry(db_path)
+    try:
+        rel = conn.execute(sql)
+        columns = [d[0] for d in rel.description]
+        raw_rows = rel.fetchmany(row_limit + 1)
+        truncated = len(raw_rows) > row_limit
+        rows = [list(r) for r in raw_rows[:row_limit]]
+    finally:
+        conn.close()
+    return {
+        "columns": columns,
+        "rows": rows,
+        "row_count": len(rows),
+        "truncated": truncated,
+    }

--- a/dango/cli/commands/mcp_server.py
+++ b/dango/cli/commands/mcp_server.py
@@ -1,0 +1,468 @@
+"""dango/cli/commands/mcp_server.py
+
+MCP server for Dango. Exposes Dango operations as typed tools for LLM agents.
+
+Architecture: local stdio only. Spawned by LLM client config — users never
+call `dango mcp` directly. Users run `dango mcp setup` once to configure
+their LLM client.
+
+Session E: read tools + setup
+Session F: mutation tools (add_source, create_model, add_schedule, run_sync, run_transform)
+
+CRITICAL: all Dango imports below are lazy (inside function bodies), never at
+module top level. The MCP server communicates over stdio — any stray stdout
+write (a stray `print()`, an eagerly-imported module that logs to stdout at
+import time, etc.) corrupts the JSON-RPC protocol. Keep it that way.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from fastmcp import FastMCP
+
+mcp = FastMCP(
+    "dango",
+    instructions=(
+        "Dango data platform MCP server. Use these tools to read catalog information, "
+        "inspect schemas and lineage, query data, and trigger Dango operations. "
+        "Always prefer these tools over direct file edits — they validate inputs and "
+        "ensure consistency with Dango's conventions."
+    ),
+)
+
+
+# ── Read tools ────────────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def list_sources() -> list[dict[str, Any]]:
+    """List all configured data sources with their sync status and row counts.
+
+    Returns a list of dicts with: name, type, enabled, last_sync, rows, status.
+    """
+    project_root = _get_project_root()
+    import asyncio
+
+    from dango.web.app import app as web_app
+    from dango.web.helpers import get_source_status_data, load_sources_config
+
+    # web/helpers.py resolves the project root via app.state.project_root
+    # (normally set by lifespan() when the FastAPI server boots). The MCP
+    # server never boots that app, so we set it here to reuse the same
+    # status-aggregation code the web UI uses.
+    web_app.state.project_root = project_root
+
+    sources_config = load_sources_config()
+    if not sources_config:
+        return []
+
+    async def _gather() -> list[Any]:
+        tasks = [get_source_status_data(source) for source in sources_config]
+        return await asyncio.gather(*tasks, return_exceptions=True)
+
+    statuses = asyncio.run(_gather())
+
+    results = []
+    for source, status in zip(sources_config, statuses, strict=True):
+        if isinstance(status, BaseException):
+            results.append(
+                {
+                    "name": source.get("name"),
+                    "type": source.get("type"),
+                    "enabled": source.get("enabled", True),
+                    "last_sync": None,
+                    "rows": None,
+                    "status": "unknown",
+                }
+            )
+            continue
+        results.append(
+            {
+                "name": status.name,
+                "type": status.type,
+                "enabled": status.enabled,
+                "last_sync": status.last_sync,
+                "rows": status.row_count,
+                "status": status.status,
+            }
+        )
+    return results
+
+
+@mcp.tool()
+def get_table_schema(table_name: str, schema: str | None = None) -> dict[str, Any]:
+    """Get the schema (columns, types, descriptions) for a table in the warehouse.
+
+    Args:
+        table_name: Table name (e.g. "stg_stripe__customers")
+        schema: Schema name (e.g. "staging", "raw_stripe"). Auto-detected if omitted.
+
+    Returns dict with: table_name, schema, columns (list of {name, type}).
+    """
+    project_root = _get_project_root()
+    db_path = project_root / "data" / "warehouse.duckdb"
+    if not db_path.exists():
+        return {"error": "No warehouse found. Run dango sync first."}
+
+    try:
+        conn = _connect_readonly_with_retry(db_path)
+        try:
+            if schema:
+                result = conn.execute(
+                    "SELECT column_name, data_type FROM information_schema.columns "
+                    "WHERE table_name = ? AND table_schema = ? ORDER BY ordinal_position",
+                    [table_name, schema],
+                ).fetchall()
+            else:
+                result = conn.execute(
+                    "SELECT table_schema, column_name, data_type FROM information_schema.columns "
+                    "WHERE table_name = ? ORDER BY table_schema, ordinal_position",
+                    [table_name],
+                ).fetchall()
+        finally:
+            conn.close()
+
+        if not result:
+            return {"error": f"Table '{table_name}' not found in warehouse"}
+
+        columns = [{"name": r[-2], "type": r[-1]} for r in result]
+        detected_schema = result[0][0] if not schema and result else schema
+        return {"table_name": table_name, "schema": detected_schema, "columns": columns}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def get_catalog(source_filter: str | None = None) -> dict[str, Any]:
+    """Get the data catalog: all tables grouped by schema with row counts.
+
+    Args:
+        source_filter: Optional source name to filter tables (e.g. "my_stripe_source")
+
+    Returns dict with tables_by_schema (schema -> list of table names) and total count.
+    """
+    project_root = _get_project_root()
+    db_path = project_root / "data" / "warehouse.duckdb"
+    if not db_path.exists():
+        return {"error": "No warehouse found. Run dango sync first."}
+
+    try:
+        conn = _connect_readonly_with_retry(db_path)
+        try:
+            tables = conn.execute(
+                "SELECT table_schema, table_name FROM information_schema.tables "
+                "WHERE table_type = 'BASE TABLE' ORDER BY table_schema, table_name"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        catalog: dict[str, list[str]] = {}
+        for schema, tname in tables:
+            if source_filter and source_filter not in schema and source_filter not in tname:
+                continue
+            catalog.setdefault(schema, []).append(tname)
+
+        return {"tables_by_schema": catalog, "total": sum(len(v) for v in catalog.values())}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def get_lineage(model_name: str | None = None) -> dict[str, Any]:
+    """Get dbt lineage from the manifest. Shows source -> staging -> intermediate -> mart flow.
+
+    Args:
+        model_name: Optional model to get lineage for. If omitted returns full DAG summary.
+
+    Returns dict with nodes and edges representing the data lineage graph.
+    """
+    project_root = _get_project_root()
+    manifest_path = project_root / "dbt" / "target" / "manifest.json"
+    if not manifest_path.exists():
+        return {"error": "No dbt manifest found. Run dango run first."}
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        nodes = manifest.get("nodes", {})
+        sources = manifest.get("sources", {})
+
+        if model_name:
+            target = next((n for n in nodes.values() if n.get("name") == model_name), None)
+            if not target:
+                return {"error": f"Model '{model_name}' not found in manifest"}
+            target_unique_id = f"model.{target.get('package_name')}.{model_name}"
+            return {
+                "name": model_name,
+                "path": target.get("original_file_path"),
+                "depends_on": target.get("depends_on", {}).get("nodes", []),
+                "referenced_by": [
+                    k
+                    for k, n in nodes.items()
+                    if target_unique_id in n.get("depends_on", {}).get("nodes", [])
+                ],
+            }
+
+        # Full summary
+        return {
+            "model_count": len([n for n in nodes.values() if n.get("resource_type") == "model"]),
+            "source_count": len(sources),
+            "models": [
+                {"name": n["name"], "schema": n.get("schema"), "layer": _infer_layer(n["name"])}
+                for n in nodes.values()
+                if n.get("resource_type") == "model"
+            ],
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def list_models() -> list[dict[str, Any]]:
+    """List all dbt models with their layer, schema, and file path.
+
+    Returns list of dicts with: name, layer, schema, path.
+    """
+    project_root = _get_project_root()
+    manifest_path = project_root / "dbt" / "target" / "manifest.json"
+    if not manifest_path.exists():
+        return [{"error": "No manifest found. Run dango run first."}]
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        return [
+            {
+                "name": n["name"],
+                "layer": _infer_layer(n["name"]),
+                "schema": n.get("schema"),
+                "path": n.get("original_file_path"),
+            }
+            for n in manifest.get("nodes", {}).values()
+            if n.get("resource_type") == "model"
+        ]
+    except Exception as e:
+        return [{"error": str(e)}]
+
+
+@mcp.tool()
+def get_model_sql(model_name: str) -> dict[str, Any]:
+    """Get the SQL source for a dbt model.
+
+    Args:
+        model_name: Model name (e.g. "stg_stripe__customers")
+
+    Returns dict with: name, sql, path.
+    """
+    project_root = _get_project_root()
+    manifest_path = project_root / "dbt" / "target" / "manifest.json"
+    if not manifest_path.exists():
+        return {"error": "No manifest found. Run dango run first."}
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        node = next(
+            (n for n in manifest.get("nodes", {}).values() if n.get("name") == model_name),
+            None,
+        )
+        if not node:
+            return {"error": f"Model '{model_name}' not found"}
+
+        sql_path = project_root / "dbt" / node.get("original_file_path", "")
+        sql = sql_path.read_text() if sql_path.exists() else node.get("raw_code", "")
+        return {"name": model_name, "sql": sql, "path": str(sql_path)}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def query(sql: str, row_limit: int = 500) -> dict[str, Any]:
+    """Run a read-only SQL query against the DuckDB warehouse.
+
+    Args:
+        sql: SQL query to execute. Must be a single SELECT statement (WITH ... SELECT
+            CTEs are allowed). Multi-statement SQL is rejected.
+        row_limit: Maximum rows to return (default 500, max 500).
+
+    Returns dict with: columns, rows, row_count, truncated.
+    """
+    try:
+        _validate_select_only(sql)
+    except ValueError as e:
+        return {"error": str(e)}
+
+    row_limit = min(row_limit, 500) if row_limit > 0 else 500
+
+    project_root = _get_project_root()
+    db_path = project_root / "data" / "warehouse.duckdb"
+    if not db_path.exists():
+        return {"error": "No warehouse found. Run dango sync first."}
+
+    try:
+        conn = _connect_readonly_with_retry(db_path)
+        try:
+            rel = conn.execute(sql)
+            columns = [d[0] for d in rel.description]
+            raw_rows = rel.fetchmany(row_limit + 1)
+            truncated = len(raw_rows) > row_limit
+            rows = [list(r) for r in raw_rows[:row_limit]]
+        finally:
+            conn.close()
+        return {
+            "columns": columns,
+            "rows": rows,
+            "row_count": len(rows),
+            "truncated": truncated,
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def get_sync_history(source_name: str | None = None, limit: int = 10) -> list[dict[str, Any]]:
+    """Get recent sync history for a source or all sources.
+
+    Args:
+        source_name: Optional source name filter. If omitted, returns the most
+            recent entries across all configured sources.
+        limit: Number of recent records to return (default 10).
+
+    Returns list of dicts with: source, status, rows_processed, duration_seconds,
+    timestamp, full_refresh.
+    """
+    project_root = _get_project_root()
+    from dango.utils.sync_history import load_sync_history
+
+    try:
+        if source_name:
+            history = load_sync_history(project_root, source_name, limit)
+            return [{**h, "source": source_name} for h in history]
+
+        from dango.config.helpers import load_config
+
+        config = load_config(project_root)
+        combined: list[dict[str, Any]] = []
+        for source in config.sources.sources:
+            for h in load_sync_history(project_root, source.name, limit):
+                combined.append({**h, "source": source.name})
+        combined.sort(key=lambda h: h.get("timestamp") or "", reverse=True)
+        return combined[:limit]
+    except Exception as e:
+        return [{"error": str(e)}]
+
+
+# ── Setup + status commands ───────────────────────────────────────────────────
+
+
+@click.group("mcp")
+def mcp_group() -> None:
+    """MCP server for AI coding agents (Claude Code, Cursor, Windsurf)."""
+
+
+@mcp_group.command("run")
+@click.pass_context
+def mcp_run(ctx: click.Context) -> None:
+    """Start the MCP stdio server. Called automatically by LLM clients — do not run manually."""
+    # show_banner=False: fastmcp's default banner is harmless to the stdio
+    # protocol (it renders to stderr), but showing it also triggers a
+    # blocking network call to PyPI to check for a newer fastmcp version on
+    # every server start. Dango's MCP server is spawned fresh by the LLM
+    # client on every session — that's an unwanted, un-opt-in-able outbound
+    # call on the local-stdio-only surface this session's egress gate exists
+    # to protect. Suppress it.
+    mcp.run(show_banner=False)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _get_project_root() -> Path:
+    """Get project root for MCP tools. Raises RuntimeError if not in a project."""
+    from dango.config.helpers import find_project_root
+
+    try:
+        return find_project_root()
+    except Exception:
+        raise RuntimeError(
+            "Not inside a Dango project. cd into your project directory first."
+        ) from None
+
+
+def _infer_layer(model_name: str) -> str:
+    if model_name.startswith("stg_"):
+        return "staging"
+    if model_name.startswith("int_"):
+        return "intermediate"
+    if model_name.startswith("fct_") or model_name.startswith("dim_"):
+        return "marts"
+    return "other"
+
+
+def _validate_select_only(sql: str) -> None:
+    """Validate that *sql* is a single SELECT (or WITH ... SELECT) statement.
+
+    Uses sqlglot for AST-level validation when available (mirrors
+    dango/web/routes/query.py's `_validate_sql`), falling back to a keyword +
+    multi-statement heuristic otherwise. Raises ValueError on rejection.
+    """
+    if not sql.strip():
+        raise ValueError("SQL query is empty")
+
+    try:
+        import sqlglot
+        import sqlglot.expressions as exp
+    except ImportError:
+        first_keyword = sql.strip().split()[0].upper()
+        if first_keyword not in ("SELECT", "WITH"):
+            raise ValueError("Only SELECT queries are allowed") from None
+        stripped = sql.strip().rstrip(";").strip()
+        if ";" in stripped:
+            raise ValueError("Multiple SQL statements are not allowed") from None
+        return
+
+    try:
+        statements = [s for s in sqlglot.parse(sql, dialect="duckdb") if s is not None]
+    except Exception as e:
+        raise ValueError(f"Invalid SQL syntax: {e}") from None
+
+    if len(statements) == 0:
+        raise ValueError("Empty SQL statement")
+    if len(statements) > 1:
+        raise ValueError("Multiple SQL statements are not allowed")
+    if not isinstance(statements[0], exp.Select):
+        raise ValueError(f"Only SELECT queries are allowed, got {type(statements[0]).__name__}")
+
+
+def _connect_readonly_with_retry(db_path: Path) -> Any:
+    """Open a read-only DuckDB connection, retrying briefly on IOException.
+
+    DuckDB is single-writer (see VAL-003 finding); a concurrent sync can
+    transiently hold the write lock even though read-only connections are
+    normally allowed alongside a writer. Mirrors the retry in
+    dango/web/routes/query.py's `_execute_query`.
+    """
+    import time
+
+    import duckdb
+
+    last_exc: Exception | None = None
+    for attempt in range(3):
+        try:
+            return duckdb.connect(str(db_path), read_only=True)
+        except duckdb.IOException as e:
+            last_exc = e
+            if attempt < 2:
+                time.sleep(0.1 * (2**attempt))
+    assert last_exc is not None
+    raise last_exc
+
+
+# ── Register subcommands from separate modules ─────────────────────────────────
+# Mirrors the cross-file registration pattern in commands/remote.py: mcp_setup.py
+# imports mcp_group from here and self-registers `setup`/`status` via
+# @mcp_group.command(...) decorators. Split out to keep this file (the read
+# tools + FastMCP server definition) under the 500-line file-size check.
+
+import dango.cli.commands.mcp_setup as _mcp_setup  # noqa: E402, F401

--- a/dango/cli/commands/mcp_server.py
+++ b/dango/cli/commands/mcp_server.py
@@ -9,20 +9,32 @@ their LLM client.
 Session E: read tools + setup
 Session F: mutation tools (add_source, create_model, add_schedule, run_sync, run_transform)
 
-CRITICAL: all Dango imports below are lazy (inside function bodies), never at
-module top level. The MCP server communicates over stdio — any stray stdout
-write (a stray `print()`, an eagerly-imported module that logs to stdout at
-import time, etc.) corrupts the JSON-RPC protocol. Keep it that way.
+CRITICAL: all *dango.* imports that touch real project/database/config state
+are lazy (inside function bodies), never at module top level. The MCP server
+communicates over stdio — any stray stdout write (a stray `print()`, an
+eagerly-imported module that logs to stdout at import time, etc.) corrupts
+the JSON-RPC protocol. Keep it that way. The one exception is the top-level
+`from dango.cli.commands.mcp_helpers import ...` below: mcp_helpers.py itself
+does zero dango.* imports at its own module level (stdlib only; all real
+dango.* work stays lazy inside its function bodies), so importing it eagerly
+here is inert and doesn't reintroduce the risk this rule guards against.
 """
 
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 
 import click
 from fastmcp import FastMCP
+
+from dango.cli.commands.mcp_helpers import (
+    _connect_readonly_with_retry,
+    _execute_query_sync,
+    _get_project_root,
+    _infer_layer,
+    _validate_select_only,
+)
 
 mcp = FastMCP(
     "dango",
@@ -34,12 +46,16 @@ mcp = FastMCP(
     ),
 )
 
+# Matches web/routes/query.py's QueryRequest.sql max_length / _DEFAULT_QUERY_TIMEOUT_SECONDS.
+_MAX_QUERY_SQL_LENGTH = 102_400
+_QUERY_TIMEOUT_SECONDS = 30
+
 
 # ── Read tools ────────────────────────────────────────────────────────────────
 
 
 @mcp.tool()
-def list_sources() -> list[dict[str, Any]]:
+async def list_sources() -> list[dict[str, Any]]:
     """List all configured data sources with their sync status and row counts.
 
     Returns a list of dicts with: name, type, enabled, last_sync, rows, status.
@@ -56,15 +72,16 @@ def list_sources() -> list[dict[str, Any]]:
     # status-aggregation code the web UI uses.
     web_app.state.project_root = project_root
 
-    sources_config = load_sources_config()
+    # This tool is a native async fastmcp tool (not a sync tool relying on
+    # fastmcp's run_in_thread=True default to make asyncio.run() safe) — it
+    # awaits directly on fastmcp's own event loop, same as
+    # web/routes/sources.py does.
+    sources_config = await asyncio.to_thread(load_sources_config)
     if not sources_config:
         return []
 
-    async def _gather() -> list[Any]:
-        tasks = [get_source_status_data(source) for source in sources_config]
-        return await asyncio.gather(*tasks, return_exceptions=True)
-
-    statuses = asyncio.run(_gather())
+    tasks = [get_source_status_data(source) for source in sources_config]
+    statuses = await asyncio.gather(*tasks, return_exceptions=True)
 
     results = []
     for source, status in zip(sources_config, statuses, strict=True):
@@ -129,9 +146,29 @@ def get_table_schema(table_name: str, schema: str | None = None) -> dict[str, An
         if not result:
             return {"error": f"Table '{table_name}' not found in warehouse"}
 
+        other_schemas: list[str] = []
+        if not schema:
+            # A table name can exist in more than one schema (e.g. a generic
+            # name reused across two raw sources). Filter to the first
+            # (alphabetically) schema's columns rather than silently merging
+            # every matching table's columns into one list — that would
+            # report a schema name whose columns don't actually match it.
+            all_schemas = list(dict.fromkeys(r[0] for r in result))
+            detected_schema = all_schemas[0]
+            other_schemas = all_schemas[1:]
+            result = [r for r in result if r[0] == detected_schema]
+        else:
+            detected_schema = schema
+
         columns = [{"name": r[-2], "type": r[-1]} for r in result]
-        detected_schema = result[0][0] if not schema and result else schema
-        return {"table_name": table_name, "schema": detected_schema, "columns": columns}
+        response = {"table_name": table_name, "schema": detected_schema, "columns": columns}
+        if other_schemas:
+            response["other_schemas"] = other_schemas
+            response["note"] = (
+                f"'{table_name}' also exists in {other_schemas}; showing '{detected_schema}'. "
+                "Pass schema= to select a different one."
+            )
+        return response
     except Exception as e:
         return {"error": str(e)}
 
@@ -191,10 +228,17 @@ def get_lineage(model_name: str | None = None) -> dict[str, Any]:
         sources = manifest.get("sources", {})
 
         if model_name:
-            target = next((n for n in nodes.values() if n.get("name") == model_name), None)
-            if not target:
+            # Use the manifest's own dict key as the unique_id rather than
+            # reconstructing "model.{package_name}.{model_name}" by hand —
+            # that reconstruction breaks for versioned dbt models (dbt-core
+            # 1.5+), whose real unique_id has a ".vN" suffix the manual
+            # string wouldn't include, silently making referenced_by empty.
+            target_entry = next(
+                ((k, n) for k, n in nodes.items() if n.get("name") == model_name), None
+            )
+            if not target_entry:
                 return {"error": f"Model '{model_name}' not found in manifest"}
-            target_unique_id = f"model.{target.get('package_name')}.{model_name}"
+            target_unique_id, target = target_entry
             return {
                 "name": model_name,
                 "path": target.get("original_file_path"),
@@ -278,16 +322,22 @@ def get_model_sql(model_name: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-def query(sql: str, row_limit: int = 500) -> dict[str, Any]:
+async def query(sql: str, row_limit: int = 500) -> dict[str, Any]:
     """Run a read-only SQL query against the DuckDB warehouse.
 
     Args:
         sql: SQL query to execute. Must be a single SELECT statement (WITH ... SELECT
-            CTEs are allowed). Multi-statement SQL is rejected.
+            CTEs are allowed). Multi-statement SQL is rejected. Capped at
+            102,400 characters (matches the web query endpoint).
         row_limit: Maximum rows to return (default 500, max 500).
 
-    Returns dict with: columns, rows, row_count, truncated.
+    Returns dict with: columns, rows, row_count, truncated. Queries are killed
+    after 30s (matching the web query endpoint's default) rather than blocking
+    the server indefinitely on an expensive query.
     """
+    if len(sql) > _MAX_QUERY_SQL_LENGTH:
+        return {"error": f"SQL query too long (max {_MAX_QUERY_SQL_LENGTH} characters)"}
+
     try:
         _validate_select_only(sql)
     except ValueError as e:
@@ -300,22 +350,15 @@ def query(sql: str, row_limit: int = 500) -> dict[str, Any]:
     if not db_path.exists():
         return {"error": "No warehouse found. Run dango sync first."}
 
+    import asyncio
+
     try:
-        conn = _connect_readonly_with_retry(db_path)
-        try:
-            rel = conn.execute(sql)
-            columns = [d[0] for d in rel.description]
-            raw_rows = rel.fetchmany(row_limit + 1)
-            truncated = len(raw_rows) > row_limit
-            rows = [list(r) for r in raw_rows[:row_limit]]
-        finally:
-            conn.close()
-        return {
-            "columns": columns,
-            "rows": rows,
-            "row_count": len(rows),
-            "truncated": truncated,
-        }
+        return await asyncio.wait_for(
+            asyncio.to_thread(_execute_query_sync, db_path, sql, row_limit),
+            timeout=_QUERY_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        return {"error": f"Query timed out after {_QUERY_TIMEOUT_SECONDS} seconds"}
     except Exception as e:
         return {"error": str(e)}
 
@@ -373,90 +416,6 @@ def mcp_run(ctx: click.Context) -> None:
     # call on the local-stdio-only surface this session's egress gate exists
     # to protect. Suppress it.
     mcp.run(show_banner=False)
-
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
-
-
-def _get_project_root() -> Path:
-    """Get project root for MCP tools. Raises RuntimeError if not in a project."""
-    from dango.config.helpers import find_project_root
-
-    try:
-        return find_project_root()
-    except Exception:
-        raise RuntimeError(
-            "Not inside a Dango project. cd into your project directory first."
-        ) from None
-
-
-def _infer_layer(model_name: str) -> str:
-    if model_name.startswith("stg_"):
-        return "staging"
-    if model_name.startswith("int_"):
-        return "intermediate"
-    if model_name.startswith("fct_") or model_name.startswith("dim_"):
-        return "marts"
-    return "other"
-
-
-def _validate_select_only(sql: str) -> None:
-    """Validate that *sql* is a single SELECT (or WITH ... SELECT) statement.
-
-    Uses sqlglot for AST-level validation when available (mirrors
-    dango/web/routes/query.py's `_validate_sql`), falling back to a keyword +
-    multi-statement heuristic otherwise. Raises ValueError on rejection.
-    """
-    if not sql.strip():
-        raise ValueError("SQL query is empty")
-
-    try:
-        import sqlglot
-        import sqlglot.expressions as exp
-    except ImportError:
-        first_keyword = sql.strip().split()[0].upper()
-        if first_keyword not in ("SELECT", "WITH"):
-            raise ValueError("Only SELECT queries are allowed") from None
-        stripped = sql.strip().rstrip(";").strip()
-        if ";" in stripped:
-            raise ValueError("Multiple SQL statements are not allowed") from None
-        return
-
-    try:
-        statements = [s for s in sqlglot.parse(sql, dialect="duckdb") if s is not None]
-    except Exception as e:
-        raise ValueError(f"Invalid SQL syntax: {e}") from None
-
-    if len(statements) == 0:
-        raise ValueError("Empty SQL statement")
-    if len(statements) > 1:
-        raise ValueError("Multiple SQL statements are not allowed")
-    if not isinstance(statements[0], exp.Select):
-        raise ValueError(f"Only SELECT queries are allowed, got {type(statements[0]).__name__}")
-
-
-def _connect_readonly_with_retry(db_path: Path) -> Any:
-    """Open a read-only DuckDB connection, retrying briefly on IOException.
-
-    DuckDB is single-writer (see VAL-003 finding); a concurrent sync can
-    transiently hold the write lock even though read-only connections are
-    normally allowed alongside a writer. Mirrors the retry in
-    dango/web/routes/query.py's `_execute_query`.
-    """
-    import time
-
-    import duckdb
-
-    last_exc: Exception | None = None
-    for attempt in range(3):
-        try:
-            return duckdb.connect(str(db_path), read_only=True)
-        except duckdb.IOException as e:
-            last_exc = e
-            if attempt < 2:
-                time.sleep(0.1 * (2**attempt))
-    assert last_exc is not None
-    raise last_exc
 
 
 # ── Register subcommands from separate modules ─────────────────────────────────

--- a/dango/cli/commands/mcp_server.py
+++ b/dango/cli/commands/mcp_server.py
@@ -22,6 +22,7 @@ here is inert and doesn't reintroduce the risk this rule guards against.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -30,8 +31,9 @@ from fastmcp import FastMCP
 
 from dango.cli.commands.mcp_helpers import (
     _connect_readonly_with_retry,
-    _execute_query_sync,
+    _execute_query_on_connection,
     _get_project_root,
+    _get_query_timeout_seconds,
     _infer_layer,
     _validate_select_only,
 )
@@ -46,9 +48,8 @@ mcp = FastMCP(
     ),
 )
 
-# Matches web/routes/query.py's QueryRequest.sql max_length / _DEFAULT_QUERY_TIMEOUT_SECONDS.
+# Matches web/routes/query.py's QueryRequest.sql max_length.
 _MAX_QUERY_SQL_LENGTH = 102_400
-_QUERY_TIMEOUT_SECONDS = 30
 
 
 # ── Read tools ────────────────────────────────────────────────────────────────
@@ -61,8 +62,6 @@ async def list_sources() -> list[dict[str, Any]]:
     Returns a list of dicts with: name, type, enabled, last_sync, rows, status.
     """
     project_root = _get_project_root()
-    import asyncio
-
     from dango.web.app import app as web_app
     from dango.web.helpers import get_source_status_data, load_sources_config
 
@@ -331,9 +330,11 @@ async def query(sql: str, row_limit: int = 500) -> dict[str, Any]:
             102,400 characters (matches the web query endpoint).
         row_limit: Maximum rows to return (default 500, max 500).
 
-    Returns dict with: columns, rows, row_count, truncated. Queries are killed
-    after 30s (matching the web query endpoint's default) rather than blocking
-    the server indefinitely on an expensive query.
+    Returns dict with: columns, rows, row_count, truncated. Times out after the
+    project's configured api.query_timeout_seconds (default 30s, matching the
+    web query endpoint) — the tool call returns an error at that point *and*
+    the in-flight DuckDB query is interrupted, not just abandoned in the
+    background.
     """
     if len(sql) > _MAX_QUERY_SQL_LENGTH:
         return {"error": f"SQL query too long (max {_MAX_QUERY_SQL_LENGTH} characters)"}
@@ -350,17 +351,43 @@ async def query(sql: str, row_limit: int = 500) -> dict[str, Any]:
     if not db_path.exists():
         return {"error": "No warehouse found. Run dango sync first."}
 
-    import asyncio
+    timeout_seconds = _get_query_timeout_seconds(project_root)
 
     try:
-        return await asyncio.wait_for(
-            asyncio.to_thread(_execute_query_sync, db_path, sql, row_limit),
-            timeout=_QUERY_TIMEOUT_SECONDS,
-        )
-    except asyncio.TimeoutError:
-        return {"error": f"Query timed out after {_QUERY_TIMEOUT_SECONDS} seconds"}
+        conn = await asyncio.to_thread(_connect_readonly_with_retry, db_path)
     except Exception as e:
         return {"error": str(e)}
+
+    # asyncio.to_thread cannot forcibly stop a worker thread once it has
+    # started executing — a plain asyncio.wait_for() around it only stops
+    # *waiting*; the query keeps running in the background against the
+    # shared default thread-pool executor. asyncio.shield() keeps a live
+    # handle to that task so that on timeout we can call conn.interrupt()
+    # (DuckDB's own thread-safe query cancellation) and then briefly wait
+    # for the worker to actually unwind before closing the connection out
+    # from under it — closing concurrently with an in-flight query is not a
+    # documented-safe operation, interrupt-then-close is.
+    task = asyncio.create_task(
+        asyncio.to_thread(_execute_query_on_connection, conn, sql, row_limit)
+    )
+    try:
+        return await asyncio.wait_for(asyncio.shield(task), timeout=timeout_seconds)
+    except asyncio.TimeoutError:
+        conn.interrupt()
+        try:
+            await asyncio.wait_for(task, timeout=5)
+        except Exception:
+            pass  # already reporting the timeout below regardless of how the interrupted query unwound
+        return {"error": f"Query timed out after {timeout_seconds} seconds"}
+    except Exception as e:
+        return {"error": str(e)}
+    finally:
+        if task.done():
+            await asyncio.to_thread(conn.close)
+        # else: worker thread never unwound within the grace period above —
+        # extremely rare (interrupt() failing to take effect). Leaking the
+        # connection handle until it eventually finishes and is garbage
+        # collected is safer than closing underneath a still-running thread.
 
 
 @mcp.tool()

--- a/dango/cli/commands/mcp_setup.py
+++ b/dango/cli/commands/mcp_setup.py
@@ -1,0 +1,119 @@
+"""dango/cli/commands/mcp_setup.py
+
+`dango mcp setup` / `dango mcp status` — LLM client config detection and
+writing. Split out of mcp_server.py to keep that file (the FastMCP server
+definition + read tools) under the file-size check; registers its commands
+onto `mcp_group` via decorator side effects on import, mirroring the
+cross-file registration pattern in commands/remote.py + remote_auth.py etc.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from dango.cli import console
+from dango.cli.commands.mcp_server import mcp_group
+
+
+@mcp_group.command("setup")
+@click.pass_context
+def mcp_setup(ctx: click.Context) -> None:
+    """Detect installed LLM clients and configure them to use dango mcp."""
+    import sys
+
+    dango_cmd = sys.executable.replace("/bin/python", "/bin/dango")
+    # Fall back to `dango` on PATH if we can't determine the venv path
+    if not Path(dango_cmd).exists():
+        dango_cmd = "dango"
+
+    config_entry = {"command": dango_cmd, "args": ["mcp", "run"]}
+    configured = []
+
+    # Claude Code: ~/.claude/settings.json
+    claude_settings = Path.home() / ".claude" / "settings.json"
+    if claude_settings.parent.exists():
+        _write_mcp_config(claude_settings, config_entry)
+        configured.append("Claude Code")
+
+    # Cursor: ~/.cursor/mcp.json
+    cursor_config = Path.home() / ".cursor" / "mcp.json"
+    if cursor_config.parent.exists():
+        _write_mcp_config(cursor_config, config_entry)
+        configured.append("Cursor")
+
+    # Windsurf: ~/.codeium/windsurf/mcp_config.json
+    windsurf_config = Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
+    if windsurf_config.parent.exists():
+        _write_mcp_config(windsurf_config, config_entry)
+        configured.append("Windsurf")
+
+    if not configured:
+        console.print("\n[yellow]No LLM clients detected.[/yellow]")
+        console.print("Supported: Claude Code, Cursor, Windsurf")
+        console.print("Install one and run `dango mcp setup` again.\n")
+        return
+
+    console.print()
+    for client in configured:
+        console.print(f"[green]✓[/green] {client} — MCP configured")
+    console.print()
+    console.print("[dim]Restart your LLM client to activate.[/dim]")
+    console.print("[dim]Run `dango mcp status` to verify the connection.[/dim]\n")
+
+
+@mcp_group.command("status")
+@click.pass_context
+def mcp_status(ctx: click.Context) -> None:
+    """Verify MCP configuration is correct for detected LLM clients."""
+    checks = {
+        "Claude Code": Path.home() / ".claude" / "settings.json",
+        "Cursor": Path.home() / ".cursor" / "mcp.json",
+        "Windsurf": Path.home() / ".codeium" / "windsurf" / "mcp_config.json",
+    }
+
+    console.print()
+    found_any = False
+    for client, path in checks.items():
+        if not path.parent.exists():
+            continue
+        found_any = True
+        if not path.exists():
+            console.print(f"[yellow]⚠[/yellow]  {client}: not configured — run `dango mcp setup`")
+            continue
+        try:
+            cfg = json.loads(path.read_text())
+            servers = cfg.get("mcpServers", {})
+            if "dango" in servers:
+                console.print(f"[green]✓[/green] {client}: dango MCP configured")
+            else:
+                console.print(
+                    f"[yellow]⚠[/yellow]  {client}: dango not in mcpServers — run `dango mcp setup`"
+                )
+        except Exception:
+            console.print(f"[red]✗[/red] {client}: config file unreadable")
+
+    if not found_any:
+        console.print("[dim]No LLM clients detected.[/dim]")
+    console.print()
+
+
+def _write_mcp_config(config_path: Path, entry: dict) -> None:
+    """Write the dango MCP entry into an LLM client config file.
+
+    Claude Code, Cursor, and Windsurf all use {"mcpServers": {...}} at the
+    config file's root.
+    """
+    existing: dict = {}
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text())
+        except Exception:
+            pass
+
+    existing.setdefault("mcpServers", {})["dango"] = entry
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(existing, indent=2))

--- a/dango/cli/commands/mcp_setup.py
+++ b/dango/cli/commands/mcp_setup.py
@@ -118,14 +118,17 @@ def _write_mcp_config(config_path: Path, entry: dict) -> None:
     the MCP section.
     """
     import os
+    import stat
     import tempfile
 
     existing: dict = {}
+    original_mode: int | None = None
     if config_path.exists():
         try:
             existing = json.loads(config_path.read_text())
         except Exception:
             pass
+        original_mode = stat.S_IMODE(config_path.stat().st_mode)
 
     existing.setdefault("mcpServers", {})["dango"] = entry
 
@@ -136,6 +139,12 @@ def _write_mcp_config(config_path: Path, entry: dict) -> None:
     try:
         with os.fdopen(fd, "w") as f:
             f.write(json.dumps(existing, indent=2))
+        # tempfile.mkstemp() always creates its file at mode 0600 regardless
+        # of the target's prior permissions. Without this, every `dango mcp
+        # setup` run would silently tighten settings.json from its actual
+        # mode (typically 0644) down to 0600. Preserve the original mode, or
+        # use a normal 0644 default the first time the file is created.
+        os.chmod(tmp_path, original_mode if original_mode is not None else 0o644)
         os.replace(tmp_path, config_path)
     except BaseException:
         Path(tmp_path).unlink(missing_ok=True)

--- a/dango/cli/commands/mcp_setup.py
+++ b/dango/cli/commands/mcp_setup.py
@@ -24,10 +24,15 @@ def mcp_setup(ctx: click.Context) -> None:
     """Detect installed LLM clients and configure them to use dango mcp."""
     import sys
 
-    dango_cmd = sys.executable.replace("/bin/python", "/bin/dango")
-    # Fall back to `dango` on PATH if we can't determine the venv path
-    if not Path(dango_cmd).exists():
-        dango_cmd = "dango"
+    # Console scripts installed by pip always live next to the interpreter
+    # (<venv>/bin/dango on POSIX, <venv>\Scripts\dango.exe on Windows). A
+    # substring replace on sys.executable (e.g. "/bin/python" -> "/bin/dango")
+    # breaks for any interpreter binary named "pythonX.Y" (leaves a trailing
+    # version suffix, e.g. "/bin/dango3.11", which doesn't exist) and is a
+    # complete no-op on Windows (no "/bin/python" substring to replace),
+    # which would write sys.executable itself — python.exe — as the command.
+    venv_dango = Path(sys.executable).parent / ("dango.exe" if sys.platform == "win32" else "dango")
+    dango_cmd = str(venv_dango) if venv_dango.exists() else "dango"
 
     config_entry = {"command": dango_cmd, "args": ["mcp", "run"]}
     configured = []
@@ -105,7 +110,16 @@ def _write_mcp_config(config_path: Path, entry: dict) -> None:
 
     Claude Code, Cursor, and Windsurf all use {"mcpServers": {...}} at the
     config file's root.
+
+    Writes atomically (temp file + os.replace) rather than a direct
+    write_text(): this is the user's real LLM client config file, which may
+    hold unrelated settings. An interrupted direct write (crash, kill,
+    laptop sleep mid-write) would leave it truncated or corrupted, not just
+    the MCP section.
     """
+    import os
+    import tempfile
+
     existing: dict = {}
     if config_path.exists():
         try:
@@ -116,4 +130,13 @@ def _write_mcp_config(config_path: Path, entry: dict) -> None:
     existing.setdefault("mcpServers", {})["dango"] = entry
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(existing, indent=2))
+    fd, tmp_path = tempfile.mkstemp(
+        dir=config_path.parent, prefix=f".{config_path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(existing, indent=2))
+        os.replace(tmp_path, config_path)
+    except BaseException:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -20,6 +20,7 @@ from dango.cli.commands.dev import dev
 from dango.cli.commands.doctor import doctor
 from dango.cli.commands.governance import governance
 from dango.cli.commands.local_backup import backup_group as local_backup_group
+from dango.cli.commands.mcp_server import mcp_group
 from dango.cli.commands.metabase_cmd import metabase
 from dango.cli.commands.migrate import migrate
 from dango.cli.commands.model import model
@@ -115,6 +116,7 @@ cli.add_command(model)
 cli.add_command(seed)
 cli.add_command(dashboard)
 cli.add_command(metabase)
+cli.add_command(mcp_group)
 cli.add_command(migrate)
 cli.add_command(remote)
 cli.add_command(notebook)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ dependencies = [
     "apscheduler>=3.11,<4",   # Job scheduling (AsyncIOScheduler + SQLAlchemy job store)
     "sqlalchemy>=2.0,<3",     # Required by APScheduler SQLAlchemyJobStore
     "croniter>=2.0,<4",       # Cron expression validation and iteration
+
+    # MCP server (local stdio, for LLM coding agents)
+    "fastmcp>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -128,6 +128,29 @@ class TestMcpSetup:
         written = json.loads((home_dir / ".claude" / "settings.json").read_text())
         assert written["mcpServers"]["dango"]["command"] == "dango"
 
+    def test_mcp_setup_preserves_file_permissions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Positive control for the tempfile.mkstemp() permission-downgrade bug:
+        mkstemp() always creates its temp file at mode 0600 regardless of the
+        target's prior mode, so a naive tmp-file+os.replace atomic write would
+        silently tighten settings.json from 0644 to 0600 on every setup run."""
+        import stat
+
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        settings_path.write_text(json.dumps({"theme": "dark"}))
+        settings_path.chmod(0o644)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["setup"])
+
+        assert result.exit_code == 0
+        mode = stat.S_IMODE(settings_path.stat().st_mode)
+        assert mode == 0o644, f"expected settings.json to stay 0644, got {oct(mode)}"
+
 
 @pytest.mark.unit
 class TestMcpStatus:
@@ -211,24 +234,73 @@ class TestQueryTool:
         assert result["truncated"] is True
 
     @pytest.mark.anyio
-    async def test_query_times_out(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """An execution that outruns the timeout returns a clean error instead of hanging."""
+    async def test_query_times_out_and_interrupts_the_connection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An execution that outruns the timeout returns a clean error, AND actually
+        calls conn.interrupt() to cancel the in-flight DuckDB query — positive control
+        for the bug where asyncio.wait_for(asyncio.to_thread(...)) only stopped
+        *waiting*, silently leaving the query running to completion in a background
+        thread against the shared default executor."""
         import time as time_module
+        from unittest.mock import MagicMock
 
-        def _slow_execute(db_path: Path, sql: str, row_limit: int) -> dict:
-            time_module.sleep(0.3)
-            return {"columns": [], "rows": [], "row_count": 0, "truncated": False}
+        import duckdb
 
         data_dir = tmp_path / "data"
         data_dir.mkdir()
-        (data_dir / "warehouse.duckdb").write_bytes(b"")  # only .exists() is checked pre-timeout
+        db_path = data_dir / "warehouse.duckdb"
+        duckdb.connect(str(db_path)).close()  # just needs to exist and be openable
+
+        real_conn = duckdb.connect(str(db_path), read_only=True)
+
+        class _ConnSpy:
+            """duckdb's connection type is a C extension — its attributes can't
+            be monkeypatched directly (they're read-only on the instance), so
+            wrap it to make .interrupt() spyable while still delegating to the
+            real connection."""
+
+            def __init__(self, real: object) -> None:
+                self._real = real
+                self.interrupt = MagicMock(wraps=real.interrupt)
+
+            def close(self) -> None:
+                self._real.close()
+
+        conn_spy = _ConnSpy(real_conn)
+
+        def _slow_execute(conn: object, sql: str, row_limit: int) -> dict:
+            time_module.sleep(0.3)
+            return {"columns": [], "rows": [], "row_count": 0, "truncated": False}
 
         monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
-        monkeypatch.setattr(mcp_server, "_execute_query_sync", _slow_execute)
-        monkeypatch.setattr(mcp_server, "_QUERY_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(mcp_server, "_connect_readonly_with_retry", lambda db_path: conn_spy)
+        monkeypatch.setattr(mcp_server, "_execute_query_on_connection", _slow_execute)
+        monkeypatch.setattr(mcp_server, "_get_query_timeout_seconds", lambda project_root: 0.05)
 
         result = await mcp_server.query("SELECT 1")
+
         assert "timed out" in result["error"]
+        conn_spy.interrupt.assert_called_once()
+
+    def test_query_timeout_honors_project_config(self, tmp_path: Path, sample_config) -> None:
+        """_get_query_timeout_seconds reads api.query_timeout_seconds from project.yml
+        rather than always using the hardcoded 30s default — positive control for the
+        gap where the MCP tool ignored the same per-project setting
+        web/routes/query.py's _get_api_config honors."""
+        from dango.cli.commands.mcp_helpers import _get_query_timeout_seconds
+        from dango.config.helpers import save_config
+
+        sample_config.api.query_timeout_seconds = 120
+        save_config(sample_config, tmp_path)
+
+        assert _get_query_timeout_seconds(tmp_path) == 120
+
+    def test_query_timeout_falls_back_to_default_when_unconfigured(self, tmp_path: Path) -> None:
+        """No project at all -> falls back to the 30s default rather than raising."""
+        from dango.cli.commands.mcp_helpers import _get_query_timeout_seconds
+
+        assert _get_query_timeout_seconds(tmp_path) == 30
 
 
 @pytest.mark.unit

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,255 @@
+"""tests/unit/test_mcp_server.py
+
+Tests for the `dango mcp` command group (dango/cli/commands/mcp_server.py):
+the read-only MCP tool functions and the setup/status CLI subcommands.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands import mcp_server
+from dango.cli.commands.mcp_server import mcp_group
+
+
+@pytest.mark.unit
+class TestMcpGroupRegistration:
+    """CLI wiring smoke tests."""
+
+    def test_mcp_help_shows_subcommands(self) -> None:
+        """``dango mcp --help`` lists run/setup/status."""
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["--help"])
+        assert result.exit_code == 0
+        assert "run" in result.output
+        assert "setup" in result.output
+        assert "status" in result.output
+
+
+@pytest.mark.unit
+class TestMcpSetup:
+    """dango mcp setup — LLM client config detection + writing."""
+
+    def test_mcp_setup_writes_claude_code_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ~/.claude/ exists, setup writes settings.json with dango in mcpServers."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["setup"])
+
+        assert result.exit_code == 0
+        settings_path = claude_dir / "settings.json"
+        assert settings_path.exists()
+        written = json.loads(settings_path.read_text())
+        assert written["mcpServers"]["dango"]["args"] == ["mcp", "run"]
+
+    def test_mcp_setup_preserves_existing_settings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Existing unrelated keys in settings.json are not clobbered."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(json.dumps({"theme": "dark"}))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["setup"])
+
+        assert result.exit_code == 0
+        written = json.loads((claude_dir / "settings.json").read_text())
+        assert written["theme"] == "dark"
+        assert written["mcpServers"]["dango"]["args"] == ["mcp", "run"]
+
+    def test_mcp_setup_no_clients(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No LLM client dirs exist -> helpful message, no error, no files written."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["setup"])
+
+        assert result.exit_code == 0
+        assert "No LLM clients detected" in result.output
+        assert not (tmp_path / ".claude").exists()
+
+
+@pytest.mark.unit
+class TestMcpStatus:
+    """dango mcp status — verification output."""
+
+    def test_mcp_status_no_clients(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["status"])
+
+        assert result.exit_code == 0
+        assert "No LLM clients detected" in result.output
+
+    def test_mcp_status_configured(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"mcpServers": {"dango": {"command": "dango", "args": ["mcp", "run"]}}})
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["status"])
+
+        assert result.exit_code == 0
+        assert "dango MCP configured" in result.output
+
+
+@pytest.mark.unit
+class TestQueryTool:
+    """query() — SELECT-only guard, row-limit cap."""
+
+    def test_query_rejects_non_select(self) -> None:
+        result = mcp_server.query("DELETE FROM foo")
+        assert "error" in result
+        assert "SELECT" in result["error"]
+
+    def test_query_rejects_multi_statement(self) -> None:
+        result = mcp_server.query("SELECT 1; DROP TABLE foo")
+        assert "error" in result
+
+    def test_query_allows_with_cte(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A WITH ... SELECT CTE is a legitimate read-only query, not just bare SELECT."""
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: Path("/nonexistent"))
+        result = mcp_server.query("WITH t AS (SELECT 1 AS x) SELECT * FROM t")
+        # Should get past validation to the "no warehouse found" branch, not a SELECT-only error.
+        assert result.get("error") != "Only SELECT queries are allowed"
+
+    def test_query_row_limit_capped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """row_limit above 500 is capped at 500, even against a table with more rows."""
+        import duckdb
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        db_path = data_dir / "warehouse.duckdb"
+        conn = duckdb.connect(str(db_path))
+        conn.execute("CREATE TABLE t AS SELECT * FROM range(600) AS r(x)")
+        conn.close()
+
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        result = mcp_server.query("SELECT * FROM t", row_limit=10_000)
+
+        assert result["row_count"] == 500
+        assert result["truncated"] is True
+
+
+@pytest.mark.unit
+class TestGetTableSchemaAndModelTools:
+    def test_get_model_sql_missing_manifest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        result = mcp_server.get_model_sql("stg_stripe__customers")
+        assert "error" in result
+        assert "No manifest found" in result["error"]
+
+    def test_list_models_missing_manifest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        result = mcp_server.list_models()
+        assert result == [{"error": "No manifest found. Run dango run first."}]
+
+    def test_get_table_schema_missing_warehouse(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        result = mcp_server.get_table_schema("some_table")
+        assert "error" in result
+        assert "No warehouse found" in result["error"]
+
+
+@pytest.mark.unit
+class TestListSources:
+    def test_list_sources_empty_project(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No sources configured -> returns empty list, no crash."""
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        monkeypatch.setattr("dango.web.helpers.load_sources_config", lambda: [], raising=True)
+        result = mcp_server.list_sources()
+        assert result == []
+
+
+@pytest.mark.unit
+class TestGetSyncHistory:
+    def test_get_sync_history_no_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Not in a Dango project -> RuntimeError propagates (matches every other tool;
+        fastmcp converts this into a tool-call error for the client, not a crash)."""
+
+        def _raise() -> Path:
+            raise RuntimeError("Not inside a Dango project.")
+
+        monkeypatch.setattr(mcp_server, "_get_project_root", _raise)
+        with pytest.raises(RuntimeError, match="Not inside a Dango project"):
+            mcp_server.get_sync_history()
+
+    def test_get_sync_history_single_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        monkeypatch.setattr(
+            "dango.utils.sync_history.load_sync_history",
+            lambda project_root, source_name, limit: [
+                {"timestamp": "2026-01-01T00:00:00Z", "status": "success", "rows_processed": 10}
+            ],
+        )
+        result = mcp_server.get_sync_history(source_name="my_source")
+        assert result == [
+            {
+                "timestamp": "2026-01-01T00:00:00Z",
+                "status": "success",
+                "rows_processed": 10,
+                "source": "my_source",
+            }
+        ]
+
+
+@pytest.mark.unit
+class TestInferLayer:
+    def test_infer_layer_staging(self) -> None:
+        assert mcp_server._infer_layer("stg_stripe__customers") == "staging"
+
+    def test_infer_layer_intermediate(self) -> None:
+        assert mcp_server._infer_layer("int_orders_enriched") == "intermediate"
+
+    def test_infer_layer_marts(self) -> None:
+        assert mcp_server._infer_layer("fct_orders") == "marts"
+        assert mcp_server._infer_layer("dim_customers") == "marts"
+
+    def test_infer_layer_other(self) -> None:
+        assert mcp_server._infer_layer("some_other_model") == "other"
+
+
+@pytest.mark.unit
+class TestValidateSelectOnly:
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            mcp_server._validate_select_only("   ")
+
+    def test_rejects_delete(self) -> None:
+        with pytest.raises(ValueError):
+            mcp_server._validate_select_only("DELETE FROM foo")
+
+    def test_rejects_multi_statement(self) -> None:
+        with pytest.raises(ValueError):
+            mcp_server._validate_select_only("SELECT 1; SELECT 2")
+
+    def test_allows_select(self) -> None:
+        mcp_server._validate_select_only("SELECT * FROM foo")
+
+    def test_allows_with_cte(self) -> None:
+        mcp_server._validate_select_only("WITH t AS (SELECT 1) SELECT * FROM t")

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -79,6 +79,55 @@ class TestMcpSetup:
         assert "No LLM clients detected" in result.output
         assert not (tmp_path / ".claude").exists()
 
+    def test_mcp_setup_resolves_venv_console_script_next_to_interpreter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Positive control for the sys.executable.replace() bug: on a
+        `pythonX.Y`-named interpreter (this repo's own documented venv setup,
+        `python3.11 -m venv venv`), a substring replace of '/bin/python' ->
+        '/bin/dango' leaves a bogus '/bin/dango3.11' path. The console script
+        must be found by looking next to the interpreter instead."""
+        home_dir = tmp_path / "home"
+        (home_dir / ".claude").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        fake_python = venv_bin / "python3.11"
+        fake_python.write_text("")
+        fake_dango = venv_bin / "dango"
+        fake_dango.write_text("")
+        monkeypatch.setattr("sys.executable", str(fake_python))
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["setup"])
+
+        assert result.exit_code == 0
+        written = json.loads((home_dir / ".claude" / "settings.json").read_text())
+        assert written["mcpServers"]["dango"]["command"] == str(fake_dango)
+
+    def test_mcp_setup_falls_back_to_bare_dango_when_no_sibling_script(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No dango console script next to the interpreter -> falls back to bare 'dango'
+        on PATH, rather than writing a nonexistent path into the config."""
+        home_dir = tmp_path / "home"
+        (home_dir / ".claude").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        fake_python = venv_bin / "python3.11"
+        fake_python.write_text("")
+        monkeypatch.setattr("sys.executable", str(fake_python))
+
+        runner = CliRunner()
+        result = runner.invoke(mcp_group, ["setup"])
+
+        assert result.exit_code == 0
+        written = json.loads((home_dir / ".claude" / "settings.json").read_text())
+        assert written["mcpServers"]["dango"]["command"] == "dango"
+
 
 @pytest.mark.unit
 class TestMcpStatus:
@@ -110,25 +159,41 @@ class TestMcpStatus:
 
 @pytest.mark.unit
 class TestQueryTool:
-    """query() — SELECT-only guard, row-limit cap."""
+    """query() — SELECT-only guard, row-limit cap, length cap, timeout. Async tool: see
+    dango/cli/CLAUDE.md's async-tool note — call directly with `await` under anyio."""
 
-    def test_query_rejects_non_select(self) -> None:
-        result = mcp_server.query("DELETE FROM foo")
+    @pytest.mark.anyio
+    async def test_query_rejects_non_select(self) -> None:
+        result = await mcp_server.query("DELETE FROM foo")
         assert "error" in result
         assert "SELECT" in result["error"]
 
-    def test_query_rejects_multi_statement(self) -> None:
-        result = mcp_server.query("SELECT 1; DROP TABLE foo")
+    @pytest.mark.anyio
+    async def test_query_rejects_multi_statement(self) -> None:
+        result = await mcp_server.query("SELECT 1; DROP TABLE foo")
         assert "error" in result
 
-    def test_query_allows_with_cte(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.anyio
+    async def test_query_allows_with_cte(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A WITH ... SELECT CTE is a legitimate read-only query, not just bare SELECT."""
         monkeypatch.setattr(mcp_server, "_get_project_root", lambda: Path("/nonexistent"))
-        result = mcp_server.query("WITH t AS (SELECT 1 AS x) SELECT * FROM t")
+        result = await mcp_server.query("WITH t AS (SELECT 1 AS x) SELECT * FROM t")
         # Should get past validation to the "no warehouse found" branch, not a SELECT-only error.
         assert result.get("error") != "Only SELECT queries are allowed"
 
-    def test_query_row_limit_capped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.anyio
+    async def test_query_rejects_oversized_sql(self) -> None:
+        """SQL longer than the 102,400-char cap (matches web/routes/query.py) is rejected
+        before ever touching the project root or the warehouse."""
+        oversized = "SELECT " + "1, " * 60_000 + "1"
+        assert len(oversized) > mcp_server._MAX_QUERY_SQL_LENGTH
+        result = await mcp_server.query(oversized)
+        assert "too long" in result["error"]
+
+    @pytest.mark.anyio
+    async def test_query_row_limit_capped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """row_limit above 500 is capped at 500, even against a table with more rows."""
         import duckdb
 
@@ -140,10 +205,30 @@ class TestQueryTool:
         conn.close()
 
         monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
-        result = mcp_server.query("SELECT * FROM t", row_limit=10_000)
+        result = await mcp_server.query("SELECT * FROM t", row_limit=10_000)
 
         assert result["row_count"] == 500
         assert result["truncated"] is True
+
+    @pytest.mark.anyio
+    async def test_query_times_out(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An execution that outruns the timeout returns a clean error instead of hanging."""
+        import time as time_module
+
+        def _slow_execute(db_path: Path, sql: str, row_limit: int) -> dict:
+            time_module.sleep(0.3)
+            return {"columns": [], "rows": [], "row_count": 0, "truncated": False}
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "warehouse.duckdb").write_bytes(b"")  # only .exists() is checked pre-timeout
+
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        monkeypatch.setattr(mcp_server, "_execute_query_sync", _slow_execute)
+        monkeypatch.setattr(mcp_server, "_QUERY_TIMEOUT_SECONDS", 0.05)
+
+        result = await mcp_server.query("SELECT 1")
+        assert "timed out" in result["error"]
 
 
 @pytest.mark.unit
@@ -171,16 +256,79 @@ class TestGetTableSchemaAndModelTools:
         assert "error" in result
         assert "No warehouse found" in result["error"]
 
+    def test_get_table_schema_ambiguous_name_filters_to_one_schema(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A table name that exists in two schemas must not have its columns merged:
+        positive control for the bug where every matching table's columns were
+        concatenated into one list under a single (misleading) schema name."""
+        import duckdb
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        db_path = data_dir / "warehouse.duckdb"
+        conn = duckdb.connect(str(db_path))
+        conn.execute("CREATE SCHEMA raw_a")
+        conn.execute("CREATE SCHEMA raw_b")
+        conn.execute("CREATE TABLE raw_a.events (a_only_col INTEGER)")
+        conn.execute("CREATE TABLE raw_b.events (b_only_col INTEGER, another_b_col INTEGER)")
+        conn.close()
+
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        result = mcp_server.get_table_schema("events")
+
+        assert result["schema"] == "raw_a"
+        assert [c["name"] for c in result["columns"]] == ["a_only_col"]
+        assert result["other_schemas"] == ["raw_b"]
+
+
+@pytest.mark.unit
+class TestGetLineage:
+    def test_referenced_by_resolves_for_versioned_model(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Positive control for the manual unique_id reconstruction bug: dbt's versioned
+        models (dbt-core 1.5+) have a real unique_id like 'model.pkg.orders.v2', which
+        f"model.{package_name}.{model_name}" doesn't produce — that silently made
+        referenced_by empty even when a real dependent exists."""
+        manifest = {
+            "nodes": {
+                "model.pkg.orders.v2": {
+                    "name": "orders",
+                    "package_name": "pkg",
+                    "resource_type": "model",
+                    "original_file_path": "models/marts/orders.sql",
+                    "depends_on": {"nodes": []},
+                },
+                "model.pkg.fct_order_summary": {
+                    "name": "fct_order_summary",
+                    "package_name": "pkg",
+                    "resource_type": "model",
+                    "depends_on": {"nodes": ["model.pkg.orders.v2"]},
+                },
+            },
+            "sources": {},
+        }
+        dbt_dir = tmp_path / "dbt" / "target"
+        dbt_dir.mkdir(parents=True)
+        (dbt_dir / "manifest.json").write_text(json.dumps(manifest))
+
+        monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
+        result = mcp_server.get_lineage(model_name="orders")
+
+        assert result["referenced_by"] == ["model.pkg.fct_order_summary"]
+
 
 @pytest.mark.unit
 class TestListSources:
-    def test_list_sources_empty_project(
+    @pytest.mark.anyio
+    async def test_list_sources_empty_project(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """No sources configured -> returns empty list, no crash."""
         monkeypatch.setattr(mcp_server, "_get_project_root", lambda: tmp_path)
         monkeypatch.setattr("dango.web.helpers.load_sources_config", lambda: [], raising=True)
-        result = mcp_server.list_sources()
+        result = await mcp_server.list_sources()
         assert result == []
 
 


### PR DESCRIPTION
## Summary
- Add `dango mcp` command group: `run` / `setup` / `status`
- MCP server (fastmcp, local stdio only) exposes 8 read tools: `list_sources`,
  `get_table_schema`, `get_catalog`, `get_lineage`, `list_models`, `get_model_sql`,
  `query`, `get_sync_history`
- `dango mcp setup` auto-configures Claude Code, Cursor, Windsurf
- `dango mcp status` verifies configuration
- All Dango imports lazy inside tool functions (no stdout pollution — the server
  communicates over stdio, so any stray stdout write corrupts the JSON-RPC protocol)

## Deviations from the session spec, found via grep before implementing
Per the task's own instruction to verify pseudocode against the live code (this
project has a documented history of task files with wrong method/function names),
I found and fixed 4 real bugs beyond the phantom import already removed pre-dispatch:

1. **`get_sync_history`** called a nonexistent
   `dango.utils.sync_history.get_recent_history`. Rewritten against the real
   `load_sync_history(project_root, source_name, limit)`; aggregates across all
   configured sources when `source_name` is omitted (no native "all sources" mode
   exists in the underlying function).
2. **`list_sources`** called `get_source_status_data(source.name, project_root=...)`.
   That function actually takes a source **dict** (not a name string), has **no
   `project_root` kwarg**, and returns a pydantic `SourceStatus` object (not a
   dict). Worse: it — and everything else in `web/helpers.py` — resolves the
   project root via `dango.web.app.app.state.project_root`, which is only
   populated by FastAPI's `lifespan()` when the real web server boots. A
   standalone MCP process never boots that app, so this would raise `RuntimeError`
   on every call, silently degrading to `status: "unknown"` for every source
   (swallowed by the original pseudocode's bare `except Exception`). Fixed by
   using `load_sources_config()` (dict-based, matches the real
   `web/routes/sources.py` call site) and setting `app.state.project_root`
   before calling — confirmed safe re: stdout (only `lifespan()` prints, never
   `create_app()`/import time).
3. **`query()`'s SELECT-only check** was a bare `startswith("SELECT")`, which
   rejects legitimate `WITH ... SELECT` CTEs and doesn't block multi-statement
   injection (`SELECT 1; DROP TABLE x`). Replaced with the same sqlglot-AST
   validation (falling back to a keyword + multi-statement check when sqlglot
   is unavailable) that `web/routes/query.py`'s `_validate_sql` already uses.
4. **Read-only DuckDB connections aren't unconditionally safe** against a
   concurrent writer, contra the spec's regression-risk note. Added the same
   retry-on-`IOException` (3x, exponential backoff) that
   `web/routes/query.py`'s `_execute_query` already uses, to `query()`,
   `get_table_schema()`, and `get_catalog()`.

Also: `mcp.run(show_banner=False)` — fastmcp's default banner triggers a
blocking network call to `https://pypi.org/pypi/fastmcp/json` on every server
start (to check for a newer fastmcp version). That's an unwanted, un-opt-in-able
outbound call on the local-stdio-only surface this session's egress dependency
gate (Session B) exists to protect, firing on every LLM-client-spawned session.
Disabled it; confirmed via the full test suite (including
`tests/unit/test_egress_allowlist.py`) that no new undisclosed host is contacted.

## Independent review round (code-review skill, high effort, run against the
## live PR diff on GitHub)
10 findings came back. Each was evaluated individually rather than applied
wholesale:

**Fixed (6):**
1. `mcp_setup.py`: `sys.executable.replace("/bin/python", "/bin/dango")` broke
   on this repo's own documented `python3.11 -m venv venv` setup (leaves a
   trailing "3.11" on the guessed path, e.g. `.../bin/dango3.11`, which doesn't
   exist) and was a complete no-op on Windows (no `/bin/python` substring to
   replace, so it would write `python.exe` itself as the command — broken with
   no fallback triggered). Replaced with `Path(sys.executable).parent /
   "dango"` — console scripts always live next to the interpreter — falling
   back to bare `"dango"` on PATH only when no sibling script exists.
2. `get_table_schema()`: omitting `schema` on a table name that exists in more
   than one schema (e.g. a generic name reused across two raw sources)
   silently merged every matching table's columns into one list under a
   single misleading schema name. Now filters to the first (alphabetical)
   schema's columns only, and surfaces the ambiguity via an `other_schemas`
   list + `note` field rather than hiding it.
3. `query()` had no execution timeout, unlike `web/routes/query.py`'s
   `asyncio.wait_for(timeout=query_timeout)`. Turned out cheap to fix once
   the DB-execution logic was already being extracted for the length-cap fix
   below: `query()` is now `async def`, wrapping
   `asyncio.to_thread(_execute_query_sync, ...)` in `asyncio.wait_for(...,
   timeout=30)` (matching the web endpoint's default), returning a clean
   error instead of hanging the server on an expensive query.
4. `_write_mcp_config()` did a direct `write_text()` onto the user's real LLM
   client config file (`~/.claude/settings.json` etc.) with no atomicity — an
   interrupted write (crash, kill, laptop sleep) could corrupt the file
   beyond just the MCP section, including unrelated settings. Now writes to a
   temp file in the same directory and `os.replace()`s it in.
5. `get_lineage()` manually reconstructed a model's `unique_id` as
   `f"model.{package_name}.{model_name}"`, which breaks for dbt's versioned
   models (dbt-core 1.5+, and this repo pins 1.10/1.11) — the real
   `unique_id` has a `.vN` suffix the reconstruction omits, silently making
   `referenced_by` empty even when a real dependent exists. Now uses the
   manifest's own dict key directly.
6. `list_sources()` was a sync tool calling `asyncio.run()` internally, which
   only avoided "cannot be called from a running event loop" because
   fastmcp's default dispatches sync tools to a worker thread
   (`run_in_thread=True`) — an undocumented dependency that would silently
   break if that default ever changed. Converted to a native `async def`
   tool that awaits directly on fastmcp's own event loop.

   Also added: a length cap on `query()`'s `sql` parameter (102,400 chars,
   matching `web/routes/query.py`'s `QueryRequest.sql` field limit) — no prior
   upfront rejection of an oversized string before it reached sqlglot/DuckDB.

   Fixing #3 and #6 together made `mcp_server.py` async-heavier and pushed it
   back over the 500-line file-size check (518 lines). Did a second real
   split: extracted the plain-function helpers (`_get_project_root`,
   `_validate_select_only`, `_connect_readonly_with_retry`,
   `_execute_query_sync`, `_infer_layer`) into a new
   `dango/cli/commands/mcp_helpers.py`. This is a *different* kind of split
   from `mcp_setup.py` — no Click decorators involved, just a normal helper
   extraction imported at the top of `mcp_server.py` (that one eager import is
   safe: `mcp_helpers.py` itself does zero `dango.*` imports at its own module
   level — all real work stays lazy inside its function bodies). Final sizes:
   `mcp_server.py` 428 lines, `mcp_setup.py` 142, `mcp_helpers.py` 119.

**Accepted trade-off, not fixed (1):**
- No audit logging on `query()`, unlike `web/routes/query.py`'s
  `log_auth_event(AuditEvent.QUERY_EXECUTED, ...)` after every execution. The
  MCP server has no authenticated-user concept to log against — it's a single
  local operator's own coding agent, not a multi-tenant web app with a `User`
  to attribute the read to. `log_auth_event`'s shape (user_id, email, ip)
  doesn't map cleanly onto that. Left as-is; flagging here rather than
  silently dropping the finding.

**Rejected, not bugs (2):**
- Raw `str(e)` in every tool's error return "violates" STANDARDS.md's
  `HTTPException(detail=str(e))` prohibition. Disagreed: that rule targets
  HTTP APIs exposed to less-trusted callers. An MCP tool returning the real
  error text to the calling agent is the standard, useful pattern here — the
  agent needs the actual DuckDB/validation error to self-correct — and every
  one of the 8 tools does this uniformly, matching the spec's own pseudocode
  throughout. Different threat model, not a violation.
- `row_limit` hardcoded at 500 instead of honoring `config.api.query_max_rows`.
  This is explicitly spec-mandated (task's "Critical code patterns — do NOT
  violate": *"query() row_limit capped at 500 — do not allow unlimited
  queries"*, and it's a required acceptance-criteria test), not an oversight.

6 new regression tests added for the fixes above, including positive controls
for the two highest-severity bugs (`get_table_schema`'s column merge — two
same-named tables in different schemas — and `sys.executable`'s broken
venv-path guess — a real `pythonX.Y`-named fake interpreter with a sibling
console script) rather than just re-reading the fixed source.

## File split (not in the original single-file plan)
`mcp_server.py` hit the repo's 500-line pre-commit file-size check twice —
once at 560 lines from the initial bug fixes, again at 518 lines from the
review-round fixes above. Final structure:
- `dango/cli/commands/mcp_server.py` (428 lines) — FastMCP instance, all 8
  read tools, `mcp_group` + `run` subcommand.
- `dango/cli/commands/mcp_setup.py` (142 lines) — `setup`/`status`
  subcommands + `_write_mcp_config`, self-registering onto `mcp_group` via
  `@mcp_group.command()`, triggered by a bottom-of-file import in
  `mcp_server.py` — mirrors the existing cross-file registration pattern in
  `commands/remote.py` + `remote_auth.py`/`remote_mgmt.py`/etc.
- `dango/cli/commands/mcp_helpers.py` (119 lines) — plain-function helpers
  used by the read tools (no Click decorators, a plain import not a
  registration-triggering one).

No behavior or CLI-surface change from any of this; `main.py` still only
imports `mcp_group`.

## Verification
- `pytest -x` (foreground, before and after each review round, and again
  after rebasing onto `v1.0.8` post-Session-D-merge): last run **4339
  passed, 30 skipped, 0 failed**
- `ruff check dango/` / `ruff format --check dango/`: clean
- `mypy dango/cli/commands/mcp_server.py dango/cli/commands/mcp_setup.py
  dango/cli/commands/mcp_helpers.py dango/cli/main.py`: no issues
- `dango mcp --help` shows `run` / `setup` / `status`
- `dango mcp setup` / `dango mcp status` — ran twice with an isolated `HOME=`
  override (never touched this session's real `~/.claude/settings.json`);
  confirmed the fixed venv-path resolution writes the actual console script
  path (`.../venv/bin/dango`), not a broken guess
- Real subprocess stdio smoke test, run both before and after the
  review-round fixes: spawned `dango mcp run` as an actual child process and
  connected with `fastmcp.Client` over real stdio transport — `list_tools()`
  returns all 8 tools, and `list_sources()`/`query(...)` (now `async def`
  tools) execute correctly through the real JSON-RPC protocol, confirming no
  stdout corruption and no regression from the sync-to-async conversion

## Second independent review round (scoped narrowly to this session's own
## fix-commit diff — not re-auditing the original 8 tools' business logic
## already covered in the first round)
6 findings, each verified empirically (not just re-read) before deciding:

**Fixed (4):**
1. `query()`'s timeout via `asyncio.wait_for(asyncio.to_thread(...))` never
   actually cancelled the running query. Verified empirically (a standalone
   repro script) that the worker thread keeps executing to completion in the
   background after the tool call has already returned a timeout error to
   the caller, holding a slot in the shared default thread-pool executor the
   whole time — directly contradicting the previous round's docstring claim
   that queries are "killed" after the timeout. `query()` now creates its
   own connection, keeps an `asyncio.shield()`-protected handle to the
   execution task, and calls `conn.interrupt()` (DuckDB's own thread-safe
   query cancellation — confirmed present via `hasattr`/live call on duckdb
   1.5.4) when the timeout fires, then waits briefly for the worker to
   actually unwind before closing the connection, rather than closing
   underneath a still-running thread.
2. `_write_mcp_config`'s atomic write (added last round) silently downgrades
   the LLM client config file's permissions to 0600 on every `dango mcp
   setup` run. Verified empirically: `tempfile.mkstemp()` always creates its
   temp file at mode 0600 regardless of the target's prior mode — a
   pre-existing 0644 `settings.json` became 0600 after `os.replace()`. Now
   preserves the original file's mode (or defaults to 0644 for a new file).
3. `_QUERY_TIMEOUT_SECONDS` was hardcoded at 30, but the web query endpoint
   it claimed to match reads a per-project configurable
   `config.api.query_timeout_seconds`. Added `_get_query_timeout_seconds()`
   so the MCP tool honors the same setting a user may have customized, not
   just the same default value.
4. Duplicate `import asyncio` inside two function bodies instead of one
   module-level import — `asyncio` is stdlib and never touched the "lazy
   `dango.*` imports only" rule the duplication seemed to be guarding
   against. Consolidated to a top-level import.

**Resolved as a side effect of fix 1 (not a separate change):** the review
also flagged that `_execute_query_on_connection`'s internal call to
`_connect_readonly_with_retry` (both defined in `mcp_helpers.py`) was only
patchable via `mcp_helpers.X` in a test, not the `mcp_server.X` names every
other helper uses — verified empirically that
`monkeypatch.setattr(mcp_server, "_connect_readonly_with_retry", fake)` had
zero effect on `query()`'s actual DB connection. Restructuring `query()` to
own the connection lifecycle itself (fix 1) means
`_execute_query_on_connection` no longer calls `_connect_readonly_with_retry`
at all, so this inconsistency no longer exists on the `query()` path.
Documented the general pattern in `mcp_helpers.py`'s module docstring so a
future helper doesn't reintroduce it.

**Reported, not fixed (1):** `_write_mcp_config`'s mkstemp+os.replace atomic
write duplicates an existing, near-identical implementation in
`dango/governance/pii_overrides.py::_save_overrides` (same pattern, same
latent 0600-permission bug, unfixed there). Extracting a shared helper would
mean touching an unrelated module this PR doesn't otherwise change —
flagging as a follow-up candidate rather than doing that refactor here.

4 new regression tests, including positive controls for both fixed bugs: a
connection-wrapper spy proving `conn.interrupt()` is actually called on
timeout (duckdb's connection type doesn't allow monkeypatching individual
methods directly, since it's a C extension type), and a test proving
`settings.json`'s file mode survives a `dango mcp setup` run unchanged.

## Regression check
- `query()` confirmed SELECT-only (including CTE + multi-statement +
  oversized-SQL cases, unit tested), with a configurable execution timeout
  that now actually interrupts the in-flight query
- DuckDB connections confirmed `read_only=True` with retry-on-lock
- No stdout output before/during `mcp.run()` confirmed via real subprocess
  test, re-run after each round of fixes
- Session D (`feat/108-telemetry-unified`) merged into `v1.0.8` (PR #442)
  partway through this session. Fetched `v1.0.8`, confirmed the only overlap
  was `main.py` (each side adds one non-overlapping import + one
  `cli.add_command(...)` line, as the task spec predicted), and rebased
  cleanly — `git rebase origin/v1.0.8` completed with no conflicts. Re-ran
  the full verification suite (ruff/mypy/`pytest -x` foreground: 4339
  passed, 0 failed) and the real subprocess stdio smoke test after the
  rebase before force-pushing.

## Not merged
Per workflow: this PR is left for the coordinating chat to review and merge.

