### PR TITLE
fix: start_docker_services port pre-flight check reads configured ports

### DIFF
--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -167,10 +167,29 @@ def start_docker_services(project_root: Path) -> None:
     if not manager.is_docker_daemon_running():
         raise RuntimeError("Docker daemon is not running. Start Docker Desktop and try again.")
 
-    # Pre-flight: Required Docker ports must be free
+    # Pre-flight: Required Docker ports must be free.
+    # Read the project's actual configured ports rather than hardcoding the
+    # defaults — a project with metabase_port/dbt_docs_port customized in
+    # project.yml (e.g. to avoid a conflict) would otherwise have this check
+    # look at the wrong ports entirely. Falls back to the same literal
+    # defaults PlatformSettings itself uses if config can't be loaded (e.g.
+    # no project.yml yet) — this function's own contract only raises
+    # RuntimeError for its own documented pre-flight reasons, so a config
+    # load failure here must not surface as a different exception type.
+    metabase_port = 3000
+    dbt_docs_port = 8081
+    try:
+        from dango.config.helpers import load_config
+
+        config = load_config(project_root)
+        metabase_port = config.platform.metabase_port
+        dbt_docs_port = config.platform.dbt_docs_port
+    except Exception:
+        pass
+
     required_docker_ports = {
-        3000: "Metabase",
-        8081: "dbt-docs",
+        metabase_port: "Metabase",
+        dbt_docs_port: "dbt-docs",
     }
 
     ports_in_use = []

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -199,6 +199,63 @@ class TestStartDockerServices:
 
         manager.start_services.assert_called_once()
 
+    def test_checks_configured_ports_not_hardcoded_defaults(self, tmp_path):
+        """A project with custom metabase_port/dbt_docs_port must have the
+        pre-flight check look at those ports, not the hardcoded 3000/8081
+        defaults — otherwise a project configured to avoid a real conflict
+        gets a misleading conflict report on the wrong ports entirely."""
+        import yaml
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        project_data = {
+            "project": {
+                "name": "Custom Port Project",
+                "created_by": "test@example.com",
+                "purpose": "Testing custom ports",
+            },
+            "platform": {
+                "metabase_port": 3001,
+                "dbt_docs_port": 8082,
+            },
+        }
+        with open(dango_dir / "project.yml", "w") as f:
+            yaml.safe_dump(project_data, f, default_flow_style=False)
+        with open(dango_dir / "sources.yml", "w") as f:
+            yaml.safe_dump({"version": "1.0", "sources": []}, f)
+
+        manager = self._make_manager()
+
+        # Only port 3000 (the OLD hardcoded default) is occupied — the
+        # configured port 3001 is free. If the fix works, this should NOT
+        # raise, because the pre-flight check looks at 3001, not 3000.
+        def fake_socket(*args, **kwargs):
+            sock = MagicMock()
+            sock.connect_ex.side_effect = lambda addr: 0 if addr[1] == 3000 else 1
+            return sock
+
+        with patch("dango.platform.DockerManager", return_value=manager):
+            with patch("dango.platform.common.startup.socket.socket", side_effect=fake_socket):
+                start_docker_services(tmp_path)  # Should not raise — 3001 is free
+
+        manager.start_services.assert_called_once()
+
+    def test_falls_back_to_defaults_when_config_unavailable(self, tmp_path):
+        """No project.yml present (e.g. called before a project exists) —
+        must fall back to the same 3000/8081 defaults as before, not raise
+        a config-loading exception through this function's RuntimeError-only
+        contract."""
+        manager = self._make_manager()
+
+        mock_sock = MagicMock()
+        mock_sock.connect_ex.return_value = 1  # ports free
+
+        with patch("dango.platform.DockerManager", return_value=manager):
+            with patch("dango.platform.common.startup.socket.socket", return_value=mock_sock):
+                start_docker_services(tmp_path)  # Should not raise
+
+        manager.start_services.assert_called_once()
+
 
 @pytest.mark.unit
 class TestSetupMetabaseIfNeeded:


### PR DESCRIPTION
## Summary
- `start_docker_services()`'s port pre-flight check hardcoded
  `{3000: "Metabase", 8081: "dbt-docs"}` regardless of a project's actual
  configured ports, even though `docker-compose.yml.j2` generation already
  correctly parameterizes from `config.platform.metabase_port`/`dbt_docs_port`
  (`cli/init.py`). A project configured on non-default ports got a misleading
  port-conflict report on the wrong ports entirely.
- Now reads the configured ports via `load_config()`, falling back to the
  same 3000/8081 literals if config can't be loaded (e.g. no project.yml
  yet yet) — preserves this function's RuntimeError-only exception contract.

## Origin
Found as an out-of-scope finding during 1.0.8-S's Metabase login-primitive
consolidation (logged in `v1.0.x-planning/1.0.8/BUGS-FOUND.md`), then hit
live while doing that PR's manual verification walkthrough — a scratch test
project configured on ports 3001/8082 to avoid a locally-running Metabase
instance still failed the pre-flight check against ports 3000/8081.

## Verification
- `pytest tests/unit/test_platform_startup.py -x -v`: 36 pass, 0 fail
  (includes 2 new tests: configured-port check works, and graceful fallback
  when no project.yml exists yet — the latter matters because the 4
  pre-existing tests in this class call the function with an empty `tmp_path`
  and no project config)
- Full suite `pytest -x -m "not egress"`: 4424 passed, 30 skipped, 0 failed
- `ruff check`, `ruff format --check`, `mypy dango/`: all clean

## Regression check
- The 4 pre-existing `TestStartDockerServices` tests pass unmodified —
  confirms the fallback-to-defaults path preserves current behavior exactly
  for a project with no custom port config (the common case)