### PR TITLE
1.0.8: Verify process identity before signaling a tracked PID

### DIFF
--- a/dango/cli/helpers/process_manager.py
+++ b/dango/cli/helpers/process_manager.py
@@ -217,7 +217,7 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
     pid = pid_record.pid if pid_record else None
 
     if pid_record is not None:
-        if not is_process_running(pid, expected_start_time=pid_record.start_time):
+        if not is_process_running(pid_record.pid, expected_start_time=pid_record.start_time):
             if verbose:
                 console.print(
                     f"[yellow]⚠[/yellow] FastAPI server PID {pid} is not running (stale PID file)"
@@ -229,7 +229,9 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
 
             # Try to kill the process — identity-verified, so a stale PID file
             # pointing at a reused PID is never signaled (see 1.0.8-OPS-1).
-            success = kill_process(pid, timeout=10, expected_start_time=pid_record.start_time)
+            success = kill_process(
+                pid_record.pid, timeout=10, expected_start_time=pid_record.start_time
+            )
 
             # Clean up PID file
             remove_pid_file(project_root)

--- a/dango/cli/helpers/process_manager.py
+++ b/dango/cli/helpers/process_manager.py
@@ -10,7 +10,13 @@ from pathlib import Path
 import psutil
 from rich.console import Console
 
-from dango.utils.process import is_process_running, kill_process
+from dango.utils.process import (
+    PidRecord,
+    is_process_running,
+    kill_process,
+    read_pid_record,
+    write_pid_record,
+)
 
 from .port_manager import check_port_in_use, get_process_using_port
 
@@ -24,20 +30,44 @@ def get_pid_file_path(project_root: Path) -> Path:
 
 def write_pid_file(project_root: Path, pid: int) -> None:
     """
-    Write PID to file.
+    Write PID to file, alongside the process's start time for identity verification.
+
+    See dango.utils.process.write_pid_record — storing the start time lets a later
+    reader detect PID reuse (1.0.8-OPS-1) instead of trusting the bare PID number.
 
     Args:
         project_root: Project root directory
         pid: Process ID to write
     """
-    pid_file = get_pid_file_path(project_root)
-    pid_file.parent.mkdir(parents=True, exist_ok=True)
-    pid_file.write_text(str(pid))
+    write_pid_record(get_pid_file_path(project_root), pid)
+
+
+def read_pid_record_for_project(project_root: Path) -> PidRecord | None:
+    """
+    Read the PID record (PID + start time) for the FastAPI server.
+
+    Old-format bare-integer PID files (pre-1.0.8-OPS-1) are returned with
+    start_time=None — "identity unknown," not an error. Callers should pass the
+    start_time through to is_process_running()/kill_process() so identity gets
+    verified whenever it's known, and falls back to existence-only checking when
+    it isn't.
+
+    Args:
+        project_root: Project root directory
+
+    Returns:
+        PidRecord if file exists and is parseable, None otherwise
+    """
+    return read_pid_record(get_pid_file_path(project_root))
 
 
 def read_pid_file(project_root: Path) -> int | None:
     """
     Read PID from file.
+
+    Backward-compatible: returns just the PID, dropping identity info. Callers that
+    intend to signal the process (kill it) should use read_pid_record_for_project()
+    instead so identity gets verified before the PID is trusted.
 
     Args:
         project_root: Project root directory
@@ -45,16 +75,8 @@ def read_pid_file(project_root: Path) -> int | None:
     Returns:
         PID if file exists and valid, None otherwise
     """
-    pid_file = get_pid_file_path(project_root)
-
-    if not pid_file.exists():
-        return None
-
-    try:
-        pid_str = pid_file.read_text().strip()
-        return int(pid_str)
-    except (ValueError, OSError):
-        return None
+    record = read_pid_record_for_project(project_root)
+    return record.pid if record else None
 
 
 def remove_pid_file(project_root: Path) -> None:
@@ -90,15 +112,17 @@ def start_fastapi_server(project_root: Path, host: str = "0.0.0.0", port: int = 
     import sys
 
     # Check if we already have a PID file first (more informative error)
-    existing_pid = read_pid_file(project_root)
-    if existing_pid and is_process_running(existing_pid):
+    existing_record = read_pid_record_for_project(project_root)
+    if existing_record and is_process_running(
+        existing_record.pid, expected_start_time=existing_record.start_time
+    ):
         raise RuntimeError(
-            f"FastAPI server is already running (PID {existing_pid}).\n"
+            f"FastAPI server is already running (PID {existing_record.pid}).\n"
             f"Stop it with 'dango stop' or check status with 'dango status'"
         )
 
     # Clean up stale PID file if exists
-    if existing_pid:
+    if existing_record:
         remove_pid_file(project_root)
 
     # Check if port is already in use (by something else)
@@ -189,10 +213,11 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
     from dango.config import ConfigLoader
 
     # Try to stop using PID file first
-    pid = read_pid_file(project_root)
+    pid_record = read_pid_record_for_project(project_root)
+    pid = pid_record.pid if pid_record else None
 
-    if pid is not None:
-        if not is_process_running(pid):
+    if pid_record is not None:
+        if not is_process_running(pid, expected_start_time=pid_record.start_time):
             if verbose:
                 console.print(
                     f"[yellow]⚠[/yellow] FastAPI server PID {pid} is not running (stale PID file)"
@@ -202,8 +227,9 @@ def stop_fastapi_server(project_root: Path, verbose: bool = True) -> bool:
             if verbose:
                 console.print(f"Stopping FastAPI server (PID {pid})...")
 
-            # Try to kill the process
-            success = kill_process(pid, timeout=10)
+            # Try to kill the process — identity-verified, so a stale PID file
+            # pointing at a reused PID is never signaled (see 1.0.8-OPS-1).
+            success = kill_process(pid, timeout=10, expected_start_time=pid_record.start_time)
 
             # Clean up PID file
             remove_pid_file(project_root)
@@ -357,7 +383,7 @@ def get_fastapi_status(project_root: Path) -> dict:
             - url: Optional[str]
             - log_file: Path
     """
-    pid = read_pid_file(project_root)
+    pid_record = read_pid_record_for_project(project_root)
     log_file = project_root / ".dango" / "web.log"
 
     # Read port from project config (default 8800)
@@ -372,9 +398,9 @@ def get_fastapi_status(project_root: Path) -> dict:
 
     status: dict = {"running": False, "pid": None, "port": port, "url": None, "log_file": log_file}
 
-    if pid and is_process_running(pid):
+    if pid_record and is_process_running(pid_record.pid, expected_start_time=pid_record.start_time):
         status["running"] = True
-        status["pid"] = pid
+        status["pid"] = pid_record.pid
         status["url"] = f"http://localhost:{port}"
 
     return status

--- a/dango/platform/local/watcher_lifecycle.py
+++ b/dango/platform/local/watcher_lifecycle.py
@@ -12,7 +12,12 @@ import subprocess
 import time
 from pathlib import Path
 
-from dango.utils.process import is_process_running, kill_process
+from dango.utils.process import (
+    is_process_running,
+    kill_process,
+    read_pid_record,
+    write_pid_record,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,19 +78,27 @@ def start_file_watcher(project_root: Path) -> int | None:
     # Check if we already have a PID file first
     pid_file = get_watcher_pid_file_path(project_root)
     if pid_file.exists():
-        try:
-            existing_pid = int(pid_file.read_text().strip())
-            if is_process_running(existing_pid):
-                raise RuntimeError(
-                    f"File watcher is already running (PID {existing_pid}).\n"
-                    f"Stop it with 'dango stop'"
-                )
-            else:
-                # Stale PID file, remove it
+        existing_record = read_pid_record(pid_file)
+        if existing_record is None:
+            # Invalid/unparseable PID file, remove it
+            try:
                 pid_file.unlink()
-        except (ValueError, OSError):
-            # Invalid PID file, remove it
-            pid_file.unlink()
+            except OSError:  # noqa: BLE001
+                pass
+        elif is_process_running(
+            existing_record.pid, expected_start_time=existing_record.start_time
+        ):
+            raise RuntimeError(
+                f"File watcher is already running (PID {existing_record.pid}).\n"
+                f"Stop it with 'dango stop'"
+            )
+        else:
+            # Stale PID file (or a PID the OS has reused for a different process —
+            # see 1.0.8-OPS-1), remove it
+            try:
+                pid_file.unlink()
+            except OSError:  # noqa: BLE001
+                pass
 
     # Log file for watcher output
     log_file = project_root / ".dango" / "watcher.log"
@@ -121,8 +134,8 @@ def start_file_watcher(project_root: Path) -> int | None:
             log_handle.close()
             raise RuntimeError(f"File watcher failed to start. Check logs at {log_file}")
 
-        # Write PID file
-        pid_file.write_text(str(proc.pid))
+        # Write PID file (with start time, for identity verification — see 1.0.8-OPS-1)
+        write_pid_record(pid_file, proc.pid)
 
         # Don't close log_handle - let subprocess write to it
 
@@ -150,22 +163,23 @@ def stop_file_watcher(project_root: Path) -> bool:
         logger.debug("No file watcher PID file found")
         return False
 
-    try:
-        pid = int(pid_file.read_text().strip())
-    except (ValueError, OSError):
+    record = read_pid_record(pid_file)
+    if record is None:
         logger.warning("Invalid file watcher PID file")
         pid_file.unlink()
         return False
+    pid = record.pid
 
-    if not is_process_running(pid):
+    if not is_process_running(pid, expected_start_time=record.start_time):
         logger.debug("File watcher PID %d is not running (stale PID file)", pid)
         pid_file.unlink()
         return False
 
     logger.debug("Stopping file watcher (PID %d)", pid)
 
-    # Try to kill the process
-    success = kill_process(pid, timeout=10)
+    # Try to kill the process — identity-verified, so a stale PID file pointing at
+    # a reused PID is never signaled (see 1.0.8-OPS-1).
+    success = kill_process(pid, timeout=10, expected_start_time=record.start_time)
 
     # Clean up PID file
     try:
@@ -204,12 +218,9 @@ def get_watcher_status(project_root: Path) -> dict:
     }
 
     if pid_file.exists():
-        try:
-            pid = int(pid_file.read_text().strip())
-            if is_process_running(pid):
-                status["running"] = True
-                status["pid"] = pid
-        except (ValueError, OSError):  # noqa: BLE001
-            pass
+        record = read_pid_record(pid_file)
+        if record and is_process_running(record.pid, expected_start_time=record.start_time):
+            status["running"] = True
+            status["pid"] = record.pid
 
     return status

--- a/dango/utils/process.py
+++ b/dango/utils/process.py
@@ -3,9 +3,88 @@
 Generic process utilities shared by platform/ and cli/.
 """
 
+import json
 import os
+from dataclasses import dataclass
+from pathlib import Path
 
 import psutil
+
+# Tolerance (seconds) when comparing a recorded process start time against the
+# live process's psutil create_time(). create_time() has sub-second precision, so an
+# exact match is expected in practice — this tolerance exists only to absorb float
+# round-tripping through JSON serialization, not to loosen the identity check.
+_START_TIME_TOLERANCE_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class PidRecord:
+    """A PID plus the process identity info needed to detect PID reuse.
+
+    ``start_time`` is ``psutil.Process(pid).create_time()`` at the moment the PID was
+    recorded. ``None`` means identity is unknown — either the record predates this
+    identity-check mechanism (an old-format bare-integer PID file) or the process
+    could not be inspected when the record was written.
+    """
+
+    pid: int
+    start_time: float | None = None
+
+
+def get_process_start_time(pid: int) -> float | None:
+    """Return the process's start time (``psutil.Process(pid).create_time()``).
+
+    Returns None if the process doesn't exist or can't be inspected. The start time
+    is monotonic and effectively unique per PID slot — it's the basis for detecting
+    when the OS has reused a PID number for an unrelated process.
+    """
+    try:
+        return psutil.Process(pid).create_time()
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return None
+
+
+def write_pid_record(pid_file: Path, pid: int) -> None:
+    """Write a PID file recording both the PID and the process's start time.
+
+    Storing the start time alongside the bare PID lets a later reader verify that a
+    PID number still refers to the same process it was recorded for, rather than
+    trusting the number alone — see PidRecord / read_pid_record.
+    """
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    start_time = get_process_start_time(pid)
+    pid_file.write_text(json.dumps({"pid": pid, "start_time": start_time}))
+
+
+def read_pid_record(pid_file: Path) -> PidRecord | None:
+    """Read a PID file, tolerating both the current JSON format and the old
+    bare-integer format written before identity verification existed.
+
+    An old-format file (or any content that isn't the expected JSON shape) is
+    treated as "identity unknown" (``start_time=None``) rather than raising — callers
+    pass that through to ``is_process_running()``/``kill_process()``, which fall back
+    to existence-only checking in that case. This keeps pre-fix projects working
+    without a crash; it does not retroactively make old PID files safe against PID
+    reuse, only new ones written by ``write_pid_record()``.
+    """
+    if not pid_file.exists():
+        return None
+    try:
+        text = pid_file.read_text().strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    try:
+        data = json.loads(text)
+        return PidRecord(pid=int(data["pid"]), start_time=data.get("start_time"))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        # Not JSON (or not the expected shape) — likely an old-format bare-integer
+        # PID file. Fall back to parsing it as a plain int with unknown identity.
+        try:
+            return PidRecord(pid=int(text), start_time=None)
+        except ValueError:
+            return None
 
 
 def ensure_std_fds() -> None:
@@ -25,35 +104,61 @@ def ensure_std_fds() -> None:
             os.open(os.devnull, os.O_RDWR)
 
 
-def is_process_running(pid: int) -> bool:
+def is_process_running(pid: int, expected_start_time: float | None = None) -> bool:
     """
-    Check if process with given PID is running.
+    Check if process with given PID is running, and — when known — verify it's the
+    same process that was originally recorded, not a different process the OS has
+    since reused the PID number for.
+
+    A bare PID existence check is not enough to safely act on a PID read from a file:
+    once a process exits, the OS is free to reuse its PID number for an unrelated
+    process. A stale PID file (e.g. from a project whose server crashed without
+    cleanup) combined with PID reuse can make a completely different, unrelated
+    process look like "the tracked process" — see 1.0.8-OPS-1. When
+    expected_start_time is provided, this compares it against the live process's
+    psutil.Process(pid).create_time(); a mismatch means the PID was reused and the
+    originally-tracked process is gone, so this returns False even though *some*
+    process currently holds that PID number.
 
     Args:
         pid: Process ID
+        expected_start_time: create_time() recorded when the PID was originally
+            written (see PidRecord/read_pid_record). None skips identity
+            verification and checks existence only — used for old-format PID files
+            that predate this check, where identity is genuinely unknown.
 
     Returns:
-        True if process is running, False otherwise
+        True if process is running (and, when expected_start_time is given, its
+        identity matches).
     """
     try:
-        # Use psutil for cross-platform compatibility
-        return bool(psutil.pid_exists(pid))
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        if not psutil.pid_exists(pid):
+            return False
+        if expected_start_time is None:
+            return True
+        actual_start_time = psutil.Process(pid).create_time()
+        return abs(actual_start_time - expected_start_time) < _START_TIME_TOLERANCE_SECONDS
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
         return False
 
 
-def kill_process(pid: int, timeout: int = 10) -> bool:
+def kill_process(pid: int, timeout: int = 10, expected_start_time: float | None = None) -> bool:
     """
     Kill process and its children gracefully (SIGTERM), then forcefully (SIGKILL) if needed.
 
     Args:
         pid: Process ID to kill
         timeout: Seconds to wait for graceful shutdown before force kill
+        expected_start_time: Optional recorded start time to verify identity against
+            before signaling — see is_process_running(). If the live process at
+            `pid` doesn't match, this is a no-op (treated as "already stopped"), not
+            an error, so a stale/reused PID is never signaled.
 
     Returns:
-        True if process was killed, False if it didn't exist or couldn't be killed
+        True if process was killed, False if it didn't exist, its identity didn't
+        match expected_start_time, or it couldn't be killed
     """
-    if not is_process_running(pid):
+    if not is_process_running(pid, expected_start_time=expected_start_time):
         return False
 
     try:

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -3,18 +3,27 @@
 Tests for dango.utils.process — generic process utilities.
 """
 
+import json
 from unittest.mock import MagicMock, patch
 
 import psutil
 import pytest
 
-from dango.utils.process import is_process_running, kill_process
+from dango.utils.process import (
+    PidRecord,
+    get_process_start_time,
+    is_process_running,
+    kill_process,
+    read_pid_record,
+    write_pid_record,
+)
 
 
 def _set_psutil_exceptions(mock_psutil):
     """Wire real psutil exception classes onto a mock psutil module."""
     mock_psutil.NoSuchProcess = psutil.NoSuchProcess
     mock_psutil.AccessDenied = psutil.AccessDenied
+    mock_psutil.ZombieProcess = psutil.ZombieProcess
 
 
 @pytest.mark.unit
@@ -41,6 +50,77 @@ class TestIsProcessRunning:
         _set_psutil_exceptions(mock_psutil)
         mock_psutil.pid_exists.side_effect = psutil.AccessDenied(9999)
         assert is_process_running(9999) is False
+
+
+@pytest.mark.unit
+class TestIsProcessRunningIdentity:
+    """1.0.8-OPS-1: identity verification via expected_start_time, mocked."""
+
+    @patch("dango.utils.process.psutil")
+    def test_matching_start_time_returns_true(self, mock_psutil):
+        mock_psutil.pid_exists.return_value = True
+        mock_proc = MagicMock()
+        mock_proc.create_time.return_value = 1000000.5
+        mock_psutil.Process.return_value = mock_proc
+
+        assert is_process_running(1234, expected_start_time=1000000.5) is True
+
+    @patch("dango.utils.process.psutil")
+    def test_mismatched_start_time_returns_false(self, mock_psutil):
+        """Simulates PID reuse: the PID exists, but belongs to a different process
+        than the one originally recorded (different create_time())."""
+        mock_psutil.pid_exists.return_value = True
+        mock_proc = MagicMock()
+        mock_proc.create_time.return_value = 2000000.0  # unrelated process's start time
+        mock_psutil.Process.return_value = mock_proc
+
+        assert is_process_running(1234, expected_start_time=1000000.5) is False
+
+    @patch("dango.utils.process.psutil")
+    def test_pid_gone_returns_false_even_with_expected_start_time(self, mock_psutil):
+        mock_psutil.pid_exists.return_value = False
+        assert is_process_running(1234, expected_start_time=1000000.5) is False
+
+    @patch("dango.utils.process.psutil")
+    def test_none_expected_start_time_skips_identity_check(self, mock_psutil):
+        """Old-format PID files (start_time unknown) fall back to existence-only."""
+        mock_psutil.pid_exists.return_value = True
+        assert is_process_running(1234, expected_start_time=None) is True
+        # create_time() must never be consulted when identity is unknown
+        mock_psutil.Process.assert_not_called()
+
+    @patch("dango.utils.process.psutil")
+    def test_no_such_process_on_create_time_returns_false(self, mock_psutil):
+        _set_psutil_exceptions(mock_psutil)
+        mock_psutil.pid_exists.return_value = True
+        mock_psutil.Process.side_effect = psutil.NoSuchProcess(1234)
+        assert is_process_running(1234, expected_start_time=1000000.5) is False
+
+
+@pytest.mark.unit
+class TestIsProcessRunningIdentityLive:
+    """Live verification (no mocking) using this test process's own real PID —
+    covers both the match case (own live process) and the mismatch case
+    (simulated PID reuse via a deliberately wrong recorded start_time)."""
+
+    def test_own_process_start_time_matches(self):
+        import os
+
+        own_pid = os.getpid()
+        real_start_time = psutil.Process(own_pid).create_time()
+
+        assert is_process_running(own_pid, expected_start_time=real_start_time) is True
+
+    def test_wrong_start_time_treated_as_pid_reuse(self):
+        import os
+
+        own_pid = os.getpid()
+        real_start_time = psutil.Process(own_pid).create_time()
+        # A start_time far from the real one simulates the PID having been
+        # reassigned by the OS to a different process since it was recorded.
+        bogus_start_time = real_start_time - 100000.0
+
+        assert is_process_running(own_pid, expected_start_time=bogus_start_time) is False
 
 
 @pytest.mark.unit
@@ -151,3 +231,130 @@ class TestKillProcess:
 
         kill_process(42, timeout=30)
         mock_psutil.wait_procs.assert_called_once_with([mock_proc], timeout=30)
+
+    def test_mismatched_identity_never_signals(self):
+        """1.0.8-OPS-1: kill_process() must not signal a PID whose identity doesn't
+        match — the core regression this fix exists to prevent. Live, unmocked: uses
+        this test process's own real PID with a deliberately wrong recorded
+        start_time (simulated PID reuse). is_process_running()'s real identity check
+        must reject it, so kill_process() returns False having never called
+        proc.terminate()/proc.kill() on anything.
+        """
+        import os
+
+        own_pid = os.getpid()
+        real_start_time = psutil.Process(own_pid).create_time()
+        bogus_start_time = real_start_time - 100000.0
+
+        # Stand in for psutil.Process so create_time() deterministically reports the
+        # real start time (as the live process actually would) — the test is about
+        # the mismatch against `bogus_start_time`, not about mocking away reality.
+        mock_proc = MagicMock()
+        mock_proc.create_time.return_value = real_start_time
+        with patch(
+            "dango.utils.process.psutil.Process", return_value=mock_proc
+        ) as mock_process_ctor:
+            result = kill_process(own_pid, expected_start_time=bogus_start_time)
+
+        assert result is False
+        # Process(pid) is consulted once — purely to compare create_time() for
+        # identity — but since it doesn't match, terminate()/kill() must never fire.
+        mock_process_ctor.assert_called_once_with(own_pid)
+        mock_proc.terminate.assert_not_called()
+        mock_proc.kill.assert_not_called()
+
+    @patch("dango.utils.process.psutil")
+    def test_matching_identity_signals_normally(self, mock_psutil):
+        _set_psutil_exceptions(mock_psutil)
+        mock_psutil.pid_exists.return_value = True
+        mock_proc = MagicMock()
+        mock_proc.create_time.return_value = 555.0
+        mock_proc.children.return_value = []
+        mock_psutil.Process.return_value = mock_proc
+        mock_psutil.wait_procs.return_value = ([mock_proc], [])
+
+        result = kill_process(42, expected_start_time=555.0)
+
+        assert result is True
+        mock_proc.terminate.assert_called_once()
+
+
+@pytest.mark.unit
+class TestGetProcessStartTime:
+    @patch("dango.utils.process.psutil")
+    def test_returns_create_time_for_live_process(self, mock_psutil):
+        mock_proc = MagicMock()
+        mock_proc.create_time.return_value = 123456.0
+        mock_psutil.Process.return_value = mock_proc
+        assert get_process_start_time(42) == 123456.0
+
+    @patch("dango.utils.process.psutil")
+    def test_no_such_process_returns_none(self, mock_psutil):
+        _set_psutil_exceptions(mock_psutil)
+        mock_psutil.Process.side_effect = psutil.NoSuchProcess(42)
+        assert get_process_start_time(42) is None
+
+    @patch("dango.utils.process.psutil")
+    def test_access_denied_returns_none(self, mock_psutil):
+        _set_psutil_exceptions(mock_psutil)
+        mock_psutil.Process.side_effect = psutil.AccessDenied(42)
+        assert get_process_start_time(42) is None
+
+    def test_live_own_process(self):
+        """No mocking — confirms real psutil integration for the current process."""
+        import os
+
+        start_time = get_process_start_time(os.getpid())
+        assert start_time is not None
+        assert start_time > 0
+
+
+@pytest.mark.unit
+class TestWritePidRecordAndReadPidRecord:
+    @patch("dango.utils.process.get_process_start_time", return_value=987.5)
+    def test_round_trip(self, _mock_start_time, tmp_path):
+        pid_file = tmp_path / "some.pid"
+        write_pid_record(pid_file, 4242)
+
+        record = read_pid_record(pid_file)
+        assert record == PidRecord(pid=4242, start_time=987.5)
+
+    def test_old_format_bare_integer_handled_gracefully(self, tmp_path):
+        """A pre-1.0.8-OPS-1 PID file (bare integer, no JSON) must not crash —
+        identity is unknown, not an error."""
+        pid_file = tmp_path / "some.pid"
+        pid_file.write_text("9876")
+
+        record = read_pid_record(pid_file)
+        assert record == PidRecord(pid=9876, start_time=None)
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert read_pid_record(tmp_path / "nope.pid") is None
+
+    def test_garbage_content_returns_none(self, tmp_path):
+        pid_file = tmp_path / "some.pid"
+        pid_file.write_text("not-json-not-int")
+        assert read_pid_record(pid_file) is None
+
+    def test_empty_file_returns_none(self, tmp_path):
+        pid_file = tmp_path / "some.pid"
+        pid_file.write_text("")
+        assert read_pid_record(pid_file) is None
+
+    def test_json_missing_pid_key_returns_none(self, tmp_path):
+        pid_file = tmp_path / "some.pid"
+        pid_file.write_text(json.dumps({"start_time": 1.0}))
+        assert read_pid_record(pid_file) is None
+
+    @patch("dango.utils.process.get_process_start_time", return_value=None)
+    def test_write_when_process_uninspectable_records_none(self, _mock_start_time, tmp_path):
+        pid_file = tmp_path / "some.pid"
+        write_pid_record(pid_file, 111)
+        record = read_pid_record(pid_file)
+        assert record == PidRecord(pid=111, start_time=None)
+
+    def test_creates_parent_dirs(self, tmp_path):
+        pid_file = tmp_path / "nested" / "dir" / "some.pid"
+        with patch("dango.utils.process.get_process_start_time", return_value=1.0):
+            write_pid_record(pid_file, 1)
+        assert pid_file.exists()

--- a/tests/unit/test_process_manager.py
+++ b/tests/unit/test_process_manager.py
@@ -3,6 +3,7 @@
 Tests for dango.cli.helpers.process_manager — FastAPI server process management.
 """
 
+import json
 import subprocess
 import sys
 from unittest.mock import MagicMock, patch
@@ -13,6 +14,7 @@ from dango.cli.helpers.process_manager import (
     get_fastapi_status,
     get_pid_file_path,
     read_pid_file,
+    read_pid_record_for_project,
     remove_pid_file,
     start_fastapi_server,
     stop_fastapi_server,
@@ -29,21 +31,41 @@ class TestGetPidFilePath:
 
 @pytest.mark.unit
 class TestWritePidFile:
-    def test_writes_pid_creates_parent_dirs(self, tmp_path):
+    @patch("dango.utils.process.get_process_start_time", return_value=1234567.89)
+    def test_writes_pid_creates_parent_dirs(self, _mock_start_time, tmp_path):
         write_pid_file(tmp_path, 1234)
         pid_file = tmp_path / ".dango" / "web.pid"
-        assert pid_file.read_text() == "1234"
+        data = json.loads(pid_file.read_text())
+        assert data == {"pid": 1234, "start_time": 1234567.89}
 
-    def test_overwrites_existing_pid_file(self, tmp_path):
+    @patch("dango.utils.process.get_process_start_time", return_value=None)
+    def test_writes_pid_with_unknown_start_time(self, _mock_start_time, tmp_path):
+        # e.g. the process couldn't be inspected right after being spawned
+        write_pid_file(tmp_path, 1234)
+        pid_file = tmp_path / ".dango" / "web.pid"
+        data = json.loads(pid_file.read_text())
+        assert data == {"pid": 1234, "start_time": None}
+
+    @patch("dango.utils.process.get_process_start_time", return_value=111.0)
+    def test_overwrites_existing_pid_file(self, mock_start_time, tmp_path):
         write_pid_file(tmp_path, 1111)
+        mock_start_time.return_value = 222.0
         write_pid_file(tmp_path, 2222)
         pid_file = tmp_path / ".dango" / "web.pid"
-        assert pid_file.read_text() == "2222"
+        data = json.loads(pid_file.read_text())
+        assert data == {"pid": 2222, "start_time": 222.0}
 
 
 @pytest.mark.unit
 class TestReadPidFile:
-    def test_valid_pid(self, tmp_path):
+    def test_valid_pid_json_format(self, tmp_path):
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "web.pid").write_text(json.dumps({"pid": 5678, "start_time": 42.0}))
+        assert read_pid_file(tmp_path) == 5678
+
+    def test_valid_pid_old_bare_integer_format(self, tmp_path):
+        """Old-format (pre-1.0.8-OPS-1) PID files are a bare integer, no JSON."""
         dango_dir = tmp_path / ".dango"
         dango_dir.mkdir()
         (dango_dir / "web.pid").write_text("5678")
@@ -63,6 +85,35 @@ class TestReadPidFile:
         dango_dir.mkdir()
         (dango_dir / "web.pid").write_text("")
         assert read_pid_file(tmp_path) is None
+
+
+@pytest.mark.unit
+class TestReadPidRecordForProject:
+    def test_json_format_returns_full_record(self, tmp_path):
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "web.pid").write_text(json.dumps({"pid": 5678, "start_time": 42.5}))
+        record = read_pid_record_for_project(tmp_path)
+        assert record.pid == 5678
+        assert record.start_time == 42.5
+
+    def test_old_bare_integer_format_has_unknown_start_time(self, tmp_path):
+        """Old-format PID files (pre-1.0.8-OPS-1) don't crash — identity unknown."""
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "web.pid").write_text("5678")
+        record = read_pid_record_for_project(tmp_path)
+        assert record.pid == 5678
+        assert record.start_time is None
+
+    def test_missing_file(self, tmp_path):
+        assert read_pid_record_for_project(tmp_path) is None
+
+    def test_invalid_content(self, tmp_path):
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "web.pid").write_text("not-a-pid")
+        assert read_pid_record_for_project(tmp_path) is None
 
 
 @pytest.mark.unit
