### PR TITLE
1.0.8: Acquire DbtLock in MCP run_transform tool

### DIFF
--- a/dango/cli/commands/mcp_mutations.py
+++ b/dango/cli/commands/mcp_mutations.py
@@ -85,8 +85,18 @@ def run_transform(select: str | None = None, full_refresh: bool = False) -> dict
     """
     project_root = _get_project_root()
     from dango.transformation import run_dbt_models
+    from dango.utils import DbtLock
 
+    # Single-writer DuckDB (VAL-003) — was the one run_dbt_models() caller
+    # missing lock acquisition. Mirrors transform.py's run(); a lock timeout
+    # (DbtLockError) falls through to the except below unchanged.
+    lock = DbtLock(
+        project_root=project_root,
+        source="mcp",
+        operation=f"run_transform select={select}" if select else "run_transform",
+    )
     try:
+        lock.acquire()
         # Correction (coordinating-chat pre-dispatch verification, 2026-09-03):
         # run_dbt_models() returns tuple[bool, str] (success, output), not a
         # single value — `if result` on a 2-tuple is always truthy regardless
@@ -96,6 +106,9 @@ def run_transform(select: str | None = None, full_refresh: bool = False) -> dict
         return {"status": "completed" if success else "failed", "output": output}
     except Exception as e:
         return {"status": "failed", "error": str(e)}
+    finally:
+        if lock._acquired:
+            lock.release()
 
 
 @mcp.tool()

--- a/tests/unit/test_mcp_mutations.py
+++ b/tests/unit/test_mcp_mutations.py
@@ -91,6 +91,80 @@ class TestRunTransform:
         result = mcp_mutations.run_transform()
         assert result == {"status": "failed", "output": "Compilation Error in model foo"}
 
+    def test_run_transform_acquires_and_releases_dbt_lock(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test for BUGS-FOUND.md 'MCP run_transform does not acquire
+        DbtLock': run_transform() was the one caller of run_dbt_models() in the
+        whole codebase with no lock acquisition (unlike dlt_runner.py,
+        web/routes/upload.py, and platform/scheduling/jobs.py x2). Assert the
+        real call order is acquire -> dbt -> release, matching transform.py's
+        `run()` CLI command."""
+        import dango.utils as dango_utils
+
+        call_order: list[str] = []
+
+        class FakeLock:
+            def __init__(self, *, project_root, source, operation):
+                call_order.append(f"init:{source}")
+                self._acquired = False
+
+            def acquire(self, timeout: float = 300) -> bool:
+                call_order.append("acquire")
+                self._acquired = True
+                return True
+
+            def release(self) -> None:
+                call_order.append("release")
+                self._acquired = False
+
+        monkeypatch.setattr(dango_utils, "DbtLock", FakeLock)
+
+        def _track_dbt(project_root, select, full_refresh):
+            call_order.append("dbt")
+            return (True, "1 of 1 OK")
+
+        monkeypatch.setattr("dango.transformation.run_dbt_models", _track_dbt)
+
+        result = mcp_mutations.run_transform()
+
+        assert result == {"status": "completed", "output": "1 of 1 OK"}
+        assert call_order == ["init:mcp", "acquire", "dbt", "release"]
+
+    def test_run_transform_lock_timeout_returns_clean_error(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When DbtLock can't be acquired (e.g. a sync or scheduled job is already
+        writing to DuckDB), run_transform() must return the tool's normal
+        {"status": "failed", "error": ...} shape — same convention as every other
+        error path in this function — rather than letting DbtLockError propagate
+        unhandled through the MCP tool boundary. Also confirms run_dbt_models()
+        is never reached when the lock can't be acquired."""
+        from dango.exceptions import DbtLockError
+        from dango.utils import DbtLock
+
+        def _raise_lock_error(self, timeout: float = 300) -> bool:
+            raise DbtLockError("Sync queue timeout. Another sync is still running.")
+
+        monkeypatch.setattr(DbtLock, "acquire", _raise_lock_error)
+
+        dbt_called = False
+
+        def _track_dbt(project_root, select, full_refresh):
+            nonlocal dbt_called
+            dbt_called = True
+            return (True, "should not run")
+
+        monkeypatch.setattr("dango.transformation.run_dbt_models", _track_dbt)
+
+        result = mcp_mutations.run_transform()
+
+        assert result == {
+            "status": "failed",
+            "error": "Sync queue timeout. Another sync is still running.",
+        }
+        assert dbt_called is False
+
 
 @pytest.mark.unit
 class TestRunDoctor:


### PR DESCRIPTION
## Summary
- `mcp_mutations.run_transform()` was the one caller of `run_dbt_models()` in the codebase with no `DbtLock` acquisition (unlike `dlt_runner.py`, `web/routes/upload.py`, `platform/scheduling/jobs.py`)
- DuckDB is single-writer (VAL-003) - an LLM agent calling this MCP tool while a sync or scheduled job writes could corrupt the warehouse
- Found by 1.0.8-D4's session while writing the MCP docs page, logged in BUGS-FOUND.md

## Changes
- `run_transform()` now wraps `run_dbt_models()` in `DbtLock`, mirroring `transform.py`'s `run()` CLI command
- Lock timeout (`DbtLockError`) falls through to the existing `except Exception` handler, returning `{"status": "failed", "error": ...}` - same shape as every other error path in this tool, no new exception propagates through the MCP boundary

## Verification
- `pytest tests/unit/test_mcp_mutations.py -v`: 21 passed, including 2 new regression tests (lock acquire/release call order, lock-timeout clean-error shape)
- `ruff check`: passed