### PR TITLE
1.0.8: Warn on unsafe git state before repo-mutating commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 |------|-------|-----------------|
 | `ingestion/dlt_runner.py` | 2885 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2340 | — (metadata-only) |
-| `cli/source_wizard.py` | 2525 | — |
+| `cli/source_wizard.py` | 2610 | — |
 | `visualization/metabase.py` | 1251 | — |
 | `cli/init.py` | 1585 | — |
 | `visualization/dashboard_manager.py` | 1117 | — |
@@ -381,12 +381,13 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `web/routes/users.py` | 540 | — (admin user CRUD + invite) |
 | `platform/local/watcher.py` | 524 | — |
 | `cli/commands/schedule.py` | 914 | — (schedule wizard + time customization) |
-| `cli/model_wizard.py` | 547 | — |
+| `cli/model_wizard.py` | 617 | — |
 | `cli/commands/remote_backup.py` | 521 | — (R2-D10: --from-local flag) |
 | `platform/cloud/scheduled_backup.py` | 606 | — (server-side scheduled backup) |
 | `governance/schema_drift.py` | 654 | — (R9-D: breaking drift protection + accept flow) |
 | `governance/pii_detector.py` | 626 | — (BUG-027/BUG-133/BUG-139/BUG-185: spaCy fallback + PERSON threshold + override application + structured data heuristic) |
 | `platform/scheduling/scheduler.py` | 514 | — (1.0.8-Q: `_setup_telemetry_heartbeat()`, a fourth fixed internal scheduler job) |
+| `cli/commands/mcp_mutations.py` | 508 | — (1.0.8-OPS-3: git guardrail wiring pushed an already-near-limit file over 500) |
 
 ## Module Documentation Index
 

