### PR TITLE
fix: configurable per-script execution timeout (Scripts page)

### DIFF
--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -13,6 +13,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | `loader.py` | Load/save YAML config files | `ConfigLoader` |
 | `helpers.py` | Config convenience functions | `find_project_root`, `get_config`, `load_config`, `save_config`, `check_unreferenced_custom_sources`, `format_unreferenced_sources_warning` |
 | `schedules.py` | Schedule config models, validation, reload. `ScheduleType` enum: SYNC, SYNC_ONLY, DBT, SCRIPT | `ScheduleConfig`, `SchedulesConfig`, `ScheduleType`, `ReloadResult`, `CRON_PRESETS`, `load_schedules_config`, `validate_schedules`, `reload_schedules`, `log_startup_checks` |
+| `scripts.py` | Per-script execution timeout override for the Scripts page (`.dango/scripts.yml`), mirroring `schedules.py`'s `timeout_minutes` pattern (1.0.8-BUGS-FOUND) | `ScriptConfig`, `ScriptsConfig`, `load_scripts_config`, `DEFAULT_SCRIPT_TIMEOUT_SECONDS` |
 | `credentials.py` | Credential loading for dlt sources | `CredentialManager`, `init_dlt_directory` |
 | `cloud_credentials.py` | Cloud provider credential persistence (`~/.dango/credentials`, INI, 0o600) | `get_do_token`, `save_do_token`, `clear_do_token` |
 | `exceptions.py` | Re-export shim — classes live in `dango/exceptions.py` | `ConfigError`, `ConfigNotFoundError`, `ConfigValidationError`, `ProjectNotFoundError` |
@@ -26,6 +27,7 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | Change config loading logic | `loader.py` | `pytest tests/unit/test_config_loader.py` |
 | Add a new config error type | `exceptions.py` | `pytest tests/unit/test_config_loader.py` |
 | Add/modify schedule config | `schedules.py` | `pytest tests/unit/test_schedules_config.py tests/unit/test_schedules_loading.py` |
+| Add/modify per-script timeout config | `scripts.py` | `pytest tests/unit/test_config_scripts.py` |
 | Add a new credential provider | `credentials.py` | Manual: create test project with `.dlt/secrets.toml` |
 
 ## Dependencies

