### PR TITLE
1.0.8-L: README known-limitations block

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 Apache 2.0 — see [LICENSE](LICENSE) for details.
 
+## Known limitations
+
+Dango is honest about what it doesn't do yet. The short version — full detail at
+[docs.getdango.dev/reference/limitations](https://docs.getdango.dev/reference/limitations):
+
+- Single-writer concurrency until the Quack migration lands (DuckDB 2.0)
+- No streaming, CDC, or reverse ETL
+- 34 sources today, added on demand
+- BYOS deployments need to configure their own backup destination (warned at deploy time)
+
 ## Links
 
 - [PyPI](https://pypi.org/project/getdango/)


### PR DESCRIPTION
## Summary
- Add short "Known limitations" block to README.md, linking to the full docs page
- Companion to the docs-repo limitations page (LAUNCH-READINESS.md E8):
  https://github.com/getdango/docs/pull/45
- BYOS bullet reflects Session M's shipped deploy-time warning (already merged
  to `v1.0.8`, verified in `dango/cli/commands/deploy.py`) rather than an open gap

## Note for reviewers
Another concurrent session (1.0.8-J, messaging rewrite) also edits README.md,
in the opening paragraph at the top of the file. This PR's diff is a single
clean hunk appending a new "## Known limitations" section near the bottom
(before "## Links"), and touches nothing else in the file — confirmed via
`git diff README.md`. Should merge cleanly as two independent hunks, but
flagging so the two PRs can be checked for overlap before merging either.

## Verification
- Rendered README locally, confirmed formatting
- `git diff README.md` shows only the new bottom section added — no other
  lines touched
- Pre-commit hooks passed on commit (trailing-whitespace, end-of-file-fixer,
  claude-md-staleness, etc.)