@@ -98,11 +149,14 @@ class TestStartFastapiServer:
         dango_dir.mkdir(parents=True, exist_ok=True)
         return dango_dir
 
+    @patch("dango.utils.process.get_process_start_time", return_value=99.0)
     @patch("dango.cli.helpers.process_manager.time.sleep")
     @patch("dango.cli.helpers.process_manager.subprocess.Popen")
     @patch("dango.cli.helpers.process_manager.check_port_in_use", return_value=False)
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=False)
-    def test_successful_start(self, _mock_running, _mock_port, mock_popen, mock_sleep, tmp_path):
+    def test_successful_start(
+        self, _mock_running, _mock_port, mock_popen, mock_sleep, _mock_start_time, tmp_path
+    ):
         self._setup_project(tmp_path)
         mock_proc = MagicMock()
         mock_proc.pid = 6000
@@ -113,7 +167,7 @@ class TestStartFastapiServer:
 
         assert pid == 6000
         pid_file = tmp_path / ".dango" / "web.pid"
-        assert pid_file.read_text() == "6000"
+        assert json.loads(pid_file.read_text()) == {"pid": 6000, "start_time": 99.0}
 
     @patch("dango.cli.helpers.process_manager.is_process_running", return_value=True)
     def test_already_running_raises(self, _mock_running, tmp_path):
@@ -248,7 +302,9 @@ class TestStopFastapiServer:
         (dango_dir / "web.pid").write_text("4000")
 
         assert stop_fastapi_server(tmp_path) is True
-        mock_kill.assert_called_once_with(4000, timeout=10)
+        # Old-format (bare-integer) PID file in this test → identity unknown (None) —
+        # kill_process() falls back to existence-only checking, as documented.
+        mock_kill.assert_called_once_with(4000, timeout=10, expected_start_time=None)
 
     @patch("dango.cli.helpers.process_manager.subprocess.run")
     @patch("dango.cli.helpers.process_manager.console")
@@ -616,4 +672,80 @@ class TestGetFastapiStatus:
         status = get_fastapi_status(tmp_path)
         assert status["running"] is False
         assert status["pid"] is None
-        assert status["url"] is None
+
+
+@pytest.mark.unit
+class TestStopFastapiServerIdentityIntegration:
+    """1.0.8-OPS-1 end-to-end coverage: real is_process_running()/kill_process()
+    (only psutil itself is mocked, not our own identity-check functions) — proves
+    the fix through the actual call chain stop_fastapi_server() exercises, not just
+    through isolated unit mocks."""
+
+    def _setup_project(self, tmp_path):
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir(parents=True, exist_ok=True)
+        return dango_dir
+
+    def _mock_psutil_exceptions(self, mock_psutil):
+        import psutil as real_psutil
+
+        mock_psutil.NoSuchProcess = real_psutil.NoSuchProcess
+        mock_psutil.AccessDenied = real_psutil.AccessDenied
+        mock_psutil.ZombieProcess = real_psutil.ZombieProcess
+
+    @patch("dango.cli.helpers.process_manager.subprocess.run")
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.utils.process.psutil")
+    def test_reused_pid_is_not_signaled(self, mock_psutil, _mock_console, mock_sub_run, tmp_path):
+        """Mismatch case: PID file records a process that has since exited; the OS
+        reused the PID number for something unrelated (different create_time()).
+        stop_fastapi_server() must treat this as stale, not kill the new occupant."""
+        self._mock_psutil_exceptions(mock_psutil)
+        dango_dir = self._setup_project(tmp_path)
+        # Recorded identity for the ORIGINAL tracked process
+        (dango_dir / "web.pid").write_text(json.dumps({"pid": 4321, "start_time": 1000.0}))
+
+        # A live process currently holds PID 4321, but it's not the one we tracked —
+        # its create_time() doesn't match what was recorded (simulated PID reuse).
+        mock_psutil.pid_exists.return_value = True
+        mock_reused_proc = MagicMock()
+        mock_reused_proc.create_time.return_value = 9_999_999.0
+        mock_psutil.Process.return_value = mock_reused_proc
+
+        with patch("dango.config.ConfigLoader") as mock_cl:
+            mock_config = MagicMock()
+            mock_config.platform.port = 8080
+            mock_cl.return_value.load_config.return_value = mock_config
+            mock_sub_run.return_value = MagicMock(returncode=1, stdout="")  # lsof: nothing on port
+
+            result = stop_fastapi_server(tmp_path, verbose=False)
+
+        assert result is False
+        # The reused process must never be signaled.
+        mock_reused_proc.terminate.assert_not_called()
+        mock_reused_proc.kill.assert_not_called()
+        # Stale PID file cleaned up, same as any other stale-PID case.
+        assert not (dango_dir / "web.pid").exists()
+
+    @patch("dango.cli.helpers.process_manager.console")
+    @patch("dango.utils.process.psutil")
+    def test_matching_pid_is_signaled(self, mock_psutil, _mock_console, tmp_path):
+        """Match case (positive control): PID file's recorded start_time agrees with
+        the live process's create_time() — the normal case of a project's own PID
+        file, read shortly after its own `dango start`. Must still kill normally."""
+        self._mock_psutil_exceptions(mock_psutil)
+        dango_dir = self._setup_project(tmp_path)
+        (dango_dir / "web.pid").write_text(json.dumps({"pid": 4321, "start_time": 1000.0}))
+
+        mock_psutil.pid_exists.return_value = True
+        mock_proc = MagicMock()
+        mock_proc.create_time.return_value = 1000.0  # matches recorded start_time
+        mock_proc.children.return_value = []
+        mock_psutil.Process.return_value = mock_proc
+        mock_psutil.wait_procs.return_value = ([mock_proc], [])
+
+        result = stop_fastapi_server(tmp_path, verbose=False)
+
+        assert result is True
+        mock_proc.terminate.assert_called_once()
+        assert not (dango_dir / "web.pid").exists()