--- a/dango/config/scripts.py
+++ b/dango/config/scripts.py
@@ -1,0 +1,91 @@
+"""dango/config/scripts.py
+
+Per-script configuration for the Scripts page — currently just an optional
+execution timeout override. Defines the ``scripts:`` section of
+``.dango/scripts.yml`` as a Pydantic model, mirroring the
+``timeout_minutes`` pattern already used by ``ScheduleConfig`` in
+``schedules.py`` (1.0.8-BUGS-FOUND: the Scripts page previously had no
+config surface at all — a hardcoded 5-minute timeout applied to every
+script with no way to override it).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from dango.config.exceptions import ConfigValidationError
+
+__all__ = [
+    "ScriptConfig",
+    "ScriptsConfig",
+    "load_scripts_config",
+]
+
+# Default timeout applied to any script not listed in scripts.yml, or listed
+# without an explicit timeout_seconds. Matches the old, hardcoded
+# _SCRIPT_TIMEOUT value that used to live in web/routes/scripts_helpers.py.
+DEFAULT_SCRIPT_TIMEOUT_SECONDS = 300
+
+
+class ScriptConfig(BaseModel):
+    """Per-script config: relative path (matches `_discover_scripts()`'s
+    `name`/`path` key) plus an optional timeout override."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    timeout_seconds: int | None = None
+
+    @field_validator("timeout_seconds")
+    @classmethod
+    def _validate_timeout_seconds(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            msg = f"timeout_seconds must be positive. Got: {v!r}"
+            raise ValueError(msg)
+        return v
+
+
+class ScriptsConfig(BaseModel):
+    """Top-level ``.dango/scripts.yml`` schema."""
+
+    scripts: list[ScriptConfig] = []
+
+    def timeout_for(self, script_path: str) -> int:
+        """Effective timeout for a script, falling back to the default."""
+        for script in self.scripts:
+            if script.path == script_path:
+                return script.timeout_seconds or DEFAULT_SCRIPT_TIMEOUT_SECONDS
+        return DEFAULT_SCRIPT_TIMEOUT_SECONDS
+
+
+def load_scripts_config(project_root: Path) -> ScriptsConfig:
+    """Load script config from ``.dango/scripts.yml``.
+
+    Returns an empty ``ScriptsConfig`` (every script gets the default
+    timeout) if the file is missing.
+
+    Raises:
+        ConfigValidationError: If the file exists but contains invalid data.
+    """
+    path = project_root / ".dango" / "scripts.yml"
+    if not path.exists():
+        return ScriptsConfig()
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data: dict[str, Any] = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        raise ConfigValidationError(f"Invalid YAML in {path}:\n{e}") from e
+
+    scripts_data = data.get("scripts")
+    if scripts_data is None:
+        return ScriptsConfig()
+
+    try:
+        return ScriptsConfig(scripts=scripts_data)
+    except Exception as e:
+        raise ConfigValidationError(f"Invalid script config in {path}:\n{e}") from e

--- a/dango/web/CLAUDE.md
+++ b/dango/web/CLAUDE.md
@@ -49,7 +49,7 @@ FastAPI web server providing REST API and WebSocket for managing Dango data pipe
 | `routes/notebooks.py` | Notebook management API + `/notebooks` page route (~506 lines) | `router` |
 | `routes/scripts.py` | Script list page and log viewer page routes | `router` |
 | `routes/scripts_api.py` | Script API endpoints: list, run, cancel, history | `router` |
-| `routes/scripts_helpers.py` | Script discovery, path validation, history, audit helpers | `_discover_scripts`, `_validate_script_path`, `_load_history`, `_append_history` |
+| `routes/scripts_helpers.py` | Script discovery, path validation, history, audit helpers. `_discover_scripts()` attaches each script's effective `timeout_seconds` (from `dango.config.scripts`, 1.0.8-BUGS-FOUND) | `_discover_scripts`, `_get_script_timeout`, `_validate_script_path`, `_load_history`, `_append_history` |
 | `routes/catalog.py` | Data catalog: columns, profiling, lineage, impact, model list/detail, search (~1338 lines) | `router` |
 | `routes/governance.py` | Schema drift + PII results API (~203 lines) | `router` |
 | `routes/monitoring.py` | Monitor results API (`/api/monitoring`, `/api/monitoring/run`, `/api/monitoring/history`), dbt test results. Page route removed in R12-M2 (test/freshness moved to catalog). Backward-compat `/api/insights*` redirects removed in M2 cloud fix. | `router` |

--- a/dango/web/routes/scripts_api.py
+++ b/dango/web/routes/scripts_api.py
@@ -24,12 +24,12 @@ from dango.web.helpers import append_log_entry, get_project_root
 from dango.web.routes.scripts_helpers import (
     _MAX_STDERR_SIZE,
     _MAX_STDOUT_SIZE,
-    _SCRIPT_TIMEOUT,
     _append_history,
     _audit,
     _cancelling,
     _discover_scripts,
     _get_log_dir,
+    _get_script_timeout,
     _load_history,
     _running_processes,
     _validate_script_path,
@@ -64,6 +64,7 @@ async def list_scripts(
             "path": script["path"],
             "last_run": last_run,
             "running": name in _running_processes,
+            "timeout_seconds": script["timeout_seconds"],
         }
         result.append(entry)
 
@@ -84,6 +85,7 @@ async def run_script(
         return validated
 
     script_path = validated
+    timeout_seconds = _get_script_timeout(project_root, name)
 
     # Check not already running
     if name in _running_processes:
@@ -163,7 +165,7 @@ async def run_script(
         try:
             stdout, stderr = await asyncio.wait_for(
                 loop.run_in_executor(None, proc.communicate),
-                timeout=_SCRIPT_TIMEOUT,
+                timeout=timeout_seconds,
             )
             finished_at = datetime.now(timezone.utc)
             duration = (finished_at - started_at).total_seconds()
@@ -186,7 +188,7 @@ async def run_script(
             duration = (finished_at - started_at).total_seconds()
             exit_code = proc.returncode if proc.returncode is not None else -1
             status = "timeout"
-            error = f"Script timed out after {_SCRIPT_TIMEOUT}s"
+            error = f"Script timed out after {timeout_seconds}s"
 
         try:
             stdout_str = stdout or ""

--- a/dango/web/routes/scripts_helpers.py
+++ b/dango/web/routes/scripts_helpers.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 
 from dango.auth.audit import AuditEvent, log_auth_event
 from dango.auth.models import User
+from dango.config.scripts import load_scripts_config
 from dango.logging import get_logger
 
 logger = get_logger(__name__)
@@ -29,7 +30,6 @@ _cancelling: set[str] = set()
 
 _MAX_STDOUT_SIZE = 1_048_576  # 1 MB
 _MAX_STDERR_SIZE = 1_048_576  # 1 MB
-_SCRIPT_TIMEOUT = 300  # 5 minutes
 
 
 # ---------------------------------------------------------------------------
@@ -90,13 +90,18 @@ def _safe_filename(script_name: str) -> str:
 def _discover_scripts(project_root: Path) -> list[dict[str, Any]]:
     """Recursively walk ``scripts/`` and return sorted ``.py`` file entries.
 
-    Skips ``__init__.py``, dotfiles, and ``_``-prefixed files and dirs.
+    Skips ``__init__.py``, dotfiles, and ``_``-prefixed files and dirs. Each
+    entry includes ``timeout_seconds`` — the effective run timeout, from
+    ``.dango/scripts.yml`` if configured, otherwise the default (see
+    ``dango.config.scripts``, 1.0.8-BUGS-FOUND).
     """
     scripts_dir = _get_scripts_dir(project_root)
     result: list[dict[str, Any]] = []
 
     if not scripts_dir.exists():
         return result
+
+    scripts_config = load_scripts_config(project_root)
 
     for py_file in sorted(scripts_dir.rglob("*.py")):
         # Skip __init__.py
@@ -110,9 +115,20 @@ def _discover_scripts(project_root: Path) -> list[dict[str, Any]]:
             continue
 
         rel_path = str(py_file.relative_to(scripts_dir))
-        result.append({"name": rel_path, "path": rel_path})
+        result.append(
+            {
+                "name": rel_path,
+                "path": rel_path,
+                "timeout_seconds": scripts_config.timeout_for(rel_path),
+            }
+        )
 
     return result
+
+
+def _get_script_timeout(project_root: Path, script_name: str) -> int:
+    """Effective run timeout for one script (see ``_discover_scripts()``)."""
+    return load_scripts_config(project_root).timeout_for(script_name)
 
 
 def _validate_script_path(project_root: Path, script_name: str) -> Path | JSONResponse:

--- a/dango/web/templates/scripts.html
+++ b/dango/web/templates/scripts.html
@@ -62,6 +62,9 @@
                                         class="text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline">
                                     <span x-text="script.name"></span>
                                 </button>
+                                <span class="text-xs text-gray-400 ml-1"
+                                      :title="'Killed if still running after ' + formatDuration(script.timeout_seconds)"
+                                      x-text="'· timeout ' + formatDuration(script.timeout_seconds)"></span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell"
                                 x-text="script.last_run ? timeAgo(script.last_run.started_at) : '—'"></td>
@@ -85,6 +88,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                                 <template x-if="isEditorPlus && !script.running">
                                     <button @click="runScript(script)"
+                                            :title="'Will be killed if still running after ' + formatDuration(script.timeout_seconds)"
                                             class="text-blue-600 hover:text-blue-800 text-xs font-medium">Run Now</button>
                                 </template>
                                 <template x-if="isEditorPlus && script.running">

--- a/tests/unit/test_config_scripts.py
+++ b/tests/unit/test_config_scripts.py
@@ -1,0 +1,111 @@
+"""tests/unit/test_config_scripts.py
+
+Tests for dango.config.scripts — per-script timeout config
+(1.0.8-BUGS-FOUND: the Scripts page previously had a hardcoded,
+unconfigurable 5-minute timeout with no config surface at all).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+class TestScriptConfigValidation:
+    def test_positive_timeout_accepted(self) -> None:
+        from dango.config.scripts import ScriptConfig
+
+        config = ScriptConfig(path="orchestrator_v2.py", timeout_seconds=1800)
+        assert config.timeout_seconds == 1800
+
+    def test_none_timeout_accepted(self) -> None:
+        from dango.config.scripts import ScriptConfig
+
+        config = ScriptConfig(path="quick_util.py")
+        assert config.timeout_seconds is None
+
+    def test_zero_timeout_rejected(self) -> None:
+        from dango.config.scripts import ScriptConfig
+
+        with pytest.raises(ValueError, match="timeout_seconds must be positive"):
+            ScriptConfig(path="x.py", timeout_seconds=0)
+
+    def test_negative_timeout_rejected(self) -> None:
+        from dango.config.scripts import ScriptConfig
+
+        with pytest.raises(ValueError, match="timeout_seconds must be positive"):
+            ScriptConfig(path="x.py", timeout_seconds=-1)
+
+
+@pytest.mark.unit
+class TestScriptsConfigTimeoutFor:
+    def test_configured_script_uses_override(self) -> None:
+        from dango.config.scripts import ScriptConfig, ScriptsConfig
+
+        config = ScriptsConfig(
+            scripts=[ScriptConfig(path="orchestrator_v2.py", timeout_seconds=1800)]
+        )
+        assert config.timeout_for("orchestrator_v2.py") == 1800
+
+    def test_unconfigured_script_uses_default(self) -> None:
+        from dango.config.scripts import DEFAULT_SCRIPT_TIMEOUT_SECONDS, ScriptsConfig
+
+        config = ScriptsConfig()
+        assert config.timeout_for("anything.py") == DEFAULT_SCRIPT_TIMEOUT_SECONDS
+
+    def test_listed_without_timeout_uses_default(self) -> None:
+        from dango.config.scripts import (
+            DEFAULT_SCRIPT_TIMEOUT_SECONDS,
+            ScriptConfig,
+            ScriptsConfig,
+        )
+
+        config = ScriptsConfig(scripts=[ScriptConfig(path="x.py")])
+        assert config.timeout_for("x.py") == DEFAULT_SCRIPT_TIMEOUT_SECONDS
+
+
+@pytest.mark.unit
+class TestLoadScriptsConfig:
+    def test_missing_file_returns_empty_config(self, tmp_path: Path) -> None:
+        from dango.config.scripts import load_scripts_config
+
+        config = load_scripts_config(tmp_path)
+        assert config.scripts == []
+
+    def test_loads_valid_yaml(self, tmp_path: Path) -> None:
+        from dango.config.scripts import load_scripts_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "scripts.yml").write_text(
+            "scripts:\n  - path: orchestrator_v2.py\n    timeout_seconds: 1800\n"
+        )
+
+        config = load_scripts_config(tmp_path)
+        assert config.timeout_for("orchestrator_v2.py") == 1800
+
+    def test_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        from dango.config.exceptions import ConfigValidationError
+        from dango.config.scripts import load_scripts_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "scripts.yml").write_text("scripts:\n  - path: x.py\n  bad indent: [\n")
+
+        with pytest.raises(ConfigValidationError):
+            load_scripts_config(tmp_path)
+
+    def test_invalid_timeout_raises(self, tmp_path: Path) -> None:
+        from dango.config.exceptions import ConfigValidationError
+        from dango.config.scripts import load_scripts_config
+
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "scripts.yml").write_text(
+            "scripts:\n  - path: x.py\n    timeout_seconds: -5\n"
+        )
+
+        with pytest.raises(ConfigValidationError):
+            load_scripts_config(tmp_path)

--- a/tests/unit/test_scripts_helpers.py
+++ b/tests/unit/test_scripts_helpers.py
@@ -127,6 +127,34 @@ class TestDiscoverScripts:
         assert "public.py" in names
         assert "nested.py" not in names
 
+
+@pytest.mark.unit
+class TestDiscoverScriptsTimeout:
+    """1.0.8-BUGS-FOUND: Scripts previously had no configurable timeout at all."""
+
+    def test_default_timeout_when_no_config(self, tmp_path: Path):
+        from dango.config.scripts import DEFAULT_SCRIPT_TIMEOUT_SECONDS
+        from dango.web.routes.scripts_helpers import _discover_scripts
+
+        _write_script(tmp_path / "scripts", "quick.py")
+
+        result = _discover_scripts(tmp_path)
+        assert result[0]["timeout_seconds"] == DEFAULT_SCRIPT_TIMEOUT_SECONDS
+
+    def test_configured_timeout_override(self, tmp_path: Path):
+        from dango.web.routes.scripts_helpers import _discover_scripts, _get_script_timeout
+
+        _write_script(tmp_path / "scripts", "orchestrator_v2.py")
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "scripts.yml").write_text(
+            "scripts:\n  - path: orchestrator_v2.py\n    timeout_seconds: 1800\n"
+        )
+
+        result = _discover_scripts(tmp_path)
+        assert result[0]["timeout_seconds"] == 1800
+        assert _get_script_timeout(tmp_path, "orchestrator_v2.py") == 1800
+
     def test_recursive_discovery(self, tmp_path: Path):
         """Recursively discovers scripts in subdirectories."""
         from dango.web.routes.scripts_helpers import _discover_scripts


### PR DESCRIPTION
## Summary
The Scripts page had a hardcoded, unconfigurable 5-minute timeout (`_SCRIPT_TIMEOUT = 300` in `scripts_helpers.py`) applied unconditionally to every script — no config surface at all (no `scripts.yml`, no frontmatter, no run-time override, no UI indication before a run got killed). Reported by the user after a real ~10-13 minute script (`orchestrator_v2.py`) was silently killed twice via the Scripts page in beta-1.

`ScheduleConfig` already solves the identical problem correctly (`timeout_minutes: int | None`) — Scripts never got the equivalent treatment.

## Changes
- New `dango/config/scripts.py`: `ScriptConfig`/`ScriptsConfig` (validated `timeout_seconds`), loaded from `.dango/scripts.yml` (git-tracked, same convention as `schedules.yml`), mirroring `schedules.py`'s pattern.
- `_discover_scripts()` (`scripts_helpers.py`) now attaches each script's effective timeout; `run_script()` (`scripts_api.py`) looks it up per-run and passes it to `asyncio.wait_for(...)` instead of the removed `_SCRIPT_TIMEOUT` constant.
- `scripts.html` surfaces the effective timeout next to the script name and in the "Run Now" button's tooltip.

**Config example** (`.dango/scripts.yml`):
```yaml
scripts:
  - path: orchestrator_v2.py
    timeout_seconds: 1800
```
Any script not listed (or listed without `timeout_seconds`) keeps the 300s default — fully backward compatible.

## Not in scope
A related-but-separate quirk was also reported: stdout/stderr comes back completely empty on a timeout kill, likely a `Popen.communicate()` re-entrancy race (the code calls `communicate()` a second/third time after `terminate()`/`kill()` while the first executor-thread call may still be in flight). Logged in `BUGS-FOUND.md` as `needs-decision` — the fix shape needs more thought than this PR's scope.

## Verification
- New tests: `tests/unit/test_config_scripts.py` (11 tests — config validation, `timeout_for()` resolution, YAML loading/error handling) + `TestDiscoverScriptsTimeout` added to `tests/unit/test_scripts_helpers.py` (2 tests — default vs configured-override wiring)
- All 49 existing + new tests for the Scripts feature pass: `pytest tests/unit/test_config_scripts.py tests/unit/test_scripts_helpers.py tests/unit/test_scripts_api.py tests/unit/test_script_history.py`
- Full suite: `pytest -q` — 4495 passed, 30 skipped, 228s
- `ruff check`, `ruff format --check`, `mypy`: all clean on changed files
- No UI-behavior test (would require a real long-running subprocess or a flaky async-timing test) — the config resolution and wiring are covered deterministically instead