### PR TITLE
1.0.8: Real queries for Data Pipeline Health dashboard

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -26,7 +26,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/metabase_cmd.py` (412 lines) | `metabase` group (`save`, `load`, `refresh`) | `metabase` |
 | `commands/model.py` (258 lines) | `model` group (`add`, `remove`) | `model` |
 | `commands/seed.py` (135 lines) | `seed` group (`add`, `list`) — dbt seed CSV management | `seed` |
-| `commands/dashboard.py` (153 lines) | `dashboard` group (`provision`) | `dashboard` |
+| `commands/dashboard.py` (215 lines) | `dashboard` group (`provision`) — materializes pipeline-health state via `dango.utils.pipeline_health` before provisioning (1.0.8-DASH-1) | `dashboard` |
 | `commands/mcp_server.py` (~460 lines) | `mcp` group + `run` command; FastMCP stdio server with 8 read-only tools (list_sources, get_table_schema, get_catalog, get_lineage, list_models, get_model_sql, query, get_sync_history) | `mcp_group`, `mcp`, `mcp_run()` |
 | `commands/mcp_mutations.py` (~485 lines) | Mutation tools registered onto the shared `mcp` FastMCP instance (run_sync, run_transform, run_doctor, add_source, list_source_types, create_model, add_schedule) — split out of mcp_server.py, not a Click module | `run_sync()`, `run_transform()`, `run_doctor()`, `add_source()`, `list_source_types()`, `create_model()`, `add_schedule()` |
 | `commands/mcp_setup.py` (~145 lines) | `mcp setup` / `mcp status` subcommands (registers onto `mcp_group` from mcp_server.py) — detects/configures Claude Code, Cursor, Windsurf | `mcp_setup()`, `mcp_status()` |

--- a/dango/cli/commands/dashboard.py
+++ b/dango/cli/commands/dashboard.py
@@ -111,6 +111,33 @@ def dashboard_provision(
         except Exception:  # noqa: BLE001
             pass
 
+        # Materialize sync history / dbt test results / source list into
+        # DuckDB tables (1.0.8-DASH-1) before creating the cards, so the
+        # dashboard reflects current state even on a project that has never
+        # synced (empty tables, honest zero state) or whose last sync
+        # predates this run of `dango dashboard provision`.
+        try:
+            from dango.utils.pipeline_health import materialize_pipeline_health
+
+            materialize_pipeline_health(project_root)
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Refresh Metabase's own DuckDB connection so it sees the write
+        # above. Metabase's embedded DuckDB connection holds a snapshot of
+        # the file as of when it was opened — this is the same reason
+        # dlt_runner.py calls refresh_metabase_connection() after every dbt
+        # run (see that function's docstring). Without this, a Metabase
+        # instance that was already running before this materialize step
+        # would keep showing pre-materialization (or stale) data on the new
+        # cards until something else happened to restart it.
+        try:
+            from dango.visualization.metabase import refresh_metabase_connection
+
+            refresh_metabase_connection(project_root, metabase_url=url)
+        except Exception:  # noqa: BLE001
+            pass
+
         # Provision dashboard
         with console.status("[cyan]Creating dashboard...[/cyan]", spinner="dots"):
             result = provision_dashboard(

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Shared utilities for process management, activity logging, sync history tracking, DuckDB schema initialization, database health monitoring, cross-process dbt locking, and persistent dbt model status.
+Shared utilities for process management, activity logging, sync history tracking, DuckDB schema initialization, database health monitoring, cross-process dbt locking, persistent dbt model status, and pipeline-health materialization for the Metabase dashboard.
 
 ## Files
 
@@ -20,7 +20,8 @@ Shared utilities for process management, activity logging, sync history tracking
 | `data_validation.py` | Schema/data integrity checks against DuckDB | `validate_cursor_field()`, `detect_schema_changes()`, `validate_data_completeness()`, `print_validation_report()` |
 | `env_file.py` | .env file parsing and serialization | `parse_env_file()`, `serialize_env_file()` |
 | `dango_db.py` (~210 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
-| `post_sync.py` (~804 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
+| `post_sync.py` (~804 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_materialize_pipeline_health()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
+| `pipeline_health.py` | Materializes sync history / dbt test results / source list into DuckDB tables (`_dango_meta` schema) for the "Data Pipeline Health" dashboard (1.0.8-DASH-1) — Metabase's container can't read the underlying JSON files directly | `materialize_pipeline_health()`, `SCHEMA` |
 | `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 
@@ -37,6 +38,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | Add a data validation check | `data_validation.py` | Manual: call against a DuckDB with test data |
 | Rotate JSONL logs | `log_rotation.py` | `pytest tests/unit/test_log_rotation.py` |
 | Change log archive retention | `log_rotation.py` (`max_age_days` param, default 90) | `pytest tests/unit/test_log_rotation.py` |
+| Change what the pipeline-health dashboard materializes | `pipeline_health.py` | `pytest tests/unit/test_pipeline_health.py` |
 
 ## Dependencies
 
@@ -51,6 +53,7 @@ Shared utilities for process management, activity logging, sync history tracking
 - `dango/web/helpers.py` — db_health, sync_history, activity_log, dbt_status
 - `dango/web/routes/sync.py` — dbt_lock
 - `dango/ingestion/dlt_runner.py` — activity_log, sync_history, db_health, post_sync (dispatch_post_sync_hooks)
+- `dango/cli/commands/dashboard.py` — pipeline_health (materialize_pipeline_health, called before provisioning so the dashboard reflects current state even without a prior sync)
 - `dango/cli/commands/platform.py` — process (kill_process)
 - `dango/cli/commands/cleanup.py` — db_health, log_rotation
 - `dango/platform/local/watcher_runner.py` — dbt_lock, dbt_status
@@ -65,7 +68,7 @@ Shared utilities for process management, activity logging, sync history tracking
 
 ## Testing
 
-- **Unit:** `pytest tests/unit/test_db_health_disk.py tests/unit/test_log_rotation.py tests/unit/test_driver_utils.py`
+- **Unit:** `pytest tests/unit/test_db_health_disk.py tests/unit/test_log_rotation.py tests/unit/test_driver_utils.py tests/unit/test_pipeline_health.py`
 - **Integration:** None yet
 - **Manual:** `dango start` exercises database.py; `dango sync` exercises activity_log, sync_history, db_health, dbt_lock; `dango cleanup` exercises log_rotation, db_health
 

