### PR TITLE
fix: bump postcss-selector-parser to patch Dependabot alert #7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
Dependabot alert #7: `postcss-selector-parser` 6.1.0-6.1.2 allows denial of service through uncontrolled AST recursion (GHSA-w9m9-85wc-3x92), low severity.

It's a transitive devDependency of `tailwindcss` (`package.json`'s only dependency) — build-time CSS compilation only, never shipped to users or reachable by an attacker against a running Dango instance. Bumped 6.1.2 -> 6.1.4 via `npm update postcss-selector-parser` (patched in 6.1.3+).

## Verification
- `npm audit`: 0 vulnerabilities (was 1 low)
- `make css-build`: succeeds, produces byte-identical `tailwind.min.css` output to before the bump — confirms zero behavioral change, pure dependency patch