### PR TITLE
1.0.8-D4: README section for MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ curl -sSL https://getdango.dev/install.sh | bash
 
 For detailed installation instructions, see the [documentation](https://docs.getdango.dev).
 
+## Use Dango with your coding agent
+
+```bash
+dango mcp setup
+```
+
+Connects Claude Code, Cursor, or Windsurf to your project over MCP — your agent can list sources,
+inspect schemas and lineage, run read-only queries, and (with your permission) trigger syncs, run
+dbt, and scaffold new models. See the [full guide](https://docs.getdango.dev/guides/mcp-claude-code/)
+for the complete tool reference and worked examples.
+
 ## Features
 
 - **33 data sources** — Stripe, Google Sheets, Google Analytics, Shopify, PostgreSQL, MySQL, CSV, REST APIs, and more


### PR DESCRIPTION
## Summary
- Add "Use Dango with your coding agent" section to README, linking to the
  full MCP docs page. Placed right after Quick Start (near the top, per
  the task spec) since it's the mechanism behind the 1.0.8 hero headline
  ("the data platform your coding agent can run")

## Verification
- Rendered README locally (read back the file, confirmed heading levels,
  code fence, and link syntax render correctly); density matches the
  existing "Known limitations" section Session L added (~11 lines)

## Companion PR
- docs repo (full MCP/Claude Code guide): getdango/docs#47