--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -28,9 +28,9 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/seed.py` (135 lines) | `seed` group (`add`, `list`) — dbt seed CSV management | `seed` |
 | `commands/dashboard.py` (215 lines) | `dashboard` group (`provision`) — materializes pipeline-health state via `dango.utils.pipeline_health` before provisioning (1.0.8-DASH-1) | `dashboard` |
 | `commands/mcp_server.py` (~460 lines) | `mcp` group + `run` command; FastMCP stdio server with 8 read-only tools (list_sources, get_table_schema, get_catalog, get_lineage, list_models, get_model_sql, query, get_sync_history) | `mcp_group`, `mcp`, `mcp_run()` |
-| `commands/mcp_mutations.py` (~485 lines) | Mutation tools registered onto the shared `mcp` FastMCP instance (run_sync, run_transform, run_doctor, add_source, list_source_types, create_model, add_schedule) — split out of mcp_server.py, not a Click module | `run_sync()`, `run_transform()`, `run_doctor()`, `add_source()`, `list_source_types()`, `create_model()`, `add_schedule()` |
+| `commands/mcp_mutations.py` (~508 lines, exempt — see `docs/file-exemptions.yml`) | Mutation tools registered onto the shared `mcp` FastMCP instance (run_sync, run_transform, run_doctor, add_source, list_source_types, create_model, add_schedule) — split out of mcp_server.py, not a Click module. `add_source`/`create_model`/`add_schedule` call `mcp_helpers._git_warnings()` (1.0.8-OPS-3) and fold any result into a `git_warning` key on success | `run_sync()`, `run_transform()`, `run_doctor()`, `add_source()`, `list_source_types()`, `create_model()`, `add_schedule()` |
 | `commands/mcp_setup.py` (~145 lines) | `mcp setup` / `mcp status` subcommands (registers onto `mcp_group` from mcp_server.py) — detects/configures Claude Code, Cursor, Windsurf | `mcp_setup()`, `mcp_status()` |
-| `commands/mcp_helpers.py` (~120 lines) | Plain-function helpers for the MCP read tools (project root, SELECT-only SQL validation, retry-on-lock DuckDB connect, blocking query execution) — split out of mcp_server.py, not a Click module | `_get_project_root()`, `_validate_select_only()`, `_connect_readonly_with_retry()`, `_execute_query_sync()` |
+| `commands/mcp_helpers.py` (~166 lines) | Plain-function helpers for the MCP read tools (project root, SELECT-only SQL validation, retry-on-lock DuckDB connect, blocking query execution) plus `_git_warnings()` (1.0.8-OPS-3) shared by the mutation tools in mcp_mutations.py — split out of mcp_server.py, not a Click module | `_get_project_root()`, `_validate_select_only()`, `_connect_readonly_with_retry()`, `_execute_query_sync()`, `_git_warnings()` |
 | `commands/remote.py` (702 lines) | `remote` group → `push`, `rollback`, `firewall`, `domain` subgroups + management commands | `remote`, `remote_push()`, `remote_rollback()`, `firewall`, `domain` |
 | `commands/migrate.py` | `migrate` group (`status`, `run`) | `migrate` |
 | `commands/serve.py` (~205 lines) | `serve` production foreground server with `--workers` option. Metabase setup failure is non-fatal (prints warning, continues to uvicorn). | `serve()` |
@@ -55,8 +55,8 @@ Click-based command-line interface for all Dango operations — project init, so
 | **Wizards** | | |
 | `init.py` (1585 lines) | Project initialization wizard, incl. first-run telemetry consent prompt | `ProjectInitializer` |
 | `wizard.py` (307 lines) | Interactive setup wizards | `ProjectWizard` |
-| `source_wizard.py` (2525 lines) | Source configuration wizard | `add_source()` |
-| `model_wizard.py` (547 lines) | dbt model creation wizard | `add_model()` |
+| `source_wizard.py` (2610 lines) | Source configuration wizard. `run()` calls `_print_git_warnings()` (1.0.8-OPS-3) right after the intro panel | `add_source()` |
+| `model_wizard.py` (617 lines) | dbt model creation wizard. `run()` calls `_print_git_warnings()` (1.0.8-OPS-3) right after the intro banner | `add_model()` |
 | **Helpers** | | |
 | `utils.py` (164 lines) | Display helpers + project context | `require_project_context()` |
 | `validate.py` (787 lines) | Project validation logic | `validate_project()` |

--- a/dango/cli/commands/mcp_helpers.py
+++ b/dango/cli/commands/mcp_helpers.py
@@ -1,10 +1,11 @@
 """dango/cli/commands/mcp_helpers.py
 
-Shared helpers for the MCP server's read tools (dango/cli/commands/mcp_server.py).
-Split out purely to keep mcp_server.py under the file-size check — these are
-plain functions, not Click-registered commands, so there's no cross-file
-command-registration pattern involved (unlike mcp_setup.py), just a normal
-helper extraction.
+Shared helpers for the MCP server's read tools (dango/cli/commands/mcp_server.py)
+and, since 1.0.8-OPS-3, _git_warnings() below for the mutation tools in
+mcp_mutations.py. Split out purely to keep mcp_server.py under the file-size
+check — these are plain functions, not Click-registered commands, so there's
+no cross-file command-registration pattern involved (unlike mcp_setup.py),
+just a normal helper extraction.
 
 Safe to import at mcp_server.py's module top level despite the "lazy Dango
 imports only" rule for that file: this module itself does zero dango.*
@@ -40,6 +41,19 @@ def _get_project_root() -> Path:
         raise RuntimeError(
             "Not inside a Dango project. cd into your project directory first."
         ) from None
+
+
+def _git_warnings(project_root: Path) -> list[str]:
+    """Non-blocking git-state warnings (on main/master, dirty tree, detached
+    HEAD) for a repo-mutating MCP tool. No human to prompt over stdio, so
+    callers fold this into their return dict as a `git_warning` key instead
+    of printing (1.0.8-OPS-3). [] for a non-git project or a clean branch."""
+    from dango.utils.git_info import check_mutation_guardrails, collect_git_info
+
+    git_info = collect_git_info(project_root)
+    if not git_info.is_git_repo:
+        return []
+    return list(check_mutation_guardrails(git_info).warnings)
 
 
 def _infer_layer(model_name: str) -> str:

--- a/dango/cli/commands/mcp_mutations.py
+++ b/dango/cli/commands/mcp_mutations.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from dango.cli.commands.mcp_helpers import _get_project_root
+from dango.cli.commands.mcp_helpers import _get_project_root, _git_warnings
 from dango.cli.commands.mcp_server import mcp
 
 # ── Trigger tools ─────────────────────────────────────────────────────────────
@@ -150,7 +150,7 @@ def add_source(
                      Use lowercase_with_underscores. Must not already exist.
         description: Human-readable description of what this source contains.
 
-    Returns dict with: status, source_name, next_steps (credentials to configure).
+    Returns dict with: status, source_name, next_steps (credentials to configure), git_warning.
     """
     project_root = _get_project_root()
     from dango.config.helpers import load_config, save_config
@@ -202,13 +202,16 @@ def add_source(
         next_steps.append(f"Add {key_name} to .dlt/secrets.toml")
     next_steps.append(f"Run: dango sync {source_name}")
 
-    return {
+    result = {
         "status": "created",
         "source_name": source_name,
         "source_type": source_type,
         "auth_type": auth_type,
         "next_steps": next_steps,
     }
+    if git_warning := _git_warnings(project_root):
+        result["git_warning"] = git_warning
+    return result
 
 
 @mcp.tool()
@@ -256,7 +259,7 @@ def create_model(
                        For staging: use source names. For others: use model names.
         description: What this model represents (written to schema.yml).
 
-    Returns dict with: status, file_path, sql_scaffold, warnings (if any).
+    Returns dict with: status, file_path, sql_scaffold, warnings (if any), git_warning.
     """
     project_root = _get_project_root()
 
@@ -386,7 +389,7 @@ select * from {first_alias}
     # Update schema.yml
     _update_schema_yml(model_dir, model_name, description, upstream_refs)
 
-    return {
+    result = {
         "status": "created",
         "file_path": str(model_path.relative_to(project_root)),
         "sql_scaffold": sql,
@@ -396,6 +399,9 @@ select * from {first_alias}
             "Run: dango run to test",
         ],
     }
+    if git_warning := _git_warnings(project_root):
+        result["git_warning"] = git_warning
+    return result
 
 
 @mcp.tool()
@@ -417,7 +423,7 @@ def add_schedule(
         timezone: Timezone for the cron (e.g. "Asia/Singapore", "US/Eastern"). Default UTC.
         skip_dbt: If True, sync only — do not run dbt transforms after sync.
 
-    Returns dict with: status, schedule_name, next_run_approx.
+    Returns dict with: status, schedule_name, next_run_approx, git_warning.
     """
     project_root = _get_project_root()
     from dango.config.helpers import load_config
@@ -454,7 +460,7 @@ def add_schedule(
     schedules_config.schedules.append(new_schedule)
     save_schedules_config(project_root, schedules_config)
 
-    return {
+    result = {
         "status": "created",
         "schedule_name": schedule_name,
         "cron": cron,
@@ -462,6 +468,9 @@ def add_schedule(
         "sources": sources,
         "next_steps": ["Run: dango schedule reload (or restart dango) to activate"],
     }
+    if git_warning := _git_warnings(project_root):
+        result["git_warning"] = git_warning
+    return result
 
 
 # ── Schema YML helper ─────────────────────────────────────────────────────────

--- a/dango/cli/model_wizard.py
+++ b/dango/cli/model_wizard.py
@@ -44,6 +44,8 @@ class ModelWizard:
         console.print("Create a new intermediate or marts model.\n")
         console.print("[dim]Staging models are auto-generated during sync.[/dim]\n")
 
+        self._print_git_warnings()
+
         # Check if dbt directory exists
         if not self.dbt_dir.exists():
             console.print("[red]Error: dbt directory not found. Run 'dango init' first.[/red]")
@@ -172,6 +174,24 @@ class ModelWizard:
         except KeyboardInterrupt:
             console.print("\n[yellow]Cancelled[/yellow]")
             return None
+
+    def _print_git_warnings(self) -> None:
+        """Warn (never block) on unsafe git state — on main/master, dirty tree,
+        or detached HEAD — before writing a new model file. Non-git projects
+        print nothing (check_mutation_guardrails() returns no warning for them
+        by design — 'not a git repo' isn't actionable for a wizard user).
+        Mirrors the warning style `dango remote push` already uses for
+        check_git_guardrails() (cli/commands/remote.py)."""
+        from dango.utils.git_info import check_mutation_guardrails, collect_git_info
+
+        git_info = collect_git_info(self.project_root)
+        if not git_info.is_git_repo:
+            return
+        result = check_mutation_guardrails(git_info)
+        for w in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {w}")
+        if result.warnings:
+            console.print()
 
     def _ask_layer(self) -> str | None:
         """Ask which model layer"""

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -111,6 +111,24 @@ class SourceWizard:
         self.env_file = project_root / ".env"
         self.secret_params = []  # Track secret parameters for .env setup
 
+    def _print_git_warnings(self) -> None:
+        """Warn (never block) on unsafe git state — on main/master, dirty tree,
+        or detached HEAD — before writing a new source to sources.yml. Non-git
+        projects print nothing (check_mutation_guardrails() returns no warning
+        for them by design — 'not a git repo' isn't actionable for a wizard
+        user). Mirrors the warning style `dango remote push` already uses for
+        check_git_guardrails() (cli/commands/remote.py)."""
+        from dango.utils.git_info import check_mutation_guardrails, collect_git_info
+
+        git_info = collect_git_info(self.project_root)
+        if not git_info.is_git_repo:
+            return
+        result = check_mutation_guardrails(git_info)
+        for w in result.warnings:
+            console.print(f"  [yellow]Warning:[/yellow] {w}")
+        if result.warnings:
+            console.print()
+
     def run(self) -> bool:
         """
         Run the source wizard
@@ -127,6 +145,8 @@ class SourceWizard:
                     border_style="cyan",
                 )
             )
+
+            self._print_git_warnings()
 
             # State machine for navigation with back button support
             source_type = None

--- a/dango/utils/CLAUDE.md
+++ b/dango/utils/CLAUDE.md
@@ -22,7 +22,7 @@ Shared utilities for process management, activity logging, sync history tracking
 | `dango_db.py` (~210 lines) | SQLite context manager for `.dango/dango.db` + schema init | `connect()`, `get_connection()` |
 | `post_sync.py` (~804 lines) | Post-sync hook dispatcher + sync notification | `dispatch_post_sync_hooks()`, `_run_profiling()`, `_profile_dbt_models()`, `_enrich_staging_tests()`, `_run_pii_scan()`, `_run_analysis()`, `_run_dbt_snapshots()`, `_materialize_pipeline_health()`, `_ensure_default_metrics()`, `_send_sync_notification()` |
 | `pipeline_health.py` | Materializes sync history / dbt test results / source list into DuckDB tables (`_dango_meta` schema) for the "Data Pipeline Health" dashboard (1.0.8-DASH-1) — Metabase's container can't read the underlying JSON files directly | `materialize_pipeline_health()`, `SCHEMA` |
-| `git_info.py` | Git repository info and deployment guardrails | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()` |
+| `git_info.py` | Git repository info, deployment guardrails, and warn-only mutation guardrails (CLI wizards + MCP tools, 1.0.8-OPS-3) | `GitInfo`, `GitGuardrailResult`, `collect_git_info()`, `check_git_guardrails()`, `check_mutation_guardrails()` |
 | `driver.py` | Metabase DuckDB driver version management + version alignment check | `METABASE_DUCKDB_DRIVER_VERSION`, `METABASE_DUCKDB_DRIVER_URL`, `get_duckdb_driver_url()`, `read_driver_version()`, `write_driver_version()`, `driver_needs_update()`, `check_version_alignment()` |
 
 ## Common Tasks
