### PR TITLE
1.0.8: Housekeeping fixes — stale count, status port, telemetry disclosure, duplicate warning

### DIFF
--- a/dango/cli/commands/model.py
+++ b/dango/cli/commands/model.py
@@ -39,13 +39,10 @@ def model_add(ctx: click.Context) -> None:
       dango model add    Run interactive wizard
     """
     from ..model_wizard import add_model
-    from ..utils import check_git_branch_warning, require_project_context
+    from ..utils import require_project_context
 
     try:
         project_root = require_project_context(ctx)
-
-        # Check git branch (gentle reminder if on main/master)
-        check_git_branch_warning(project_root)
 
         model_path = add_model(project_root)
 

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -1023,9 +1023,11 @@ def status(ctx: click.Context) -> None:
                 status_text = (
                     f"[{svc_status.value}]● {svc_status.value.capitalize()}[/{svc_status.value}]"
                 )
-            table.add_row("Metabase (port 3000)", status_text)
+            table.add_row(f"Metabase (port {config.platform.metabase_port})", status_text)
         else:
-            table.add_row("Metabase (port 3000)", "[red]● Stopped[/red]")
+            table.add_row(
+                f"Metabase (port {config.platform.metabase_port})", "[red]● Stopped[/red]"
+            )
 
         console.print(table)
         console.print()

--- a/dango/cli/commands/source.py
+++ b/dango/cli/commands/source.py
@@ -87,20 +87,13 @@ def source_add(ctx: click.Context) -> None:
     """
     Add a new data source (interactive wizard).
 
-    Supports 27+ sources across 9 categories:
-      - Marketing & Analytics (7): Facebook Ads, Google Ads, Sheets, Analytics, etc.
-      - Business & CRM (7): HubSpot, Salesforce, Zendesk, Jira, etc.
-      - E-commerce & Payment (1): Stripe
-      - Files & Storage (2): Notion, Email Inbox
-      - Databases (1): MongoDB
-      - Streaming (2): Kafka, Kinesis
-      - Development (1): GitHub
-      - Communication (1): Slack
-      - Local & Custom (2): CSV, REST API
+    Supports 35+ data source types across marketing/analytics, business/CRM,
+    e-commerce, files/storage, databases, streaming, development, and
+    communication tools. Run this command to see the full current list.
     """
     from dango.cli.source_wizard import add_source
 
-    from ..utils import check_git_branch_warning, check_v01x_project
+    from ..utils import check_v01x_project
 
     check_v01x_project()
 
@@ -108,9 +101,6 @@ def source_add(ctx: click.Context) -> None:
     if not project_root:
         console.print("[red]❌ Not in a dango project directory[/red]")
         return
-
-    # Check git branch (gentle reminder if on main/master)
-    check_git_branch_warning(project_root)
 
     # Run wizard
     success = add_source(project_root)

--- a/dango/cli/commands/telemetry.py
+++ b/dango/cli/commands/telemetry.py
@@ -96,6 +96,8 @@ def telemetry_status(ctx: click.Context) -> None:
     console.print()
     console.print(table)
     console.print(
+        "\n[dim]dango/dbt/dlt are shared across every project on this machine; "
+        "metabase applies only to this project.[/dim]"
         "\n[dim]controls telemetry for the components Dango configures — "
         "full egress docs: docs/network-egress.yml[/dim]\n"
     )

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1563,11 +1563,14 @@ on-run-end:
     def _prompt_telemetry_consent(self, config: DangoConfig) -> None:
         """Ask for anonymous telemetry consent on first `dango init` run.
 
-        No-op when telemetry is already ruled out by CI detection, a
-        prior stored answer, or an opt-out (``DO_NOT_TRACK``,
-        ``DANGO_TELEMETRY``, or ``telemetry: false`` in
-        ``~/.dango/config.yml``) — in all of those cases the user is
-        never prompted at all.
+        Never shows the interactive prompt when telemetry is already ruled
+        out by CI detection, a prior stored answer, or an opt-out
+        (``DO_NOT_TRACK``, ``DANGO_TELEMETRY``, or ``telemetry: false`` in
+        ``~/.dango/config.yml``). CI detection and opt-out stay completely
+        silent; a prior stored answer instead prints a one-line
+        informational note, since that answer came from a *different*
+        project on this machine and the user has no other way to know it's
+        being inherited here.
 
         Also a no-op, without persisting anything, when no real answer
         can be obtained at all — see `_ask_telemetry_consent` for what
@@ -1585,7 +1588,14 @@ on-run-end:
             set_telemetry_enabled,
         )
 
-        if is_ci() or has_recorded_consent() or not is_telemetry_enabled():
+        if is_ci() or not is_telemetry_enabled():
+            return
+        if has_recorded_consent():
+            console.print(
+                "[dim]Telemetry: already configured machine-wide "
+                f"({'on' if is_telemetry_enabled() else 'off'}) — "
+                "`dango telemetry status` to review, `dango telemetry off --all` to change.[/dim]"
+            )
             return
 
         console.print()

--- a/dango/cli/init.py
+++ b/dango/cli/init.py
@@ -1588,14 +1588,21 @@ on-run-end:
             set_telemetry_enabled,
         )
 
-        if is_ci() or not is_telemetry_enabled():
+        if is_ci():
             return
         if has_recorded_consent():
+            # Checked before the is_telemetry_enabled() gate below: a prior
+            # recorded answer can itself be "off" (opted out), in which case
+            # is_telemetry_enabled() also returns False — checking it first
+            # would silently swallow the disclosure for exactly the case
+            # (an inherited opt-out) this message exists to surface.
             console.print(
                 "[dim]Telemetry: already configured machine-wide "
                 f"({'on' if is_telemetry_enabled() else 'off'}) — "
                 "`dango telemetry status` to review, `dango telemetry off --all` to change.[/dim]"
             )
+            return
+        if not is_telemetry_enabled():
             return
 
         console.print()

--- a/dango/web/templates/telemetry.html
+++ b/dango/web/templates/telemetry.html
@@ -13,6 +13,11 @@
                 bundled dbt, dlt, and Metabase tools. Does not claim anything about network traffic
                 outside these four providers.
             </p>
+            <p class="text-sm text-gray-500 mt-1">
+                Dango, dbt, and dlt settings are shared across every Dango project on this machine —
+                changing one here changes it everywhere. Metabase is the one exception: its setting
+                applies only to this project's own Metabase instance.
+            </p>
         </div>
 
         <!-- Error banner -->

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -6,9 +6,15 @@ Verifies all command modules import correctly and all expected
 commands appear in the CLI help output.
 """
 
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 
+from dango.cli.commands.model import model_add
+from dango.cli.commands.source import source_add
 from dango.cli.main import cli
 
 
@@ -189,3 +195,76 @@ class TestCliCommandRegistration:
         from dango.cli.main import cli as cli_group  # noqa: F811
 
         assert cli_group is not None
+
+
+def _init_git_repo(path: Path, branch: str = "main") -> None:
+    """Create a real git repo at `path` on the given branch (main is git's
+    default init branch on modern git, so no checkout needed for that case)."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "checkout", "-b", branch], check=True, capture_output=True
+    )
+    (path / "committed.txt").write_text("hello")
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True
+    )
+
+
+@pytest.mark.unit
+class TestGitWarningDeduplication:
+    """1.0.8-Q1: `model add` and `source add` used to print both the old
+    boxed 'Git Branch Reminder' panel (check_git_branch_warning(),
+    cli/utils.py) and the newer plain-text warning from the wizard's own
+    _print_git_warnings() (model_wizard.py / source_wizard.py). The boxed
+    panel call was removed from both CLI commands — only the wizard's own
+    plain warning should remain.
+    """
+
+    def test_model_add_on_main_shows_only_one_warning(self, tmp_path: Path) -> None:
+        """`dango model add` on a main-branch repo prints the wizard's plain
+        'Warning:' line exactly once, and never the old boxed panel.
+
+        No dbt/ directory exists, so ModelWizard.run() prints its intro,
+        prints the git warning, then exits early with 'dbt directory not
+        found' — this exercises the real warning path without needing to
+        mock the interactive question prompts.
+        """
+        dango_dir = tmp_path / ".dango"
+        dango_dir.mkdir()
+        (dango_dir / "project.yml").write_text(
+            "project:\n  name: test\n  created_by: test\n  purpose: test project\n"
+        )
+        _init_git_repo(tmp_path, branch="main")
+
+        runner = CliRunner()
+        with patch("dango.cli.utils.require_project_context", return_value=tmp_path):
+            result = runner.invoke(model_add, obj={"project_root": tmp_path})
+
+        assert "Git Branch Reminder" not in result.output
+        assert result.output.count("Warning:") == 1
+
+    def test_source_add_on_main_shows_only_one_warning(self, tmp_path: Path) -> None:
+        """`dango source add` on a main-branch repo prints the wizard's plain
+        'Warning:' line exactly once, and never the old boxed panel.
+
+        Only the interactive source-type selection is mocked (to cancel
+        immediately) — everything before it, including the git warning, is
+        the real SourceWizard.run() path.
+        """
+        _init_git_repo(tmp_path, branch="main")
+
+        runner = CliRunner()
+        with patch("dango.cli.source_wizard.SourceWizard._select_source_flat", return_value=None):
+            result = runner.invoke(source_add, obj={"project_root": tmp_path})
+
+        assert "Git Branch Reminder" not in result.output
+        assert result.output.count("Warning:") == 1

--- a/tests/unit/test_cli_init_telemetry.py
+++ b/tests/unit/test_cli_init_telemetry.py
@@ -182,6 +182,35 @@ class TestPromptTelemetryConsent:
         mock_ask.assert_not_called()
         assert any("already configured machine-wide" in p for p in printed)
 
+    def test_second_init_prints_info_line_when_consent_previously_declined(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression test: a prior recorded *opt-out* ("no") must also print
+        the informational line, not stay silent.
+
+        `is_telemetry_enabled()` itself returns False once a stored "no" is
+        recorded (it's one of the opt-out signals it checks), so gating on
+        `not is_telemetry_enabled()` before `has_recorded_consent()` would
+        silently swallow this exact case — the only case where an inherited
+        decision is a *change* from Dango's default (on) the user might not
+        expect. `has_recorded_consent()` must be checked first.
+        """
+        telemetry.set_telemetry_enabled(False)
+        assert telemetry.has_recorded_consent() is True
+        assert telemetry.is_telemetry_enabled() is False  # sanity: the opt-out signal itself
+
+        initializer = ProjectInitializer(tmp_path)
+        printed: list[str] = []
+        with (
+            patch("dango.cli.init._ask_telemetry_consent") as mock_ask,
+            patch("dango.cli.init.console") as mock_console,
+        ):
+            mock_console.print.side_effect = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            initializer._prompt_telemetry_consent(_make_config())
+
+        mock_ask.assert_not_called()
+        assert any("already configured machine-wide (off)" in p for p in printed)
+
     def test_ci_skip_still_silent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """CI detection stays completely silent — no prompt, no informational line."""
         monkeypatch.setenv("CI", "true")

--- a/tests/unit/test_cli_init_telemetry.py
+++ b/tests/unit/test_cli_init_telemetry.py
@@ -163,6 +163,58 @@ class TestPromptTelemetryConsent:
         assert telemetry.is_telemetry_enabled() is False
         assert telemetry.has_recorded_consent() is True
 
+    def test_second_init_prints_info_line_when_consent_already_recorded(
+        self, tmp_path: Path
+    ) -> None:
+        """A second `dango init` (consent already recorded from a prior project)
+        prints an informational line instead of staying silent, and does not
+        show the interactive prompt."""
+        telemetry.set_telemetry_enabled(True)
+        initializer = ProjectInitializer(tmp_path)
+        printed: list[str] = []
+        with (
+            patch("dango.cli.init._ask_telemetry_consent") as mock_ask,
+            patch("dango.cli.init.console") as mock_console,
+        ):
+            mock_console.print.side_effect = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            initializer._prompt_telemetry_consent(_make_config())
+
+        mock_ask.assert_not_called()
+        assert any("already configured machine-wide" in p for p in printed)
+
+    def test_ci_skip_still_silent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CI detection stays completely silent — no prompt, no informational line."""
+        monkeypatch.setenv("CI", "true")
+        initializer = ProjectInitializer(tmp_path)
+        printed: list[str] = []
+        with (
+            patch("dango.cli.init._ask_telemetry_consent") as mock_ask,
+            patch("dango.cli.init.console") as mock_console,
+        ):
+            mock_console.print.side_effect = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            initializer._prompt_telemetry_consent(_make_config())
+
+        mock_ask.assert_not_called()
+        assert printed == []
+
+    def test_opted_out_skip_still_silent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit opt-out (DO_NOT_TRACK) stays completely silent — no
+        prompt, no informational line."""
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        initializer = ProjectInitializer(tmp_path)
+        printed: list[str] = []
+        with (
+            patch("dango.cli.init._ask_telemetry_consent") as mock_ask,
+            patch("dango.cli.init.console") as mock_console,
+        ):
+            mock_console.print.side_effect = lambda *a, **kw: printed.append(str(a[0]) if a else "")
+            initializer._prompt_telemetry_consent(_make_config())
+
+        mock_ask.assert_not_called()
+        assert printed == []
+
     def test_no_real_answer_skips_without_persisting_or_pinging(self, tmp_path: Path) -> None:
         """When _ask_telemetry_consent() returns None (no real answer obtained), nothing is recorded.
 

--- a/tests/unit/test_cli_status_metabase_port.py
+++ b/tests/unit/test_cli_status_metabase_port.py
@@ -1,0 +1,108 @@
+"""tests/unit/test_cli_status_metabase_port.py
+
+1.0.8-Q1: `dango status` used to hardcode the literal string
+"Metabase (port 3000)" in its table row label, even when the project is
+configured for a different Metabase port. Regression test for the fix
+that reads the real configured port off `config.platform.metabase_port`.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.cli.commands.platform import status
+
+
+def _make_config_loader(metabase_port: int) -> MagicMock:
+    """Create a mock ConfigLoader returning a config with the given
+    Metabase port and otherwise-sane defaults for `status()`."""
+    mock_config = MagicMock()
+    mock_config.project.name = "test-project"
+    mock_config.project.organization = None
+    mock_config.platform.metabase_port = metabase_port
+    mock_config.platform.auto_sync = False
+
+    mock_loader = MagicMock()
+    mock_loader.return_value.load_config.return_value = mock_config
+    return mock_loader
+
+
+def _make_fastapi_status(tmp_path: Path) -> dict:
+    return {
+        "running": False,
+        "pid": None,
+        "port": 8800,
+        "url": "http://localhost:8800",
+        "log_file": tmp_path / ".dango" / "web.log",  # doesn't exist
+    }
+
+
+@pytest.mark.unit
+class TestStatusMetabasePort:
+    """`status()` must show the project's configured Metabase port, not a
+    hardcoded 3000."""
+
+    def _invoke(self, tmp_path: Path, metabase_port: int, docker_running: bool = True):
+        mock_loader = _make_config_loader(metabase_port)
+
+        mock_svc_status = MagicMock()
+        mock_svc_status.value = "running" if docker_running else "stopped"
+        mock_docker_manager = MagicMock()
+        mock_docker_manager.return_value.get_service_status.return_value = {
+            "metabase": mock_svc_status
+        }
+
+        mock_net_config = MagicMock()
+        mock_net_config.return_value.get_project_info.return_value = None
+        mock_net_config.return_value.list_projects.return_value = {}
+
+        mock_nginx_manager = MagicMock()
+        mock_nginx_manager.return_value.is_running.return_value = False
+
+        runner = CliRunner()
+        with (
+            patch("dango.cli.utils.require_project_context", return_value=tmp_path),
+            patch("dango.config.ConfigLoader", mock_loader),
+            patch("dango.platform.DockerManager", mock_docker_manager),
+            patch("dango.platform.network.NetworkConfig", mock_net_config),
+            patch("dango.platform.network.NginxManager", mock_nginx_manager),
+            patch(
+                "dango.cli.helpers.process_manager.get_fastapi_status",
+                return_value=_make_fastapi_status(tmp_path),
+            ),
+            patch(
+                "dango.platform.watcher_lifecycle.get_watcher_status",
+                return_value={"running": False},
+            ),
+            patch("dango.config.helpers.is_running_on_cloud", return_value=False),
+            patch(
+                "dango.cli.commands.upgrade.get_latest_version_cached",
+                return_value=None,
+            ),
+        ):
+            return runner.invoke(status, obj={"project_root": str(tmp_path)})
+
+    def test_status_shows_configured_metabase_port(self, tmp_path: Path) -> None:
+        """A non-default configured Metabase port (3001) is shown, and the
+        old hardcoded 3000 is not."""
+        result = self._invoke(tmp_path, metabase_port=3001)
+
+        assert "Metabase (port 3001)" in result.output
+        assert "Metabase (port 3000)" not in result.output
+
+    def test_status_shows_default_metabase_port(self, tmp_path: Path) -> None:
+        """The default port (3000) still renders correctly when configured
+        as such — this is not a case of "any number works", it's the real
+        configured value happening to be 3000."""
+        result = self._invoke(tmp_path, metabase_port=3000)
+
+        assert "Metabase (port 3000)" in result.output
+
+    def test_status_shows_configured_port_when_stopped(self, tmp_path: Path) -> None:
+        """The non-default port also renders correctly in the 'Stopped' row."""
+        result = self._invoke(tmp_path, metabase_port=3001, docker_running=False)
+
+        assert "Metabase (port 3001)" in result.output
+        assert "Metabase (port 3000)" not in result.output


### PR DESCRIPTION
## Summary
- Fix 4 independent, low-risk findings from BUGS-FOUND.md (manual review, 2026-09-06/07):
  - `dango source add --help`'s stale "27+ sources" count (4th location this cycle, PR #463 missed it)
  - `dango status`'s hardcoded "Metabase (port 3000)" label (3rd instance of a bug class fixed twice
    already this cycle, PRs #459/#460)
  - Telemetry settings page/CLI never disclosed dango/dbt/dlt are machine-wide, Metabase is
    project-scoped; `dango init`'s consent-skip path was completely silent on every project after
    the first
  - `dango model add`/`source add` printed two separate, redundant git-branch warnings on main/master

## Verification
- `pytest -x`: 4540 passed, 30 skipped, 0 failed
- `ruff check` / `ruff format --check` / `mypy dango/`: all clean on changed files
- `make css-build`: zero diff on `tailwind.min.css` (telemetry.html change only used existing
  utility classes, as expected)
- Live-verified `dango status`'s fix by running the real `status()` command end-to-end (all
  external deps mocked, no exception swallowed) with `platform.metabase_port=3001` — output shows
  `Metabase (port 3001)`, confirmed absent `Metabase (port 3000)`
- Live-verified `dango model add`/`source add` on real git repos (real `git init`, branch `main`)
  through the actual wizard code path up to the warning print (only the interactive prompt step
  mocked) — output contains the plain `Warning:` line exactly once, never the old boxed
  "Git Branch Reminder" panel
- Live-verified `dango init`'s second-project informational line and that the CI/opt-out skip
  paths stay fully silent, via `_prompt_telemetry_consent()` unit tests

## Regression check
- `check_git_branch_warning()` still has other live callers (`source_edit`... actually
  `source remove`/`sync` at `dango/cli/commands/source.py` lines ~446, ~762) — untouched
- `mcp_helpers.py::_git_warnings()` — untouched, separate MCP call site
- `tests/unit/test_cli_sync.py` — no delta (24 tests, all pass)
- `tests/unit/test_egress_allowlist.py`, `test_telemetry.py` — no delta beyond the new tests in
  `test_cli_init_telemetry.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyYKvCUZcrvQwMHh1sNWEp