### PR TITLE
fix: setup_metabase_if_needed passes configured metabase_port to setup_metabase

### DIFF
--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -301,11 +301,29 @@ def setup_metabase_if_needed(
             )
             return {"already_configured": False, "success": True, "skipped": True}
 
+    # Read the project's actual configured Metabase port rather than relying
+    # on setup_metabase()'s own http://localhost:3000 default — a project
+    # configured on a non-default port (e.g. to avoid a real conflict) would
+    # otherwise have its admin-setup API calls silently target the wrong
+    # Metabase instance entirely. The URL setup_metabase() is called with
+    # gets persisted into .dango/metabase.yml's "metabase_url" key, so every
+    # downstream reader of that file (sync_metabase_schema,
+    # set_metabase_telemetry, etc.) inherits the correct port from this one
+    # fix — no other call site needs to change.
+    metabase_port = 3000
+    try:
+        from dango.config.helpers import load_config
+
+        metabase_port = load_config(project_root).platform.metabase_port
+    except Exception:
+        pass
+
     setup_result = setup_metabase(
         project_root,
         project_name,
         admin_email,
         organization=organization,
+        metabase_url=f"http://localhost:{metabase_port}",
         cloud_mode=is_cloud_mode(project_root),
     )
 

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -318,6 +318,53 @@ class TestSetupMetabaseIfNeeded:
         assert result["success"] is True
         assert result["duckdb_connected"] is True
 
+    def test_calls_setup_metabase_with_configured_port(self, tmp_path, monkeypatch):
+        """setup_metabase() must be called with the project's actual configured
+        metabase_port, not the hardcoded localhost:3000 default — otherwise a
+        project on a non-default port silently targets the wrong Metabase
+        instance entirely (confirmed live: this exact scenario hit a real,
+        unrelated Metabase instance during 1.0.8-S's manual verification)."""
+        import yaml
+
+        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "admin@test.com")
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        project_data = {
+            "project": {
+                "name": "Custom Port",
+                "created_by": "test@example.com",
+                "purpose": "Testing",
+            },
+            "platform": {"metabase_port": 3001},
+        }
+        with open(dango_dir / "project.yml", "w") as f:
+            yaml.safe_dump(project_data, f)
+        with open(dango_dir / "sources.yml", "w") as f:
+            yaml.safe_dump({"version": "1.0", "sources": []}, f)
+
+        setup_result = {"success": True, "duckdb_connected": True, "errors": []}
+        with patch(
+            "dango.visualization.metabase.setup_metabase", return_value=setup_result
+        ) as mock_setup:
+            setup_metabase_if_needed(tmp_path, "MyProject", None)
+
+        _, kwargs = mock_setup.call_args
+        assert kwargs["metabase_url"] == "http://localhost:3001"
+
+    def test_falls_back_to_default_port_when_config_unavailable(self, tmp_path, monkeypatch):
+        """No project.yml present — must fall back to localhost:3000, not raise
+        a config-loading exception."""
+        monkeypatch.setenv("DANGO_ADMIN_EMAIL", "admin@test.com")
+        setup_result = {"success": True, "duckdb_connected": True, "errors": []}
+
+        with patch(
+            "dango.visualization.metabase.setup_metabase", return_value=setup_result
+        ) as mock_setup:
+            setup_metabase_if_needed(tmp_path, "MyProject", None)
+
+        _, kwargs = mock_setup.call_args
+        assert kwargs["metabase_url"] == "http://localhost:3000"
+
     def test_skips_when_no_admin_email(self, tmp_path, monkeypatch):
         """setup_metabase_if_needed skips when no admin email is available."""
         monkeypatch.delenv("DANGO_ADMIN_EMAIL", raising=False)


### PR DESCRIPTION
## Summary
- `setup_metabase_if_needed()` called `setup_metabase()` with no `metabase_url`
  argument, so it always used the hardcoded `http://localhost:3000` default
  regardless of the project's actual configured `metabase_port`.
- Now reads `config.platform.metabase_port` and passes
  `metabase_url=f"http://localhost:{metabase_port}"` explicitly, falling back
  to the same `localhost:3000` default if config can't be loaded.

## Origin
Confirmed live during 1.0.8-S's manual verification walkthrough: a scratch
project configured on port 3001 (to avoid a real, unrelated Metabase instance
running on 3000) still had `setup_metabase()` try to create an admin user
against port 3000 — "user already exists" (true, on the unrelated instance),
followed by a correctly-rejected default-credentials login. No state was
mutated on the unrelated instance (both calls were cleanly rejected by
Metabase itself), but the wrong-target behavior is real and reproducible.

The URL persists into `.dango/metabase.yml`'s `metabase_url` key, so
`set_metabase_telemetry()` (which reads that key when not given an explicit
override) inherits the fix automatically. `sync_metabase_schema()` has the
same bug class but doesn't read the stored URL at all — separately tracked
in `v1.0.x-planning/1.0.8/BUGS-FOUND.md`, not fixed here.

## Verification
- `pytest tests/unit/test_platform_startup.py -x -v`: 38 pass, 0 fail
  (2 new tests: configured port is passed through, and fallback works with
  no project.yml present)
- Full suite `pytest -x -m "not egress"`: 4426 passed, 30 skipped, 0 failed
- `ruff check`, `ruff format --check`, `mypy dango/`: all clean

## Regression check
- All 5 pre-existing `TestSetupMetabaseIfNeeded` tests pass unmodified
- No assertions in existing tests depend on `setup_metabase`'s exact call
  arguments (all mock it via `return_value=`), confirmed via grep before
  changing the call site