### PR TITLE
1.0.8-Q: Weekly telemetry heartbeat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `platform/cloud/scheduled_backup.py` | 606 | — (server-side scheduled backup) |
 | `governance/schema_drift.py` | 654 | — (R9-D: breaking drift protection + accept flow) |
 | `governance/pii_detector.py` | 626 | — (BUG-027/BUG-133/BUG-139/BUG-185: spaCy fallback + PERSON threshold + override application + structured data heuristic) |
+| `platform/scheduling/scheduler.py` | 514 | — (1.0.8-Q: `_setup_telemetry_heartbeat()`, a fourth fixed internal scheduler job) |
 
 ## Module Documentation Index
 

--- a/dango/CLAUDE.md
+++ b/dango/CLAUDE.md
@@ -10,7 +10,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 |------|---------|----------------------|
 | `__init__.py` | Package metadata: version, author, license | `__version__`, `__author__`, `__license__` |
 | `logging.py` | Structured logging (structlog + stdlib integration) | `configure_logging()`, `get_logger()`, `bind_contextvars`, `clear_contextvars`, `unbind_contextvars` |
-| `telemetry.py` | Opt-in anonymous install telemetry (machine-level UUID in `~/.dango/`) | `is_ci()`, `is_telemetry_enabled()`, `has_recorded_consent()`, `set_telemetry_enabled()`, `ping()` |
+| `telemetry.py` | Opt-in anonymous install + weekly heartbeat telemetry (machine-level UUID in `~/.dango/`) | `is_ci()`, `is_telemetry_enabled()`, `has_recorded_consent()`, `set_telemetry_enabled()`, `ping()`, `heartbeat()`, `heartbeat_job()` |
 
 ## Common Tasks
 
@@ -31,7 +31,7 @@ Root Python package for Dango — contains all module subpackages (cli, config, 
 - `dango.logging` — `get_logger()` used by `web/routes/`, `web/middleware/`, `web/app.py`, `platform/scheduling/`, `platform/notifications/`, `oauth/web_flow.py`, `utils/log_rotation.py`, `utils/post_sync.py`, `cli/commands/schedule.py`, `cli/commands/remote_env.py`, `governance/`, `analysis/`; `configure_logging()` called by entry points. Note: `notebooks/` uses stdlib `logging` directly, not `dango.logging`.
 - `pyproject.toml` defines `getdango` as the installable package
 - Entry point: `dango.cli.main:cli` (configured in `pyproject.toml`)
-- `dango.telemetry` — `cli/init.py` (`ProjectInitializer._prompt_telemetry_consent()`) is the only caller; stdlib `urllib.request`/`json`/`platform`/`uuid` only, plus lazy `yaml` for the opt-out config file. No new pip dependency.
+- `dango.telemetry` — `cli/init.py` (`ProjectInitializer._prompt_telemetry_consent()`) fires the install ping; `platform/scheduling/scheduler.py` (`SchedulerService._setup_telemetry_heartbeat()`) registers `heartbeat_job()` as a weekly internal scheduler job. Stdlib `urllib.request`/`json`/`platform`/`uuid` only, plus lazy `yaml` for the opt-out config file and a lazy `dango.config.helpers.get_config` import inside `heartbeat_job()`. No new pip dependency.
 
 ## Testing
 

--- a/dango/platform/scheduling/CLAUDE.md
+++ b/dango/platform/scheduling/CLAUDE.md
@@ -9,7 +9,7 @@ APScheduler-based job scheduling for Dango data pipelines. Manages scheduled syn
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` (64 lines) | Re-exports public API | `SchedulerService`, `ResilienceConfig`, `run_with_resilience`, history functions, job functions |
-| `scheduler.py` (448 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
+| `scheduler.py` (514 lines) | APScheduler wrapper with SQLite persistence, event listeners, cancellation | `SchedulerService` |
 | `resilience.py` (245 lines) | Retry with backoff, timeout via thread kill, cancellation flags | `ResilienceConfig`, `run_with_resilience`, `_execute_with_timeout`, `_raise_in_thread` |
 | `history.py` (499 lines) | Execution history tracking in scheduler SQLite DB | `record_start`, `record_completion`, `record_failure`, `record_cancellation`, `record_timeout`, `get_schedule_history`, `get_recent_history`, `get_average_duration`, `get_last_run`, `cleanup_old_records` |
 | `jobs.py` (1627 lines) | Module-level job functions (pickle-safe for APScheduler). Supports `skip_dbt` for SYNC_ONLY schedules and `run_scheduled_script` for SCRIPT schedules. Writes to activity log on start/complete/fail/timeout/cancel. | `configure_jobs`, `run_scheduled_sync`, `run_scheduled_dbt`, `run_scheduled_script` |

--- a/dango/platform/scheduling/scheduler.py
+++ b/dango/platform/scheduling/scheduler.py
@@ -143,6 +143,7 @@ class SchedulerService:
         self._setup_history_cleanup()
         self._setup_login_attempts_cleanup()
         self._setup_sync_log_cleanup()
+        self._setup_telemetry_heartbeat()
         self._log_startup_summary()
         self._check_dual_scheduler()
 
@@ -447,6 +448,22 @@ class SchedulerService:
             )
         except Exception:  # noqa: BLE001
             logger.debug("sync_log_cleanup_setup_failed", exc_info=True)
+
+    def _setup_telemetry_heartbeat(self) -> None:
+        """Register the weekly telemetry heartbeat (system job, not user-visible)."""
+        try:
+            from dango.telemetry import heartbeat_job
+
+            self._scheduler.add_job(
+                heartbeat_job,
+                "interval",
+                weeks=1,
+                args=[str(self._project_root)],
+                id="dango-internal:telemetry-heartbeat",
+                replace_existing=True,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("telemetry_heartbeat_setup_failed", exc_info=True)
 
     def _log_missed_recovery(self) -> None:
         """Log count of missed jobs that will be recovered on startup."""

--- a/dango/telemetry.py
+++ b/dango/telemetry.py
@@ -1,7 +1,12 @@
 """dango/telemetry.py
 
-Opt-in anonymous telemetry: a single "install ping" fired once at
-`dango init`. No heartbeat, no scheduler hook — that is future scope.
+Opt-in anonymous telemetry: a one-time "install ping" fired at `dango
+init`, plus a weekly "heartbeat" ping registered as a fixed internal
+scheduler job (`SchedulerService._setup_telemetry_heartbeat()` in
+`platform/scheduling/scheduler.py`) whenever `dango start` runs. The
+heartbeat exists so an "active install" (>=2 heartbeats, >=7 days
+apart) is measurable — the install ping alone can't distinguish a
+one-time `dango init` from an install still in active use weeks later.
 
 Payload is limited to an anonymous install UUID, Dango version, Python
 version, OS name, and source *type* names (e.g. "postgres", "stripe") —
@@ -312,3 +317,52 @@ def _send_ping(event: str, source_types: list[str] | None) -> None:
         urllib.request.urlopen(req, timeout=_TIMEOUT_SECONDS)
     except Exception:
         pass
+
+
+def heartbeat(source_types: list[str] | None = None) -> None:
+    """Fire an anonymous ``"heartbeat"`` telemetry ping.
+
+    A thin wrapper around `ping()` — reuses its threading/timeout/opt-out
+    logic unchanged. Called weekly by `heartbeat_job()` via the scheduler's
+    fixed internal ``dango-internal:telemetry-heartbeat`` job (see
+    `SchedulerService._setup_telemetry_heartbeat()`), never directly by
+    user-facing code.
+
+    Args:
+        source_types: Configured source *type* names only (e.g.
+            ``["postgres", "stripe"]``) — never source names, credentials,
+            or schema content.
+    """
+    ping("heartbeat", source_types=source_types)
+
+
+def heartbeat_job(project_root: str) -> None:
+    """Module-level, picklable wrapper for the scheduled heartbeat job.
+
+    APScheduler 3.x requires module-level functions for job persistence
+    (matching `cleanup_history_job`/`cleanup_login_attempts_job`'s
+    convention of taking `project_root` as a plain string, not a `Path` —
+    APScheduler's `SQLAlchemyJobStore` needs args to be picklable).
+
+    Reads configured source *type* names the same way
+    `_prompt_telemetry_consent()` does in `cli/init.py`
+    (``config.sources.get_enabled_sources()`` -> ``.type.value``). A
+    config load failure still lets the heartbeat fire (with no
+    ``source_types``) rather than skip it entirely — matching this
+    module's existing "telemetry must never break, and never blocks on a
+    detail it doesn't strictly need" posture.
+
+    Args:
+        project_root: Dango project root as a string (APScheduler
+            serializes args).
+    """
+    source_types: list[str] | None = None
+    try:
+        from dango.config.helpers import get_config
+
+        config = get_config(Path(project_root))
+        source_types = [s.type.value for s in config.sources.get_enabled_sources()]
+    except Exception:
+        pass
+
+    heartbeat(source_types=source_types)

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -382,6 +382,12 @@ exemptions:
 
   # --- Phase 4 scheduling ---
 
+  - file: dango/platform/scheduling/scheduler.py
+    lines: 514
+    category: exempt
+    reason: "1.0.8-Q: Added _setup_telemetry_heartbeat(), a fourth fixed internal job (weekly telemetry heartbeat) following the existing _setup_history_cleanup/_setup_login_attempts_cleanup/_setup_sync_log_cleanup pattern. Pushed the file ~14 lines over the 500-line limit."
+    review_by: "v1.1"
+
   - file: dango/utils/post_sync.py
     lines: 815
     category: exempt

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -398,6 +398,33 @@ class TestSchedulerServiceHistoryIntegration:
         assert call_kwargs[1]["id"] == "dango-internal:login-attempts-cleanup"
         assert call_kwargs[1]["hours"] == 6
 
+    def test_setup_telemetry_heartbeat_registers_job(self, tmp_path):
+        """_setup_telemetry_heartbeat should register a weekly interval job."""
+        svc = _make_service(tmp_path)
+        svc._project_root = tmp_path
+
+        svc._setup_telemetry_heartbeat()
+
+        svc._scheduler.add_job.assert_called_once()
+        args, call_kwargs = svc._scheduler.add_job.call_args
+        assert args[1] == "interval"
+        assert call_kwargs["id"] == "dango-internal:telemetry-heartbeat"
+        assert call_kwargs["weeks"] == 1
+
+    def test_setup_telemetry_heartbeat_uses_replace_existing(self, tmp_path):
+        """_setup_telemetry_heartbeat should pass replace_existing=True.
+
+        This is what makes a second `dango start` not duplicate the job —
+        same idempotency mechanism the other three internal jobs rely on.
+        """
+        svc = _make_service(tmp_path)
+        svc._project_root = tmp_path
+
+        svc._setup_telemetry_heartbeat()
+
+        call_kwargs = svc._scheduler.add_job.call_args
+        assert call_kwargs[1]["replace_existing"] is True
+
 
 @pytest.mark.unit
 class TestSchedulerServiceCoroutineBridge:

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -281,3 +281,74 @@ class TestPing:
         # no User-Agent (urllib sends none by default) — regression test
         # for a live 403 caught during manual verification.
         assert request.get_header("User-agent")
+
+
+@pytest.mark.unit
+class TestHeartbeat:
+    """Tests for telemetry.heartbeat() — the weekly scheduled ping.
+
+    heartbeat() is a thin wrapper: it must call into ping()'s existing
+    threading/timeout/opt-out logic rather than duplicate it, so these
+    tests assert on the delegation itself, not on threading behavior
+    already covered by TestPing.
+    """
+
+    def test_heartbeat_reuses_ping_mechanism(self) -> None:
+        """heartbeat() calls ping("heartbeat", ...) — no reimplemented logic."""
+        with patch("dango.telemetry.ping") as mock_ping:
+            telemetry.heartbeat(source_types=["postgres"])
+        mock_ping.assert_called_once_with("heartbeat", source_types=["postgres"])
+
+    def test_heartbeat_respects_telemetry_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With telemetry disabled, heartbeat() is a no-op — same as ping()'s behavior.
+
+        heartbeat() doesn't check is_telemetry_enabled() itself (that
+        would be a second, separate opt-out check); it inherits the
+        no-op entirely from ping(), verified here via a real opt-out
+        signal (DO_NOT_TRACK) with threading mocked so a real network
+        call is never attempted either way.
+        """
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        with patch("dango.telemetry.threading.Thread") as mock_thread:
+            telemetry.heartbeat(source_types=["postgres"])
+        mock_thread.assert_not_called()
+
+
+@pytest.mark.unit
+class TestHeartbeatJob:
+    """Tests for telemetry.heartbeat_job() — the module-level APScheduler entry point."""
+
+    def test_reads_enabled_source_types_and_calls_heartbeat(self, tmp_path: Path) -> None:
+        """heartbeat_job() reads configured source *type* names and passes them through."""
+        mock_source_a = Mock()
+        mock_source_a.type.value = "postgres"
+        mock_source_b = Mock()
+        mock_source_b.type.value = "stripe"
+
+        mock_config = Mock()
+        mock_config.sources.get_enabled_sources.return_value = [mock_source_a, mock_source_b]
+
+        with (
+            patch("dango.config.helpers.get_config", return_value=mock_config) as mock_get_config,
+            patch("dango.telemetry.heartbeat") as mock_heartbeat,
+        ):
+            telemetry.heartbeat_job(str(tmp_path))
+
+        mock_get_config.assert_called_once_with(tmp_path)
+        mock_heartbeat.assert_called_once_with(source_types=["postgres", "stripe"])
+
+    def test_config_load_failure_still_fires_heartbeat(self, tmp_path: Path) -> None:
+        """A config load failure doesn't prevent the heartbeat — it just loses source_types.
+
+        Matches this module's "telemetry must never break" posture:
+        a project.yml parse error shouldn't silently kill the one signal
+        (`LAUNCH-READINESS.md`'s "active install" definition) that needs
+        this job to actually run every week.
+        """
+        with (
+            patch("dango.config.helpers.get_config", side_effect=RuntimeError("boom")),
+            patch("dango.telemetry.heartbeat") as mock_heartbeat,
+        ):
+            telemetry.heartbeat_job(str(tmp_path))
+
+        mock_heartbeat.assert_called_once_with(source_types=None)


### PR DESCRIPTION
## Summary
- Add weekly telemetry heartbeat, reusing telemetry.py's existing ping()
  mechanism (event="heartbeat") — closes the gap where LAUNCH-READINESS.md's
  "active install" definition (>=2 heartbeats, >=7 days apart) was
  unmeasurable because only the one-time install ping existed (1.0.8-C)
- Registered as a fixed internal scheduler job
  (`dango-internal:telemetry-heartbeat`), not user-visible via
  `dango schedule` — follows the exact pattern of the three existing
  internal jobs (`_setup_history_cleanup`, `_setup_login_attempts_cleanup`,
  `_setup_sync_log_cleanup`)

## Changes
- `dango/telemetry.py`: added `heartbeat(source_types=None)` (thin wrapper
  around `ping("heartbeat", ...)`, no duplicated threading/timeout/opt-out
  logic) and `heartbeat_job(project_root: str)` (module-level, picklable
  APScheduler entry point — reads enabled source *type* names via
  `config.sources.get_enabled_sources()`, same pattern as
  `cli/init.py`'s `_prompt_telemetry_consent()`; falls back to no
  `source_types` rather than skipping the ping if config loading fails).
  Updated the module docstring, which previously said "No heartbeat... that
  is future scope."
- `dango/platform/scheduling/scheduler.py`: added
  `SchedulerService._setup_telemetry_heartbeat()`, called from `start()`
  alongside the other three internal-job setup calls, right before
  `_log_startup_summary()`. Registers `heartbeat_job` on a weekly
  `"interval"` trigger with `id="dango-internal:telemetry-heartbeat"` and
  `replace_existing=True`. No `coalesce`/`max_instances` passed explicitly
  — inherited from the scheduler-wide `job_defaults`, matching the other
  three jobs' style.
- `docs/file-exemptions.yml`, `CLAUDE.md`, `dango/platform/scheduling/CLAUDE.md`:
  the new method pushed `scheduler.py` to 514 lines (over the 500-line
  file-size-check limit) — added an exemption entry and synced the two
  line-count references.

## Background finding (not fixed here, no gap)
Per the task's instruction to check whether `dango schedule list`
structurally shows `dango-internal:*` jobs: it does not, and this isn't a
new guarantee added by this PR — `dango schedule list` (CLI) reads only
from `.dango/schedules.yml` via `_load_schedules_yaml()` and never touches
`scheduler.get_jobs()` at all. The web `/api/schedules` endpoint
(`web/routes/schedules.py::list_schedules`) does call `scheduler.get_jobs()`,
but only to build a `next_run_time` lookup dict keyed by job id — the
returned list is built by iterating `config.schedules`, so `dango-internal:*`
jobs (all four of them, not just this new one) were already structurally
invisible before this PR. No fix needed; nothing to newly test.

## Verification
- `pytest -x`: 4350 passed, 30 skipped, 0 failed (full suite)
- `pytest tests/unit/test_telemetry.py tests/unit/test_scheduler.py -q`:
  113 passed
- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: all files formatted
- `mypy dango/`: no issues found in 236 source files
- Manual: started a `SchedulerService` against a temp project root,
  confirmed via `scheduler.get_jobs()` that
  `dango-internal:telemetry-heartbeat` registers with an `interval[7 days,
  0:00:00]` trigger; started a second `SchedulerService` against the same
  `.dango/scheduler.db` to simulate a second `dango start` and confirmed
  no duplicate job (still exactly 1, `replace_existing=True` at work).
  Repeated with `DO_NOT_TRACK=1` set — the job still registers (scheduling
  isn't gated on the opt-out), but calling `heartbeat_job()` directly with
  `threading.Thread` mocked confirmed it never spawns a send thread (no-op),
  matching `ping()`'s existing opt-out behavior via `is_telemetry_enabled()`.

## Regression check
- Grepped `SchedulerService(` across `dango/` and `tests/` — the only
  production call site is `dango/web/app.py:184`, inside `dango start`'s
  platform startup. CLI-only invocations (e.g. `dango sync` run standalone)
  never construct a `SchedulerService`, so this change doesn't fire outside
  `dango start`/`dango serve`.
- No existing test asserts the exact job count/list `SchedulerService.start()`
  registers (checked `tests/unit/test_scheduler.py`'s `TestSchedulerServiceLifecycle`
  — its `start()` tests assert on `add_listener.call_count`, never
  `add_job.call_count`), so adding a fourth internal job doesn't break
  anything there.