@@ -63,6 +63,8 @@ Shared utilities for process management, activity logging, sync history tracking
 - `dango/governance/` — dango_db (connect)
 - `dango/notebooks/` — dango_db (connect)
 - `dango/analysis/` — dango_db (connect)
+- `dango/cli/commands/remote.py` — git_info (check_git_guardrails, cloud deploy/push path)
+- `dango/cli/model_wizard.py`, `dango/cli/source_wizard.py`, `dango/cli/commands/mcp_helpers.py` — git_info (check_mutation_guardrails, 1.0.8-OPS-3 warn-only guardrails for the CLI wizards and MCP mutation tools)
 
 **Not yet imported:** `data_validation.py` (prepared utility, not integrated into any module)
 

--- a/dango/utils/git_info.py
+++ b/dango/utils/git_info.py
@@ -127,3 +127,48 @@ def check_git_guardrails(
         warnings=tuple(warnings),
         errors=tuple(errors),
     )
+
+
+def check_mutation_guardrails(
+    git_info: GitInfo,
+    *,
+    protected_branches: tuple[str, ...] = ("main", "master"),
+) -> GitGuardrailResult:
+    """Check git state before a local repo-mutating command (CLI wizard or MCP tool).
+
+    This is a sibling of check_git_guardrails(), not a caller of it — deliberately, not
+    an oversight. check_git_guardrails()'s branch check flags being OFF an
+    *expected_branch* (deploy semantics: "you must be on the branch you're pushing to
+    the server"). Mutation entry points (dango model add, dango source add, and the MCP
+    create_model/add_source/add_schedule tools) need the opposite signal: flag being ON
+    a shared/protected branch, since the write lands directly on it with no review.
+    Reusing check_git_guardrails() here — even with allow_branch=True — would either
+    warn on the wrong condition or require passing expected_branch=<the branch we're
+    already on> just to suppress it, which is more contorted than a small, purpose-built
+    sibling that reuses the same GitInfo/GitGuardrailResult/collect_git_info() building
+    blocks and the same warning message style.
+
+    Always warn-only: passed is always True. 1.0.8-OPS-3 is an explicit warn-don't-block
+    decision — these are local file writes, not a production deploy, so
+    check_git_guardrails()'s hard-block-by-default behavior does not apply here.
+    """
+    warnings: list[str] = []
+
+    if not git_info.is_git_repo:
+        warnings.append("Not a git repository — skipping git checks.")
+        return GitGuardrailResult(passed=True, warnings=tuple(warnings))
+
+    if git_info.branch == "HEAD":
+        warnings.append("Detached HEAD — no branch tracking.")
+    elif git_info.branch and git_info.branch in protected_branches:
+        warnings.append(
+            f"On branch '{git_info.branch}' — this change will be written directly "
+            "to that branch. Consider creating a feature branch first."
+        )
+
+    if git_info.is_clean is False:
+        warnings.append("Working tree has uncommitted changes.")
+    elif git_info.is_clean is None:
+        warnings.append("Could not determine working tree status.")
+
+    return GitGuardrailResult(passed=True, warnings=tuple(warnings))

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -178,9 +178,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/source_wizard.py
-    lines: 2525
+    lines: 2610
     category: exempt
