### PR TITLE
1.0.8-M: BYOS deploy warning — no backup destination

### DIFF
--- a/dango/cli/commands/deploy.py
+++ b/dango/cli/commands/deploy.py
@@ -314,6 +314,12 @@ def _print_deploy_success(
             "\n  [bold]Backups:[/bold] Enabled (daily at 02:00 UTC to Spaces). "
             "Run [bold]dango remote backup download[/bold] to save a local copy."
         )
+    else:
+        console.print(
+            "\n  [yellow]Backups:[/yellow] Not configured. Backups are stored on this "
+            "server only — if the server is lost, so are your backups. "
+            "See https://docs.getdango.dev/deployment/backups for BYOS backup options."
+        )
     if warnings:
         for w in warnings:
             console.print(f"  [yellow]Warning:[/yellow] {w}")

--- a/tests/unit/test_deploy_backup_warning.py
+++ b/tests/unit/test_deploy_backup_warning.py
@@ -1,0 +1,41 @@
+"""tests/unit/test_deploy_backup_warning.py
+
+Tests for the backup-status warning printed by `_print_deploy_success()`
+(dango/cli/commands/deploy.py). BYOS deploys always pass backup_enabled=False,
+which previously printed nothing about backups at all. This covers the new
+warning shown for that case, and confirms the existing "enabled" message is
+unaffected.
+"""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestBackupWarning:
+    def test_warning_shown_when_backup_disabled(self, capsys):
+        from dango.cli.commands.deploy import _print_deploy_success
+
+        _print_deploy_success(
+            url="https://example.com",
+            ip="1.2.3.4",
+            admin_email="admin@example.com",
+            warnings=[],
+            backup_enabled=False,
+        )
+        captured = capsys.readouterr()
+        assert "Backups" in captured.out
+        assert "Not configured" in captured.out or "server only" in captured.out
+
+    def test_no_warning_when_backup_enabled(self, capsys):
+        from dango.cli.commands.deploy import _print_deploy_success
+
+        _print_deploy_success(
+            url="https://example.com",
+            ip="1.2.3.4",
+            admin_email="admin@example.com",
+            warnings=[],
+            backup_enabled=True,
+        )
+        captured = capsys.readouterr()
+        assert "Enabled" in captured.out
+        assert "Not configured" not in captured.out


### PR DESCRIPTION
## Summary
- Add a visible warning to deploy-success output when backup_enabled=False
- Fixes the fact that BYOS deploys currently complete with zero mention of backups
- Corrects LAUNCH-READINESS.md's original claim (backup retention has no auto-deletion —
  verified false, GFS retention already exists via `scheduled_backup.py::_apply_retention()`);
  this session addresses the real gap instead: BYOS has no backup-destination configuration
  path (ROADMAP.md B-1, full fix out of scope, this ships the honest warning)
- Warning links to `docs.getdango.dev/deployment/backups`, which already exists and documents
  the manual Spaces/S3-compatible setup for BYOS (`docs/docs/deployment/backups.md`, "Scheduled
  Backups" → BYOS tab)

## Changes
- `dango/cli/commands/deploy.py`: `_print_deploy_success()` gets an `else` branch on the
  existing `if backup_enabled:` check, printing a yellow warning that backups are stored
  server-only when `backup_enabled=False`. No change to `backup_enabled`'s default or to
  either caller's logic (`_print_byos_success()` still always passes `False`;
  `_handle_do_deploy_with_config()` still passes `config.enable_backups`, which can also be
  `False` if Spaces is declined in the DO wizard — the generic wording ("stored on this server
  only") reads correctly for that case too).
- `tests/unit/test_deploy_backup_warning.py` (new): covers both the disabled-warning and
  enabled-message cases via direct calls to `_print_deploy_success()`.

## Verification
- `pytest tests/unit/test_deploy_backup_warning.py -x -v`: 2 pass, 0 fail
- `pytest -x`: 4352 pass, 30 skipped, 0 fail
- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: 236 files already formatted
- Manual: called `_print_deploy_success()` directly with `backup_enabled=False` and `=True`
  and read the printed Rich output in isolation — confirmed the warning text, wording, and
  color read correctly in both cases (see PR discussion/session log for captured output)
- No live `dango deploy --byos` run was performed in this session — CLAUDE.md's shared-project
  rule prohibits testing on `tests/beta-1/` from a worktree session; per that same doc, live
  deploy verification is the coordinating chat's responsibility before merge. Verification here
  was limited to the unit tests and the isolated manual function calls above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyYKvCUZcrvQwMHh1sNWEp