### PR TITLE
1.0.8: Fix stdout/stderr race in Scripts timeout/kill path

### DIFF
--- a/dango/web/routes/scripts_api.py
+++ b/dango/web/routes/scripts_api.py
@@ -162,9 +162,10 @@ async def run_script(
     async def _wait_for_completion() -> None:
         stdout = ""
         stderr = ""
+        communicate_future = loop.run_in_executor(None, proc.communicate)
         try:
             stdout, stderr = await asyncio.wait_for(
-                loop.run_in_executor(None, proc.communicate),
+                asyncio.shield(communicate_future),
                 timeout=timeout_seconds,
             )
             finished_at = datetime.now(timezone.utc)
@@ -177,12 +178,12 @@ async def run_script(
             proc.terminate()
             try:
                 stdout, stderr = await asyncio.wait_for(
-                    loop.run_in_executor(None, proc.communicate),
+                    asyncio.shield(communicate_future),
                     timeout=5,
                 )
             except asyncio.TimeoutError:
                 proc.kill()
-                stdout, stderr = await loop.run_in_executor(None, proc.communicate)
+                stdout, stderr = await communicate_future
 
             finished_at = datetime.now(timezone.utc)
             duration = (finished_at - started_at).total_seconds()

--- a/tests/unit/test_scripts_wait_for_completion.py
+++ b/tests/unit/test_scripts_wait_for_completion.py
@@ -1,0 +1,213 @@
+"""tests/unit/test_scripts_wait_for_completion.py
+
+Regression tests for the stdout/stderr race in `_wait_for_completion()`
+(1.0.8-Q5). Split out of `test_scripts_api.py` (file-size-check hard
+limit is 500 lines) since these tests each launch a real subprocess and
+need real wall-clock waits — they don't fit the mock-heavy style of the
+rest of the scripts API test suite.
+
+`_wait_for_completion` is a private nested closure inside `run_script()`,
+so it can't be imported directly — these tests call the real
+`run_script()` route function (bypassing FastAPI's `Depends` resolution
+by passing `user`/`request` positionally) with a REAL subprocess, then
+poll the on-disk run metadata for completion. A mocked `proc.communicate`
+cannot reproduce this bug: it is a genuine race between two independent
+`run_in_executor` threads reading the same OS pipes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dango.auth.models import Role, User
+
+_PATCH_API = "dango.web.routes.scripts_api"
+
+
+def _make_admin_user() -> User:
+    return User(id="admin-id", email="admin@test.com", role=Role.ADMIN, is_active=True)
+
+
+def _write_script(scripts_dir: Path, name: str, content: str) -> Path:
+    """Create a script file and return its path."""
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    file_path = scripts_dir / name
+    file_path.write_text(content)
+    return file_path
+
+
+async def _run_script_and_wait(
+    tmp_path: Path,
+    script_content: str,
+    timeout_seconds: int,
+    script_name: str = "race.py",
+    max_wait: float = 20.0,
+) -> tuple[dict[str, Any], str, str]:
+    """Run a real script through `run_script()` and wait for completion.
+
+    Returns (meta, stdout_text, stderr_text) once the background
+    `_wait_for_completion()` task has finished writing results to disk.
+    """
+    import dango.web.routes.scripts_helpers as helpers
+    from dango.web.routes.scripts_api import run_script
+
+    _write_script(tmp_path / "scripts", script_name, script_content)
+    helpers._running_processes.clear()
+
+    admin = _make_admin_user()
+    fake_request = SimpleNamespace(client=None)
+
+    with (
+        patch(f"{_PATCH_API}.get_project_root", return_value=tmp_path),
+        patch(f"{_PATCH_API}._get_script_timeout", return_value=timeout_seconds),
+        patch(f"{_PATCH_API}.append_log_entry"),
+        patch(f"{_PATCH_API}.ws_manager") as mock_ws,
+    ):
+        mock_ws.broadcast = AsyncMock()
+
+        response = await run_script(name=script_name, request=fake_request, user=admin)
+        body = json.loads(bytes(response.body))
+        run_id = body["run_id"]
+
+        log_dir = helpers._get_log_dir(tmp_path) / run_id
+        meta_path = log_dir / "meta.json"
+
+        deadline = time.monotonic() + max_wait
+        meta: dict[str, Any] = json.loads(meta_path.read_text())
+        while meta.get("status") == "running":
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"_wait_for_completion() did not finish within {max_wait}s (last meta: {meta})"
+                )
+            await asyncio.sleep(0.05)
+            meta = json.loads(meta_path.read_text())
+
+        stdout_text = (log_dir / "stdout.txt").read_text(encoding="utf-8")
+        stderr_text = (log_dir / "stderr.txt").read_text(encoding="utf-8")
+
+    return meta, stdout_text, stderr_text
+
+
+@pytest.mark.unit
+class TestWaitForCompletionRace:
+    """Regression tests for the communicate() pipe race (1.0.8-Q5)."""
+
+    def test_wait_for_completion_captures_output_on_normal_exit(self, tmp_path: Path):
+        """A fast script that exits before the timeout captures its stdout."""
+        meta, stdout_text, _stderr_text = asyncio.run(
+            _run_script_and_wait(
+                tmp_path,
+                script_content="print('hello')\n",
+                timeout_seconds=5,
+                script_name="normal.py",
+            )
+        )
+        assert meta["status"] == "success"
+        assert meta["exit_code"] == 0
+        assert "hello" in stdout_text
+
+    def test_wait_for_completion_captures_output_before_terminate(self, tmp_path: Path):
+        """Core regression test: output printed before a timeout-triggered
+        terminate() must still be captured — this is the exact race fixed by
+        reusing a single `communicate()` future via `asyncio.shield()`
+        instead of issuing a new competing `run_in_executor` call per stage.
+        """
+        script = "import sys, time\nprint('before kill', flush=True)\ntime.sleep(10)\n"
+        meta, stdout_text, _stderr_text = asyncio.run(
+            _run_script_and_wait(
+                tmp_path,
+                script_content=script,
+                timeout_seconds=1,
+                script_name="before_kill.py",
+            )
+        )
+        assert meta["status"] == "timeout"
+        assert "before kill" in stdout_text
+
+    def test_wait_for_completion_terminate_succeeds_within_grace_period(self, tmp_path: Path):
+        """A process that dies promptly on SIGTERM never needs SIGKILL, and
+        its pre-terminate output is still captured.
+        """
+        import dango.web.routes.scripts_helpers as helpers
+        from dango.web.routes.scripts_api import run_script
+
+        script = "import sys, time\nprint('before term', flush=True)\ntime.sleep(10)\n"
+        script_name = "grace.py"
+        _write_script(tmp_path / "scripts", script_name, script)
+        helpers._running_processes.clear()
+
+        admin = _make_admin_user()
+        fake_request = SimpleNamespace(client=None)
+
+        async def _run() -> tuple[dict[str, Any], str, MagicMock]:
+            with (
+                patch(f"{_PATCH_API}.get_project_root", return_value=tmp_path),
+                patch(f"{_PATCH_API}._get_script_timeout", return_value=1),
+                patch(f"{_PATCH_API}.append_log_entry"),
+                patch(f"{_PATCH_API}.ws_manager") as mock_ws,
+            ):
+                mock_ws.broadcast = AsyncMock()
+
+                response = await run_script(name=script_name, request=fake_request, user=admin)
+                body = json.loads(bytes(response.body))
+                run_id = body["run_id"]
+
+                # The real Popen object is stored synchronously before
+                # run_script() returns — spy on its real .kill so we can
+                # assert it was never invoked, while the process itself
+                # (and its SIGTERM handling) stays completely real.
+                proc = helpers._running_processes[script_name]
+                kill_spy = MagicMock(wraps=proc.kill)
+                proc.kill = kill_spy  # type: ignore[method-assign]
+
+                log_dir = helpers._get_log_dir(tmp_path) / run_id
+                meta_path = log_dir / "meta.json"
+
+                deadline = time.monotonic() + 20.0
+                meta = json.loads(meta_path.read_text())
+                while meta.get("status") == "running":
+                    if time.monotonic() > deadline:
+                        raise TimeoutError(f"did not finish in time (last meta: {meta})")
+                    await asyncio.sleep(0.05)
+                    meta = json.loads(meta_path.read_text())
+
+                stdout_text = (log_dir / "stdout.txt").read_text(encoding="utf-8")
+            return meta, stdout_text, kill_spy
+
+        meta, stdout_text, kill_spy = asyncio.run(_run())
+
+        assert meta["status"] == "timeout"
+        assert "before term" in stdout_text
+        kill_spy.assert_not_called()
+
+    def test_wait_for_completion_requires_kill(self, tmp_path: Path):
+        """A process that ignores SIGTERM forces the SIGKILL escalation path,
+        and output produced before the kill is still captured correctly.
+        """
+        script = (
+            "import signal, sys, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "print('before kill', flush=True)\n"
+            "time.sleep(30)\n"
+        )
+        meta, stdout_text, _stderr_text = asyncio.run(
+            _run_script_and_wait(
+                tmp_path,
+                script_content=script,
+                timeout_seconds=1,
+                script_name="requires_kill.py",
+                max_wait=30.0,
+            )
+        )
+        assert meta["status"] == "timeout"
+        assert "before kill" in stdout_text
+        # SIGKILL exit: returncode is the negative signal number on POSIX.
+        assert meta["exit_code"] < 0


### PR DESCRIPTION
## Summary
- Fix a real, live-confirmed race condition on `beta-1`: the Scripts page's timeout/kill path called
  `proc.communicate()` up to three separate times via independent `run_in_executor` calls, causing
  concurrent reads of the same stdout/stderr pipes — the losing call got empty output, so timed-out
  scripts showed no captured output even though they had printed some before being killed.
- Root cause: `run_in_executor`'s Future can't actually stop an already-running blocking call when
  `asyncio.wait_for` times out and "cancels" it — the original communicate() kept running in the
  background while a second, competing call raced it for the same pipes.
- Fix: call `communicate()` exactly once, reuse that single future across every escalation stage via
  `asyncio.shield()`, instead of issuing a new call at each timeout stage.

## Verification
- `pytest -x`: 4581 passed, 30 skipped, 0 failed (full suite)
- New regression test (`test_wait_for_completion_captures_output_before_terminate` in
  `tests/unit/test_scripts_wait_for_completion.py`) uses a real subprocess (not mocked) that prints
  output then sleeps past the timeout — explicitly confirmed to **fail** against the pre-fix code
  (`AssertionError: assert 'before kill' in ''`) by temporarily reverting the fix via `git stash`, then
  confirmed to **pass** after re-applying the fix.
- All three escalation paths tested with real subprocesses, all passing:
  - `test_wait_for_completion_captures_output_on_normal_exit` — fast script, no timeout
  - `test_wait_for_completion_captures_output_before_terminate` — SIGTERM path (core regression)
  - `test_wait_for_completion_terminate_succeeds_within_grace_period` — SIGTERM succeeds within 5s
    grace window; spied on the real `proc.kill` to confirm it's never called
  - `test_wait_for_completion_requires_kill` — process ignores SIGTERM (`SIG_IGN`), forces the
    SIGKILL escalation; output still captured, `exit_code < 0` confirms the kill landed
- Live-verified: ran a real script (`race_timeout.py`, prints `"before kill"` then sleeps 30s, configured
  via `.dango/scripts.yml` with `timeout_seconds: 5`) through the Scripts page UI on an isolated scratch
  project (not `tests/beta-1`). Clicked "Run Now", waited past the timeout, opened the run's log viewer —
  it shows `STDOUT: before kill`, status `timeout`, exit code `-15` (SIGTERM), duration `5.0s`. Before this
  fix, the same scenario left stdout empty.
- Confirmed `run_in_executor(None, proc.communicate)` now appears exactly once in `_wait_for_completion()`
  (`grep -c` on the function body).
- `ruff check dango/`, `ruff format --check dango/`, `mypy dango/`: all pass.

## Regression check
- Confirmed `cancel_script()`'s `_force_kill()` (wraps `proc.wait`, not `proc.communicate`, reads no
  pipes) is unaffected by this race — left unchanged.
- Confirmed normal (non-timeout) script completion is unaffected.

## Notes on deviations from the original task prompt
- The prompt's suggested file target, `tests/unit/test_scripts_api.py`, already existed and fit the
  three simpler tests, but adding all four new subprocess-based tests there would have pushed it to 655
  lines, failing the repo's hard 500-line `file-size-check` pre-commit hook. Split the new
  `TestWaitForCompletionRace` class into a new file, `tests/unit/test_scripts_wait_for_completion.py`,
  per the prompt's own fallback instruction ("create a new file if none fits"). `test_scripts_api.py`
  itself is untouched (byte-identical diff after the split).
- No other deviations — line numbers, function shape, and the `_force_kill()` non-affectedness all
  matched the prompt exactly.

## Verification
- `pytest -x`: 4581 passed, 30 skipped, 0 failed