### PR TITLE
1.0.8: Fill in CHANGELOG.md [Unreleased] section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Telemetry — `dango init` now asks for one-time, anonymous opt-in consent before sending an install ping; declining, running in CI, or setting `DO_NOT_TRACK`/`DANGO_TELEMETRY` skips it silently
+- `dango telemetry` command (`status` / `on` / `off`) — control telemetry for Dango, dbt, dlt, and Metabase together with `--all`, or one at a time with `--provider`
+- `/settings/telemetry` page — toggle telemetry status from the web UI, matching the CLI command
+- MCP server — `dango mcp setup` configures Claude Code, Cursor, or Windsurf to talk to your Dango project; 15 tools cover reading (sources, schema, catalog, lineage, models, SQL, sync history, ad-hoc queries) and making changes (running syncs/transforms/doctor, adding sources/schedules, creating models) through the same functions the CLI itself uses
+- `dango init`, `dango source add`, and `dango model add` now generate and keep a `CLAUDE.md` file up to date in the project, summarizing its purpose, sources, and models for AI coding assistants
+- `dango validate` now warns when model or column descriptions are missing or left as `# TODO` placeholders
+- Deploy output now warns when backups aren't configured for BYOS/self-hosted deploys, with a link to the backup setup docs
+
 ### Fixed
 
 - dbt-core 1.10.22 → 1.11.14, dbt-duckdb 1.10.1 → 1.11.0, Metabase v0.59.1 → v0.62.18, Metabase DuckDB JDBC driver 1.5.3.0 → 1.5.4.0
+- `dango generate` no longer rewrites every staging model file (and its timestamp) on every sync when nothing actually changed — previously this produced diff noise on every run even with no real schema changes. Manually customized models are also no longer overwritten by default; use the new `--force` flag to regenerate them anyway
+- Sync progress: the UI no longer looks like it's stuck for up to ~90 seconds between a sync finishing and dbt starting — a "data loaded, running transforms" update now appears in between
+- Metabase: `dango start`'s port pre-flight check now reads the project's configured Metabase/dbt-docs ports instead of always checking 3000/8081
+- Metabase: first-run setup now targets the project's configured Metabase port instead of always defaulting to `localhost:3000`
 
 ## [1.0.7] - 2026-08-27
 


### PR DESCRIPTION
## Summary
- Fill in CHANGELOG.md's [Unreleased] section with all genuinely user-facing
  changes from the 1.0.8 cycle (previously only had Session A's dependency
  bump entry, missing ~20 merged PRs)

## Verification
- Reviewed all 22 merged PRs to v1.0.8 (`gh pr list --repo getdango/dango
  --state merged --base v1.0.8`, re-verified live before writing — matches
  the task file's table exactly, no new merges since it was written).
- Excluded 9 with no user-visible behavior change:
  - #438 (B) egress allowlist CI test — CI/test infra only
  - #441 (P) remove dead failures list — internal cleanup, verified via diff
    (no behavior change)
  - #444 (R) consolidate dbt telemetry into config.yml — internal storage
    refactor, CLI output unchanged
  - #445 (Q) weekly telemetry heartbeat — registered as a fixed internal
    scheduler job, explicitly not user-visible via `dango schedule`
    (confirmed in PR body/README)
  - #448 (V) dlt telemetry init investigation — investigation only, no
    product change; confirmed opt-out already works, no gap found
  - #452 (O) wire Metabase Docker integration test into CI — CI/test infra
    only
  - #454 (L) README known-limitations block — README/doc addition, not code
    behavior; excluded to match [1.0.7]'s convention (that section lists no
    doc-only additions either)
  - #455 (J) messaging rewrite — marketing copy (README opening paragraph +
    pyproject.toml description string), not product behavior
  - #458 (S) Metabase login primitive consolidation — verified via PR body:
    zero behavior change, `setup_metabase()` byte-for-byte untouched
- Included 12 (some combined) as 11 changelog bullets:
  - #440 (C) telemetry opt-in consent prompt
  - #442 (D) `dango telemetry` command
  - #457 (U) `/settings/telemetry` web page
  - #443 (E) + #456 (F) combined into one MCP server entry (15 tools total,
    feature-level per task-file instruction, not per-tool)
  - #449 (G) CLAUDE.md scaffold
  - #450 (H) `dango validate` TODO/empty-description warnings
  - #446 (M) BYOS deploy backup warning
  - #439 (A) dependency bumps — already present, left as-is
  - #451 (N) idempotent staging regen + `--force` flag — folded into one
    Fixed entry (no `### Changed` section exists in [1.0.7], so following
    that file's convention of folding behavior changes into Fixed)
  - #447 (I) WebSocket `sync_data_loaded` event
  - #459 + #460 (both same-day out-of-cycle bug fixes) — two separate
    Metabase port-config Fixed entries, one per distinct call site fixed
- Style/voice matches [1.0.7]'s existing entries: read the full [1.0.7]
  section as the template before writing, one line per user-visible change
  written from the user's perspective, `### Added`/`### Fixed` grouping only
- No `## [1.0.8]` heading created — entries added to the existing
  `## [Unreleased]` section per RELEASE-WORKFLOW.md
- `docs/community/changelog.md` untouched (confirmed: only CHANGELOG.md in
  this diff, that file lives in a separate repo entirely)
- Confirmed valid Markdown by eye: list nesting, heading levels, and
  section order (Added before Fixed, matching [1.0.7]) all correct

https://claude.ai/code/session_01MyYKvCUZcrvQwMHh1sNWEp