### PR TITLE
1.0.8: Fix broken MySQL source type (SourceType/registry drift)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ dango/                          # Python package source
 │   ├── dlt_runner.py           # ⚠ 2885 lines — orchestrates full sync pipeline
 │   ├── csv_loader.py           # Multi-format file loading with dedup (922 lines)
 │   ├── sources/
-│   │   └── registry.py         # Source metadata (33 source types)
+│   │   └── registry.py         # Source metadata (34 source types)
 │   └── dlt_sources/            # 127 files — helper files are custom Dango code (safe to modify); vendored connectors should not be changed
 │
 ├── transformation/             # Level 1 — dbt model generation & execution

--- a/dango/cli/source_wizard.py
+++ b/dango/cli/source_wizard.py
@@ -1,6 +1,6 @@
 """dango/cli/source_wizard.py
 
-Metadata-driven wizard that works for all 27+ data sources. Uses SOURCE_REGISTRY for display names, categories, and parameters.
+Metadata-driven wizard that works for all 34 data sources. Uses SOURCE_REGISTRY for display names, categories, and parameters.
 """
 
 from pathlib import Path

--- a/dango/config/CLAUDE.md
+++ b/dango/config/CLAUDE.md
@@ -69,3 +69,5 @@ Loads, validates, and manages dango project configuration files (project.yml, so
 | `models.py` field names | Changing field names breaks existing project.yml/sources.yml files |
 | `models.py` `SourceType` enum values | Enum values are stored in user config files and referenced across modules |
 | `exceptions.py` re-export shim | Exception classes are caught by name in cli/, web/, and ingestion/. Adding/removing classes here must mirror `dango/exceptions.py`. |
+
+Carve-out for `SourceType`: a member with zero registry entry, no wizard path, and no `dlt_runner.py` handling (confirmed via grep) was never reachable and can't exist in a real persisted config, so it can be removed — the rule protects values a live config could actually contain, not dead ones (see 1.0.8-Q3's removal of `SCRAPY`).

--- a/dango/config/models.py
+++ b/dango/config/models.py
@@ -21,7 +21,7 @@ class DeduplicationStrategy(str, Enum):
 
 
 class SourceType(str, Enum):
-    """Data source types — 35 source types (27 dlt verified + CSV + Local Files + REST API + dlt_native + Filesystem + PostgreSQL + sql_database + Scrapy)"""
+    """Data source types — 35 source types (27 dlt verified + CSV + Local Files + REST API + dlt_native + Filesystem + PostgreSQL + MySQL + sql_database)"""
 
     # Local/Custom
     CSV = "csv"
@@ -57,9 +57,10 @@ class SourceType(str, Enum):
     NOTION = "notion"
     INBOX = "inbox"
 
-    # Databases (3)
+    # Databases (4)
     MONGODB = "mongodb"
     POSTGRESQL = "postgres"
+    MYSQL = "mysql"
     SQL_DATABASE = "sql_database"  # Generic for 24 SQL databases via dlt
 
     # Streaming (2)
@@ -69,10 +70,9 @@ class SourceType(str, Enum):
     # Development (1)
     GITHUB = "github"
 
-    # Other (5)
+    # Other (4)
     SLACK = "slack"
     CHESS = "chess"
-    SCRAPY = "scrapy"
     STRAPI = "strapi"
     PERSONIO = "personio"
 

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -2,15 +2,15 @@
 
 ## Purpose
 
-Loads data into DuckDB from external sources via dlt pipelines and local files, with a central registry of 33 supported data sources.
+Loads data into DuckDB from external sources via dlt pipelines and local files, with a central registry of 34 supported data sources.
 
 ## Source Selection
 
-Registry contains 33 sources: 27 dlt verified (vendored in `dlt_sources/`) + CSV
+Registry contains 34 sources: 27 dlt verified (vendored in `dlt_sources/`) + CSV
 (custom, hidden) + Local Files (unified, primary wizard entry) + dlt_native
 (passthrough) + filesystem (hidden, cloud storage) + rest_api (dlt core built-in) +
-PostgreSQL (dlt sql_database wrapper). Excluded: generic `sql_database` (too complex
-for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see P5-006).
+PostgreSQL + MySQL (dlt sql_database wrapper). Excluded: generic `sql_database` (too
+complex for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see P5-006).
 
 ## Files
 

