### PR TITLE
1.0.8-R: Consolidate dbt telemetry into config.yml

### DIFF
--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -172,10 +172,18 @@ def _set_dbt_telemetry(enabled: bool) -> None:
     Machine-level (~/.dango/), matching Dango's own telemetry identity scope
     (see dango/telemetry.py) — one opt-out covers every project on the
     machine. Read by _dbt_telemetry_env() in transformation/__init__.py.
+
+    Raises:
+        click.ClickException: If the write fails (e.g. permission denied,
+            disk full) — converted from `_write_global_config_key()`'s
+            False return so `--all` can skip this provider and continue,
+            matching the error-handling contract `set_metabase_telemetry()`
+            uses.
     """
     from dango.telemetry import _write_global_config_key
 
-    _write_global_config_key("dbt_telemetry", enabled)
+    if not _write_global_config_key("dbt_telemetry", enabled):
+        raise click.ClickException("Could not write ~/.dango/config.yml")
 
 
 def _set_dlt_telemetry(enabled: bool, project_root: Path | None) -> None:

--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -2,8 +2,9 @@
 
 Unified telemetry control for Dango, dbt, dlt, and Metabase — a single
 command surface that writes through to each provider's own real config
-mechanism (Dango's ~/.dango/telemetry.json, a dbt subprocess env sentinel,
-dlt's .dlt/config.toml, and Metabase's admin Setting API). This controls
+mechanism (Dango's ~/.dango/telemetry.json, dbt's dbt_telemetry key in
+~/.dango/config.yml, dlt's .dlt/config.toml, and Metabase's admin Setting
+API). This controls
 telemetry for the components Dango configures; it does not claim anything
 about network traffic outside those four providers.
 """
@@ -166,28 +167,15 @@ def _set_provider(provider: str, enabled: bool, project_root: Path | None) -> No
 
 
 def _set_dbt_telemetry(enabled: bool) -> None:
-    """Write the dbt telemetry sentinel file, read by `_dbt_telemetry_env()`
-    in transformation/__init__.py to decide whether to inject
-    DBT_SEND_ANONYMOUS_USAGE_STATS=false into the dbt subprocess env.
+    """Write dbt's opt-out state to ~/.dango/config.yml under the dbt_telemetry key.
 
     Machine-level (~/.dango/), matching Dango's own telemetry identity scope
     (see dango/telemetry.py) — one opt-out covers every project on the
-    machine.
-
-    Raises:
-        click.ClickException: If the sentinel file can't be written (e.g.
-            ~/.dango is read-only or otherwise inaccessible) — converted
-            from a raw OSError so `--all` can skip this provider and
-            continue with the rest instead of crashing the whole command,
-            matching the error-handling contract set_metabase_telemetry()
-            uses for every one of its own failure modes.
+    machine. Read by _dbt_telemetry_env() in transformation/__init__.py.
     """
-    sentinel = Path.home() / ".dango" / "dbt_telemetry"
-    try:
-        sentinel.parent.mkdir(parents=True, exist_ok=True)
-        sentinel.write_text("true" if enabled else "false")
-    except OSError as e:
-        raise click.ClickException(f"Could not write dbt telemetry sentinel: {e}") from e
+    from dango.telemetry import _write_global_config_key
+
+    _write_global_config_key("dbt_telemetry", enabled)
 
 
 def _set_dlt_telemetry(enabled: bool, project_root: Path | None) -> None:
@@ -242,11 +230,11 @@ def _set_metabase_telemetry(enabled: bool, project_root: Path | None) -> None:
 
 
 def _get_dbt_telemetry_state() -> bool:
-    """Return dbt's current opt-in state per the sentinel file (default: on)."""
-    sentinel = Path.home() / ".dango" / "dbt_telemetry"
-    if sentinel.exists():
-        return sentinel.read_text().strip() == "true"
-    return True  # default on
+    """Return dbt's current opt-in state per ~/.dango/config.yml (default: on)."""
+    from dango.telemetry import _read_global_config
+
+    data = _read_global_config()
+    return bool(data.get("dbt_telemetry", True))
 
 
 def _get_dlt_telemetry_state(project_root: Path | None) -> bool:

--- a/dango/telemetry.py
+++ b/dango/telemetry.py
@@ -137,12 +137,20 @@ def _read_global_config() -> dict[str, Any]:
         return {}
 
 
-def _write_global_config_key(key: str, value: Any) -> None:
+def _write_global_config_key(key: str, value: Any) -> bool:
     """Set a single key in ~/.dango/config.yml, preserving every other key.
 
-    Best-effort, matching this module's existing telemetry-write conventions
-    (set_telemetry_enabled) — never raises; a failure to persist just means
-    the setting doesn't stick and can be retried.
+    Never raises — matching this module's existing telemetry-write
+    conventions (set_telemetry_enabled). Instead, returns whether the write
+    succeeded so callers that need an honest failure signal (e.g.
+    `_set_dbt_telemetry()`, which converts a False return into a
+    click.ClickException so `--all` can skip and continue) can act on it,
+    while a caller with a genuinely best-effort contract can ignore the
+    return value.
+
+    Returns:
+        True if the key was written to disk, False if the write failed for
+        any reason (the setting doesn't stick and can be retried).
     """
     try:
         _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
@@ -152,8 +160,9 @@ def _write_global_config_key(key: str, value: Any) -> None:
         data[key] = value
         with open(_GLOBAL_CONFIG_FILE, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        return True
     except Exception:
-        pass
+        return False
 
 
 def has_recorded_consent() -> bool:

--- a/dango/telemetry.py
+++ b/dango/telemetry.py
@@ -124,6 +124,38 @@ def is_telemetry_enabled() -> bool:
     return True
 
 
+def _read_global_config() -> dict[str, Any]:
+    """Read ~/.dango/config.yml, returning {} if absent, unreadable, or malformed."""
+    if not _GLOBAL_CONFIG_FILE.is_file():
+        return {}
+    try:
+        import yaml
+
+        with open(_GLOBAL_CONFIG_FILE) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _write_global_config_key(key: str, value: Any) -> None:
+    """Set a single key in ~/.dango/config.yml, preserving every other key.
+
+    Best-effort, matching this module's existing telemetry-write conventions
+    (set_telemetry_enabled) — never raises; a failure to persist just means
+    the setting doesn't stick and can be retried.
+    """
+    try:
+        _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        import yaml
+
+        data = _read_global_config()
+        data[key] = value
+        with open(_GLOBAL_CONFIG_FILE, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+    except Exception:
+        pass
+
+
 def has_recorded_consent() -> bool:
     """Check whether the user has already answered the telemetry prompt.
 

--- a/dango/transformation/__init__.py
+++ b/dango/transformation/__init__.py
@@ -20,8 +20,8 @@ def _dbt_telemetry_env() -> dict[str, str]:
     """Return an env dict for the dbt subprocess, with telemetry disabled if opted out.
 
     Always a complete copy of os.environ ({**os.environ}) — never mutates
-    os.environ in place. The opt-out state comes from the sentinel file
-    dango/cli/commands/telemetry.py writes (~/.dango/dbt_telemetry),
+    os.environ in place. The opt-out state comes from the dbt_telemetry key
+    in ~/.dango/config.yml, written by dango/cli/commands/telemetry.py,
     machine-level like Dango's own telemetry identity. DBT_SEND_ANONYMOUS_USAGE_STATS
     is dbt-core's actual documented env var (dbt/cli/params.py); DO_NOT_TRACK
     is set alongside it as defense in depth, matching the community
@@ -29,9 +29,11 @@ def _dbt_telemetry_env() -> dict[str, str]:
     """
     import os
 
+    from dango.telemetry import _read_global_config
+
     env = {**os.environ}
-    sentinel = Path.home() / ".dango" / "dbt_telemetry"
-    if sentinel.exists() and sentinel.read_text().strip() == "false":
+    data = _read_global_config()
+    if data.get("dbt_telemetry", True) is False:
         env["DBT_SEND_ANONYMOUS_USAGE_STATS"] = "false"
         env["DO_NOT_TRACK"] = "1"
     return env

--- a/tests/unit/test_telemetry_unified.py
+++ b/tests/unit/test_telemetry_unified.py
@@ -40,13 +40,13 @@ class TestDbtTelemetryEnv:
     """_dbt_telemetry_env() — the helper wired into all three dbt subprocess.run calls."""
 
     def test_dbt_env_includes_opt_out(self, tmp_path: Path) -> None:
-        """When the sentinel file says 'false', the env carries the real
-        dbt-core opt-out var (DBT_SEND_ANONYMOUS_USAGE_STATS — verified
+        """When config.yml's dbt_telemetry key is False, the env carries the
+        real dbt-core opt-out var (DBT_SEND_ANONYMOUS_USAGE_STATS — verified
         against installed dbt-core in test_egress_allowlist.py) plus
         DO_NOT_TRACK as defense in depth."""
-        sentinel = tmp_path / ".dango" / "dbt_telemetry"
-        sentinel.parent.mkdir(parents=True)
-        sentinel.write_text("false")
+        from dango.telemetry import _write_global_config_key
+
+        _write_global_config_key("dbt_telemetry", False)
 
         env = _dbt_telemetry_env()
 
@@ -54,8 +54,8 @@ class TestDbtTelemetryEnv:
         assert env["DO_NOT_TRACK"] == "1"
 
     def test_dbt_env_default_clean(self, tmp_path: Path) -> None:
-        """When no sentinel file exists, the env is an unmodified copy of
-        os.environ — no telemetry opt-out vars injected."""
+        """When config.yml has no dbt_telemetry key, the env is an
+        unmodified copy of os.environ — no telemetry opt-out vars injected."""
         env = _dbt_telemetry_env()
 
         assert "DBT_SEND_ANONYMOUS_USAGE_STATS" not in env
@@ -65,9 +65,9 @@ class TestDbtTelemetryEnv:
         """Regression risk from the task spec: never mutate os.environ in place."""
         import os
 
-        sentinel = tmp_path / ".dango" / "dbt_telemetry"
-        sentinel.parent.mkdir(parents=True)
-        sentinel.write_text("false")
+        from dango.telemetry import _write_global_config_key
+
+        _write_global_config_key("dbt_telemetry", False)
 
         env = _dbt_telemetry_env()
 
@@ -149,26 +149,63 @@ class TestDltWriteThrough:
 
 
 @pytest.mark.unit
-class TestDbtSentinelErrorHandling:
-    """Review fix #1: _set_dbt_telemetry() must convert a raw OSError into
-    click.ClickException, matching the contract every other provider's
-    write-through follows — otherwise `dango telemetry off --all` crashes
-    outright instead of skipping dbt and continuing with the rest."""
+class TestDbtTelemetryConfigWriteThrough:
+    """1.0.8-R: _set_dbt_telemetry()/_get_dbt_telemetry_state() now write
+    through to the dbt_telemetry key in ~/.dango/config.yml via the shared
+    _write_global_config_key()/_read_global_config() helpers, replacing the
+    old bespoke ~/.dango/dbt_telemetry sentinel file. This intentionally
+    changes the error-handling contract superseded here: dbt's write-through
+    is now best-effort and never raises, matching dango's own
+    set_telemetry_enabled() (both share _write_global_config_key()) rather
+    than the raise-on-OSError contract dlt/metabase still use — a write
+    failure just means the setting doesn't stick, same as it already works
+    for the dango provider today."""
 
-    def test_write_failure_raises_click_exception_not_oserror(
+    def test_set_dbt_telemetry_writes_config_yml_key(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_dbt_telemetry_state, _set_dbt_telemetry
+
+        _set_dbt_telemetry(False)
+
+        config_path = tmp_path / ".dango" / "config.yml"
+        assert config_path.exists()
+        assert "dbt_telemetry: false" in config_path.read_text()
+        assert _get_dbt_telemetry_state() is False
+
+    def test_get_dbt_telemetry_state_defaults_on(self, tmp_path: Path) -> None:
+        from dango.cli.commands.telemetry import _get_dbt_telemetry_state
+
+        assert _get_dbt_telemetry_state() is True
+
+    def test_write_failure_is_silent_not_raised(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        import click
-
+        """Matching the best-effort contract of _write_global_config_key()
+        (and dango's own set_telemetry_enabled()): a write failure (e.g.
+        permission denied) never raises, it just means the setting doesn't
+        stick and can be retried."""
         from dango.cli.commands.telemetry import _set_dbt_telemetry
 
-        def _raise_oserror(self: Path, *args: object, **kwargs: object) -> None:
+        def _raise_oserror(*args: object, **kwargs: object) -> None:
             raise OSError("permission denied")
 
-        monkeypatch.setattr(Path, "write_text", _raise_oserror)
+        monkeypatch.setattr("builtins.open", _raise_oserror)
 
-        with pytest.raises(click.ClickException):
-            _set_dbt_telemetry(False)
+        _set_dbt_telemetry(False)  # must not raise
+
+    def test_dbt_telemetry_write_preserves_other_config_keys(self, tmp_path: Path) -> None:
+        """Read-modify-write must never clobber unrelated keys already in
+        config.yml — e.g. Dango's own telemetry opt-out."""
+        from dango.cli.commands.telemetry import _set_dbt_telemetry
+        from dango.telemetry import _write_global_config_key
+
+        _write_global_config_key("telemetry", False)
+
+        _set_dbt_telemetry(True)
+
+        config_path = tmp_path / ".dango" / "config.yml"
+        content = config_path.read_text()
+        assert "telemetry: false" in content
+        assert "dbt_telemetry: true" in content
 
 
 @pytest.mark.unit

--- a/tests/unit/test_telemetry_unified.py
+++ b/tests/unit/test_telemetry_unified.py
@@ -153,13 +153,12 @@ class TestDbtTelemetryConfigWriteThrough:
     """1.0.8-R: _set_dbt_telemetry()/_get_dbt_telemetry_state() now write
     through to the dbt_telemetry key in ~/.dango/config.yml via the shared
     _write_global_config_key()/_read_global_config() helpers, replacing the
-    old bespoke ~/.dango/dbt_telemetry sentinel file. This intentionally
-    changes the error-handling contract superseded here: dbt's write-through
-    is now best-effort and never raises, matching dango's own
-    set_telemetry_enabled() (both share _write_global_config_key()) rather
-    than the raise-on-OSError contract dlt/metabase still use — a write
-    failure just means the setting doesn't stick, same as it already works
-    for the dango provider today."""
+    old bespoke ~/.dango/dbt_telemetry sentinel file. The error-handling
+    contract is unchanged from before the consolidation: _write_global_config_key()
+    itself never raises (it returns True/False), but _set_dbt_telemetry()
+    checks that return value and raises click.ClickException on False —
+    same raise-on-write-failure contract dlt/metabase use, so `--all` can
+    report `! dbt: skipped — ...` instead of a false `✓`."""
 
     def test_set_dbt_telemetry_writes_config_yml_key(self, tmp_path: Path) -> None:
         from dango.cli.commands.telemetry import _get_dbt_telemetry_state, _set_dbt_telemetry
@@ -176,13 +175,18 @@ class TestDbtTelemetryConfigWriteThrough:
 
         assert _get_dbt_telemetry_state() is True
 
-    def test_write_failure_is_silent_not_raised(
+    def test_write_failure_raises_click_exception_not_oserror(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Matching the best-effort contract of _write_global_config_key()
-        (and dango's own set_telemetry_enabled()): a write failure (e.g.
-        permission denied) never raises, it just means the setting doesn't
-        stick and can be retried."""
+        """A real write failure (e.g. permission denied, disk full) must
+        surface as click.ClickException so `--all` can skip this provider
+        and continue — not be swallowed into a false success. Routed
+        through _write_global_config_key()'s False return rather than a
+        raw try/except around Path.write_text() directly, since
+        _set_dbt_telemetry() now delegates the write to the shared
+        helper."""
+        import click
+
         from dango.cli.commands.telemetry import _set_dbt_telemetry
 
         def _raise_oserror(*args: object, **kwargs: object) -> None:
@@ -190,7 +194,28 @@ class TestDbtTelemetryConfigWriteThrough:
 
         monkeypatch.setattr("builtins.open", _raise_oserror)
 
-        _set_dbt_telemetry(False)  # must not raise
+        with pytest.raises(click.ClickException):
+            _set_dbt_telemetry(False)
+
+    def test_write_global_config_key_returns_false_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_write_global_config_key() itself never raises — it signals
+        failure via its return value so callers can decide whether to
+        raise (dbt) or stay silent (dango's own set_telemetry_enabled())."""
+        from dango.telemetry import _write_global_config_key
+
+        def _raise_oserror(*args: object, **kwargs: object) -> None:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr("builtins.open", _raise_oserror)
+
+        assert _write_global_config_key("dbt_telemetry", False) is False
+
+    def test_write_global_config_key_returns_true_on_success(self, tmp_path: Path) -> None:
+        from dango.telemetry import _write_global_config_key
+
+        assert _write_global_config_key("dbt_telemetry", False) is True
 
     def test_dbt_telemetry_write_preserves_other_config_keys(self, tmp_path: Path) -> None:
         """Read-modify-write must never clobber unrelated keys already in


### PR DESCRIPTION
## Summary
- Replaced the bespoke ~/.dango/dbt_telemetry sentinel file with a dbt_telemetry
  key in the existing ~/.dango/config.yml mechanism, matching how Dango's own
  telemetry key already works
- Added shared _read_global_config()/_write_global_config_key() helpers in
  dango/telemetry.py for any future provider needing the same pattern.
  `_write_global_config_key()` returns `bool` (True on a successful write,
  False if the write failed) rather than raising — `_set_dbt_telemetry()`
  checks that return value and raises `click.ClickException` on `False`,
  preserving the original raise-on-write-failure contract so `--all` can
  correctly report `! dbt: skipped — ...` instead of a false `✓`

## Verification
- `pytest -x`: 4344 pass, 0 fail, 30 skipped (pre-existing skips, unrelated to this change)
- `pytest tests/unit/test_telemetry.py tests/unit/test_telemetry_unified.py -x -v`: 81 pass, 0 fail
- `ruff check dango/`: pass
- `ruff format --check dango/`: pass
- `mypy dango/`: pass, no issues in 236 source files
- Manual: `HOME=/tmp/dango-r-verify dango telemetry off --provider dbt` — confirmed
  `dbt_telemetry: false` written to config.yml; `dango telemetry status` correctly
  shows `dbt-core │ off`
- Manual: wrote `telemetry: false` to config.yml first, then toggled dbt_telemetry
  off — confirmed both keys present afterward (`telemetry: false` untouched,
  `dbt_telemetry: false` added)

## Regression check
- `is_telemetry_enabled()` left completely unchanged (no refactor taken, per the
  task's "your call" option) — its own tests pass unchanged, confirming no
  behavior difference before/after
- `grep -rn "dbt_telemetry" dango/` shows no remaining reference to a bare
  `~/.dango/dbt_telemetry` file path — only the `config.yml` key name and the
  `_dbt_telemetry_env()`/`_get_dbt_telemetry_state()`/`_set_dbt_telemetry()`
  function names
- `test_telemetry_unified_metabase.py` has zero dbt references (confirmed via
  grep) — no changes needed there
- `_write_global_config_key()` has exactly one caller (`_set_dbt_telemetry()`)
  plus its own direct tests — confirmed via grep. `set_telemetry_enabled()`
  does NOT use this helper (it writes its own separate `telemetry.json`
  identity file), so the return-type change is isolated to the dbt path

## Error-handling contract (final state)
`_set_dbt_telemetry()` raises `click.ClickException` on a real write failure
(permission denied, disk full, `~/.dango` unwritable, etc.) — the exact same
contract it had before this consolidation, and the same contract dlt/metabase
use, so `--all` correctly skips and reports `! dbt: skipped — ...` rather than
a false `✓ dbt: telemetry disabled`. The shared `_write_global_config_key()`
helper itself never raises (matching `set_telemetry_enabled()`'s existing
best-effort style) — it signals failure via its `bool` return value instead,
and `_set_dbt_telemetry()` is the one caller that converts `False` into a
`ClickException`. An earlier revision of this PR left `_set_dbt_telemetry()`
silently swallowing write failures (no failure signal at all); that was a
real regression, caught in review, and is fixed by this return-value check.

## Known gap (deliberate)
- No migration for the old sentinel file — 1.0.8 hasn't shipped yet, so no real
  user has it. A machine with a stale ~/.dango/dbt_telemetry file will silently
  revert to dbt-telemetry-on until it's toggled again post-upgrade.