-    reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting. P7-011 added metrics generation. P5c grew +529 lines (credential unification, resource selection, dedup collection). P8-001 added REST API wizard enhancements: headers, query params, endpoint testing, data_selector/primary_key suggestions (+267 lines)."
+    reason: "Interactive source configuration wizard. Sequential prompting logic doesn't benefit from splitting. P7-011 added metrics generation. P5c grew +529 lines (credential unification, resource selection, dedup collection). P8-001 added REST API wizard enhancements: headers, query params, endpoint testing, data_selector/primary_key suggestions (+267 lines). 1.0.8-OPS-3 added _print_git_warnings() (+~19 lines)."
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
@@ -234,9 +234,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/cli/model_wizard.py
-    lines: 547
+    lines: 617
     category: exempt
-    reason: "Interactive dbt model creation wizard. Sequential prompting, stable. 1.0.7-1: Added table selection + CTE scaffold generation."
+    reason: "Interactive dbt model creation wizard. Sequential prompting, stable. 1.0.7-1: Added table selection + CTE scaffold generation. 1.0.8-OPS-3 added _print_git_warnings() (+~16 lines)."
     review_by: "v1.1"
 
 # Removed: dango/platform/network.py — now 486 lines, within limit (TASK-088)
@@ -386,6 +386,12 @@ exemptions:
     lines: 514
     category: exempt
     reason: "1.0.8-Q: Added _setup_telemetry_heartbeat(), a fourth fixed internal job (weekly telemetry heartbeat) following the existing _setup_history_cleanup/_setup_login_attempts_cleanup/_setup_sync_log_cleanup pattern. Pushed the file ~14 lines over the 500-line limit."
+    review_by: "v1.1"
+
+  - file: dango/cli/commands/mcp_mutations.py
+    lines: 508
+    category: exempt
+    reason: "1.0.8-OPS-3: Wired check_mutation_guardrails() (git-state warnings) into add_source/create_model/add_schedule, surfacing a git_warning key on their return dicts. The file was already at 499/500 lines before this change (5 mutation tools is a lot of surface area, per its own module docstring on why it was split out of mcp_server.py) — the actual _git_warnings() helper itself lives in mcp_helpers.py, not here, to keep the addition minimal. Pushed the file ~8 lines over the 500-line limit."
     review_by: "v1.1"
 
   - file: dango/utils/post_sync.py

--- a/tests/unit/test_git_info.py
+++ b/tests/unit/test_git_info.py
@@ -15,6 +15,7 @@ from dango.utils.git_info import (
     GitInfo,
     _strip_credentials,
     check_git_guardrails,
+    check_mutation_guardrails,
     collect_git_info,
 )
 
@@ -263,6 +264,84 @@ class TestCheckGitGuardrails:
         assert result.passed is True
         assert len(result.warnings) == 2
         assert len(result.errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_mutation_guardrails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCheckMutationGuardrails:
+    """Test warn-only git guardrails for CLI wizard / MCP mutation entry points
+    (1.0.8-OPS-3). Unlike check_git_guardrails() (deploy path), this never
+    blocks — passed is always True — and flags being ON a protected branch,
+    not off an expected one."""
+
+    def test_not_a_git_repo_never_blocks(self) -> None:
+        info = GitInfo(is_git_repo=False)
+        result = check_mutation_guardrails(info)
+        assert result.passed is True
+        assert result.errors == ()
+        assert len(result.warnings) == 1
+        assert "Not a git" in result.warnings[0]
+
+    def test_clean_feature_branch_no_warnings(self) -> None:
+        """On a feature branch with a clean tree — the common case — no warnings."""
+        info = GitInfo(
+            commit_sha="a" * 40,
+            branch="feat/my-feature",
+            is_clean=True,
+            is_git_repo=True,
+        )
+        result = check_mutation_guardrails(info)
+        assert result.passed is True
+        assert result.warnings == ()
+        assert result.errors == ()
+
+    def test_on_main_warns(self) -> None:
+        info = GitInfo(commit_sha="a" * 40, branch="main", is_clean=True, is_git_repo=True)
+        result = check_mutation_guardrails(info)
+        assert result.passed is True
+        assert result.errors == ()
+        assert len(result.warnings) == 1
+        assert "main" in result.warnings[0]
+
+    def test_on_master_warns(self) -> None:
+        info = GitInfo(commit_sha="a" * 40, branch="master", is_clean=True, is_git_repo=True)
+        result = check_mutation_guardrails(info)
+        assert result.passed is True
+        assert len(result.warnings) == 1
+        assert "master" in result.warnings[0]
+
+    def test_dirty_tree_warns_never_blocks(self) -> None:
+        """Dirty tree is an error in check_git_guardrails() by default; here it must
+        only ever warn — this is the warn-don't-block requirement from 1.0.8-OPS-3."""
+        info = GitInfo(commit_sha="a" * 40, branch="feat/x", is_clean=False, is_git_repo=True)
+        result = check_mutation_guardrails(info)
+        assert result.passed is True
+        assert result.errors == ()
+        assert len(result.warnings) == 1
+        assert "uncommitted" in result.warnings[0]
+
+    def test_on_main_and_dirty_both_warn(self) -> None:
+        info = GitInfo(commit_sha="a" * 40, branch="main", is_clean=False, is_git_repo=True)
+        result = check_mutation_guardrails(info)
+        assert result.passed is True
+        assert len(result.warnings) == 2
+
+    def test_detached_head_warns(self) -> None:
+        info = GitInfo(commit_sha="a" * 40, branch="HEAD", is_clean=True, is_git_repo=True)
+        result = check_mutation_guardrails(info)
+        assert result.passed is True
+        assert any("Detached HEAD" in w for w in result.warnings)
+
+    def test_custom_protected_branches(self) -> None:
+        """protected_branches is overridable — e.g. a repo using 'trunk' instead of main."""
+        info = GitInfo(commit_sha="a" * 40, branch="trunk", is_clean=True, is_git_repo=True)
+        result = check_mutation_guardrails(info, protected_branches=("trunk",))
+        assert len(result.warnings) == 1
+        assert "trunk" in result.warnings[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_mutations.py
+++ b/tests/unit/test_mcp_mutations.py
@@ -283,6 +283,100 @@ class TestCreateModel:
 
 
 @pytest.mark.unit
+class TestGitWarning:
+    """1.0.8-OPS-3: add_source/create_model/add_schedule surface git-state
+    warnings via a `git_warning` key in their return dict — there's no human
+    to prompt over stdio, so this is how the calling agent sees it. The
+    `project` fixture's tmp_path is never a git repo, so these tests
+    monkeypatch mcp_mutations._git_warnings() directly rather than needing a
+    real git repo; the underlying detection logic (on main/master, dirty
+    tree) is covered separately in test_git_info.py::TestCheckMutationGuardrails."""
+
+    def test_add_source_includes_git_warning_when_present(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            mcp_mutations, "_git_warnings", lambda project_root: ["On branch 'main' — ..."]
+        )
+        result = mcp_mutations.add_source("csv", "new_csv_source")
+        assert result["status"] == "created"
+        assert result["git_warning"] == ["On branch 'main' — ..."]
+
+    def test_add_source_omits_git_warning_when_clean(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mcp_mutations, "_git_warnings", lambda project_root: [])
+        result = mcp_mutations.add_source("csv", "another_csv_source")
+        assert result["status"] == "created"
+        assert "git_warning" not in result
+
+    def test_add_source_error_path_has_no_git_warning(self, project: Path) -> None:
+        """Validation failures (nothing written) don't need a git_warning key at all —
+        only successful mutations do."""
+        result = mcp_mutations.add_source("csv", "test_source")  # duplicate name
+        assert result == {"error": "Source 'test_source' already exists in sources.yml"}
+        assert "git_warning" not in result
+
+    def test_create_model_includes_git_warning_when_present(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            mcp_mutations,
+            "_git_warnings",
+            lambda project_root: ["Working tree has uncommitted changes."],
+        )
+        result = mcp_mutations.create_model("int_orders_summary", "intermediate", [])
+        assert result["status"] == "created"
+        assert result["git_warning"] == ["Working tree has uncommitted changes."]
+        # The pre-existing "warnings" key (naming/anti-pattern) is a separate concept —
+        # confirm the two don't collide.
+        assert result["warnings"] == []
+
+    def test_create_model_omits_git_warning_when_clean(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mcp_mutations, "_git_warnings", lambda project_root: [])
+        result = mcp_mutations.create_model("int_orders_clean", "intermediate", [])
+        assert result["status"] == "created"
+        assert "git_warning" not in result
+
+    def test_add_schedule_includes_git_warning_when_present(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            mcp_mutations, "_git_warnings", lambda project_root: ["On branch 'master' — ..."]
+        )
+        result = mcp_mutations.add_schedule("weekly_sync", "0 7 * * 1", ["test_source"])
+        assert result["status"] == "created"
+        assert result["git_warning"] == ["On branch 'master' — ..."]
+
+    def test_add_schedule_omits_git_warning_when_clean(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(mcp_mutations, "_git_warnings", lambda project_root: [])
+        result = mcp_mutations.add_schedule("monthly_sync", "0 7 1 * *", ["test_source"])
+        assert result["status"] == "created"
+        assert "git_warning" not in result
+
+    def test_non_git_project_never_crashes_and_omits_key(self, project: Path) -> None:
+        """project fixture's tmp_path is a plain directory, never git-initialized —
+        confirms _git_warnings() (and therefore all three tools) handles a non-git
+        project gracefully with no exception and no git_warning key, using the real
+        (unmocked) collect_git_info()/check_mutation_guardrails() call chain."""
+        result = mcp_mutations.add_source("csv", "non_git_source")
+        assert result["status"] == "created"
+        assert "git_warning" not in result
+
+        result2 = mcp_mutations.create_model("int_non_git", "intermediate", [])
+        assert result2["status"] == "created"
+        assert "git_warning" not in result2
+
+        result3 = mcp_mutations.add_schedule("non_git_sched", "0 7 * * *", ["test_source"])
+        assert result3["status"] == "created"
+        assert "git_warning" not in result3
+
+
+@pytest.mark.unit
 class TestAddSchedule:
     def test_add_schedule_missing_source(self, project: Path) -> None:
         result = mcp_mutations.add_schedule("daily_sync", "0 7 * * *", ["nonexistent_source"])

--- a/tests/unit/test_model_wizard.py
+++ b/tests/unit/test_model_wizard.py
@@ -3,6 +3,9 @@
 Tests for dbt model wizard.
 """
 
+import subprocess
+from unittest.mock import patch
+
 import pytest
 
 from dango.cli.model_wizard import ModelWizard
@@ -17,6 +20,89 @@ def project_root(tmp_path):
         "project:\n  name: test\n  created_by: test\n  purpose: test project\n"
     )
     return tmp_path
+
+
+def _init_git_repo(path, branch="main", dirty=False):
+    """Create a real git repo at `path` on the given branch (main is git's
+    default init branch on modern git, so no checkout needed for that case)."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "checkout", "-b", branch], check=True, capture_output=True
+    )
+    (path / "committed.txt").write_text("hello")
+    # -A picks up the .dango/project.yml the project_root fixture already wrote,
+    # not just committed.txt — otherwise the tree would be dirty even in the
+    # "clean" test case.
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True
+    )
+    if dirty:
+        (path / "dirty.txt").write_text("uncommitted")
+
+
+# ---------------------------------------------------------------------------
+# 1.0.8-OPS-3: git guardrail warnings before writing a new model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPrintGitWarnings:
+    """ModelWizard._print_git_warnings() — warn-only git state check called
+    from run() before the wizard starts collecting input."""
+
+    def test_on_main_prints_warning(self, project_root):
+        _init_git_repo(project_root, branch="main")
+        wizard = ModelWizard(project_root)
+
+        with patch("dango.cli.model_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()
+
+        assert any("main" in p and "Warning" in p for p in printed)
+
+    def test_clean_feature_branch_prints_nothing(self, project_root):
+        _init_git_repo(project_root, branch="feat/my-model")
+        wizard = ModelWizard(project_root)
+
+        with patch("dango.cli.model_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()
+
+        assert printed == []
+
+    def test_dirty_tree_prints_warning(self, project_root):
+        _init_git_repo(project_root, branch="feat/my-model", dirty=True)
+        wizard = ModelWizard(project_root)
+
+        with patch("dango.cli.model_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()
+
+        assert any("uncommitted" in p for p in printed)
+
+    def test_non_git_project_does_not_crash_or_print(self, project_root):
+        """project_root is a plain tmp_path, never git-initialized here — must not
+        raise and must not print anything (nothing actionable for a wizard user)."""
+        wizard = ModelWizard(project_root)
+
+        with patch("dango.cli.model_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()  # must not raise
+
+        assert printed == []
 
 
 @pytest.fixture

--- a/tests/unit/test_source_wizard.py
+++ b/tests/unit/test_source_wizard.py
@@ -5,11 +5,100 @@ Unit tests for source wizard UX bugs (P2-2, P2-4, P2-6, P2-7, P8-3).
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from dango.ingestion.sources.registry import SOURCE_REGISTRY
+
+
+def _init_git_repo(path, branch="main", dirty=False):
+    """Create a real git repo at `path` on the given branch."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "checkout", "-b", branch], check=True, capture_output=True
+    )
+    (path / "committed.txt").write_text("hello")
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True
+    )
+    if dirty:
+        (path / "dirty.txt").write_text("uncommitted")
+
+
+# ---------------------------------------------------------------------------
+# 1.0.8-OPS-3: git guardrail warnings before writing a new source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPrintGitWarnings:
+    """SourceWizard._print_git_warnings() — warn-only git state check called
+    from run() right after the intro panel, before the state machine starts."""
+
+    def test_on_main_prints_warning(self, tmp_path):
+        from dango.cli.source_wizard import SourceWizard
+
+        _init_git_repo(tmp_path, branch="main")
+        wizard = SourceWizard(tmp_path)
+
+        with patch("dango.cli.source_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()
+
+        assert any("main" in p and "Warning" in p for p in printed)
+
+    def test_clean_feature_branch_prints_nothing(self, tmp_path):
+        from dango.cli.source_wizard import SourceWizard
+
+        _init_git_repo(tmp_path, branch="feat/my-source")
+        wizard = SourceWizard(tmp_path)
+
+        with patch("dango.cli.source_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()
+
+        assert printed == []
+
+    def test_dirty_tree_prints_warning(self, tmp_path):
+        from dango.cli.source_wizard import SourceWizard
+
+        _init_git_repo(tmp_path, branch="feat/my-source", dirty=True)
+        wizard = SourceWizard(tmp_path)
+
+        with patch("dango.cli.source_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()
+
+        assert any("uncommitted" in p for p in printed)
+
+    def test_non_git_project_does_not_crash_or_print(self, tmp_path):
+        """tmp_path is a plain directory, never git-initialized here — must not
+        raise and must not print anything."""
+        from dango.cli.source_wizard import SourceWizard
+
+        wizard = SourceWizard(tmp_path)
+
+        with patch("dango.cli.source_wizard.console") as mock_console:
+            printed = []
+            mock_console.print = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            wizard._print_git_warnings()  # must not raise
+
+        assert printed == []
+
 
 # ---------------------------------------------------------------------------
 # P2-2: Success message requires actual auth tokens


### PR DESCRIPTION
## Summary
- Wired the existing `check_git_guardrails()` mechanism (previously only used by `dango remote push`) into 5 more entry points that write to git-tracked project files with zero prior git awareness: CLI's `model_wizard.py`/`add_model()`, `source_wizard.py`/`add_source()`, and MCP's `create_model`/`add_source`/`add_schedule`.
- New `check_mutation_guardrails()` (sibling function, not a caller of `check_git_guardrails()` - the semantics are inverted: deploy warns when OFF the expected branch, mutations should warn when ON a protected branch).
- Warn-only, never blocks. CLI prints a warning; MCP surfaces it via a `git_warning` key on the tool's return value (no human to prompt).

## Not done, flagging rather than skipping silently
- `docs/guides/mcp-claude-code.md`'s Safety section (docs repo) should mention the new `git_warning` key - ran out of session budget before reaching this.

## Verification
- 88 tests passed
- `ruff check`: passed
- `docs/file-exemptions.yml` updated for the one file (`mcp_mutations.py`) that crossed 500 lines by ~8, with justification