--- a/dango/utils/pipeline_health.py
+++ b/dango/utils/pipeline_health.py
@@ -1,0 +1,318 @@
+"""dango/utils/pipeline_health.py
+
+Materializes pipeline-health state (sync history, dbt test results, and the
+configured source list) into real DuckDB tables under the ``_dango_meta``
+schema of the project's warehouse.
+
+Why this exists: Metabase's Docker container only mounts ``./data:/data:ro``
+(see ``templates/docker-compose.yml.j2``) — it has no access to
+``.dango/history/*.json``, ``.dango/dbt_model_status.json``, or
+``dbt/target/run_results.json``. The "Data Pipeline Health" dashboard
+(``dango/visualization/metabase.py``, ``DASHBOARD_QUERIES``) is provisioned
+as native SQL cards that Metabase executes itself against the DuckDB
+warehouse — it cannot read those JSON files directly. This module is the
+bridge: it reads the JSON state Dango already tracks and writes a small,
+denormalized copy into DuckDB tables Metabase *can* see, in the ``_dango_meta``
+schema (following the ``_dango_*`` naming precedent already anticipated in
+``dango/visualization/CLAUDE.md``'s "Don't Modify" notes for
+``DASHBOARD_QUERIES``).
+
+Design choice — Python step, not a dbt model:
+    A new dbt model using ``read_json_auto()`` was considered (and confirmed
+    to parse the sync-history JSON shape correctly). It was rejected for
+    ``dbt_test_results`` specifically: ``dbt/target/run_results.json`` is
+    overwritten by dbt at the *end* of a whole dbt invocation (see
+    ``dlt_runner.py``'s backup/restore of ``run_results.json`` around the
+    ``generate_dbt_docs()`` call). A dbt model added to that same invocation
+    would run *before* the invocation's own results are written, so it would
+    always read the *previous* run's test results, not the current one — a
+    permanent one-cycle lag. Reading sync history and sources.yml via a dbt
+    model has no such problem, but keeping one mechanism for all three
+    matches how ``_profile_dbt_models()`` in ``utils/post_sync.py`` already
+    reads ``run_results.json`` directly with plain Python *after* dbt has
+    fully finished (which is the correct time to read it).
+
+Called from two places, both safe to call repeatedly (each run fully
+replaces the materialized tables' contents):
+    - ``utils/post_sync.py`` (``dispatch_post_sync_hooks``), after every
+      ``dango sync`` — keeps the tables fresh with the latest sync + dbt run.
+    - ``cli/commands/dashboard.py`` (``dashboard_provision``), immediately
+      before creating dashboard cards — guarantees the tables exist (even if
+      empty, e.g. fresh install with no sync history) so provisioning never
+      fails, and that a manual re-provision always reflects current state.
+
+Never raises — mirrors the "best-effort" contract of the other post-sync
+hooks in ``utils/post_sync.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from dango.logging import get_logger
+
+logger = get_logger(__name__)
+
+SCHEMA = "_dango_meta"
+
+# dbt test-node statuses that count as "passed". Different dbt/adapter
+# versions have been observed to report either the TestStatus vocabulary
+# ("pass"/"fail"/"warn"/"error"/"skipped") or the generic RunStatus
+# vocabulary ("success"/"error"/"skipped") for test nodes — verified against
+# a real project's run_results.json where dbt-duckdb reported "success" for
+# passing tests, not "pass". Both are treated as passing here.
+_PASSING_TEST_STATUSES = {"pass", "success", "warn"}
+_FAILING_TEST_STATUSES = {"fail", "error"}
+# Anything else (e.g. "skipped") is excluded from pass/fail counts entirely.
+
+
+def _ensure_schema(conn: Any) -> None:
+    """Create the ``_dango_meta`` schema and tables if they don't exist yet.
+
+    Safe to call on a fresh project that has never synced — this is what
+    lets ``dango dashboard provision`` succeed with an honest empty state
+    instead of erroring on missing tables.
+    """
+    conn.execute(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.sync_history (
+            source_name VARCHAR,
+            sync_timestamp TIMESTAMP,
+            status VARCHAR,
+            duration_seconds DOUBLE,
+            rows_processed BIGINT,
+            error_message VARCHAR
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.dbt_test_results (
+            unique_id VARCHAR,
+            status VARCHAR,
+            passed BOOLEAN,
+            message VARCHAR,
+            execution_time DOUBLE,
+            run_generated_at TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.source_overview (
+            source_name VARCHAR,
+            source_type VARCHAR,
+            enabled BOOLEAN
+        )
+        """
+    )
+
+
+def _materialize_sync_history(conn: Any, project_root: Path, source_names: list[str]) -> None:
+    """Rewrite ``_dango_meta.sync_history`` from ``.dango/history/<source>.json``.
+
+    Reads the full retained history (up to the 100-entry cap enforced by
+    ``save_sync_history_entry``) for every currently-configured source, not
+    just the default ``load_sync_history()`` limit of 10 — the sync-history
+    and row-count-trend cards need up to 30 days of entries.
+    """
+    from dango.utils.sync_history import load_sync_history
+
+    rows: list[tuple[Any, ...]] = []
+    for source_name in source_names:
+        try:
+            entries = load_sync_history(project_root, source_name, limit=100)
+        except Exception:
+            logger.warning("pipeline_health_sync_history_read_error", source=source_name)
+            continue
+
+        for entry in entries:
+            timestamp = entry.get("timestamp")
+            if not timestamp:
+                continue
+            try:
+                parsed_ts = datetime.fromisoformat(timestamp)
+            except (TypeError, ValueError):
+                logger.debug(
+                    "pipeline_health_sync_history_bad_timestamp",
+                    source=source_name,
+                    timestamp=timestamp,
+                )
+                continue
+
+            rows.append(
+                (
+                    source_name,
+                    parsed_ts,
+                    entry.get("status"),
+                    entry.get("duration_seconds"),
+                    entry.get("rows_processed"),
+                    entry.get("error_message"),
+                )
+            )
+
+    conn.execute(f"DELETE FROM {SCHEMA}.sync_history")
+    if rows:
+        conn.executemany(
+            f"INSERT INTO {SCHEMA}.sync_history "
+            "(source_name, sync_timestamp, status, duration_seconds, rows_processed, error_message) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _materialize_dbt_test_results(conn: Any, project_root: Path) -> None:
+    """Rewrite ``_dango_meta.dbt_test_results`` from ``dbt/target/run_results.json``.
+
+    Only test nodes (``unique_id`` starting with ``"test."``) are kept —
+    models/seeds/operations are out of scope for this table. If the file
+    doesn't exist yet (no dbt run has completed), the table is left empty.
+    """
+    run_results_path = project_root / "dbt" / "target" / "run_results.json"
+    if not run_results_path.exists():
+        conn.execute(f"DELETE FROM {SCHEMA}.dbt_test_results")
+        return
+
+    try:
+        run_results = json.loads(run_results_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        logger.warning("pipeline_health_run_results_read_error", exc_info=True)
+        return
+
+    generated_at_raw = run_results.get("metadata", {}).get("generated_at")
+    generated_at: datetime | None = None
+    if generated_at_raw:
+        try:
+            generated_at = datetime.fromisoformat(generated_at_raw.replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            generated_at = None
+
+    rows: list[tuple[Any, ...]] = []
+    for result in run_results.get("results", []):
+        unique_id = result.get("unique_id", "")
+        if not unique_id.startswith("test."):
+            continue
+
+        status = result.get("status")
+        if status in _PASSING_TEST_STATUSES:
+            passed: bool | None = True
+        elif status in _FAILING_TEST_STATUSES:
+            passed = False
+        else:
+            passed = None  # e.g. "skipped" — excluded from pass/fail counts
+
+        rows.append(
+            (
+                unique_id,
+                status,
+                passed,
+                result.get("message"),
+                result.get("execution_time"),
+                generated_at,
+            )
+        )
+
+    conn.execute(f"DELETE FROM {SCHEMA}.dbt_test_results")
+    if rows:
+        conn.executemany(
+            f"INSERT INTO {SCHEMA}.dbt_test_results "
+            "(unique_id, status, passed, message, execution_time, run_generated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
+
+def _materialize_source_overview(conn: Any, project_root: Path) -> list[str]:
+    """Rewrite ``_dango_meta.source_overview`` from the project's ``sources.yml``.
+
+    Returns the list of configured source names, so the caller can reuse it
+    for the sync-history materialization step without loading config twice.
+    """
+    from dango.config.helpers import get_config
+
+    try:
+        config = get_config(project_root)
+        sources = config.sources.sources
+    except Exception:
+        logger.warning("pipeline_health_config_read_error", exc_info=True)
+        conn.execute(f"DELETE FROM {SCHEMA}.source_overview")
+        return []
+
+    rows = [(s.name, s.type.value, s.enabled) for s in sources]
+
+    conn.execute(f"DELETE FROM {SCHEMA}.source_overview")
+    if rows:
+        conn.executemany(
+            f"INSERT INTO {SCHEMA}.source_overview (source_name, source_type, enabled) "
+            "VALUES (?, ?, ?)",
+            rows,
+        )
+
+    return [s.name for s in sources]
+
+
+def materialize_pipeline_health(project_root: Path) -> None:
+    """Materialize sync history, dbt test results, and the source list into
+    DuckDB tables under the ``_dango_meta`` schema, so the "Data Pipeline
+    Health" dashboard's native SQL cards (``DASHBOARD_QUERIES`` in
+    ``visualization/metabase.py``) can show real data.
+
+    Each call fully replaces the three tables' contents (DELETE + INSERT) —
+    data volumes are small (a handful of sources, up to 100 history entries
+    each, a few hundred dbt test nodes) so a full rewrite is simpler and
+    cheaper than incremental upserts, and guarantees no stale rows survive a
+    source being removed from ``sources.yml``.
+
+    Never raises — best-effort, matching the contract of the other
+    post-sync hooks in ``utils/post_sync.py``. Safe to call on a project
+    that has never synced (creates empty tables) and safe to call
+    repeatedly (e.g. once per sync, and again at ``dango dashboard
+    provision`` time).
+
+    DuckDB is single-writer (VAL-003) — this opens a read-write connection,
+    so (unlike the read-only ``duckdb.connect(..., config={"access_mode":
+    "read_only"})`` calls elsewhere in ``post_sync.py``) it must serialize
+    against other writers via ``DbtLock``, the same mechanism
+    ``dlt_runner.py``'s dbt-run step and every other ``run_dbt_models()``
+    caller uses (see PR #464, which fixed the one caller that had skipped
+    it). Uses a short 15s timeout rather than the usual 300s default: this
+    is a quick metadata write (a handful of small DELETE+INSERT statements),
+    not a real dbt run, and a multi-minute stall here would be a bad user
+    experience for `dango dashboard provision` specifically. A timeout just
+    means this call's data goes stale until the next successful sync or
+    provision — never fatal, per the never-raises contract above.
+    """
+    import duckdb  # lazy import, matches dlt_runner.py / post_sync.py pattern
+
+    from dango.exceptions import DbtLockError
+    from dango.utils.dbt_lock import DbtLock
+
+    db_path = project_root / "data" / "warehouse.duckdb"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lock = DbtLock(project_root, source="pipeline-health", operation="materialize dashboard state")
+    try:
+        lock.acquire(timeout=15)
+    except DbtLockError:
+        logger.info("pipeline_health_lock_busy_skipped")
+        return
+
+    conn = None
+    try:
+        conn = duckdb.connect(str(db_path))
+        _ensure_schema(conn)
+        source_names = _materialize_source_overview(conn, project_root)
+        _materialize_sync_history(conn, project_root, source_names)
+        _materialize_dbt_test_results(conn, project_root)
+        logger.info("pipeline_health_materialized", source_count=len(source_names))
+    except Exception:
+        logger.warning("pipeline_health_materialize_error", exc_info=True)
+    finally:
+        if conn is not None:
+            conn.close()
+        if lock._acquired:
+            lock.release()

--- a/dango/utils/post_sync.py
+++ b/dango/utils/post_sync.py
@@ -335,6 +335,37 @@ def _run_dbt_snapshots(project_root: Path) -> None:
         logger.error("dbt_snapshots_error", exc_info=True)
 
 
+def _materialize_pipeline_health(project_root: Path) -> None:
+    """Materialize sync history / dbt test results / source list into DuckDB
+    tables for the "Data Pipeline Health" dashboard (1.0.8-DASH-1).
+
+    Runs after dbt (and dbt docs generation, which briefly overwrites then
+    restores ``run_results.json`` — see ``dlt_runner.py``) has fully
+    completed, so ``dbt/target/run_results.json`` reflects the sync that
+    just finished. Failures are logged but do not fail the sync.
+
+    Note on staleness: ``dlt_runner.py`` already calls
+    ``refresh_metabase_connection()`` (which restarts the Metabase
+    container so its long-lived embedded DuckDB connection sees new data —
+    see that function's docstring) earlier in the sync flow, *before*
+    post-sync hooks run. This hook's write therefore lands one refresh
+    cycle late for a Metabase instance that's already open and being
+    looked at mid-sync — it self-heals on the *next* sync's refresh. A
+    second container restart here (to make this specific write visible
+    immediately) was deliberately not added: it would double Metabase's
+    per-sync restart/downtime for a background hook nobody is watching in
+    real time. The path that must be fresh immediately —
+    ``dango dashboard provision`` — materializes and refreshes for itself
+    (see ``cli/commands/dashboard.py``), independent of this hook.
+    """
+    try:
+        from dango.utils.pipeline_health import materialize_pipeline_health
+
+        materialize_pipeline_health(project_root)
+    except Exception:
+        logger.error("pipeline_health_hook_error", exc_info=True)
+
+
 # ---------------------------------------------------------------------------
 # Post-sync dispatcher
 # ---------------------------------------------------------------------------
@@ -381,6 +412,7 @@ def dispatch_post_sync_hooks(
         ("pii_scan", lambda: _run_pii_scan(project_root, sources)),
         ("analysis", lambda: _run_analysis(project_root, sources)),
         ("dbt_snapshots", lambda: _run_dbt_snapshots(project_root)),
+        ("pipeline_health", lambda: _materialize_pipeline_health(project_root)),
     ]:
         try:
             hook_fn()

--- a/dango/visualization/CLAUDE.md
+++ b/dango/visualization/CLAUDE.md
@@ -25,6 +25,7 @@ Integrates with Metabase for dashboard provisioning, auto-setup, schema synchron
 
 **Imports from:**
 - No dango module imports (isolated module). Uses `requests` to call Metabase API, reads credentials from `.dango/metabase.yml` at runtime.
+- `DASHBOARD_QUERIES`' SQL (not Python imports) reads the `_dango_meta` schema tables written by `dango.utils.pipeline_health.materialize_pipeline_health()` (1.0.8-DASH-1) — `cli/commands/dashboard.py` calls that function (and `refresh_metabase_connection()`, below) before provisioning, not this module.
 
 **Used by:**
 - `dango/cli/main.py` — Metabase CLI commands (`dango metabase setup/sync/export/import/provision/refresh`)

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -20,7 +20,20 @@ logger = logging.getLogger(__name__)
 
 
 # Dashboard SQL Queries
-# These queries work against DuckDB with dlt state tables
+#
+# These queries run against the `_dango_meta` schema of the DuckDB warehouse
+# (sync_history, dbt_test_results, source_overview tables), NOT hardcoded
+# constants. That schema is populated by
+# `dango.utils.pipeline_health.materialize_pipeline_health()` — see that
+# module's docstring for why materialization (rather than e.g. mounting the
+# underlying JSON state files into Metabase's container) was chosen, and
+# `dango/templates/docker-compose.yml.j2` for why the JSON files aren't
+# directly reachable from Metabase in the first place (its container only
+# mounts `./data:/data:ro`).
+#
+# 1.0.8-DASH-1: replaced the previous hardcoded placeholder SQL (health
+# score always 100/"Excellent", tests always "All Tests Passing", etc. —
+# see BUGS-FOUND.md's "Data Pipeline Health" entry) with the queries below.
 
 DASHBOARD_QUERIES = {
     "source_overview": {
@@ -28,15 +41,21 @@ DASHBOARD_QUERIES = {
         "description": "Overview of all configured data sources",
         "sql": """
         SELECT
-            name as source_name,
-            type as source_type,
-            enabled,
-            'Synced' as status  -- Placeholder, will be enhanced with actual state
-        FROM (VALUES
-            ('sample', 'csv', true),
-            ('demo', 'csv', true)
-        ) as t(name, type, enabled)
-        -- TODO: Replace with actual sources.yml data
+            so.source_name,
+            so.source_type,
+            so.enabled,
+            COALESCE(
+                (
+                    SELECT sh.status
+                    FROM _dango_meta.sync_history sh
+                    WHERE sh.source_name = so.source_name
+                    ORDER BY sh.sync_timestamp DESC
+                    LIMIT 1
+                ),
+                'never synced'
+            ) AS status
+        FROM _dango_meta.source_overview so
+        ORDER BY so.source_name
         """,
         "visualization": "table",
     },
@@ -50,10 +69,14 @@ DASHBOARD_QUERIES = {
             FROM generate_series(0, 6) as t(n)
         )
         SELECT
-            sync_date::DATE as date,
-            0 as syncs_completed  -- Placeholder
-        FROM sync_dates
-        ORDER BY sync_date DESC
+            sd.sync_date::DATE as date,
+            COUNT(sh.source_name) as syncs_completed
+        FROM sync_dates sd
+        LEFT JOIN _dango_meta.sync_history sh
+            ON date_trunc('day', sh.sync_timestamp) = sd.sync_date
+            AND sh.status = 'success'
+        GROUP BY sd.sync_date
+        ORDER BY sd.sync_date DESC
         """,
         "visualization": "line",
     },
@@ -62,11 +85,21 @@ DASHBOARD_QUERIES = {
         "description": "How recent is the data in each source",
         "sql": """
         SELECT
-            'sample_data' as source_name,
-            COUNT(*) as row_count,
-            MAX(CURRENT_TIMESTAMP) as last_updated
-        FROM (SELECT 1)  -- Placeholder
-        -- TODO: Query actual staging tables
+            so.source_name,
+            (
+                SELECT sh.rows_processed
+                FROM _dango_meta.sync_history sh
+                WHERE sh.source_name = so.source_name AND sh.status = 'success'
+                ORDER BY sh.sync_timestamp DESC
+                LIMIT 1
+            ) AS last_sync_row_count,
+            (
+                SELECT MAX(sh2.sync_timestamp)
+                FROM _dango_meta.sync_history sh2
+                WHERE sh2.source_name = so.source_name AND sh2.status = 'success'
+            ) AS last_updated
+        FROM _dango_meta.source_overview so
+        ORDER BY last_updated DESC NULLS LAST
         """,
         "visualization": "table",
     },
@@ -74,15 +107,31 @@ DASHBOARD_QUERIES = {
         "name": "Row Counts Over Time",
         "description": "Track data growth across all sources",
         "sql": """
+        -- Cumulative (not per-day) total: sync_history.rows_processed is the
+        -- count processed *in that sync* (often an incremental delta), not a
+        -- running warehouse total, so a running SUM approximates overall
+        -- data growth over the window — matching the "Row Counts Over Time"
+        -- / area-chart intent better than a per-day bar would.
         WITH dates AS (
             SELECT date_trunc('day', CURRENT_DATE - INTERVAL (n) DAY) as date
             FROM generate_series(0, 29) as t(n)
+        ),
+        daily_rows AS (
+            SELECT
+                date_trunc('day', sync_timestamp) as date,
+                SUM(rows_processed) as rows_that_day
+            FROM _dango_meta.sync_history
+            WHERE status = 'success'
+            GROUP BY 1
         )
         SELECT
-            date::DATE,
-            0 as total_rows  -- Placeholder
-        FROM dates
-        ORDER BY date
+            d.date::DATE as date,
+            SUM(COALESCE(dr.rows_that_day, 0)) OVER (
+                ORDER BY d.date ROWS UNBOUNDED PRECEDING
+            ) as total_rows
+        FROM dates d
+        LEFT JOIN daily_rows dr ON dr.date = d.date
+        ORDER BY d.date
         """,
         "visualization": "area",
     },
@@ -90,11 +139,25 @@ DASHBOARD_QUERIES = {
         "name": "dbt Test Results",
         "description": "Data quality tests from dbt",
         "sql": """
+        WITH latest_run AS (
+            SELECT MAX(run_generated_at) as run_generated_at
+            FROM _dango_meta.dbt_test_results
+        ),
+        latest_tests AS (
+            SELECT dtr.*
+            FROM _dango_meta.dbt_test_results dtr, latest_run lr
+            WHERE dtr.run_generated_at = lr.run_generated_at
+                AND dtr.passed IS NOT NULL  -- excludes skipped tests
+        )
         SELECT
-            'All Tests Passing' as status,
-            0 as failed_tests,
-            0 as total_tests
-        -- TODO: Parse dbt test results
+            CASE
+                WHEN COUNT(*) = 0 THEN 'No tests run yet'
+                WHEN SUM(CASE WHEN NOT passed THEN 1 ELSE 0 END) = 0 THEN 'All Tests Passing'
+                ELSE 'Tests Failing'
+            END as status,
+            COALESCE(SUM(CASE WHEN NOT passed THEN 1 ELSE 0 END), 0) as failed_tests,
+            COUNT(*) as total_tests
+        FROM latest_tests
         """,
         "visualization": "scalar",
     },
@@ -102,10 +165,75 @@ DASHBOARD_QUERIES = {
         "name": "Pipeline Health Score",
         "description": "Overall health of data pipeline (0-100)",
         "sql": """
+        -- Health score definition: a 50/50 weighted average of
+        --   (a) sync success rate — % of enabled sources whose most recent
+        --       sync attempt succeeded (sources that have never synced are
+        --       excluded from this rate, not counted as failures), and
+        --   (b) dbt test pass rate — % of tests passing in the latest dbt run.
+        -- If only one signal has data (e.g. sources synced but dbt has
+        -- never run), that signal is used alone. If neither has data
+        -- (fresh install), the score is 0 with an honest message instead of
+        -- a fake "Excellent" — see BUGS-FOUND.md's "Data Pipeline Health"
+        -- entry for why this matters.
+        WITH sync_health AS (
+            SELECT
+                COUNT(*) as total_enabled,
+                SUM(CASE WHEN latest_status = 'success' THEN 1 ELSE 0 END) as succeeded
+            FROM (
+                SELECT
+                    so.source_name,
+                    (
+                        SELECT sh.status
+                        FROM _dango_meta.sync_history sh
+                        WHERE sh.source_name = so.source_name
+                        ORDER BY sh.sync_timestamp DESC
+                        LIMIT 1
+                    ) as latest_status
+                FROM _dango_meta.source_overview so
+                WHERE so.enabled
+            ) t
+            WHERE latest_status IS NOT NULL
+        ),
+        test_health AS (
+            SELECT
+                COUNT(*) as total_tests,
+                SUM(CASE WHEN passed THEN 1 ELSE 0 END) as passed_tests
+            FROM _dango_meta.dbt_test_results dtr, (
+                SELECT MAX(run_generated_at) as m FROM _dango_meta.dbt_test_results
+            ) lr
+            WHERE dtr.run_generated_at = lr.m AND dtr.passed IS NOT NULL
+        )
         SELECT
-            100 as health_score,
-            'Excellent' as status,
-            'All sources syncing successfully' as message
+            CASE
+                WHEN sh.total_enabled = 0 AND th.total_tests = 0 THEN 0
+                WHEN sh.total_enabled > 0 AND th.total_tests > 0 THEN
+                    ROUND(
+                        0.5 * (sh.succeeded::DOUBLE / sh.total_enabled) * 100
+                        + 0.5 * (th.passed_tests::DOUBLE / th.total_tests) * 100
+                    )
+                WHEN sh.total_enabled > 0 THEN
+                    ROUND((sh.succeeded::DOUBLE / sh.total_enabled) * 100)
+                ELSE
+                    ROUND((th.passed_tests::DOUBLE / th.total_tests) * 100)
+            END as health_score,
+            CASE
+                WHEN sh.total_enabled = 0 AND th.total_tests = 0 THEN 'No data yet'
+                WHEN sh.total_enabled = 0 OR sh.succeeded = sh.total_enabled THEN
+                    CASE WHEN th.total_tests = 0 OR th.passed_tests = th.total_tests
+                         THEN 'Excellent' ELSE 'Needs Attention' END
+                WHEN (sh.succeeded::DOUBLE / sh.total_enabled) >= 0.8 THEN 'Good'
+                ELSE 'Needs Attention'
+            END as status,
+            CASE
+                WHEN sh.total_enabled = 0 AND th.total_tests = 0
+                    THEN 'No sources have synced yet and no dbt tests have run'
+                ELSE
+                    COALESCE(sh.succeeded, 0) || '/' || COALESCE(sh.total_enabled, 0)
+                    || ' sources synced successfully, '
+                    || COALESCE(th.passed_tests, 0) || '/' || COALESCE(th.total_tests, 0)
+                    || ' dbt tests passing'
+            END as message
+        FROM sync_health sh, test_health th
         """,
         "visualization": "gauge",
     },

--- a/tests/unit/test_pipeline_health.py
+++ b/tests/unit/test_pipeline_health.py
@@ -1,0 +1,372 @@
+"""tests/unit/test_pipeline_health.py
+
+Tests for dango.utils.pipeline_health — materializes sync history, dbt test
+results, and the source list into DuckDB tables (`_dango_meta` schema) for
+the "Data Pipeline Health" dashboard (1.0.8-DASH-1).
+
+Also exercises the rewritten DASHBOARD_QUERIES SQL in
+dango/visualization/metabase.py by running it against a real DuckDB
+connection populated by materialize_pipeline_health() — this is the
+"unit test the SQL" half of the task's Tests requirement; the live
+Metabase check is separate (see PR description).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from dango.utils.pipeline_health import SCHEMA, materialize_pipeline_health
+
+
+def _write_project(
+    project_root: Path,
+    sources_yaml: str = "version: '1.0'\nsources: []\n",
+) -> None:
+    """Write the minimal .dango/project.yml + sources.yml get_config() needs."""
+    dango_dir = project_root / ".dango"
+    dango_dir.mkdir(parents=True, exist_ok=True)
+    (dango_dir / "project.yml").write_text(
+        "project:\n  name: test\n  created_by: test\n  purpose: test\n"
+    )
+    (dango_dir / "sources.yml").write_text(sources_yaml)
+
+
+def _write_history(project_root: Path, source_name: str, entries: list[dict]) -> None:
+    history_dir = project_root / ".dango" / "history"
+    history_dir.mkdir(parents=True, exist_ok=True)
+    (history_dir / f"{source_name}.json").write_text(json.dumps(entries))
+
+
+def _write_run_results(project_root: Path, results: list[dict], generated_at: str) -> None:
+    target_dir = project_root / "dbt" / "target"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "run_results.json").write_text(
+        json.dumps({"metadata": {"generated_at": generated_at}, "results": results})
+    )
+
+
+def _query(project_root: Path, sql: str) -> list[tuple]:
+    conn = duckdb.connect(str(project_root / "data" / "warehouse.duckdb"), read_only=True)
+    try:
+        return conn.execute(sql).fetchall()
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+class TestMaterializeFreshInstall:
+    """A project with no sync/dbt history must materialize empty tables, never crash."""
+
+    def test_fresh_install_creates_empty_tables(self, tmp_path: Path) -> None:
+        _write_project(tmp_path)
+
+        materialize_pipeline_health(tmp_path)
+
+        for table in ("sync_history", "dbt_test_results", "source_overview"):
+            assert _query(tmp_path, f"SELECT * FROM {SCHEMA}.{table}") == []
+
+    def test_missing_project_config_does_not_raise(self, tmp_path: Path) -> None:
+        """No .dango/project.yml at all (get_config will raise internally) — never propagates."""
+        materialize_pipeline_health(tmp_path)  # should not raise
+
+        assert _query(tmp_path, f"SELECT * FROM {SCHEMA}.source_overview") == []
+
+    def test_idempotent_schema_creation(self, tmp_path: Path) -> None:
+        """Calling twice in a row doesn't error (CREATE SCHEMA/TABLE IF NOT EXISTS)."""
+        _write_project(tmp_path)
+
+        materialize_pipeline_health(tmp_path)
+        materialize_pipeline_health(tmp_path)  # should not raise
+
+
+@pytest.mark.unit
+class TestMaterializeSourceOverview:
+    def test_reads_real_sources_yml(self, tmp_path: Path) -> None:
+        _write_project(
+            tmp_path,
+            sources_yaml=(
+                "version: '1.0'\n"
+                "sources:\n"
+                "  - name: orders\n"
+                "    type: csv\n"
+                "    enabled: true\n"
+                "    csv:\n"
+                "      directory: csv_data\n"
+                "  - name: legacy\n"
+                "    type: csv\n"
+                "    enabled: false\n"
+                "    csv:\n"
+                "      directory: legacy_data\n"
+            ),
+        )
+
+        materialize_pipeline_health(tmp_path)
+
+        rows = _query(
+            tmp_path,
+            f"SELECT source_name, source_type, enabled FROM {SCHEMA}.source_overview "
+            "ORDER BY source_name",
+        )
+        assert rows == [("legacy", "csv", False), ("orders", "csv", True)]
+
+    def test_full_rewrite_drops_removed_sources(self, tmp_path: Path) -> None:
+        """A source removed from sources.yml doesn't linger in the table."""
+        _write_project(
+            tmp_path,
+            sources_yaml=(
+                "version: '1.0'\nsources:\n  - name: a\n    type: csv\n    enabled: true\n"
+                "    csv:\n      directory: a_data\n"
+            ),
+        )
+        materialize_pipeline_health(tmp_path)
+        assert _query(tmp_path, f"SELECT source_name FROM {SCHEMA}.source_overview") == [("a",)]
+
+        _write_project(tmp_path, sources_yaml="version: '1.0'\nsources: []\n")
+        materialize_pipeline_health(tmp_path)
+        assert _query(tmp_path, f"SELECT source_name FROM {SCHEMA}.source_overview") == []
+
+
+@pytest.mark.unit
+class TestMaterializeSyncHistory:
+    def test_reads_real_history_files(self, tmp_path: Path) -> None:
+        _write_project(
+            tmp_path,
+            sources_yaml=(
+                "version: '1.0'\nsources:\n  - name: orders\n    type: csv\n    enabled: true\n"
+                "    csv:\n      directory: csv_data\n"
+            ),
+        )
+        _write_history(
+            tmp_path,
+            "orders",
+            [
+                {
+                    "timestamp": "2026-08-01T00:00:00+00:00",
+                    "status": "success",
+                    "duration_seconds": 1.5,
+                    "rows_processed": 10,
+                    "error_message": None,
+                },
+                {
+                    "timestamp": "2026-08-02T00:00:00+00:00",
+                    "status": "failed",
+                    "duration_seconds": 0.5,
+                    "rows_processed": 0,
+                    "error_message": "boom",
+                },
+            ],
+        )
+
+        materialize_pipeline_health(tmp_path)
+
+        rows = _query(
+            tmp_path,
+            f"SELECT source_name, status, rows_processed, error_message "
+            f"FROM {SCHEMA}.sync_history ORDER BY sync_timestamp",
+        )
+        assert rows == [
+            ("orders", "success", 10, None),
+            ("orders", "failed", 0, "boom"),
+        ]
+
+    def test_entry_missing_timestamp_is_skipped(self, tmp_path: Path) -> None:
+        """A malformed entry (no timestamp) is dropped, not a crash."""
+        _write_project(
+            tmp_path,
+            sources_yaml=(
+                "version: '1.0'\nsources:\n  - name: orders\n    type: csv\n    enabled: true\n"
+                "    csv:\n      directory: csv_data\n"
+            ),
+        )
+        _write_history(tmp_path, "orders", [{"status": "success", "rows_processed": 5}])
+
+        materialize_pipeline_health(tmp_path)
+
+        assert _query(tmp_path, f"SELECT * FROM {SCHEMA}.sync_history") == []
+
+
+@pytest.mark.unit
+class TestMaterializeDbtTestResults:
+    def test_passing_and_failing_tests_classified(self, tmp_path: Path) -> None:
+        _write_project(tmp_path)
+        _write_run_results(
+            tmp_path,
+            results=[
+                {"unique_id": "model.proj.stg_orders", "status": "success"},
+                {"unique_id": "test.proj.not_null_orders_id", "status": "pass"},
+                {"unique_id": "test.proj.not_null_orders_amount", "status": "success"},
+                {"unique_id": "test.proj.accepted_values_orders_status", "status": "fail"},
+                {"unique_id": "test.proj.unique_orders_id", "status": "skipped"},
+            ],
+            generated_at="2026-08-01T12:00:00Z",
+        )
+
+        materialize_pipeline_health(tmp_path)
+
+        rows = _query(
+            tmp_path,
+            f"SELECT unique_id, status, passed FROM {SCHEMA}.dbt_test_results ORDER BY unique_id",
+        )
+        assert rows == [
+            ("test.proj.accepted_values_orders_status", "fail", False),
+            ("test.proj.not_null_orders_amount", "success", True),
+            ("test.proj.not_null_orders_id", "pass", True),
+            ("test.proj.unique_orders_id", "skipped", None),
+        ]
+        # model. node is excluded entirely — only test. nodes are kept
+        assert _query(tmp_path, f"SELECT COUNT(*) FROM {SCHEMA}.dbt_test_results")[0][0] == 4
+
+    def test_no_run_results_file_leaves_table_empty(self, tmp_path: Path) -> None:
+        _write_project(tmp_path)
+
+        materialize_pipeline_health(tmp_path)
+
+        assert _query(tmp_path, f"SELECT * FROM {SCHEMA}.dbt_test_results") == []
+
+    def test_malformed_run_results_does_not_raise(self, tmp_path: Path) -> None:
+        _write_project(tmp_path)
+        target_dir = tmp_path / "dbt" / "target"
+        target_dir.mkdir(parents=True)
+        (target_dir / "run_results.json").write_text("not json{{{")
+
+        materialize_pipeline_health(tmp_path)  # should not raise
+
+
+@pytest.mark.unit
+class TestMaterializeLocking:
+    def test_busy_lock_skips_without_raising(self, tmp_path: Path) -> None:
+        """If another process holds the DbtLock, materialize skips silently."""
+        from dango.utils.dbt_lock import DbtLock
+
+        _write_project(tmp_path)
+
+        holder = DbtLock(tmp_path, source="test", operation="hold lock")
+        holder.acquire()
+        try:
+            materialize_pipeline_health(tmp_path)  # should not raise, should not hang
+        finally:
+            holder.release()
+
+        # Schema/tables were never created since the lock was never acquired
+        conn = duckdb.connect(str(tmp_path / "data" / "warehouse.duckdb"))
+        try:
+            schemas = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT schema_name FROM information_schema.schemata"
+                ).fetchall()
+            ]
+        finally:
+            conn.close()
+        assert SCHEMA not in schemas
+
+
+@pytest.mark.unit
+class TestDashboardQueriesSql:
+    """Runs the real DASHBOARD_QUERIES SQL (metabase.py) against a DuckDB
+    populated by materialize_pipeline_health() — the closest thing to a unit
+    test for native SQL cards that only really run inside Metabase."""
+
+    def _setup(self, tmp_path: Path) -> None:
+        _write_project(
+            tmp_path,
+            sources_yaml=(
+                "version: '1.0'\nsources:\n"
+                "  - name: orders\n    type: csv\n    enabled: true\n"
+                "    csv:\n      directory: csv_data\n"
+            ),
+        )
+        now = datetime.now(timezone.utc)
+        _write_history(
+            tmp_path,
+            "orders",
+            [
+                {
+                    "timestamp": now.isoformat(),
+                    "status": "success",
+                    "duration_seconds": 1.0,
+                    "rows_processed": 10,
+                    "error_message": None,
+                }
+            ],
+        )
+        _write_run_results(
+            tmp_path,
+            results=[
+                {"unique_id": "test.proj.not_null_orders_id", "status": "pass"},
+                {"unique_id": "test.proj.not_null_orders_amount", "status": "fail"},
+            ],
+            generated_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+        materialize_pipeline_health(tmp_path)
+
+    def test_fresh_install_queries_do_not_error(self, tmp_path: Path) -> None:
+        """Every DASHBOARD_QUERIES SQL string runs cleanly against empty tables."""
+        from dango.visualization.metabase import DASHBOARD_QUERIES
+
+        _write_project(tmp_path)
+        materialize_pipeline_health(tmp_path)
+
+        conn = duckdb.connect(str(tmp_path / "data" / "warehouse.duckdb"), read_only=True)
+        try:
+            for _key, query_def in DASHBOARD_QUERIES.items():
+                conn.execute(query_def["sql"]).fetchall()  # must not raise
+        finally:
+            conn.close()
+
+    def test_source_overview_shows_status_and_no_hardcoded_rows(self, tmp_path: Path) -> None:
+        from dango.visualization.metabase import DASHBOARD_QUERIES
+
+        self._setup(tmp_path)
+        rows = _query(tmp_path, DASHBOARD_QUERIES["source_overview"]["sql"])
+        assert rows == [("orders", "csv", True, "success")]
+        # The old hardcoded rows must be gone
+        names = {r[0] for r in rows}
+        assert "sample" not in names
+        assert "demo" not in names
+
+    def test_dbt_test_results_reflects_real_pass_fail(self, tmp_path: Path) -> None:
+        from dango.visualization.metabase import DASHBOARD_QUERIES
+
+        self._setup(tmp_path)
+        rows = _query(tmp_path, DASHBOARD_QUERIES["dbt_test_results"]["sql"])
+        assert rows == [("Tests Failing", 1, 2)]
+
+    def test_pipeline_health_score_is_not_hardcoded_100(self, tmp_path: Path) -> None:
+        from dango.visualization.metabase import DASHBOARD_QUERIES
+
+        self._setup(tmp_path)
+        rows = _query(tmp_path, DASHBOARD_QUERIES["pipeline_health_score"]["sql"])
+        assert len(rows) == 1
+        score, status, message = rows[0]
+        # 1/1 source synced (100) + 1/2 tests passing (50), weighted 50/50 = 75
+        assert score == 75.0
+        assert status == "Needs Attention"
+        assert "1/1 sources synced successfully" in message
+        assert "1/2 dbt tests passing" in message
+
+    def test_data_freshness_shows_real_timestamp_and_row_count(self, tmp_path: Path) -> None:
+        from dango.visualization.metabase import DASHBOARD_QUERIES
+
+        self._setup(tmp_path)
+        rows = _query(tmp_path, DASHBOARD_QUERIES["data_freshness"]["sql"])
+        assert len(rows) == 1
+        source_name, row_count, last_updated = rows[0]
+        assert source_name == "orders"
+        assert row_count == 10
+        assert last_updated is not None
+
+    def test_row_counts_trend_is_cumulative(self, tmp_path: Path) -> None:
+        from dango.visualization.metabase import DASHBOARD_QUERIES
+
+        self._setup(tmp_path)
+        rows = _query(tmp_path, DASHBOARD_QUERIES["row_counts_trend"]["sql"])
+        totals = [r[1] for r in rows]
+        # Cumulative sum never decreases and ends at >= the single sync's rows_processed
+        assert totals == sorted(totals)
+        assert totals[-1] == 10


### PR DESCRIPTION
## Summary
- Replace the "Data Pipeline Health" dashboard's 6 hardcoded placeholder
  queries with real ones, materializing sync history / dbt test results /
  source list into DuckDB tables Metabase can query (chosen over mounting
  the raw JSON state files into Metabase's container, per BUGS-FOUND.md)

## Materialization approach

**New `_dango_meta` schema in the DuckDB warehouse, written by a Python step
(`dango/utils/pipeline_health.py`), not a dbt model.**

- Metabase's Docker container only mounts `./data:/data:ro`
  (`templates/docker-compose.yml.j2`) — it has no access to
  `.dango/history/*.json`, `.dango/dbt_model_status.json`, or
  `dbt/target/run_results.json`. A materialization step is required to
  bridge that state into something Metabase's native-SQL cards can query.
- **Schema choice:** `_dango_meta` — a new dedicated schema (explicitly
  named as an option in the task spec, and matched by
  `dango/visualization/CLAUDE.md`'s existing "Don't Modify" note that
  `DASHBOARD_QUERIES` "reference internal dango table schemas (`_dango_*`,
  `_dlt_*`)"). Not `raw_*`/`main` — those are already hidden from Metabase's
  UI by `hide_internal_tables()`. Not `marts` — that's dbt-owned business
  data, and this isn't either (it's pipeline metadata Dango writes directly,
  not dbt output).
- **Python step, not a dbt model:** considered a new dbt model reading the
  JSON files via `read_json_auto()` — confirmed it parses the sync-history
  shape correctly (`SELECT * FROM read_json_auto('.dango/history/x.json')`
  round-trips fine). Rejected specifically for `dbt_test_results`:
  `dbt/target/run_results.json` is only finalized at the *end* of a whole
  dbt invocation (confirmed by tracing `dlt_runner.py`'s
  backup-before-docs-generate / restore-after of that exact file). A dbt
  model added to that same invocation would run *before* its own
  invocation's results are written, so it would permanently read the
  *previous* run's test results — a one-cycle lag with no fix within a
  single dbt run. A plain-Python step run after dbt fully completes (same
  pattern `_profile_dbt_models()` already uses in `post_sync.py`) avoids
  this. Reading `sync_history` and `sources.yml` has no such ordering
  problem, but one mechanism for all three is simpler than a hybrid.
- **Called from two places**, both idempotent (full DELETE+INSERT rewrite
  each time):
  - `dispatch_post_sync_hooks()` (`post_sync.py`) — after every `dango
    sync`.
  - `dango dashboard provision` (`cli/commands/dashboard.py`) — immediately
    before creating cards, so the dashboard is correct even on first
    provision with zero prior sync history (empty tables, honest zero
    state — required by the task's acceptance criteria).
- **Single-writer DuckDB (VAL-003):** the write is wrapped in a `DbtLock`
  (15s timeout — this is a quick metadata write, not a real dbt run; a
  timeout just means this call's data goes stale until the next sync/
  provision, never fatal). Matches the fix in PR #464 for the one
  `run_dbt_models()` caller that had skipped lock acquisition.
- **Metabase staleness:** discovered during live verification that
  Metabase's embedded DuckDB connection holds a snapshot as of when it was
  opened — a write made while Metabase is already running doesn't become
  visible until `refresh_metabase_connection()` restarts the container
  (same mechanism `dlt_runner.py` already relies on after every dbt run).
  `dango dashboard provision` now calls this after materializing, so a
  freshly-provisioned dashboard is guaranteed current. The post-sync hook
  path does *not* add a second restart (would double Metabase's per-sync
  downtime for a hook nobody is watching in real time) — it self-heals on
  the next sync's existing refresh; see the comment in
  `_materialize_pipeline_health()` (`post_sync.py`) for the full reasoning.

## Query changes (`DASHBOARD_QUERIES`, `visualization/metabase.py`)

- `source_overview`: real `sources.yml` data (name/type/enabled), joined
  against the latest sync status per source (`'never synced'` if none) —
  was hardcoded `sample`/`demo` rows.
- `sync_history`: real per-day successful-sync counts from the last 7 days
  — was always 0.
- `data_freshness`: real `MAX(sync_timestamp)` + last successful sync's
  `rows_processed` per source — was a literal `SELECT 1`.
- `row_counts_trend`: **cumulative** running sum of `rows_processed` over
  30 days (chosen over per-day, since sync history stores rows processed
  *in that sync*, not a running warehouse total — cumulative better matches
  the "data growth" / area-chart intent; documented in a SQL comment) — was
  always 0.
- `dbt_test_results`: real pass/fail counts from the latest materialized
  dbt run — was always "All Tests Passing", 0/0.
- `pipeline_health_score`: **defined explicitly in a SQL comment** — 50/50
  weighted average of (a) % of enabled sources whose most recent sync
  succeeded and (b) % of dbt tests passing in the latest run; falls back to
  whichever single signal exists if only one does; shows `0` / "No data
  yet" (not a fake "Excellent") when neither exists yet — was hardcoded
  100/"Excellent".

`DASHBOARD_QUERIES`' dict shape (`name`, `description`, `sql`,
`visualization`) is unchanged, so `MetabaseProvisioner.create_card()`
required no changes.

## Regression risk

- Did not touch `add_card_to_dashboard`/`set_dashboard_cards`/
  `get_database_id` (PRs #467/#468) or any Metabase login/session code.
- Did not add any new Docker volume mounts — the whole point of the chosen
  approach is to avoid that.
- New dbt model was *not* added (see reasoning above) — no dbt
  staging/intermediate/marts conventions to follow here.

## Verification
- `pytest -x`: 4455 passed, 30 skipped, 0 failed (full suite, not just the
  new file)
- `ruff check` / `ruff format --check`: passed
- **Live check** (scratch project `tests/test-dash1`, not beta-1): created
  a project with a real CSV source (`orders`, 5 rows), ran `dango sync` and
  `dango run`, then `dango dashboard provision` against a real Metabase
  instance and opened the dashboard in a browser at each stage:
  - **Fresh install** (before any sync): all 6 cards show honest zero/empty
    state — `0` health score, "No data yet", "never synced", empty
    freshness/trend tables. No crash.
  - **After a healthy sync + passing dbt tests**: Pipeline Health Score
    `100`/"Excellent", dbt Test Results "All Tests Passing", Data Sources
    Overview shows `orders`/`csv`/`true`, Data Freshness shows 5 rows with
    a real timestamp, Row Counts Over Time shows the real cumulative jump
    to 5.
  - **After deliberately adding a failing dbt test** (`accepted_values` on
    `order_id` that can't pass): re-materialized and re-queried directly —
    dbt Test Results correctly flipped to "Tests Failing" (1 failed / 5
    total), Pipeline Health Score correctly dropped to `90`/"Needs
    Attention" (0.5×100 sync + 0.5×80 tests). Reverted before the final
    browser check.
  - All three states differ from each other and from the old hardcoded
    constants, confirming both the materialization and the SQL respond to
    real pipeline state, not just render successfully.
- 17 new unit tests in `tests/unit/test_pipeline_health.py`: cover fresh-
  install (no crash, empty tables), real JSON parsing (sync history, run
  results, sources.yml), dbt test pass/fail/skipped classification, the
  `DbtLock` busy-skip path, and — since the queries are plain SQL, feasible
  to test directly — run every `DASHBOARD_QUERIES` string against a
  DuckDB populated by `materialize_pipeline_health()` and assert on the
  actual returned values (health score, pass/fail counts, cumulative row
  totals, no more hardcoded `sample`/`demo` rows).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MyYKvCUZcrvQwMHh1sNWEp