--- a/tests/unit/test_watcher_lifecycle.py
+++ b/tests/unit/test_watcher_lifecycle.py
@@ -3,6 +3,7 @@
 Tests for dango.platform.watcher_lifecycle — watcher subprocess lifecycle management.
 """
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -33,10 +34,13 @@ class TestStartFileWatcher:
         dango_dir.mkdir(parents=True, exist_ok=True)
         return dango_dir
 
+    @patch("dango.utils.process.get_process_start_time", return_value=42.0)
     @patch("dango.platform.local.watcher_lifecycle.time.sleep")
     @patch("dango.platform.local.watcher_lifecycle.subprocess.Popen")
     @patch("dango.platform.local.watcher_lifecycle.is_process_running")
-    def test_successful_start_returns_pid(self, mock_running, mock_popen, mock_sleep, tmp_path):
+    def test_successful_start_returns_pid(
+        self, mock_running, mock_popen, mock_sleep, _mock_start_time, tmp_path
+    ):
         self._setup_project(tmp_path)
         mock_proc = MagicMock()
         mock_proc.pid = 5555
@@ -47,7 +51,7 @@ class TestStartFileWatcher:
 
         assert pid == 5555
         pid_file = tmp_path / ".dango" / "watcher.pid"
-        assert pid_file.read_text() == "5555"
+        assert json.loads(pid_file.read_text()) == {"pid": 5555, "start_time": 42.0}
 
     @patch("dango.platform.local.watcher_lifecycle.is_process_running", return_value=True)
     def test_already_running_raises_runtime_error(self, _mock_running, tmp_path):
@@ -183,7 +187,8 @@ class TestStopFileWatcher:
         pid_file.write_text("4444")
 
         assert stop_file_watcher(tmp_path) is True
-        mock_kill.assert_called_once_with(4444, timeout=10)
+        # Old-format (bare-integer) PID file in this test → identity unknown (None).
+        mock_kill.assert_called_once_with(4444, timeout=10, expected_start_time=None)
         assert not pid_file.exists()
 
     @patch("dango.platform.local.watcher_lifecycle.kill_process", return_value=False)
@@ -195,6 +200,63 @@ class TestStopFileWatcher:
 
         assert stop_file_watcher(tmp_path) is False
         assert not pid_file.exists()  # PID file still cleaned up
+
+
+@pytest.mark.unit
+class TestStopFileWatcherIdentityIntegration:
+    """1.0.8-OPS-1 end-to-end coverage for watcher.pid: real is_process_running()/
+    kill_process() (only psutil mocked), same bug class and fix shape as web.pid."""
+
+    def _setup_project(self, tmp_path):
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir(parents=True, exist_ok=True)
+        return dango_dir
+
+    def _mock_psutil_exceptions(self, mock_psutil):
+        import psutil as real_psutil
+
+        mock_psutil.NoSuchProcess = real_psutil.NoSuchProcess
+        mock_psutil.AccessDenied = real_psutil.AccessDenied
+        mock_psutil.ZombieProcess = real_psutil.ZombieProcess
+
+    @patch("dango.utils.process.psutil")
+    def test_reused_pid_is_not_signaled(self, mock_psutil, tmp_path):
+        """Mismatch case: watcher.pid records a process that has since exited; the
+        OS reused the PID for something unrelated. Must not be signaled."""
+        self._mock_psutil_exceptions(mock_psutil)
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text(json.dumps({"pid": 6543, "start_time": 1000.0}))
+
+        mock_psutil.pid_exists.return_value = True
+        mock_reused_proc = MagicMock()
+        mock_reused_proc.create_time.return_value = 9_999_999.0
+        mock_psutil.Process.return_value = mock_reused_proc
+
+        assert stop_file_watcher(tmp_path) is False
+        mock_reused_proc.terminate.assert_not_called()
+        mock_reused_proc.kill.assert_not_called()
+        assert not pid_file.exists()
+
+    @patch("dango.utils.process.psutil")
+    def test_matching_pid_is_signaled(self, mock_psutil, tmp_path):
+        """Match case (positive control): recorded start_time agrees with the live
+        process's create_time() — must still kill normally."""
+        self._mock_psutil_exceptions(mock_psutil)
+        dango_dir = self._setup_project(tmp_path)
+        pid_file = dango_dir / "watcher.pid"
+        pid_file.write_text(json.dumps({"pid": 6543, "start_time": 1000.0}))
+
+        mock_psutil.pid_exists.return_value = True
+        mock_proc = MagicMock()
+        mock_proc.create_time.return_value = 1000.0
+        mock_proc.children.return_value = []
+        mock_psutil.Process.return_value = mock_proc
+        mock_psutil.wait_procs.return_value = ([mock_proc], [])
+
+        assert stop_file_watcher(tmp_path) is True
+        mock_proc.terminate.assert_called_once()
+        assert not pid_file.exists()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- `is_process_running()`/`kill_process()` checked PID existence only, no identity verification. A stale PID file (from a project whose server died without cleanup) combined with OS PID reuse could make `kill_process()` signal a completely unrelated running process - and its children, since `kill_process()` also kills subprocesses of the target PID.
- Not theoretical: root-caused live against a real incident - a persistent local dango instance was killed this session by exactly this mechanism (confirmed via macOS unified log + the killed subprocess's own `exit_code: -15`, i.e. SIGTERM).

## Changes
- PID files now store `{pid, start_time}` instead of a bare integer
- `is_process_running()`/`kill_process()` accept optional `expected_start_time`, verify against `psutil.Process(pid).create_time()` before signaling; mismatch = "already stopped," not signaled
- Old-format bare-integer PID files handled gracefully (identity unknown, existence-only fallback, no crash)
- Applied to both the FastAPI server (process_manager.py) and the file watcher (watcher_lifecycle.py)

## Verification
- 105 tests passed, including a genuine live test against the current process (not just mocked mismatch cases)
- `ruff check`: passed