### PR TITLE
1.0.8: Consolidate telemetry storage to machine level

### DIFF
--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -2,9 +2,9 @@
 
 Unified telemetry control for Dango, dbt, dlt, and Metabase — a single
 command surface that writes through to each provider's own real config
-mechanism (Dango's ~/.dango/telemetry.json, dbt's dbt_telemetry key in
-~/.dango/config.yml, dlt's .dlt/config.toml, and Metabase's admin Setting
-API). This controls
+mechanism (Dango's ~/.dango/telemetry.json, dbt's dbt_telemetry key and
+dlt's dlt_telemetry key — both in ~/.dango/config.yml as of 1.0.8-OPS-2 —
+and Metabase's admin Setting API). This controls
 telemetry for the components Dango configures; it does not claim anything
 about network traffic outside those four providers.
 
@@ -30,9 +30,12 @@ from dango.telemetry import PROVIDERS
 
 # Providers whose write-through requires an active Dango project (project_root
 # is not None). Used by the --all path to downgrade a missing-project failure
-# to a warning instead of aborting the whole command — dango and dbt are
-# machine-level and always succeed regardless of project context.
-_PROJECT_SCOPED_PROVIDERS = ("dlt", "metabase")
+# to a warning instead of aborting the whole command — dango, dbt, and dlt
+# (1.0.8-OPS-2: dlt moved to machine-level ~/.dango/config.yml) are
+# machine-level and always succeed regardless of project context. Only
+# metabase remains project-scoped (it write-through's via a live API call
+# using per-project credentials in .dango/metabase.yml).
+_PROJECT_SCOPED_PROVIDERS = ("metabase",)
 
 
 @click.group("telemetry")
@@ -200,36 +203,32 @@ def _set_dbt_telemetry(enabled: bool) -> None:
 
 
 def _set_dlt_telemetry(enabled: bool, project_root: Path | None) -> None:
-    """Write dlthub_telemetry to .dlt/config.toml under [runtime].
+    """Write dlt's opt-out state to ~/.dango/config.yml under the dlt_telemetry key.
 
-    Thin wrapper (1.0.8-U) around `dango.telemetry.set_dlt_telemetry_state()`
-    — the actual read/write logic lives there (Level 0) so
-    `web/routes/telemetry.py` (Level 2) can call it too without importing
-    this Level-3 module. This wrapper's only job is the `project_root is
-    None` check (CLI-specific — the web route always has a project_root)
-    and translating that function's plain exceptions into
-    `click.ClickException` with identical message text to before the
-    relocation.
+    Thin wrapper (1.0.8-U, machine-level since 1.0.8-OPS-2) around
+    `dango.telemetry.set_dlt_telemetry_state()` — the actual read/write
+    logic lives there (Level 0) so `web/routes/telemetry.py` (Level 2) can
+    call it too without importing this Level-3 module. `project_root` is
+    accepted but unused now that dlt telemetry is machine-level rather than
+    project-scoped (kept for call-site symmetry with the other
+    `_set_*_telemetry` helpers, all of which take `project_root`). This
+    wrapper's only job is translating `set_dlt_telemetry_state()`'s plain
+    `OSError` into `click.ClickException`.
 
     Raises:
-        click.ClickException: If project_root is None, if the file can't
-            be read/written (OSError — e.g. permissions), or if the
-            existing .dlt/config.toml is malformed (a ValueError wrapping
-            tomlkit.exceptions.TOMLKitError, e.g. from manual editing) —
-            the latter two converted from raw exceptions so `--all` can
-            skip this provider and continue, same contract as dbt above
-            and Metabase's set_metabase_telemetry().
+        click.ClickException: If the write fails (e.g. permission denied,
+            disk full) — same message text as before the 1.0.8-U
+            relocation, so `--all` can skip this provider and continue,
+            matching the error-handling contract `set_metabase_telemetry()`
+            uses.
     """
+    del project_root  # unused — dlt telemetry is machine-level, see docstring
     from dango.telemetry import set_dlt_telemetry_state
 
-    if project_root is None:
-        raise click.ClickException("Must be run inside a Dango project for dlt control")
     try:
-        set_dlt_telemetry_state(project_root, enabled)
-    except OSError as e:
-        raise click.ClickException(f"Could not write .dlt/config.toml: {e}") from e
-    except ValueError as e:
-        raise click.ClickException(f"Could not parse .dlt/config.toml: {e}") from e
+        set_dlt_telemetry_state(enabled)
+    except OSError:
+        raise click.ClickException("Could not write ~/.dango/config.yml") from None
 
 
 def _set_metabase_telemetry(enabled: bool, project_root: Path | None) -> None:
@@ -260,10 +259,14 @@ def _get_dbt_telemetry_state() -> bool:
 
 
 def _get_dlt_telemetry_state(project_root: Path | None) -> bool:
-    """Return dlt's current opt-in state per .dlt/config.toml (default: on).
+    """Return dlt's current opt-in state per ~/.dango/config.yml (default: on).
 
-    Thin wrapper (1.0.8-U) — the actual read logic now lives in
-    `dango.telemetry.get_dlt_telemetry_state()` (Level 0).
+    Thin wrapper (1.0.8-U, machine-level since 1.0.8-OPS-2) — the actual
+    read logic now lives in `dango.telemetry.get_dlt_telemetry_state()`
+    (Level 0). `project_root` is still passed through (rather than dropped
+    like the dbt wrapper above) so a legacy per-project `.dlt/config.toml`
+    opt-out can be migrated into ~/.dango/config.yml on first read — see
+    that function's docstring.
     """
     from dango.telemetry import get_dlt_telemetry_state
 

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -254,6 +254,7 @@ class ProjectInitializer:
 .dango/auth.yml
 .dango/dbt_model_status.json
 .dango/history/
+.dango/metabase_telemetry_state
 data/
 metabase-data/
 metabase-plugins/

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -17,7 +17,7 @@ for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see P5-006).
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
 | `__init__.py` | Public exports | `DltPipelineRunner`, `run_sync`, `CSVLoader`, `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata`, `get_source_capabilities` |
-| `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync` (accepts `progress_callback` for dbt phase reporting; imports `SyncTimeoutError` from `dango.exceptions`) |
+| `dlt_runner.py` | Generic pipeline runner for all dlt and custom sources | `DltPipelineRunner`, `run_sync` (accepts `progress_callback` for dbt phase reporting; imports `SyncTimeoutError` from `dango.exceptions`); `_apply_dlt_telemetry_env()` — sets dlt's `RUNTIME__DLTHUB_TELEMETRY` env var from the machine-level opt-out (1.0.8-OPS-2), called at the top of both `_run_dlt_native_source()` and `_run_dlt_source()`, before any dlt config resolution |
 | `csv_loader.py` | Multi-format file loading (CSV, JSON, JSONL, Parquet) with metadata tracking and 4 dedup strategies | `CSVLoader`, `SUPPORTED_READ_FUNCTIONS` (imports `CSVSchemaMismatchError` from `dango.exceptions`) |
 | `credential_health.py` | Cross-references configured sources against available credentials (OAuth tokens, API keys, service accounts) | `run_credential_checks()`, `get_cached_credential_health()` (5-minute in-process cache) |
 | `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata`, `get_source_capabilities` |
@@ -32,6 +32,7 @@ for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see P5-006).
 | Change CSV loading behavior | `csv_loader.py` | `pytest tests/unit/test_csv_loader.py` (when created) |
 | Change sync execution logic | `dlt_runner.py` | Manual: `dango sync <source_name>` |
 | Add a new dedup strategy | `csv_loader.py` + `config/models.py` (`DeduplicationStrategy`) | Manual: sync CSV source with new strategy |
+| Change dlt telemetry opt-out env injection | `dlt_runner.py` (`_apply_dlt_telemetry_env`) — mirror both call sites (`_run_dlt_native_source`, `_run_dlt_source`) | `pytest tests/unit/test_telemetry_unified.py tests/unit/test_egress_allowlist.py` |
 
 ## Dependencies
 

--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -67,6 +67,48 @@ def _is_duckdb_lock_error(error: BaseException) -> bool:
     return any(keyword in error_str for keyword in _DUCKDB_LOCK_KEYWORDS)
 
 
+def _apply_dlt_telemetry_env(project_root: Path) -> None:
+    """Set dlt's RUNTIME__DLTHUB_TELEMETRY env var from the machine-level opt-out.
+
+    dlt runs in-process here (`dlt.pipeline(...)` below), not via subprocess
+    like dbt (`_dbt_telemetry_env()` in `transformation/__init__.py`) — so
+    there is no per-invocation env dict to pass. dlt's `EnvironProvider`
+    reads `os.environ` live at config-resolution time
+    (dlt/common/configuration/providers/environ.py), so the only way to
+    inject the machine-level opt-out is to set the actual process env var
+    before creating the pipeline.
+
+    `RUNTIME__DLTHUB_TELEMETRY` is dlt's own env-var override for
+    `RuntimeConfiguration.dlthub_telemetry` — verified empirically against
+    dlt 1.28.1 (not just read from docs, per 1.0.8-OPS-2's verification
+    requirement): `RuntimeConfiguration.__section__ == "runtime"`, and
+    `EnvironProvider.get_key_name()` uppercases `"__".join((*sections,
+    key))`, giving `RUNTIME__DLTHUB_TELEMETRY` — no `DLT__` prefix. Also
+    confirmed the env var overrides an explicit `.dlt/config.toml` value,
+    which is what lets this override a project's stale pre-1.0.8-OPS-2
+    opt-out file without needing to touch or delete that file.
+
+    dlt caches whether telemetry has started per-process
+    (`dlt.common.runtime.telemetry._TELEMETRY_STARTED`) — this only takes
+    effect for the FIRST dlt pipeline created after this call in a given
+    process, identical to the caching behavior before this change (the
+    opt-out lived in `.dlt/config.toml` then, read via the same
+    `RuntimeConfiguration` resolution at the same point in dlt's pipeline
+    lifecycle) — not a new limitation introduced here.
+
+    Args:
+        project_root: Current project root — passed through to
+            `get_dlt_telemetry_state()` so a legacy per-project
+            `.dlt/config.toml` opt-out gets migrated into
+            `~/.dango/config.yml` on first read (see that function's
+            docstring).
+    """
+    from dango.telemetry import get_dlt_telemetry_state
+
+    enabled = get_dlt_telemetry_state(project_root)
+    os.environ["RUNTIME__DLTHUB_TELEMETRY"] = "true" if enabled else "false"
+
+
 class DltPipelineRunner:
     """
     Generic pipeline runner for all dlt sources
@@ -934,6 +976,17 @@ class DltPipelineRunner:
         original_cwd = os.getcwd()
         os.chdir(self.project_root)
 
+        # IMPORTANT: Must happen before ANY dlt config resolution below —
+        # calling the @dlt.source-decorated source_function (a few lines
+        # down) already triggers dlt's RunContext/RuntimeConfiguration
+        # resolution (and, on the first such access in this process,
+        # telemetry init) via dlt's own config-injection machinery, which
+        # then caches on that RunContext for the rest of this sync. Setting
+        # the env var any later (e.g. right before dlt.pipeline() below) is
+        # too late — confirmed empirically while building this: the
+        # opt-out silently didn't apply until this was moved here.
+        _apply_dlt_telemetry_env(self.project_root)
+
         try:
             # Try to import source from custom_sources/ directory first
             import sys
@@ -1343,6 +1396,11 @@ class DltPipelineRunner:
         # Change to project root as additional fallback
         original_cwd = os.getcwd()
         os.chdir(self.project_root)
+
+        # IMPORTANT: Must happen before ANY dlt config resolution below — see
+        # the identical comment in _run_dlt_native_source for why this can't
+        # wait until right before dlt.pipeline().
+        _apply_dlt_telemetry_env(self.project_root)
 
         try:
             # Dynamic import of dlt source

--- a/dango/telemetry.py
+++ b/dango/telemetry.py
@@ -210,62 +210,87 @@ def set_dbt_telemetry_state(enabled: bool) -> None:
         raise OSError("Could not write ~/.dango/config.yml")
 
 
-def get_dlt_telemetry_state(project_root: Path | None) -> bool:
-    """Return dlt's current opt-in state per .dlt/config.toml (default: on).
+def _read_legacy_dlt_toml_opt_out(project_root: Path) -> bool | None:
+    """Read a pre-1.0.8-OPS-2 project-level dlt opt-out, for one-time migration only.
 
-    Relocated here (Level 0) from `cli/commands/telemetry.py`'s
-    `_get_dlt_telemetry_state()` (1.0.8-U) — only touches `.dlt/config.toml`
-    via `tomlkit` (third-party), no dango-internal import, so this has
-    always belonged at Level 0.
+    Returns the explicit ``[runtime].dlthub_telemetry`` value from the
+    project's `.dlt/config.toml` if present and parseable, or None if the
+    file is absent, unparseable, or has no explicit value (dlt's own
+    default is True, same as ours, so an absent key needs no migration).
+
+    Never raises — this is a best-effort read for migration purposes only,
+    not the source of truth going forward (see `get_dlt_telemetry_state`).
     """
-    if project_root is None:
-        return True
     config_path = project_root / ".dlt" / "config.toml"
     if not config_path.exists():
-        return True
+        return None
     try:
         import tomlkit
 
         doc = tomlkit.parse(config_path.read_text())
-        val = doc.get("runtime", {}).get("dlthub_telemetry", True)
-        return bool(val)
+        runtime = doc.get("runtime")
+        if runtime is None or "dlthub_telemetry" not in runtime:
+            return None
+        return bool(runtime["dlthub_telemetry"])
     except Exception:
-        return True
+        return None
 
 
-def set_dlt_telemetry_state(project_root: Path, enabled: bool) -> None:
-    """Write dlthub_telemetry to .dlt/config.toml under [runtime].
+def get_dlt_telemetry_state(project_root: Path | None = None) -> bool:
+    """Return dlt's current opt-in state per ~/.dango/config.yml (default: on).
 
-    Writes a native TOML boolean (not a string) to match the value type
-    dlt's own `dlt telemetry switch` CLI writes —
-    RuntimeConfiguration.dlthub_telemetry is a bool-typed field.
+    Machine-level (1.0.8-OPS-2), matching `get_dbt_telemetry_state()` —
+    moved off project-level `.dlt/config.toml` (which was git-tracked by
+    default, the exact inconsistency this task fixes: see
+    `1.0.x-planning/1.0.8/OPS-2-telemetry-storage-consolidation.md`).
 
-    Relocated here (Level 0), moved verbatim from
-    `cli/commands/telemetry.py`'s `_set_dlt_telemetry()` body (1.0.8-U),
-    minus the `click.ClickException` wrapping — this module has no `click`
-    import (Level 0 cannot depend on Level 3). Callers that need a
-    `click.ClickException` (the CLI) catch the exceptions below and wrap
-    them with the same message text as before the relocation.
+    One-time migration: if the global config has no `dlt_telemetry` key yet
+    AND `project_root` is given AND that project's `.dlt/config.toml` has an
+    explicit `dlthub_telemetry = false` from before this change, that
+    opt-out is migrated into `~/.dango/config.yml` (written once, here) so
+    an existing user's prior "no" answer survives the storage move instead
+    of silently reverting to the new default. A prior explicit `true` needs
+    no migration (matches the new default already). The legacy file itself
+    is left untouched — dlt may still read it directly, but
+    `_apply_dlt_telemetry_env()` (dango/ingestion/dlt_runner.py) always
+    overrides it with the machine-level value via the env var before any
+    dlt pipeline runs, so the legacy file stops being consulted for
+    anything dango-controlled from this point on.
+
+    Args:
+        project_root: Current project root, if any — only used to look for
+            a legacy opt-out to migrate on first read. Not required for
+            subsequent reads once the global key exists.
+    """
+    data = _read_global_config()
+    if "dlt_telemetry" in data:
+        return bool(data["dlt_telemetry"])
+
+    if project_root is not None:
+        legacy = _read_legacy_dlt_toml_opt_out(project_root)
+        if legacy is False:
+            _write_global_config_key("dlt_telemetry", False)
+            return False
+
+    return True
+
+
+def set_dlt_telemetry_state(enabled: bool) -> None:
+    """Write dlt's opt-out state to ~/.dango/config.yml under the dlt_telemetry key.
+
+    Machine-level (1.0.8-OPS-2), matching `set_dbt_telemetry_state()` — one
+    opt-out covers every project on the machine, translated into dlt's own
+    `RUNTIME__DLTHUB_TELEMETRY` env-var override at pipeline-invocation time
+    by `_apply_dlt_telemetry_env()` (dango/ingestion/dlt_runner.py), never
+    written into a project's git-tracked `.dlt/config.toml`.
 
     Raises:
-        OSError: If the file can't be read/written (e.g. permissions).
-        ValueError: Wrapping `tomlkit.exceptions.TOMLKitError` if the
-            existing `.dlt/config.toml` is malformed (e.g. from manual
-            editing).
+        OSError: If the write fails (e.g. permission denied, disk full) —
+            converted from `_write_global_config_key()`'s False return so
+            callers get an honest failure signal to act on.
     """
-    import tomlkit
-    from tomlkit.exceptions import TOMLKitError
-
-    config_path = project_root / ".dlt" / "config.toml"
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        doc = tomlkit.parse(config_path.read_text()) if config_path.exists() else tomlkit.document()
-    except TOMLKitError as e:
-        raise ValueError(str(e)) from e
-    if "runtime" not in doc:
-        doc.add("runtime", tomlkit.table())
-    doc["runtime"]["dlthub_telemetry"] = enabled
-    config_path.write_text(tomlkit.dumps(doc))
+    if not _write_global_config_key("dlt_telemetry", enabled):
+        raise OSError("Could not write ~/.dango/config.yml")
 
 
 def has_recorded_consent() -> bool:

--- a/dango/web/routes/telemetry.py
+++ b/dango/web/routes/telemetry.py
@@ -91,8 +91,11 @@ def _set_provider_state(provider: str, enabled: bool, project_root: Path) -> Non
     """Write through the enabled/disabled state for a single provider.
 
     Raises:
-        OSError: dbt write failure.
-        ValueError: dlt malformed/unwritable .dlt/config.toml.
+        OSError: dbt or dlt write failure (~/.dango/config.yml) — dlt moved
+            to this machine-level key in 1.0.8-OPS-2, matching dbt, so it
+            no longer raises ValueError for a malformed project-level
+            .dlt/config.toml (that file is no longer written by this code
+            path at all).
         click.ClickException: Metabase API/credentials failure —
             `set_metabase_telemetry()` (dango/visualization/metabase.py)
             raises this directly rather than a plain exception (an
@@ -105,7 +108,7 @@ def _set_provider_state(provider: str, enabled: bool, project_root: Path) -> Non
     elif provider == "dbt":
         set_dbt_telemetry_state(enabled)
     elif provider == "dlt":
-        set_dlt_telemetry_state(project_root, enabled)
+        set_dlt_telemetry_state(enabled)
     elif provider == "metabase":
         set_metabase_telemetry(project_root, enabled)
     else:

--- a/docs/network-egress.yml
+++ b/docs/network-egress.yml
@@ -34,7 +34,16 @@ telemetry:
     sends: "OS, Python version, invocation success/duration, hashed model content (Snowplow)"
   - host: telemetry.scalevector.ai
     provider: dlt
-    control: "dlthub_telemetry=false in .dlt/config.toml, or dlt --disable-telemetry"
+    control: >
+      `dango telemetry off --provider dlt` (or `--all`), which writes the
+      dlt_telemetry key to ~/.dango/config.yml (machine-level, since
+      1.0.8-OPS-2 — previously project-level .dlt/config.toml, which was
+      git-tracked by default) and is translated into dlt's own
+      RUNTIME__DLTHUB_TELEMETRY env-var override right before each
+      dlt.pipeline() call (dango/ingestion/dlt_runner.py:_apply_dlt_telemetry_env).
+      A user can still set dlthub_telemetry=false in a project's
+      .dlt/config.toml directly, or use dlt's own `dlt --disable-telemetry`
+      CLI, but Dango no longer writes or reads that file for this setting.
     sends: "command names, hashed pipeline/dataset names, execution times, OS"
   - host: metabase.com
     provider: metabase
@@ -85,26 +94,28 @@ notes:
   - "dbt and dlt telemetry env vars/config are read by their own subprocesses/library
      calls, not a separate Dango network layer. dango telemetry off --all writes
      these through to each tool's real config (dango/cli/commands/telemetry.py)."
-  - "dlt's write-through (dlthub_telemetry=false in .dlt/config.toml) is a confirmed
-     real no-op-when-set, not an open question. 1.0.8-V (2026-09-03) resolved this:
-     for any source type that actually calls dlt.pipeline() (DLT_NATIVE and the
-     generic path used by all 27+ verified/rest_api/PostgreSQL sources — everything
-     except CSV/LOCAL_FILES), dlt's telemetry runtime DOES initialize on every sync
-     (RunContext.runtime_config is touched, unconditionally, by
-     dlt/pipeline/track.py's on_end_trace_step hook on every extract/normalize/load
-     step) — this generalizes to every source type Dango has, since they all share
-     the same DltPipelineRunner extract/normalize/load call path. With
-     dlthub_telemetry left unset (dlt's own default = on), this test verified a real
-     outbound send is attempted to telemetry.scalevector.ai. With dlthub_telemetry=false
-     written to .dlt/config.toml — the exact write-through `dango telemetry off
-     --provider dlt` performs — that send is confirmed suppressed (dlt's anon
-     tracker never receives an endpoint to send to, verified with DNS resolution to
-     telemetry.scalevector.ai blocked and asserted unreached). So: the opt-out was
-     never a no-op — it correctly disables live dlt telemetry for every real source
-     type Dango ships, and users who ran `dango telemetry off --all` before this was
-     confirmed were, in fact, already protected. The CSV-only finding above remains
-     accurate for CSV/LOCAL_FILES specifically (still the one path with nothing live
-     to flip, since it never touches dlt.pipeline() at all) — see
+  - "dlt's write-through is a confirmed real no-op-when-set, not an open question.
+     1.0.8-V (2026-09-03) resolved this against the pre-1.0.8-OPS-2 .dlt/config.toml
+     mechanism; 1.0.8-OPS-2 (2026-09-04) moved the storage to machine-level
+     ~/.dango/config.yml (translated into dlt's RUNTIME__DLTHUB_TELEMETRY env var
+     right before each dlt.pipeline() call) and re-verified the same live-suppression
+     result against the new mechanism. For any source type that actually calls
+     dlt.pipeline() (DLT_NATIVE and the generic path used by all 27+
+     verified/rest_api/PostgreSQL sources — everything except CSV/LOCAL_FILES), dlt's
+     telemetry runtime DOES initialize on every sync (RunContext.runtime_config is
+     touched, unconditionally, by dlt/pipeline/track.py's on_end_trace_step hook on
+     every extract/normalize/load step) — this generalizes to every source type Dango
+     has, since they all share the same DltPipelineRunner extract/normalize/load call
+     path. With the machine-level dlt_telemetry key unset (default = on), this test
+     verified a real outbound send is attempted to telemetry.scalevector.ai. With
+     dlt_telemetry=false written to ~/.dango/config.yml — the exact write-through
+     `dango telemetry off --provider dlt` performs since 1.0.8-OPS-2 — that send is
+     confirmed suppressed (dlt's anon tracker never receives an endpoint to send to,
+     verified with DNS resolution to telemetry.scalevector.ai blocked and asserted
+     unreached). So: the opt-out was never a no-op — it correctly disables live dlt
+     telemetry for every real source type Dango ships. The CSV-only finding above
+     remains accurate for CSV/LOCAL_FILES specifically (still the one path with
+     nothing live to flip, since it never touches dlt.pipeline() at all) — see
      tests/unit/test_egress_allowlist.py's TestLiveEgressDetection class docstrings
      (both tests) for the full empirical/code-level detail on each path."
   - "Marimo update check host (marimo.io/api/oss/latest-version) is not listed above

--- a/tests/unit/test_egress_allowlist.py
+++ b/tests/unit/test_egress_allowlist.py
@@ -9,7 +9,6 @@ visibly on an undisclosed host, which is the detection mechanism §A5 asks for.
 
 from __future__ import annotations
 
-import inspect
 import socket
 from pathlib import Path
 from typing import Any
@@ -101,57 +100,6 @@ class _AllowlistGuard:
 
 
 @pytest.mark.unit
-class TestNetworkEgressDoc:
-    """Doc-consistency and real-introspection checks — no network, fast."""
-
-    def test_network_egress_yml_exists(self) -> None:
-        assert EGRESS_DOC.exists(), "docs/network-egress.yml not found"
-        data = _load_egress_doc()
-        assert "telemetry" in data
-        assert "functional" in data
-
-    def test_network_egress_yml_has_all_known_providers(self) -> None:
-        data = _load_egress_doc()
-        providers: set[str] = set()
-        for i, entry in enumerate(data["telemetry"]):
-            provider = entry.get("provider")
-            assert provider, (
-                f"docs/network-egress.yml: telemetry entry {i} is missing a "
-                f"'provider' key: {entry!r}"
-            )
-            providers.add(provider)
-        assert providers == {"dango", "dbt-core", "dlt", "metabase"}
-
-    def test_dlt_runtime_configuration_has_telemetry_field(self) -> None:
-        """Real introspection against the installed dlt version, not a
-        hardcoded string comparison. Catches a silent rename of the field
-        docs/network-egress.yml claims controls dlt's telemetry (this is
-        exactly the risk LAUNCH-READINESS.md §A2 calls out: "If dlt renames
-        dlthub_telemetry... a silent failure means you are telling users
-        something false")."""
-        from dlt.common.configuration.specs.runtime_configuration import (
-            RuntimeConfiguration,
-        )
-
-        fields = RuntimeConfiguration.__dataclass_fields__
-        assert "dlthub_telemetry" in fields, (
-            "dlt renamed its telemetry opt-out field — update "
-            "docs/network-egress.yml and the write-through in the telemetry command"
-        )
-
-    def test_dbt_send_anonymous_usage_stats_envvar_name(self) -> None:
-        """Real check against the installed dbt-core source, not memory.
-        Catches a silent rename of the env var docs/network-egress.yml
-        documents as dbt's telemetry opt-out control."""
-        from dbt.cli import params as dbt_params
-
-        source = inspect.getsource(dbt_params)
-        assert "DBT_SEND_ANONYMOUS_USAGE_STATS" in source, (
-            "dbt-core's telemetry opt-out env var name changed — update "
-            "docs/network-egress.yml and the write-through in the telemetry command"
-        )
-
-
 @pytest.mark.unit
 @pytest.mark.egress
 class TestLiveEgressDetection:
@@ -344,32 +292,46 @@ class TestLiveEgressDetection:
            source; whether a live send is actually attempted depends on
            `dlthub_telemetry`.
 
-        2. Does `dango telemetry off --provider dlt`'s config.toml
-           write-through (`dlthub_telemetry=false`) suppress it? YES,
-           confirmed below: with the flag set, `_ANON_TRACKER_ENDPOINT`
-           stays None and no live send to telemetry.scalevector.ai is
-           attempted (same `_AllowlistGuard` mechanism as the test above,
-           with telemetry.scalevector.ai deliberately excluded from the
-           allowed set so an attempt is caught, not silently let through
-           because it's normally a documented host).
+        2. Does `dango telemetry off --provider dlt`'s write-through
+           suppress it? YES, confirmed below: with the opt-out set,
+           `_ANON_TRACKER_ENDPOINT` stays None and no live send to
+           telemetry.scalevector.ai is attempted (same `_AllowlistGuard`
+           mechanism as the test above, with telemetry.scalevector.ai
+           deliberately excluded from the allowed set so an attempt is
+           caught, not silently let through because it's normally a
+           documented host).
 
         Two phases, matching the "run it twice" approach: Phase 1 uses dlt's
         own default (`dlthub_telemetry` unset, defaults True) and proves a
-        live send IS attempted. Phase 2 writes `dlthub_telemetry = false`
-        under `[runtime]` in `.dlt/config.toml` -- the exact write-through
-        `_set_dlt_telemetry()` (cli/commands/telemetry.py) performs -- and
-        proves the send is NOT attempted.
+        live send IS attempted. Phase 2 calls
+        `dango.telemetry.set_dlt_telemetry_state(False)` -- the exact
+        write-through `dango telemetry off --provider dlt` performs since
+        1.0.8-OPS-2 (machine-level `~/.dango/config.yml`, translated into
+        dlt's own `RUNTIME__DLTHUB_TELEMETRY` env-var override by
+        `_apply_dlt_telemetry_env()` in `dlt_runner.py` right before each
+        `dlt.pipeline()` call -- no longer a direct write to
+        `.dlt/config.toml`, which is what this test drove pre-1.0.8-OPS-2)
+        -- and proves the send is NOT attempted.
+
+        `~/.dango/` is isolated via a monkeypatched `Path.home()` (plus the
+        `dango.telemetry` module's already-resolved path constants, which a
+        bare `Path.home()` patch alone would not reach) so this test never
+        reads or writes the real machine's `~/.dango/config.yml` -- both
+        phases exercise the opt-out purely through that isolated file, the
+        same mechanism a real `dango telemetry off --provider dlt` /
+        `dango sync` pair would use across two separate OS processes on a
+        real machine.
 
         `switch_context()` (dlt.common.runtime.run_context) between phases is
-        not optional: `Pipeline.__init__` caches
-        `config.runtime.pluggable_run_context.context` as a plain attribute,
-        and dlt's config providers cache parsed file content in memory. Two
-        `dlt.pipeline()` calls in one *process* would otherwise reuse Phase
-        1's already-resolved config instead of picking up Phase 2's file
-        write -- confirmed while building this test (without
-        `switch_context()`, Phase 2 incorrectly showed the endpoint still
-        set). A real second `dango sync` is a fresh OS process and wouldn't
-        need this; it's purely an artifact of sharing one pytest process.
+        not optional: `RunContext.runtime_config` is a lazy-init property
+        that resolves `RuntimeConfiguration()` once and caches it on the
+        (process-lifetime) `RunContext` singleton -- Phase 2's fresh
+        `RUNTIME__DLTHUB_TELEMETRY` env var would otherwise never be
+        re-read, since `EnvironProvider` reads `os.environ` live but the
+        *singleton* holding Phase 1's already-resolved config never gets
+        this far again. A real second `dango sync` is a fresh OS process and
+        wouldn't need this; it's purely an artifact of sharing one pytest
+        process.
 
         `stop_telemetry()` runs inside each `with guard:` block, before the
         guard exits (forced-flush, same as the test above) -- and, crucially,
@@ -383,6 +345,7 @@ class TestLiveEgressDetection:
         from dlt.common.runtime.run_context import switch_context
         from dlt.common.runtime.telemetry import is_telemetry_started, stop_telemetry
 
+        import dango.telemetry as dango_telemetry
         from dango.cli.init import init_project
         from dango.config.models import DataSource, DltNativeConfig, SourceType
         from dango.ingestion import run_sync
@@ -390,6 +353,20 @@ class TestLiveEgressDetection:
 
         monkeypatch.setenv("DBT_SEND_ANONYMOUS_USAGE_STATS", "false")
         monkeypatch.setenv("DO_NOT_TRACK", "1")
+
+        # Isolate ~/.dango/ (1.0.8-OPS-2 moved dlt's opt-out here) so this
+        # test never touches the real machine's telemetry config — same
+        # pattern as tests/unit/test_telemetry_unified.py's _isolated_home
+        # fixture. A bare Path.home() patch is not enough: dango.telemetry's
+        # _CONFIG_DIR/_GLOBAL_CONFIG_FILE constants are already resolved at
+        # import time, so they're patched directly too.
+        fake_home = tmp_path / "_fake_home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        fake_config_dir = fake_home / ".dango"
+        monkeypatch.setattr(dango_telemetry, "_CONFIG_DIR", fake_config_dir)
+        monkeypatch.setattr(dango_telemetry, "_IDENTITY_FILE", fake_config_dir / "telemetry.json")
+        monkeypatch.setattr(dango_telemetry, "_GLOBAL_CONFIG_FILE", fake_config_dir / "config.yml")
 
         # Same pre-seed rationale as the test above: avoid a real driver
         # download during init, out of scope for what this test detects.
@@ -459,20 +436,34 @@ class TestLiveEgressDetection:
             f"reason if expected, do not loosen this test to make it pass."
         )
 
-        # --- Phase 2: dlthub_telemetry explicitly disabled, same write-through
-        # `dango telemetry off --provider dlt` performs ---
-        import tomlkit
+        # --- Phase 2: dlt telemetry explicitly disabled via the 1.0.8-OPS-2
+        # machine-level write-through `dango telemetry off --provider dlt`
+        # performs -- ~/.dango/config.yml (isolated above), not
+        # .dlt/config.toml.
+        dango_telemetry.set_dlt_telemetry_state(False)
 
-        config_path = tmp_path / ".dlt" / "config.toml"
-        doc = tomlkit.parse(config_path.read_text())
-        if "runtime" not in doc:
-            doc.add("runtime", tomlkit.table())
-        doc["runtime"]["dlthub_telemetry"] = False
-        config_path.write_text(tomlkit.dumps(doc))
+        # Apply the env var directly here, rather than waiting for
+        # run_sync() below to reach _apply_dlt_telemetry_env() on its own:
+        # switch_context() below (PluggableRunContext.reload() ->
+        # add_extras()) eagerly re-resolves RuntimeConfiguration and calls
+        # start_telemetry() as a side effect of the reload itself -- before
+        # run_sync() gets a chance to run -- so RUNTIME__DLTHUB_TELEMETRY
+        # must already reflect the new state by this point, or
+        # switch_context() re-initializes telemetry from the stale Phase-1
+        # env var ("true") and _TELEMETRY_STARTED latches True again before
+        # Phase 2's own _apply_dlt_telemetry_env() call ever runs. A real
+        # process never calls switch_context() at all -- _apply_dlt_telemetry_env()
+        # already runs before any dlt code touches the RunContext for a
+        # given sync (moved there in this same change specifically because
+        # of this ordering requirement) -- so this mirrors production
+        # ordering, not something being carved out only for the test.
+        from dango.ingestion.dlt_runner import _apply_dlt_telemetry_env
 
-        # See docstring: forces a brand-new RunContext so the rewritten
-        # config.toml is actually re-read, instead of reusing Phase 1's
-        # in-process-cached RuntimeConfiguration/providers.
+        _apply_dlt_telemetry_env(tmp_path)
+
+        # Forces a brand-new RunContext so the env var above is actually
+        # picked up, instead of reusing Phase 1's in-process-cached
+        # RuntimeConfiguration/providers.
         switch_context(str(tmp_path))
 
         guard2 = _AllowlistGuard(restricted_allowed)
@@ -480,11 +471,13 @@ class TestLiveEgressDetection:
             result2 = run_sync(tmp_path, [source], skip_dbt=True)
 
             assert anon_tracker._ANON_TRACKER_ENDPOINT is None, (
-                "dango telemetry off --provider dlt's .dlt/config.toml "
-                "write-through (dlthub_telemetry=false) did NOT suppress "
-                "dlt's anon tracker -- this is a live privacy/telemetry-"
-                "disclosure bug. Do not fix it here: file a BUGS-FOUND.md "
-                "entry per this task's scope (see 1.0.8-V prompt)."
+                "dango telemetry off --provider dlt's ~/.dango/config.yml "
+                "write-through (1.0.8-OPS-2, translated into dlt's "
+                "RUNTIME__DLTHUB_TELEMETRY env var by "
+                "_apply_dlt_telemetry_env() in dlt_runner.py) did NOT "
+                "suppress dlt's anon tracker -- this is a live "
+                "privacy/telemetry-disclosure bug. Do not fix it here: file "
+                "a BUGS-FOUND.md entry per this task's scope."
             )
 
             stop_telemetry()

--- a/tests/unit/test_network_egress_doc.py
+++ b/tests/unit/test_network_egress_doc.py
@@ -1,0 +1,72 @@
+"""tests/unit/test_network_egress_doc.py
+
+Doc-consistency and real-introspection checks for docs/network-egress.yml —
+no network, fast. Split out of test_egress_allowlist.py (which covers live
+DNS-blocked egress detection) to stay under the 500-line file-size check.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EGRESS_DOC = REPO_ROOT / "docs" / "network-egress.yml"
+
+
+def _load_egress_doc() -> dict[str, Any]:
+    return yaml.safe_load(EGRESS_DOC.read_text())
+
+
+class TestNetworkEgressDoc:
+    """Doc-consistency and real-introspection checks — no network, fast."""
+
+    def test_network_egress_yml_exists(self) -> None:
+        assert EGRESS_DOC.exists(), "docs/network-egress.yml not found"
+        data = _load_egress_doc()
+        assert "telemetry" in data
+        assert "functional" in data
+
+    def test_network_egress_yml_has_all_known_providers(self) -> None:
+        data = _load_egress_doc()
+        providers: set[str] = set()
+        for i, entry in enumerate(data["telemetry"]):
+            provider = entry.get("provider")
+            assert provider, (
+                f"docs/network-egress.yml: telemetry entry {i} is missing a "
+                f"'provider' key: {entry!r}"
+            )
+            providers.add(provider)
+        assert providers == {"dango", "dbt-core", "dlt", "metabase"}
+
+    def test_dlt_runtime_configuration_has_telemetry_field(self) -> None:
+        """Real introspection against the installed dlt version, not a
+        hardcoded string comparison. Catches a silent rename of the field
+        docs/network-egress.yml claims controls dlt's telemetry (this is
+        exactly the risk LAUNCH-READINESS.md §A2 calls out: "If dlt renames
+        dlthub_telemetry... a silent failure means you are telling users
+        something false")."""
+        from dlt.common.configuration.specs.runtime_configuration import (
+            RuntimeConfiguration,
+        )
+
+        fields = RuntimeConfiguration.__dataclass_fields__
+        assert "dlthub_telemetry" in fields, (
+            "dlt renamed its telemetry opt-out field — update "
+            "docs/network-egress.yml and the write-through in the telemetry command"
+        )
+
+    def test_dbt_send_anonymous_usage_stats_envvar_name(self) -> None:
+        """Real check against the installed dbt-core source, not memory.
+        Catches a silent rename of the env var docs/network-egress.yml
+        documents as dbt's telemetry opt-out control."""
+        from dbt.cli import params as dbt_params
+
+        source = inspect.getsource(dbt_params)
+        assert "DBT_SEND_ANONYMOUS_USAGE_STATS" in source, (
+            "dbt-core's telemetry opt-out env var name changed — update "
+            "docs/network-egress.yml and the write-through in the telemetry command"
+        )

--- a/tests/unit/test_telemetry_unified.py
+++ b/tests/unit/test_telemetry_unified.py
@@ -87,22 +87,26 @@ class TestDbtTelemetryEnv:
 
 @pytest.mark.unit
 class TestDltWriteThrough:
-    """_set_dlt_telemetry / _get_dlt_telemetry_state — .dlt/config.toml write-through."""
+    """_set_dlt_telemetry / _get_dlt_telemetry_state — ~/.dango/config.yml
+    write-through (1.0.8-OPS-2: moved off project-level .dlt/config.toml,
+    which was git-tracked by default — see
+    v1.0.x-planning/1.0.8/OPS-2-telemetry-storage-consolidation.md).
+    `project_root` is still accepted by both CLI wrappers (for --all's
+    downgrade-to-warning bookkeeping and legacy-opt-out migration
+    respectively) but no longer determines where the value is stored."""
 
     def test_dlt_write_through(self, tmp_path: Path) -> None:
         from dango.cli.commands.telemetry import _set_dlt_telemetry
 
         _set_dlt_telemetry(False, tmp_path)
 
-        config_path = tmp_path / ".dlt" / "config.toml"
+        config_path = tmp_path / ".dango" / "config.yml"
         assert config_path.exists()
         content = config_path.read_text()
-        assert "dlthub_telemetry" in content
-        # Written as a native TOML boolean (unquoted), matching the type of
-        # dlt's own dlthub_telemetry field (RuntimeConfiguration.dlthub_telemetry: bool)
-        # and the value type dlt's own CLI writes via WritableConfigValue(..., bool, ...).
-        assert "false" in content
-        assert '"false"' not in content
+        assert "dlt_telemetry: false" in content
+
+        # And the project-level legacy file must NOT be touched.
+        assert not (tmp_path / ".dlt" / "config.toml").exists()
 
     def test_dlt_read_state_off(self, tmp_path: Path) -> None:
         from dango.cli.commands.telemetry import _get_dlt_telemetry_state, _set_dlt_telemetry
@@ -124,37 +128,66 @@ class TestDltWriteThrough:
 
         assert _get_dlt_telemetry_state(tmp_path) is True
 
-    def test_dlt_malformed_existing_toml_raises_click_exception(self, tmp_path: Path) -> None:
-        """Review fix #1: a hand-corrupted .dlt/config.toml must raise
-        click.ClickException (so --all can skip and continue), not a raw
-        tomlkit.exceptions.TOMLKitError."""
-        import click
-
-        from dango.cli.commands.telemetry import _set_dlt_telemetry
-
-        config_path = tmp_path / ".dlt" / "config.toml"
-        config_path.parent.mkdir(parents=True)
-        config_path.write_text("[runtime\ndlthub_telemetry = true\n")  # missing ']'
-
-        with pytest.raises(click.ClickException):
-            _set_dlt_telemetry(False, tmp_path)
-
     def test_dlt_write_failure_raises_click_exception_not_oserror(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Review fix #1: a real OSError writing .dlt/config.toml (disk
-        full, permissions) must surface as click.ClickException."""
+        """A real OSError writing ~/.dango/config.yml (disk full,
+        permissions) must surface as click.ClickException — same contract
+        as _set_dbt_telemetry."""
         import click
 
         from dango.cli.commands.telemetry import _set_dlt_telemetry
 
-        def _raise_oserror(self: Path, *args: object, **kwargs: object) -> None:
+        def _raise_oserror(*args: object, **kwargs: object) -> None:
             raise OSError("disk full")
 
-        monkeypatch.setattr(Path, "write_text", _raise_oserror)
+        monkeypatch.setattr("builtins.open", _raise_oserror)
 
         with pytest.raises(click.ClickException):
             _set_dlt_telemetry(False, tmp_path)
+
+    def test_dlt_legacy_toml_opt_out_migrated_on_first_read(self, tmp_path: Path) -> None:
+        """1.0.8-OPS-2 migration decision: a pre-existing project-level
+        .dlt/config.toml opt-out (dlthub_telemetry = false) is migrated
+        into ~/.dango/config.yml the first time it's read through the CLI
+        wrapper, rather than silently reverting to the new default. A
+        second read must not require the legacy file any more."""
+        import tomlkit
+
+        from dango.cli.commands.telemetry import _get_dlt_telemetry_state
+
+        config_path = tmp_path / ".dlt" / "config.toml"
+        config_path.parent.mkdir(parents=True)
+        doc = tomlkit.document()
+        doc.add("runtime", tomlkit.table())
+        doc["runtime"]["dlthub_telemetry"] = False
+        config_path.write_text(tomlkit.dumps(doc))
+
+        assert _get_dlt_telemetry_state(tmp_path) is False
+
+        global_config = tmp_path / ".dango" / "config.yml"
+        assert "dlt_telemetry: false" in global_config.read_text()
+
+        # Second read must not need the legacy file at all.
+        config_path.unlink()
+        assert _get_dlt_telemetry_state(tmp_path) is False
+
+    def test_dlt_legacy_toml_opt_in_needs_no_migration(self, tmp_path: Path) -> None:
+        """An explicit `dlthub_telemetry = true` in the legacy file matches
+        the new default already — no migration write should happen."""
+        import tomlkit
+
+        from dango.cli.commands.telemetry import _get_dlt_telemetry_state
+
+        config_path = tmp_path / ".dlt" / "config.toml"
+        config_path.parent.mkdir(parents=True)
+        doc = tomlkit.document()
+        doc.add("runtime", tomlkit.table())
+        doc["runtime"]["dlthub_telemetry"] = True
+        config_path.write_text(tomlkit.dumps(doc))
+
+        assert _get_dlt_telemetry_state(tmp_path) is True
+        assert not (tmp_path / ".dango" / "config.yml").exists()
 
 
 @pytest.mark.unit
@@ -262,7 +295,9 @@ class TestTelemetryStatusCommand:
 @pytest.mark.unit
 class TestTelemetryOffAllOutsideProject:
     """Regression risk + acceptance criterion: `--all` outside a project must
-    succeed for dango+dbt and warn (not crash) for dlt+metabase."""
+    succeed for dango+dbt+dlt (all machine-level as of 1.0.8-OPS-2) and warn
+    (not crash) for metabase (still project-scoped — write-through is a live
+    API call using per-project credentials)."""
 
     def test_off_all_outside_project_warns_not_crashes(self, tmp_path: Path) -> None:
         runner = CliRunner()
@@ -272,15 +307,27 @@ class TestTelemetryOffAllOutsideProject:
         assert result.exit_code == 0, result.output
         assert "dango: telemetry disabled" in result.output
         assert "dbt: telemetry disabled" in result.output
-        assert "dlt" in result.output and "skipped" in result.output
+        assert "dlt: telemetry disabled" in result.output
         assert "metabase" in result.output and "skipped" in result.output
 
-    def test_off_provider_dlt_outside_project_raises(self, tmp_path: Path) -> None:
-        """A single explicit --provider request outside a project is a hard
-        error, not a silent skip — this is a deliberate action, not a sweep."""
+    def test_off_provider_dlt_outside_project_succeeds(self, tmp_path: Path) -> None:
+        """1.0.8-OPS-2: dlt telemetry is machine-level now, so an explicit
+        --provider dlt request no longer requires an active Dango project
+        (unlike metabase, which still does — see the class docstring)."""
         runner = CliRunner()
         with runner.isolated_filesystem(temp_dir=tmp_path):
             result = runner.invoke(cli, ["telemetry", "off", "--provider", "dlt"])
+
+        assert result.exit_code == 0, result.output
+        assert "dlt: telemetry disabled" in result.output
+
+    def test_off_provider_metabase_outside_project_raises(self, tmp_path: Path) -> None:
+        """A single explicit --provider request outside a project is a hard
+        error, not a silent skip — this is a deliberate action, not a sweep.
+        Only metabase remains project-scoped after 1.0.8-OPS-2."""
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["telemetry", "off", "--provider", "metabase"])
 
         assert result.exit_code != 0
         assert "Dango project" in result.output
@@ -376,42 +423,69 @@ class TestLevel0DbtDltTelemetryFunctions:
 
         assert get_dlt_telemetry_state(tmp_path) is True
         assert get_dlt_telemetry_state(None) is True
+        assert get_dlt_telemetry_state() is True
 
     def test_set_get_dlt_telemetry_state_round_trip(self, tmp_path: Path) -> None:
+        """1.0.8-OPS-2: dlt telemetry is machine-level (~/.dango/config.yml)
+        like dbt's — set_dlt_telemetry_state() takes no project_root."""
         from dango.telemetry import get_dlt_telemetry_state, set_dlt_telemetry_state
 
-        set_dlt_telemetry_state(tmp_path, False)
+        set_dlt_telemetry_state(False)
+        assert get_dlt_telemetry_state() is False
         assert get_dlt_telemetry_state(tmp_path) is False
-        set_dlt_telemetry_state(tmp_path, True)
-        assert get_dlt_telemetry_state(tmp_path) is True
+        set_dlt_telemetry_state(True)
+        assert get_dlt_telemetry_state() is True
 
-    def test_set_dlt_telemetry_state_malformed_toml_raises_value_error(
-        self, tmp_path: Path
+    def test_set_dlt_telemetry_state_raises_plain_oserror(
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A malformed .dlt/config.toml raises ValueError (wrapping
-        tomlkit's TOMLKitError) here — the CLI wrapper is what converts
-        this to click.ClickException."""
+        """Level 0 has no click import — a write failure must surface as a
+        plain OSError, not click.ClickException (that translation is
+        cli/commands/telemetry.py's job) — same contract as
+        set_dbt_telemetry_state."""
         from dango.telemetry import set_dlt_telemetry_state
+
+        def _raise_oserror(*args: object, **kwargs: object) -> None:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr("builtins.open", _raise_oserror)
+
+        with pytest.raises(OSError):
+            set_dlt_telemetry_state(False)
+
+    def test_get_dlt_telemetry_state_migration_writes_global_config(self, tmp_path: Path) -> None:
+        """1.0.8-OPS-2 migration decision: a pre-existing project-level
+        .dlt/config.toml opt-out is migrated into ~/.dango/config.yml on
+        first read, so an existing opted-out user's prior "no" answer isn't
+        silently dropped by the storage move (see task file's Background /
+        migration-decision section)."""
+        import tomlkit
+
+        from dango.telemetry import get_dlt_telemetry_state
 
         config_path = tmp_path / ".dlt" / "config.toml"
         config_path.parent.mkdir(parents=True)
-        config_path.write_text("[runtime\ndlthub_telemetry = true\n")  # missing ']'
+        doc = tomlkit.document()
+        doc.add("runtime", tomlkit.table())
+        doc["runtime"]["dlthub_telemetry"] = False
+        config_path.write_text(tomlkit.dumps(doc))
 
-        with pytest.raises(ValueError):
-            set_dlt_telemetry_state(tmp_path, False)
+        result = get_dlt_telemetry_state(tmp_path)
 
-    def test_set_dlt_telemetry_state_write_failure_raises_plain_oserror(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        assert result is False
+        global_config = tmp_path / ".dango" / "config.yml"
+        assert global_config.exists()
+        assert "dlt_telemetry: false" in global_config.read_text()
+
+    def test_get_dlt_telemetry_state_no_migration_without_project_root(
+        self, tmp_path: Path
     ) -> None:
-        from dango.telemetry import set_dlt_telemetry_state
+        """Without a project_root, there's nothing to migrate from — the
+        machine-level default applies, same as a brand-new install."""
+        from dango.telemetry import get_dlt_telemetry_state
 
-        def _raise_oserror(self: Path, *args: object, **kwargs: object) -> None:
-            raise OSError("disk full")
-
-        monkeypatch.setattr(Path, "write_text", _raise_oserror)
-
-        with pytest.raises(OSError):
-            set_dlt_telemetry_state(tmp_path, False)
+        assert get_dlt_telemetry_state(None) is True
+        assert not (tmp_path / ".dango" / "config.yml").exists()
 
     def test_providers_constant(self) -> None:
         from dango.telemetry import PROVIDERS

--- a/tests/unit/test_web_telemetry.py
+++ b/tests/unit/test_web_telemetry.py
@@ -171,7 +171,9 @@ class TestSetTelemetry:
         assert resp.status_code == 200
         mock_set.assert_called_once_with(True)
 
-    def test_toggle_dlt_provider(self, admin_client: TestClient, tmp_path: Path) -> None:
+    def test_toggle_dlt_provider(self, admin_client: TestClient) -> None:
+        """dlt is machine-level since 1.0.8-OPS-2 — set_dlt_telemetry_state()
+        no longer takes project_root (matching set_dbt_telemetry_state())."""
         with patch("dango.web.routes.telemetry.set_dlt_telemetry_state") as mock_set:
             resp = admin_client.post(
                 "/api/telemetry",
@@ -179,7 +181,7 @@ class TestSetTelemetry:
                 headers=HEADERS,
             )
         assert resp.status_code == 200
-        mock_set.assert_called_once_with(tmp_path, False)
+        mock_set.assert_called_once_with(False)
 
     def test_toggle_metabase_provider(self, admin_client: TestClient, tmp_path: Path) -> None:
         with patch("dango.web.routes.telemetry.set_metabase_telemetry") as mock_set:


### PR DESCRIPTION
## Summary
- Telemetry storage was inconsistent: dango/dbt already lived in machine-level `~/.dango/config.yml` (never git-tracked), but dlt lived in the project's own `.dlt/config.toml` (git-tracked by default) - meaning a telemetry toggle could produce a real, uncommitted-vs-committed git diff depending on branch, unlike every other provider.
- `dlt` telemetry now lives in `~/.dango/config.yml` too, translated into dlt's real `RUNTIME__DLTHUB_TELEMETRY` env-var override at pipeline-invocation time, never written to `.dlt/config.toml`. A prior explicit opt-out is migrated once; a prior `true`/absent value needs no migration.
- `.dango/metabase_telemetry_state` added to the generated `.gitignore` (was missing).
- No CLI/web UI behavior change.

## Verification
- Live check: `dango telemetry off --all` in an isolated scratch project - confirmed `dlt_telemetry: false` written to `~/.dango/config.yml`, `.dlt/config.toml` completely untouched
- All egress/telemetry unit tests pass, including the live dlt-pipeline egress-detection test updated for the new mechanism
- `ruff check`: passed