### PR TITLE
fix: mock webbrowser.open in test_deploy_backup_warning.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,27 @@ from tests.factories.config_factories import (
 _session_id = f"{Path.cwd().name}:{os.getpid()}"
 
 
+def _blocked_webbrowser_open(url, *args, **kwargs):
+    raise AssertionError(
+        f"webbrowser.open({url!r}) called without being mocked. Tests must never open a "
+        "real browser — patch webbrowser.open (or the module-level `webbrowser` import, "
+        "for source modules that import it at module scope) explicitly in the test."
+    )
+
+
+@pytest.fixture(autouse=True)
+def _block_real_webbrowser_open(monkeypatch):
+    """Fail loudly if any test path reaches a real, unmocked webbrowser.open() call.
+
+    A test in this suite once called a function with url="https://example.com" without
+    realizing that function unconditionally opens a real browser — every run of that test
+    opened a real tab, on every machine, for weeks, undetected by grep because the call site
+    and the URL string live in different files. This fixture turns any future instance of
+    that bug class into an immediate, loud test failure instead of a silent side effect.
+    """
+    monkeypatch.setattr("webbrowser.open", _blocked_webbrowser_open)
+
+
 def pytest_sessionstart(session):
     logger = logging.getLogger("pytest.session")
     logger.info("=" * 60)

--- a/tests/unit/test_deploy_backup_warning.py
+++ b/tests/unit/test_deploy_backup_warning.py
@@ -7,6 +7,8 @@ warning shown for that case, and confirms the existing "enabled" message is
 unaffected.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 
@@ -15,13 +17,14 @@ class TestBackupWarning:
     def test_warning_shown_when_backup_disabled(self, capsys):
         from dango.cli.commands.deploy import _print_deploy_success
 
-        _print_deploy_success(
-            url="https://example.com",
-            ip="1.2.3.4",
-            admin_email="admin@example.com",
-            warnings=[],
-            backup_enabled=False,
-        )
+        with patch("webbrowser.open"):
+            _print_deploy_success(
+                url="https://example.com",
+                ip="1.2.3.4",
+                admin_email="admin@example.com",
+                warnings=[],
+                backup_enabled=False,
+            )
         captured = capsys.readouterr()
         assert "Backups" in captured.out
         assert "Not configured" in captured.out or "server only" in captured.out
@@ -29,13 +32,14 @@ class TestBackupWarning:
     def test_no_warning_when_backup_enabled(self, capsys):
         from dango.cli.commands.deploy import _print_deploy_success
 
-        _print_deploy_success(
-            url="https://example.com",
-            ip="1.2.3.4",
-            admin_email="admin@example.com",
-            warnings=[],
-            backup_enabled=True,
-        )
+        with patch("webbrowser.open"):
+            _print_deploy_success(
+                url="https://example.com",
+                ip="1.2.3.4",
+                admin_email="admin@example.com",
+                warnings=[],
+                backup_enabled=True,
+            )
         captured = capsys.readouterr()
         assert "Enabled" in captured.out
         assert "Not configured" not in captured.out


### PR DESCRIPTION
## Summary
- `_print_deploy_success()` (`dango/cli/commands/deploy.py:334-336`) unconditionally calls `webbrowser.open(url)` at the end — real, intended UX for `dango deploy` (opens the deployed URL after success).
- `tests/unit/test_deploy_backup_warning.py` (added by Session M, new in 1.0.8) calls this function directly with `url="https://example.com"` and never mocked `webbrowser` — so every run of this test opened a real browser tab to example.com on the machine running the tests.
- Root-caused via live bisection across the full test suite (repeated, previously-unexplained example.com tabs during 1.0.8 testing/dispatch sessions — correlated with "our tasks running," never happened before 1.0.8, explained by this test being new in 1.0.8).
- `webbrowser` is imported locally inside the function (this repo's lazy-import convention), not at module level, so the fix patches `webbrowser.open` directly rather than `dango.cli.commands.deploy.webbrowser` (the latter would raise `AttributeError` since there's no module-level attribute to patch).
- Checked every other `webbrowser.open` call site in the codebase (`oauth/__init__.py`, `cli/oauth.py`, `cli/commands/platform.py`, `cli/commands/notebook.py`) for the same missing-mock pattern — all already correctly mocked or unreached by any test.
- **Follow-up commit:** added an autouse fixture in `tests/conftest.py` that patches `webbrowser.open` globally to raise if called unmocked, in every test. Turns any future instance of this bug class into an immediate, loud test failure instead of a silent side effect only a human happening to notice a stray tab would catch.

## Verification
- `pytest tests/unit/test_deploy_backup_warning.py -v`: 2 passed, confirmed live (twice) that no browser tab opens
- Full suite: `pytest -q` — 4482 passed, 30 skipped, ~222-227s across three separate live runs — confirmed live each time (with the user watching) that no browser tab opens anywhere in the full run
- Full suite re-confirmed clean after adding the autouse guard fixture (4482 passed, 0 new failures) — existing tests that patch `webbrowser.open` directly or patch a module-level `webbrowser` import (`dango.oauth`, `dango.cli.oauth`) are unaffected
- `ruff check`, `ruff format --check`, `mypy`: all clean on changed files