### PR TITLE
1.0.8: Fix dango dashboard provision - hardcoded port + broken database lookup

### DIFF
--- a/dango/cli/commands/dashboard.py
+++ b/dango/cli/commands/dashboard.py
@@ -21,13 +21,15 @@ def dashboard(ctx: click.Context) -> None:
 
 
 @dashboard.command("provision")
-@click.option("--url", default="http://localhost:3000", help="Metabase URL")
+@click.option("--url", default=None, help="Metabase URL (default: project's configured port)")
 @click.option(
     "--username", default=None, help="Metabase admin username (auto-detected from auth DB)"
 )
 @click.option("--password", prompt=True, hide_input=True, help="Metabase admin password")
 @click.pass_context
-def dashboard_provision(ctx: click.Context, url: str, username: str | None, password: str) -> None:
+def dashboard_provision(
+    ctx: click.Context, url: str | None, username: str | None, password: str
+) -> None:
     """
     Provision Data Pipeline Health dashboard in Metabase.
 
@@ -41,13 +43,30 @@ def dashboard_provision(ctx: click.Context, url: str, username: str | None, pass
     The dashboard provides instant visibility into your data pipeline.
 
     Examples:
-      dango dashboard provision                  # Use defaults (localhost:3000)
+      dango dashboard provision                  # Use the project's configured Metabase port
       dango dashboard provision --url http://metabase.local
     """
     from rich.panel import Panel
     from rich.table import Table
 
     from dango.visualization import provision_dashboard
+
+    project_root = ctx.obj["project_root"]
+
+    # Read the project's actual configured Metabase port rather than
+    # defaulting to localhost:3000 — a project configured on a non-default
+    # port would otherwise have this command silently target the wrong (or a
+    # different project's) Metabase instance. Same pattern as
+    # setup_metabase_if_needed() in platform/common/startup.py.
+    if url is None:
+        metabase_port = 3000
+        try:
+            from dango.config.helpers import load_config
+
+            metabase_port = load_config(project_root).platform.metabase_port
+        except Exception:  # noqa: BLE001
+            pass
+        url = f"http://localhost:{metabase_port}"
 
     # Resolve admin email: env var → auth DB → fallback
     if username is None:
@@ -60,7 +79,6 @@ def dashboard_provision(ctx: click.Context, url: str, username: str | None, pass
                 from dango.auth.database import list_users
                 from dango.auth.models import Role
 
-                project_root = ctx.obj["project_root"]
                 db_path = get_auth_db_path(project_root)
                 if db_path.exists():
                     users = list_users(db_path, active_only=True)
@@ -78,9 +96,26 @@ def dashboard_provision(ctx: click.Context, url: str, username: str | None, pass
         console.print(f"Connecting to Metabase at {url}...")
         console.print()
 
+        # Read the known DuckDB database ID persisted by setup_metabase() at
+        # first-run time, so provision_dashboard() doesn't need to guess it
+        # via get_database_id()'s "DuckDB" substring search — which never
+        # matches setup_metabase()'s actual f"{org_name} Analytics" naming.
+        database_id = None
+        try:
+            import yaml
+
+            credentials_file = project_root / ".dango" / "metabase.yml"
+            if credentials_file.exists():
+                stored = yaml.safe_load(credentials_file.read_text())
+                database_id = (stored or {}).get("database", {}).get("id")
+        except Exception:  # noqa: BLE001
+            pass
+
         # Provision dashboard
         with console.status("[cyan]Creating dashboard...[/cyan]", spinner="dots"):
-            result = provision_dashboard(metabase_url=url, username=username, password=password)
+            result = provision_dashboard(
+                metabase_url=url, username=username, password=password, database_id=database_id
+            )
 
         if result["success"]:
             console.print("[green]✅ Dashboard provisioned successfully![/green]\n")

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -363,9 +363,20 @@ class MetabaseProvisioner:
 
         return True
 
-    def provision_pipeline_health_dashboard(self) -> dict[str, Any]:
+    def provision_pipeline_health_dashboard(self, database_id: int | None = None) -> dict[str, Any]:
         """
         Provision complete Data Pipeline Health dashboard
+
+        Args:
+            database_id: Known Metabase database ID to use directly, bypassing
+                the name-search fallback below. `setup_metabase()` names the
+                DuckDB connection ``f"{org_name} Analytics"`` and persists its
+                ID in ``.dango/metabase.yml`` — passing that ID here avoids
+                relying on `get_database_id()`'s default `"DuckDB"` substring
+                search, which never matches that naming convention (found
+                2026-09-04: every real project's database name is
+                "<org> Analytics", never containing the literal word
+                "DuckDB", so the search always failed).
 
         Returns:
             Summary of provisioning results
@@ -383,8 +394,11 @@ class MetabaseProvisioner:
             summary["errors"].append("Authentication failed")
             return summary
 
-        # Get database ID
-        database_id = self.get_database_id()
+        # Get database ID: prefer the caller-supplied known ID; fall back to
+        # the name-search only when no ID was supplied (e.g. a caller that
+        # doesn't have access to .dango/metabase.yml).
+        if database_id is None:
+            database_id = self.get_database_id()
         if not database_id:
             summary["errors"].append("DuckDB database not found in Metabase")
             return summary
@@ -450,6 +464,7 @@ def provision_dashboard(
     metabase_url: str = "http://localhost:3000",
     username: str = "admin@example.com",
     password: str = "admin123",
+    database_id: int | None = None,
 ) -> dict[str, Any]:
     """
     Convenience function to provision Data Pipeline Health dashboard
@@ -458,12 +473,16 @@ def provision_dashboard(
         metabase_url: Metabase instance URL
         username: Admin username
         password: Admin password
+        database_id: Known Metabase database ID — see
+            `MetabaseProvisioner.provision_pipeline_health_dashboard`'s docstring
+            for why this should be supplied whenever the caller has it
+            (e.g. from `.dango/metabase.yml`).
 
     Returns:
         Provisioning summary
     """
     provisioner = MetabaseProvisioner(metabase_url, username, password)
-    return provisioner.provision_pipeline_health_dashboard()
+    return provisioner.provision_pipeline_health_dashboard(database_id=database_id)
 
 
 def create_pipeline_health_dashboard(project_root: Path) -> dict[str, Any]:

--- a/tests/unit/test_metabase_dashboard_provision.py
+++ b/tests/unit/test_metabase_dashboard_provision.py
@@ -1,0 +1,41 @@
+"""tests/unit/test_metabase_dashboard_provision.py
+
+Regression tests for `dango dashboard provision`'s known-database-id bypass.
+Split out of test_metabase_api.py to stay under the 500-line file-size check.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestProvisionPipelineHealthDashboardDatabaseId:
+    """Regression: get_database_id()'s default "DuckDB" substring search
+    never matches setup_metabase()'s f"{org_name} Analytics" naming — a
+    known database_id now bypasses that search (found 2026-09-04)."""
+
+    def test_known_database_id_skips_search(self) -> None:
+        from dango.visualization.metabase import MetabaseProvisioner
+
+        provisioner = MetabaseProvisioner()
+        provisioner.authenticate = MagicMock(return_value=True)  # type: ignore[method-assign]
+        provisioner.get_database_id = MagicMock()  # type: ignore[method-assign]
+
+        provisioner.provision_pipeline_health_dashboard(database_id=99)
+
+        provisioner.get_database_id.assert_not_called()
+
+    def test_no_database_id_falls_back_to_search(self) -> None:
+        from dango.visualization.metabase import MetabaseProvisioner
+
+        provisioner = MetabaseProvisioner()
+        provisioner.authenticate = MagicMock(return_value=True)  # type: ignore[method-assign]
+        provisioner.get_database_id = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        result = provisioner.provision_pipeline_health_dashboard()
+
+        provisioner.get_database_id.assert_called_once()
+        assert result["errors"] == ["DuckDB database not found in Metabase"]


### PR DESCRIPTION
## Summary
Two bugs found live-verifying `dango dashboard provision` end-to-end (part of `PRE-PUBLISH-VERIFICATION.md`'s Metabase live pass):

1. `--url` defaulted to hardcoded `http://localhost:3000`, ignoring the project's configured `metabase_port` - same bug family already fixed elsewhere this cycle (PRs #459, #460), missed here.
2. `get_database_id()`'s default search looks for a database name containing the literal substring `"DuckDB"`. `setup_metabase()` always names the connection `f"{org_name} Analytics"` - which never contains that substring - so this command has never been able to find the database in any real project. Fixed by reading the known database ID from `.dango/metabase.yml` (already persisted by `setup_metabase()`) instead of re-searching by name.

## Verification
- Live-verified against a real Metabase 0.62.18 instance on a non-default port (3901): dashboard created with all 6 cards attached, previously failed with "DuckDB database not found in Metabase"
- `pytest tests/unit/ -k "metabase or dashboard"`: 201 passed
- `ruff check`: passed