### PR TITLE
1.0.8: Fix README source count (33/34 -> 35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For detailed installation instructions, see the [documentation](https://docs.get
 
 ## Features
 
-- **33 data sources** — Stripe, Google Sheets, Google Analytics, Shopify, PostgreSQL, MySQL, CSV, REST APIs, and more
+- **35 data sources** — Stripe, Google Sheets, Google Analytics, Shopify, PostgreSQL, MySQL, CSV, REST APIs, and more
 - **Auto-generated dbt models** — staging models created automatically when you add a source
 - **Data catalog** — browse tables, columns, and profiling stats; view dbt lineage and test results
 - **Web dashboard** — monitor syncs, manage sources, and view platform health
@@ -80,7 +80,7 @@ All data stays local in DuckDB. No external warehouse needed.
 
 | Component | Tool | Role |
 |-----------|------|------|
-| Ingestion | [dlt](https://dlthub.com/) | Load data from 33+ sources |
+| Ingestion | [dlt](https://dlthub.com/) | Load data from 35 sources |
 | Warehouse | [DuckDB](https://duckdb.org/) | Embedded analytics database |
 | Transformation | [dbt](https://www.getdbt.com/) | SQL modeling and testing |
 | Dashboards | [Metabase](https://www.metabase.com/) | BI and SQL queries |
@@ -106,7 +106,7 @@ Dango is honest about what it doesn't do yet. The short version — full detail 
 
 - Single-writer concurrency until the Quack migration lands (DuckDB 2.0)
 - No streaming, CDC, or reverse ETL
-- 34 sources today, added on demand
+- 35 sources today, added on demand
 - BYOS deployments need to configure their own backup destination (warned at deploy time)
 
 ## Links


### PR DESCRIPTION
## Summary
- README stated the source count three different, all-wrong ways: "33 data sources", "33+ sources", "34 sources today"
- Verified the real count via `len(list(SourceType))` == 35
- Found by 1.0.8-T10 while drafting launch posts and cross-checking factual claims against live source

## Verification
- `python3 -c "from dango.config.models import SourceType; print(len(list(SourceType)))"` -> 35
- Grepped README.md for other source-count mentions, no others found