### PR TITLE
fix: two low-priority BUGS-FOUND.md items (init dot-in-name, Metabase credential defaults)

### DIFF
--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -3,6 +3,7 @@
 Handles creation of new Dango projects.
 """
 
+import re
 from pathlib import Path
 
 from rich.console import Console
@@ -1112,8 +1113,12 @@ custom_sources/
 
     def _create_dbt_project(self, config: DangoConfig):
         """Create dbt project configuration files"""
-        # Sanitize project name for dbt (lowercase, underscores only)
-        dbt_project_name = config.project.name.lower().replace(" ", "_").replace("-", "_")
+        # Sanitize project name for dbt: must match dbt's project-name regex
+        # (^[^\d\W]\w*$ — starts with a letter/underscore, rest is word chars only).
+        # Any character outside [A-Za-z0-9_] (dots, spaces, hyphens, etc.) becomes "_".
+        dbt_project_name = re.sub(r"\W", "_", config.project.name.lower())
+        if re.match(r"^\d", dbt_project_name):
+            dbt_project_name = f"_{dbt_project_name}"
 
         # Create dbt_project.yml
         dbt_project_content = f"""# dbt Project Configuration

--- a/dango/visualization/CLAUDE.md
+++ b/dango/visualization/CLAUDE.md
@@ -8,7 +8,7 @@ Integrates with Metabase for dashboard provisioning, auto-setup, schema synchron
 
 | File | Purpose | Key Functions/Classes |
 |------|---------|----------------------|
-| `__init__.py` | Public exports | `provision_dashboard`, `create_pipeline_health_dashboard` |
+| `__init__.py` | Public exports | `provision_dashboard` |
 | `metabase.py` | Metabase auto-setup, DuckDB connection, schema sync | `MetabaseProvisioner`, `setup_metabase`, `sync_metabase_schema`, `refresh_metabase_connection`, `set_metabase_telemetry`, `get_metabase_telemetry_state` |
 | `dashboard_manager.py` | YAML-based dashboard/question export and import with rollback | `DashboardManager`, `import_dashboards` |
 

--- a/dango/visualization/__init__.py
+++ b/dango/visualization/__init__.py
@@ -4,6 +4,6 @@ Metabase Dashboard Integration
 Provides tools for creating and provisioning Metabase dashboards.
 """
 
-from .metabase import create_pipeline_health_dashboard, provision_dashboard
+from .metabase import provision_dashboard
 
-__all__ = ["provision_dashboard", "create_pipeline_health_dashboard"]
+__all__ = ["provision_dashboard"]

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -280,16 +280,19 @@ class MetabaseProvisioner:
     def __init__(
         self,
         metabase_url: str = "http://localhost:3000",
-        username: str = "admin@example.com",
-        password: str = "admin123",
+        username: str = "",
+        password: str = "",
     ):
         """
         Initialize Metabase provisioner
 
         Args:
             metabase_url: Metabase instance URL
-            username: Admin username
-            password: Admin password
+            username: Admin username. Defaults to "" — real callers must supply this
+                explicitly; it previously defaulted to "admin@example.com", a
+                hardcoded-credential-shaped trap for any future caller (see
+                1.0.8-BUGS-FOUND.md)
+            password: Admin password. Defaults to "", same reasoning as username
         """
         self.metabase_url = metabase_url.rstrip("/")
         self.username = username
@@ -590,8 +593,9 @@ class MetabaseProvisioner:
 
 def provision_dashboard(
     metabase_url: str = "http://localhost:3000",
-    username: str = "admin@example.com",
-    password: str = "admin123",
+    *,
+    username: str,
+    password: str,
     database_id: int | None = None,
 ) -> dict[str, Any]:
     """
@@ -609,23 +613,8 @@ def provision_dashboard(
     Returns:
         Provisioning summary
     """
-    provisioner = MetabaseProvisioner(metabase_url, username, password)
+    provisioner = MetabaseProvisioner(metabase_url, username=username, password=password)
     return provisioner.provision_pipeline_health_dashboard(database_id=database_id)
-
-
-def create_pipeline_health_dashboard(project_root: Path) -> dict[str, Any]:
-    """
-    Create Data Pipeline Health dashboard for a Dango project
-
-    Args:
-        project_root: Path to Dango project root
-
-    Returns:
-        Provisioning summary
-    """
-    # Read Metabase credentials from project config if available
-    # For now, use defaults
-    return provision_dashboard()
 
 
 def generate_secure_password(length: int = 20) -> str:

--- a/tests/unit/test_dbt_project_name_sanitization.py
+++ b/tests/unit/test_dbt_project_name_sanitization.py
@@ -1,0 +1,49 @@
+"""tests/unit/test_dbt_project_name_sanitization.py
+
+Tests for ProjectInitializer._create_dbt_project()'s project-name sanitization.
+A project directory name containing a dot (e.g. "review-1.0.8") previously produced
+an invalid dbt project name that failed dbt's own validation regex (^[^\\d\\W]\\w*$)
+at `dbt docs generate` time, well after most of `dango init` had already run.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from dango.cli.init import ProjectInitializer
+from tests.factories.config_factories import make_dango_config, make_project_context
+
+# Mirrors dbt's own project-name validation regex.
+_DBT_NAME_RE = re.compile(r"^[^\d\W]\w*$")
+
+
+def _generated_name(tmp_path: Path, project_display_name: str) -> str:
+    (tmp_path / "dbt" / "macros").mkdir(parents=True)
+    initializer = ProjectInitializer(tmp_path)
+    config = make_dango_config(project=make_project_context(name=project_display_name))
+    initializer._create_dbt_project(config)
+    content = (tmp_path / "dbt" / "dbt_project.yml").read_text()
+    match = re.search(r"^name: '([^']*)'", content, re.MULTILINE)
+    assert match is not None, "dbt_project.yml missing a name: field"
+    return match.group(1)
+
+
+@pytest.mark.unit
+class TestDbtProjectNameSanitization:
+    def test_dot_in_name_is_sanitized(self, tmp_path: Path) -> None:
+        """A dot (e.g. from a directory like "review-1.0.8") must not reach dbt_project.yml."""
+        name = _generated_name(tmp_path, "review-1.0.8")
+        assert _DBT_NAME_RE.match(name), f"{name!r} does not match dbt's project-name regex"
+
+    def test_leading_digit_is_sanitized(self, tmp_path: Path) -> None:
+        """dbt's regex forbids a leading digit even after word-char sanitization."""
+        name = _generated_name(tmp_path, "2026 Analytics")
+        assert _DBT_NAME_RE.match(name), f"{name!r} does not match dbt's project-name regex"
+
+    def test_normal_name_unaffected(self, tmp_path: Path) -> None:
+        """Existing behavior for a plain name is unchanged."""
+        name = _generated_name(tmp_path, "Test Analytics")
+        assert name == "test_analytics"

--- a/tests/unit/test_metabase_credential_defaults.py
+++ b/tests/unit/test_metabase_credential_defaults.py
@@ -1,0 +1,33 @@
+"""tests/unit/test_metabase_credential_defaults.py
+
+Regression tests for 1.0.8-BUGS-FOUND.md's "Hardcoded-looking Metabase credential
+defaults on an unused exported function" entry: MetabaseProvisioner() and
+provision_dashboard() defaulted username/password to "admin@example.com"/"admin123",
+and the only real caller of that default, create_pipeline_health_dashboard(), was
+dead code (zero callers, confirmed via grep) that has since been deleted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+class TestMetabaseCredentialDefaults:
+    def test_provisioner_no_longer_defaults_to_guessable_credentials(self) -> None:
+        from dango.visualization.metabase import MetabaseProvisioner
+
+        provisioner = MetabaseProvisioner()
+        assert provisioner.username != "admin@example.com"
+        assert provisioner.password != "admin123"
+
+    def test_provision_dashboard_requires_credentials(self) -> None:
+        from dango.visualization.metabase import provision_dashboard
+
+        with pytest.raises(TypeError):
+            provision_dashboard()  # type: ignore[call-arg]
+
+    def test_dead_code_function_removed(self) -> None:
+        import dango.visualization as viz
+
+        assert not hasattr(viz, "create_pipeline_health_dashboard")


### PR DESCRIPTION
## Summary
Closes both remaining `open` (low-priority) entries in `v1.0.x-planning/1.0.8/BUGS-FOUND.md`:

1. **`dango init` fails ungracefully on a project directory name containing a dot** (e.g. `review-1.0.8`) — dbt's project-name regex (`^[^\d\W]\w*$`) rejected the dot at `dbt docs generate` time, well after most of init had already run, with a misleading "install dbt-duckdb" suggested fix. `dango/cli/init.py::_create_dbt_project()` now strips any character outside `[A-Za-z0-9_]` (not just spaces/hyphens) and guards against a leading digit.

2. **Hardcoded-looking Metabase credential defaults on an unused exported function** — `MetabaseProvisioner()`/`provision_dashboard()` defaulted `username`/`password` to `"admin@example.com"`/`"admin123"`. The only caller that ever used the default, `create_pipeline_health_dashboard()`, was dead code (zero callers anywhere in the app, confirmed via grep; its own comment said `"For now, use defaults"`) — deleted, along with its export. `provision_dashboard()` (one real caller, `cli/commands/dashboard.py`, already passes both explicitly) now requires both keyword-only. `MetabaseProvisioner()`'s defaults are neutralized to `""` rather than removed outright, since 17+ existing unit tests instantiate it with no args and never assert on the credential values — removing the defaults entirely would mean rewriting all of them for a bug whose real risk (the dead-code caller) is already gone.

## Verification
- `pytest tests/unit/test_dbt_project_name_sanitization.py tests/unit/test_metabase_credential_defaults.py tests/unit/test_metabase_dashboard_provision.py tests/unit/test_metabase_api.py tests/unit/test_metabase_setup.py -v`: 42 passed
- Full suite: `pytest -q` — 4488 passed, 30 skipped, 223.89s (branch rebased onto `v1.0.8` post-#473 to pick up the webbrowser-guard fixture first)
- `ruff check`, `ruff format --check`, `mypy`: all clean on changed files