--- a/dango/ingestion/CLAUDE.md
+++ b/dango/ingestion/CLAUDE.md
@@ -21,7 +21,7 @@ complex for wizard — use dlt_native) and Shopify (`wizard_enabled=False`, see 
 | `csv_loader.py` | Multi-format file loading (CSV, JSON, JSONL, Parquet) with metadata tracking and 4 dedup strategies | `CSVLoader`, `SUPPORTED_READ_FUNCTIONS` (imports `CSVSchemaMismatchError` from `dango.exceptions`) |
 | `credential_health.py` | Cross-references configured sources against available credentials (OAuth tokens, API keys, service accounts) | `run_credential_checks()`, `get_cached_credential_health()` (5-minute in-process cache) |
 | `sources/__init__.py` | Sources subpackage exports | Re-exports `SOURCE_REGISTRY`, `CATEGORIES`, `get_source_metadata`, `get_source_capabilities` |
-| `sources/registry.py` | Central registry of 33 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category`, `get_source_capabilities` |
+| `sources/registry.py` | Central registry of 34 supported data sources with metadata | `SOURCE_REGISTRY`, `CATEGORIES`, `AuthType`, `get_source_metadata`, `get_sources_by_category`, `get_source_capabilities` |
 | `dlt_sources/` | dlt verified source implementations (27 directories, 105+ files) — helper files are custom Dango code | See "Don't Modify" section for guidelines |
 
 ## Common Tasks

--- a/dango/ingestion/sources/registry.py
+++ b/dango/ingestion/sources/registry.py
@@ -1,6 +1,6 @@
 """dango/ingestion/sources/registry.py
 
-Metadata registry for all 33 supported data sources (27 dlt verified + CSV + Local Files + dlt_native + REST API + PostgreSQL + Filesystem).
+Metadata registry for all 34 supported data sources (27 dlt verified + CSV + Local Files + dlt_native + REST API + PostgreSQL + MySQL + Filesystem).
 """
 
 from enum import Enum
@@ -21,7 +21,7 @@ class AuthType(str, Enum):
 # SOURCE SELECTION CRITERIA
 # ============================================================================
 #
-# This registry contains 33 sources in five categories:
+# This registry contains 34 sources in five categories:
 #   1. dlt verified sources (27): All connectors vendored in dlt_sources/. Each
 #      uses its own dlt verified source package (e.g., facebook_ads, hubspot).
 #   2. CSV (1): Custom CSVLoader — not dlt. For local structured CSV files.
@@ -33,8 +33,8 @@ class AuthType(str, Enum):
 #   5. dlt core built-ins (2): filesystem + rest_api. Built into dlt, no vendoring.
 #      filesystem: cloud storage (S3/GCS/Azure). Hidden from wizard — use local_files for local.
 #      rest_api: connect any REST API via declarative config.
-#   6. PostgreSQL (1): Dedicated wizard entry backed by dlt's built-in
-#      sql_database source. Structured params for the most common DB use case.
+#   6. PostgreSQL + MySQL (2): Dedicated wizard entries backed by dlt's built-in
+#      sql_database source. Structured params for the most common DB use cases.
 #
 # Excluded dlt verified sources:
 #   - sql_database (generic): Too complex for wizard UI (arbitrary table selectors,
@@ -2735,7 +2735,7 @@ CATEGORIES = {
     "Streaming": ["kafka", "kinesis"],
     "Development": ["github"],
     "Communication": ["slack"],
-    "Other": ["chess", "strapi", "personio"],  # scrapy not available
+    "Other": ["chess", "strapi", "personio"],
 }
 
 

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import pytest
 
+from dango.config.models import DataSource, SourceType
 from dango.ingestion.sources.registry import (
     SOURCE_REGISTRY,
     get_source_capabilities,
@@ -102,3 +103,55 @@ class TestSourceCapabilities:
                             f"{source_type}.column_descriptions.{resource_name}.{col_name} "
                             f"contains YAML-unsafe characters: {desc}\nError: {e}"
                         ) from e
+
+
+@pytest.mark.unit
+class TestSourceTypeRegistryDrift:
+    """Regression tests for SourceType/SOURCE_REGISTRY drift (1.0.8-Q3).
+
+    Real bug: SOURCE_REGISTRY["mysql"] had wizard_enabled=True but "mysql" was never
+    added to the SourceType enum, so `dango source add` crashed with a Pydantic
+    ValidationError on save after a user completed the entire MySQL wizard flow.
+    """
+
+    def test_mysql_source_saves_without_error(self) -> None:
+        """DataSource(type='mysql') must construct without raising.
+
+        This is the actual regression test for the bug: before the fix, this raised
+        a Pydantic ValidationError because 'mysql' was not a SourceType enum member.
+        """
+        ds = DataSource(name="test", type="mysql")
+        assert ds.type == SourceType.MYSQL
+
+    def test_every_wizard_enabled_registry_entry_has_matching_enum_value(self) -> None:
+        """Every wizard-enabled registry entry must have a matching SourceType value.
+
+        Catches the exact class of bug that caused the mysql crash: a registry entry
+        with wizard_enabled=True that has no corresponding SourceType enum member.
+        Without a matching enum value, the wizard walks the user through the full
+        flow and then crashes with a ValidationError on save, losing everything they
+        entered.
+        """
+        wizard_enabled_keys = [
+            key for key, metadata in SOURCE_REGISTRY.items() if metadata.get("wizard_enabled")
+        ]
+        assert wizard_enabled_keys, "Expected at least one wizard_enabled registry entry"
+
+        missing = []
+        for key in wizard_enabled_keys:
+            try:
+                SourceType(key)
+            except ValueError:
+                missing.append(key)
+
+        assert not missing, (
+            f"wizard_enabled registry entries with no matching SourceType enum value: "
+            f"{missing}. These would crash `dango source add` with a Pydantic "
+            f"ValidationError after the user completes the wizard."
+        )
+
+    def test_scrapy_no_longer_a_valid_source_type(self) -> None:
+        """scrapy was removed from SourceType — it had zero implementation anywhere
+        (no registry entry, no dlt_runner.py handling) and was vestigial."""
+        with pytest.raises(ValueError):
+            SourceType("scrapy")


### PR DESCRIPTION
## Summary
- Fix a real, live-confirmed bug: `dango source add` crashed with a Pydantic ValidationError when a
  user selected MySQL and completed the wizard, losing everything they entered. Root cause: "mysql"
  existed in SOURCE_REGISTRY with wizard_enabled: True but was never added to the SourceType enum.
- Added SourceType.MYSQL = "mysql" (Databases group, alongside POSTGRESQL, which uses the identical
  dlt `sql_database` mechanism and works fine today).
- Removed SourceType.SCRAPY = "scrapy": grep confirmed zero references anywhere in the codebase
  outside its own enum definition (`grep -rn "scrapy\|SCRAPY" dango/ --include="*.py"` → only the
  enum line itself and a `registry.py` comment that explicitly said "scrapy not available"; the
  same grep against `tests/` returned zero hits). No registry entry, no `dlt_runner.py` handling,
  no wizard entry — vestigial, same class of drift as the mysql bug but lower severity since nobody
  could ever select it.
- Fixed 3 stale source-count mentions (`registry.py`, `source_wizard.py`, `ingestion/CLAUDE.md`) from
  the old "33"/"27+" counts to the real, live-verified count of 34
  (`len(SOURCE_REGISTRY)` = 34; `len(list(SourceType))` = 35 = 34 registry entries + `sql_database`,
  which is intentionally enum-only with no registry entry).

`sql_database` is untouched — confirmed via `git diff` that `registry.py`'s only changes are
comment/docstring updates (stale counts + the now-obsolete "scrapy not available" comment); no
registry entries were added or removed.

## Verification
- `pytest -x` (full suite, not a subset): **4564 passed, 30 skipped, 0 failed** (~239s)
- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: 240 files already formatted
- `mypy dango/`: Success, no issues in 240 source files
- Live-verified: `DataSource(name="t", type="mysql")` no longer raises (confirmed inside the fixed
  worktree; a first attempt without `PYTHONPATH` pointing at the worktree hit the main clone's stale
  editable install and reproduced the exact pre-fix error — itself further live confirmation of the
  bug, and a reminder of the known worktree editable-install gotcha).
- Regression test confirmed to fail against the pre-fix code, pass against the fix: temporarily
  stashed the `models.py` enum change and re-ran `TestSourceTypeRegistryDrift` — all 3 new tests
  failed with the exact bug signature (`wizard_enabled registry entries with no matching SourceType
  enum value: ['mysql']`, and the scrapy `ValueError`-not-raised failure). Restored the fix and all 3
  passed again.
- Live end-to-end (with one disclosed substitution): true interactive-TTY arrow-key automation via
  `expect` was not reliably drivable in this sandbox — there's no controlling tty for `stty` to size
  the pty, and python-inquirer's raw-mode key reads did not consume queued arrow-key escape sequences
  sent over the pty (they echoed back unconsumed instead of navigating the list). Instead, drove the
  actual `SourceWizard` class — the exact object `dango source add` instantiates via
  `dango.cli.source_wizard.add_source()` — against a real scratch project, with only `inquirer.prompt`
  answered programmatically. Every other step ran as real, unmocked production code: the parameter
  collection state machine, `DataSource` construction, Pydantic validation, the `sources.yml` write,
  and a `ConfigLoader.validate_config()` + reload round-trip. Result: wizard selected MySQL, named the
  source, reused a pre-populated `.env` credential, saved successfully, config validated, and the
  reloaded `DataSource.type` came back as `SourceType.MYSQL`.

## Regression check
- Confirmed no exhaustive match/case over SourceType exists that the new/removed enum members could
  break: `grep -rn "match source_type\|match .*\.type:\|match.*SourceType" dango/` → zero hits,
  re-verified against current `v1.0.8` code (not just the original investigation's claim).
- `get_source_metadata()` unaffected — plain dict `.get()` lookup by registry key string, unchanged.