### PR TITLE
1.0.8-J: Messaging rewrite (dango repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![License](https://img.shields.io/github/license/getdango/dango)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/getdango/dango)](https://github.com/getdango/dango)
 
-**Open-source data platform for small teams.**
+**The data platform your coding agent can run.**
 
-Dango gives you a complete data stack — ingestion, warehouse, transformations, and dashboards — in a single CLI. It combines [dlt](https://dlthub.com/) for data loading, [DuckDB](https://duckdb.org/) as the analytics database, [dbt](https://www.getdbt.com/) for SQL transformations, and [Metabase](https://www.metabase.com/) for dashboards. One `pip install`, one command to start.
+Dango gives you a complete data stack — ingestion, warehouse, transformations, and dashboards — with the operational machinery a self-assembled stack (or an LLM improvising one) doesn't have: sync queue management, lock recovery, empty-replace protection, schema drift detection, credential health checks, and backups. It combines [dlt](https://dlthub.com/) for data loading, [DuckDB](https://duckdb.org/) as the analytics database, [dbt](https://www.getdbt.com/) for SQL transformations, and [Metabase](https://www.metabase.com/) for dashboards. One `pip install`, one command to start.
 
 > **Upgrading from v0.1.x?** v1.0.0 is a complete rewrite. Back up your data and run `dango init` to create a new v1 project. See the [migration guide](https://docs.getdango.dev) for details.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "getdango"
 version = "1.0.7"
-description = "Open source data platform built with production-grade tools - dlt, dbt, DuckDB, and Metabase"
+description = "The data platform your coding agent can run — dlt, dbt, DuckDB, and Metabase, with the operational machinery agents shouldn't improvise"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Retire "CSV to dashboard in minutes" / setup-time positioning
- New framing leads with the operating claim: "the data platform your coding agent can run"
- Updates README opening paragraph and pyproject.toml description
- Companion PR in website repo updates the hero and messaging brief (link added once opened)

## Verification
- `pip install -e .` succeeds; `pip show getdango` shows the new description
- `pytest -q`: 4379 pass, 1 fail, 30 skipped. The failure
  (`tests/unit/test_egress_allowlist.py::TestLiveEgressDetection::test_dlt_native_source_sync_initializes_telemetry_and_opt_out_suppresses_it`)
  passes in isolation (`pytest tests/unit/test_egress_allowlist.py::...` → 1 passed) — it's a
  pre-existing order-dependent flake, unrelated to this copy-only change (no code touched, only
  README.md prose and the pyproject.toml `description` string).
- Manually reviewed README rendering (diff is two paragraph replacements, no markdown structure changes)
- `pyproject.toml` description is 137 chars, plain text, no markdown/backticks/links — well under PyPI's practical limit

## Scope note
Copy-only, matches 1.0.8-J prompt exactly. Diff touches only the two lines specified
(README.md opening paragraph, pyproject.toml `description`) — confirmed via `git diff` before
committing. No overlap with the concurrent 1.0.8-L session, which appends a new "## Known
limitations" section near the bottom of README.md.