### PR TITLE
1.0.8: --full-refresh must clear local dlt pipeline cache

### DIFF
--- a/dango/ingestion/dlt_runner.py
+++ b/dango/ingestion/dlt_runner.py
@@ -1089,6 +1089,20 @@ class DltPipelineRunner:
                 pipeline.drop()
             except Exception as e:
                 console.print(f"  ⚠️  Could not drop pipeline state: {e}")
+            self._clear_local_pipeline_cache(pipeline_name)
+            # Re-create the pipeline object: the one above was constructed
+            # against the on-disk working directory we just deleted, and dlt's
+            # Pipeline does not lazily recreate that directory before
+            # extract()/normalize()/load() — reusing the stale in-memory
+            # object here raises FileNotFoundError on schemas/ mid-sync
+            # (confirmed via live testing on a scratch project). A fresh
+            # dlt.pipeline() call bootstraps a clean directory exactly like it
+            # would for a pipeline_name that has never been synced before.
+            pipeline = dlt.pipeline(
+                pipeline_name=pipeline_name,
+                destination=dlt.destinations.duckdb(credentials=str(self.duckdb_path)),
+                dataset_name=dataset_name,
+            )
 
         try:
             # Phase 1: Extract (API calls, NO LOCK, with retry for network errors)
@@ -1477,6 +1491,23 @@ class DltPipelineRunner:
                 pipeline.drop()
             except Exception as e:
                 console.print(f"  ⚠️  Could not drop pipeline state: {e}")
+            # NOTE: this method's pipeline is always named `source_name` (see
+            # dlt.pipeline(pipeline_name=source_name, ...) above) — unlike
+            # _run_dlt_native_source, there is no separate pipeline_name override.
+            self._clear_local_pipeline_cache(source_name)
+            # Re-create the pipeline object: the one above was constructed
+            # against the on-disk working directory we just deleted, and dlt's
+            # Pipeline does not lazily recreate that directory before
+            # extract()/normalize()/load() — reusing the stale in-memory
+            # object here raises FileNotFoundError on schemas/ mid-sync
+            # (confirmed via live testing on a scratch project). A fresh
+            # dlt.pipeline() call bootstraps a clean directory exactly like it
+            # would for a pipeline_name that has never been synced before.
+            pipeline = dlt.pipeline(
+                pipeline_name=source_name,
+                destination=dlt.destinations.duckdb(credentials=str(self.duckdb_path)),
+                dataset_name=dataset_name,
+            )
 
         try:
             # Phase 1: Extract (API calls, NO LOCK, with retry for network errors)
@@ -2714,6 +2745,36 @@ Need help? Visit: https://github.com/getdango/dango/issues
         except Exception as e:
             console.print(f"  [dim]⚠️  Could not backup state: {e}[/dim]")
             return None
+
+    def _clear_local_pipeline_cache(self, pipeline_name: str) -> None:
+        """Ensure the local dlt pipeline working directory is actually gone after
+        a full refresh. pipeline.drop() is expected to clear this, but its
+        failure is caught and only logged elsewhere in this file — a full
+        refresh must not silently proceed with stale local incremental cursor
+        state still present, since that state is independent of the destination
+        schema drop and can survive it.
+
+        pipeline_name is always sourced from trusted config (config.pipeline_name
+        or source_name in _run_dlt_native_source; source_name directly in
+        _run_dlt_source) — never raw/unsanitized external input. See
+        _backup_dlt_state above, which already performs filesystem operations
+        (shutil.copytree) on this exact path with these exact inputs.
+        """
+        import shutil
+
+        dlt_home = Path(os.path.expanduser("~/.dlt"))
+        pipeline_state_dir = dlt_home / "pipelines" / pipeline_name
+
+        if not pipeline_state_dir.exists():
+            return
+
+        try:
+            shutil.rmtree(pipeline_state_dir)
+            console.print(
+                f"  [dim]🗑️  Cleared local pipeline cache ({pipeline_state_dir.name})[/dim]"
+            )
+        except Exception as e:
+            console.print(f"  ⚠️  Could not clear local pipeline cache: {e}")
 
     def _restore_dlt_state(self, backup_dir: Path | None):
         """

--- a/tests/unit/test_dlt_runner_full_refresh.py
+++ b/tests/unit/test_dlt_runner_full_refresh.py
@@ -7,6 +7,11 @@ Tests cover:
 - _restore_dlt_state is called with correct single argument on failure
 - Row count warning when new count < previous count
 - Backup preserved (not cleaned up) when row count drops
+
+See also test_dlt_runner_local_cache.py for 1.0.8-Q6 (--full-refresh must
+clear the local ~/.dlt/pipelines/{pipeline_name}/ cache, not just the
+destination DB schema) — split into its own file to stay under the
+file-size-check line limit.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_dlt_runner_local_cache.py
+++ b/tests/unit/test_dlt_runner_local_cache.py
@@ -1,0 +1,438 @@
+"""tests/unit/test_dlt_runner_local_cache.py
+
+Unit tests for 1.0.8-Q6: --full-refresh must clear the local dlt pipeline
+cache at ~/.dlt/pipelines/{pipeline_name}/, not just the destination DB
+schema.
+
+Split out of test_dlt_runner_full_refresh.py (which covers the pre-existing
+BUG-229 backup/restore behavior) to keep both files under the 500-line
+file-size-check limit.
+
+Tests cover:
+- _clear_local_pipeline_cache() removes the directory when it exists, no-ops
+  when it doesn't, and swallows (logs) errors rather than raising
+- Both _run_dlt_native_source and _run_dlt_source call it after pipeline.drop()
+  inside `if full_refresh:` — and, critically, still call it even when
+  pipeline.drop() itself raises (the actual production bug)
+- A non-full-refresh sync never calls it / never touches the directory
+- Both methods re-create the `pipeline` object after clearing the cache —
+  found via live testing on a scratch project: dlt's Pipeline instance does
+  not lazily recreate its on-disk working directory before
+  extract()/normalize()/load(), so reusing the pre-clear pipeline object
+  raises FileNotFoundError on schemas/ mid-sync
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _patch_home(monkeypatch, fake_home):
+    """Redirect os.path.expanduser("~...") to fake_home for the duration of a test.
+
+    Both _backup_dlt_state and the new _clear_local_pipeline_cache resolve the
+    dlt state directory via os.path.expanduser("~/.dlt"), so patching the
+    global os.path.expanduser (rather than anything module-local) covers both.
+    """
+    monkeypatch.setattr(
+        "os.path.expanduser",
+        lambda p: str(fake_home) + p[1:] if p.startswith("~") else p,
+    )
+
+
+@pytest.mark.unit
+class TestClearLocalPipelineCache:
+    """Direct unit tests for the new _clear_local_pipeline_cache() helper
+    (1.0.8-Q6), isolated from the surrounding sync flow."""
+
+    def _make_runner(self):
+        from dango.ingestion.dlt_runner import DltPipelineRunner
+
+        return DltPipelineRunner.__new__(DltPipelineRunner)
+
+    def test_removes_existing_pipeline_dir(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        pipeline_dir = fake_home / ".dlt" / "pipelines" / "my_pipeline"
+        pipeline_dir.mkdir(parents=True)
+        (pipeline_dir / "state.json").write_text("{}")
+        _patch_home(monkeypatch, fake_home)
+
+        runner = self._make_runner()
+        runner._clear_local_pipeline_cache("my_pipeline")
+
+        assert not pipeline_dir.exists()
+
+    def test_noop_when_dir_missing(self, tmp_path, monkeypatch):
+        """Must not raise when there's nothing to clear (e.g. first-ever sync)."""
+        fake_home = tmp_path / "home"
+        _patch_home(monkeypatch, fake_home)
+
+        runner = self._make_runner()
+        runner._clear_local_pipeline_cache("never_synced_pipeline")  # no raise
+
+    @patch("dango.ingestion.dlt_runner.console")
+    def test_swallows_rmtree_exception(self, mock_console, tmp_path, monkeypatch):
+        """If rmtree itself fails, log it (matches pipeline.drop()'s existing
+        catch-and-log convention) rather than crashing the sync."""
+        fake_home = tmp_path / "home"
+        pipeline_dir = fake_home / ".dlt" / "pipelines" / "locked_pipeline"
+        pipeline_dir.mkdir(parents=True)
+        _patch_home(monkeypatch, fake_home)
+
+        runner = self._make_runner()
+        with patch("shutil.rmtree", side_effect=OSError("simulated: file in use")):
+            runner._clear_local_pipeline_cache("locked_pipeline")  # no raise
+
+        assert mock_console.print.called
+
+
+@pytest.mark.unit
+class TestFullRefreshClearsLocalPipelineCacheNative:
+    """1.0.8-Q6 regression tests for _run_dlt_native_source.
+
+    Real production bug: pipeline.drop() alone was relied on to clear
+    ~/.dlt/pipelines/{pipeline_name}/. Its failure was caught and only logged,
+    so a full refresh could silently proceed with stale local incremental
+    cursor state intact even though the destination schema was dropped.
+    """
+
+    def _make_runner(self, tmp_path):
+        from dango.ingestion.dlt_runner import DltPipelineRunner
+
+        runner = DltPipelineRunner.__new__(DltPipelineRunner)
+        runner.project_root = tmp_path
+        runner.duckdb_path = tmp_path / "data" / "warehouse.duckdb"
+        runner.duckdb_path.parent.mkdir(parents=True, exist_ok=True)
+        runner._current_oauth_warning = None
+        return runner
+
+    def _make_native_source_config(self, pipeline_name="test_pipeline"):
+        config = MagicMock()
+        config.name = "test_source"
+        config.type.value = "dlt_native"
+        config.dlt_native.source_module = "test_module"
+        config.dlt_native.source_function = "test_func"
+        config.dlt_native.pipeline_name = pipeline_name
+        config.dlt_native.dataset_name = "raw_test"
+        config.dlt_native.source_args = {}
+        return config
+
+    def _make_stale_cache_dir(self, tmp_path, monkeypatch, pipeline_name="test_pipeline"):
+        fake_home = tmp_path / "home"
+        pipeline_dir = fake_home / ".dlt" / "pipelines" / pipeline_name
+        pipeline_dir.mkdir(parents=True)
+        (pipeline_dir / "state.json").write_text('{"cursor": "stale"}')
+        _patch_home(monkeypatch, fake_home)
+        return pipeline_dir
+
+    @patch("dango.ingestion.dlt_runner.console")
+    @patch("dango.ingestion.dlt_runner.dlt")
+    @patch("dango.ingestion.dlt_runner.importlib")
+    @patch("os.chdir")
+    @patch("os.getcwd", return_value="/tmp")
+    def test_full_refresh_clears_local_pipeline_cache_after_pipeline_drop_succeeds(
+        self,
+        mock_getcwd,
+        mock_chdir,
+        mock_importlib,
+        mock_dlt,
+        mock_console,
+        tmp_path,
+        monkeypatch,
+    ):
+        pipeline_dir = self._make_stale_cache_dir(tmp_path, monkeypatch)
+
+        runner = self._make_runner(tmp_path)
+        config = self._make_native_source_config()
+
+        mock_source = MagicMock()
+        mock_module = MagicMock()
+        mock_module.test_func.return_value = mock_source
+        mock_importlib.import_module.return_value = mock_module
+
+        mock_pipeline = MagicMock()  # pipeline.drop() succeeds by default
+        mock_dlt.pipeline.return_value = mock_pipeline
+
+        runner._extract_load_stats = MagicMock(return_value={"rows_loaded": 5})
+
+        result = runner._run_dlt_native_source(config, full_refresh=True)
+
+        assert result["status"] == "success"
+        assert not pipeline_dir.exists()
+        # Regression check (found via live testing on a scratch project): the
+        # pipeline object must be re-created after the clear, or dlt's
+        # Pipeline instance raises FileNotFoundError on schemas/ during the
+        # extract phase that follows, because it was constructed against the
+        # working directory we just deleted.
+        assert mock_dlt.pipeline.call_count == 2
+
+    @patch("dango.ingestion.dlt_runner.console")
+    @patch("dango.ingestion.dlt_runner.dlt")
+    @patch("dango.ingestion.dlt_runner.importlib")
+    @patch("os.chdir")
+    @patch("os.getcwd", return_value="/tmp")
+    def test_full_refresh_clears_local_pipeline_cache_even_if_pipeline_drop_fails(
+        self,
+        mock_getcwd,
+        mock_chdir,
+        mock_importlib,
+        mock_dlt,
+        mock_console,
+        tmp_path,
+        monkeypatch,
+    ):
+        """THE regression test for 1.0.8-Q6.
+
+        Mocks pipeline.drop() to raise, simulating the exact observed failure
+        mode. This must FAIL against the pre-fix code (the local cache would
+        survive) and PASS against the fix.
+        """
+        pipeline_dir = self._make_stale_cache_dir(tmp_path, monkeypatch)
+
+        runner = self._make_runner(tmp_path)
+        config = self._make_native_source_config()
+
+        mock_source = MagicMock()
+        mock_module = MagicMock()
+        mock_module.test_func.return_value = mock_source
+        mock_importlib.import_module.return_value = mock_module
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.drop.side_effect = RuntimeError("simulated pipeline.drop() failure")
+        mock_dlt.pipeline.return_value = mock_pipeline
+
+        runner._extract_load_stats = MagicMock(return_value={"rows_loaded": 5})
+
+        result = runner._run_dlt_native_source(config, full_refresh=True)
+
+        # Sync proceeds despite pipeline.drop() failing (existing catch-and-log
+        # behavior for that call is unchanged).
+        assert result["status"] == "success"
+        # The actual regression assertion.
+        assert not pipeline_dir.exists(), (
+            "local dlt pipeline cache survived a failed pipeline.drop() call — "
+            "_clear_local_pipeline_cache() did not run (or did not fail-safe)"
+        )
+        assert mock_dlt.pipeline.call_count == 2
+
+    @patch("dango.ingestion.dlt_runner.console")
+    @patch("dango.ingestion.dlt_runner.dlt")
+    @patch("dango.ingestion.dlt_runner.importlib")
+    @patch("os.chdir")
+    @patch("os.getcwd", return_value="/tmp")
+    def test_non_full_refresh_sync_never_touches_local_pipeline_cache(
+        self,
+        mock_getcwd,
+        mock_chdir,
+        mock_importlib,
+        mock_dlt,
+        mock_console,
+        tmp_path,
+        monkeypatch,
+    ):
+        pipeline_dir = self._make_stale_cache_dir(tmp_path, monkeypatch)
+
+        runner = self._make_runner(tmp_path)
+        config = self._make_native_source_config()
+
+        mock_source = MagicMock()
+        mock_module = MagicMock()
+        mock_module.test_func.return_value = mock_source
+        mock_importlib.import_module.return_value = mock_module
+
+        mock_pipeline = MagicMock()
+        mock_dlt.pipeline.return_value = mock_pipeline
+
+        runner._extract_load_stats = MagicMock(return_value={"rows_loaded": 5})
+        runner._clear_local_pipeline_cache = MagicMock()
+
+        result = runner._run_dlt_native_source(config, full_refresh=False)
+
+        assert result["status"] == "success"
+        runner._clear_local_pipeline_cache.assert_not_called()
+        assert pipeline_dir.exists()
+        # Non-full-refresh must not pay the pipeline-recreation cost either.
+        assert mock_dlt.pipeline.call_count == 1
+
+
+@pytest.mark.unit
+class TestFullRefreshClearsLocalPipelineCacheDltSource:
+    """Mirrors TestFullRefreshClearsLocalPipelineCacheNative for _run_dlt_source.
+
+    Unlike _run_dlt_native_source, this method has no separate `pipeline_name`
+    config override — dlt.pipeline(pipeline_name=source_name, ...) always uses
+    source_name directly, so the local cache directory is keyed on source_name.
+    """
+
+    def _make_runner(self, tmp_path):
+        from dango.ingestion.dlt_runner import DltPipelineRunner
+
+        runner = DltPipelineRunner.__new__(DltPipelineRunner)
+        runner.project_root = tmp_path
+        runner.duckdb_path = tmp_path / "data" / "warehouse.duckdb"
+        runner.duckdb_path.parent.mkdir(parents=True, exist_ok=True)
+        runner._current_oauth_warning = None
+        return runner
+
+    def _make_source_config(self, name="test_source2"):
+        config = MagicMock()
+        config.name = name
+        return config
+
+    def _stub_runner_methods(self, runner):
+        """Stub out the parts of _run_dlt_source unrelated to this fix
+        (source-kwargs assembly, OAuth, registry-driven dataset naming, and
+        the dynamic dlt source import) so the test exercises the real
+        full_refresh / pipeline.drop() / _clear_local_pipeline_cache path."""
+        runner._build_source_config = MagicMock(return_value={})
+        runner._check_oauth_token_expiry = MagicMock(return_value=None)
+        runner._inject_oauth_credentials = MagicMock(side_effect=lambda _type, kwargs: kwargs)
+        runner._get_dataset_name = MagicMock(return_value="raw_test_source2")
+        runner._load_dlt_source = MagicMock(return_value=MagicMock())
+        runner._extract_load_stats = MagicMock(return_value={"rows_loaded": 5})
+
+    def _make_stale_cache_dir(self, tmp_path, monkeypatch, source_name="test_source2"):
+        fake_home = tmp_path / "home"
+        pipeline_dir = fake_home / ".dlt" / "pipelines" / source_name
+        pipeline_dir.mkdir(parents=True)
+        (pipeline_dir / "state.json").write_text('{"cursor": "stale"}')
+        _patch_home(monkeypatch, fake_home)
+        return pipeline_dir
+
+    @patch("dango.ingestion.dlt_runner.get_source_metadata")
+    @patch("dango.ingestion.dlt_runner.console")
+    @patch("dango.ingestion.dlt_runner.dlt")
+    @patch("os.chdir")
+    @patch("os.getcwd", return_value="/tmp")
+    def test_full_refresh_clears_local_pipeline_cache_after_pipeline_drop_succeeds(
+        self,
+        mock_getcwd,
+        mock_chdir,
+        mock_dlt,
+        mock_console,
+        mock_get_metadata,
+        tmp_path,
+        monkeypatch,
+    ):
+        pipeline_dir = self._make_stale_cache_dir(tmp_path, monkeypatch)
+        mock_get_metadata.return_value = {"dlt_package": "pkg", "dlt_function": "func"}
+
+        runner = self._make_runner(tmp_path)
+        self._stub_runner_methods(runner)
+        config = self._make_source_config()
+
+        mock_pipeline = MagicMock()  # pipeline.drop() succeeds by default
+        mock_dlt.pipeline.return_value = mock_pipeline
+
+        result = runner._run_dlt_source(config, full_refresh=True)
+
+        assert result["status"] == "success"
+        assert not pipeline_dir.exists()
+        # Regression check (found via live testing on a scratch project): see
+        # the identical comment in TestFullRefreshClearsLocalPipelineCacheNative.
+        assert mock_dlt.pipeline.call_count == 2
+
+    @patch("dango.ingestion.dlt_runner.get_source_metadata")
+    @patch("dango.ingestion.dlt_runner.console")
+    @patch("dango.ingestion.dlt_runner.dlt")
+    @patch("os.chdir")
+    @patch("os.getcwd", return_value="/tmp")
+    def test_full_refresh_clears_local_pipeline_cache_even_if_pipeline_drop_fails(
+        self,
+        mock_getcwd,
+        mock_chdir,
+        mock_dlt,
+        mock_console,
+        mock_get_metadata,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Mirrors the native regression test: pipeline.drop() raises, and the
+        local cache (keyed on source_name here) must still be gone afterward."""
+        pipeline_dir = self._make_stale_cache_dir(tmp_path, monkeypatch)
+        mock_get_metadata.return_value = {"dlt_package": "pkg", "dlt_function": "func"}
+
+        runner = self._make_runner(tmp_path)
+        self._stub_runner_methods(runner)
+        config = self._make_source_config()
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.drop.side_effect = RuntimeError("simulated pipeline.drop() failure")
+        mock_dlt.pipeline.return_value = mock_pipeline
+
+        result = runner._run_dlt_source(config, full_refresh=True)
+
+        assert result["status"] == "success"
+        assert not pipeline_dir.exists(), (
+            "local dlt pipeline cache survived a failed pipeline.drop() call in "
+            "_run_dlt_source — _clear_local_pipeline_cache() did not run "
+            "(or did not fail-safe)"
+        )
+        assert mock_dlt.pipeline.call_count == 2
+
+    @patch("dango.ingestion.dlt_runner.get_source_metadata")
+    @patch("dango.ingestion.dlt_runner.console")
+    @patch("dango.ingestion.dlt_runner.dlt")
+    @patch("os.chdir")
+    @patch("os.getcwd", return_value="/tmp")
+    def test_non_full_refresh_sync_never_touches_local_pipeline_cache(
+        self,
+        mock_getcwd,
+        mock_chdir,
+        mock_dlt,
+        mock_console,
+        mock_get_metadata,
+        tmp_path,
+        monkeypatch,
+    ):
+        pipeline_dir = self._make_stale_cache_dir(tmp_path, monkeypatch)
+        mock_get_metadata.return_value = {"dlt_package": "pkg", "dlt_function": "func"}
+
+        runner = self._make_runner(tmp_path)
+        self._stub_runner_methods(runner)
+        runner._clear_local_pipeline_cache = MagicMock()
+        config = self._make_source_config()
+
+        mock_pipeline = MagicMock()
+        mock_dlt.pipeline.return_value = mock_pipeline
+
+        result = runner._run_dlt_source(config, full_refresh=False)
+
+        assert result["status"] == "success"
+        runner._clear_local_pipeline_cache.assert_not_called()
+        assert pipeline_dir.exists()
+        assert mock_dlt.pipeline.call_count == 1
+
+
+@pytest.mark.unit
+class TestClearLocalPipelineCacheCallSites:
+    """Structural checks that both full_refresh blocks call the new helper
+    with the correct, in-scope variable name (pipeline_name vs source_name)."""
+
+    def test_native_source_calls_with_pipeline_name(self):
+        import inspect
+
+        from dango.ingestion.dlt_runner import DltPipelineRunner
+
+        source = inspect.getsource(DltPipelineRunner._run_dlt_native_source)
+        assert "self._clear_local_pipeline_cache(pipeline_name)" in source
+        drop_pos = source.find("pipeline.drop()")
+        clear_pos = source.find("self._clear_local_pipeline_cache(pipeline_name)")
+        assert 0 <= drop_pos < clear_pos
+
+    def test_dlt_source_calls_with_source_name(self):
+        """_run_dlt_source has no separate pipeline_name variable — its dlt
+        pipeline is always named after source_name (see dlt.pipeline(
+        pipeline_name=source_name, ...) in that method)."""
+        import inspect
+
+        from dango.ingestion.dlt_runner import DltPipelineRunner
+
+        source = inspect.getsource(DltPipelineRunner._run_dlt_source)
+        assert "self._clear_local_pipeline_cache(source_name)" in source
+        assert "self._clear_local_pipeline_cache(pipeline_name)" not in source
+        drop_pos = source.find("pipeline.drop()")
+        clear_pos = source.find("self._clear_local_pipeline_cache(source_name)")
+        assert 0 <= drop_pos < clear_pos


### PR DESCRIPTION
## Summary
- Fix a real, live-confirmed bug found on a production project: `--full-refresh` on a merge-based
  dlt_native/dlt source did not reliably reset incremental cursor state, because dlt keeps a second,
  independent copy of that state on the local filesystem (~/.dlt/pipelines/{pipeline_name}/) that
  the existing DROP SCHEMA + pipeline.drop() sequence relied entirely on pipeline.drop() to clear —
  and pipeline.drop()'s failure was silently caught and only logged, letting the sync proceed with
  stale local state intact.
- Added `_clear_local_pipeline_cache()`, called after pipeline.drop() in both `_run_dlt_native_source`
  and `_run_dlt_source`'s full_refresh blocks, to explicitly guarantee the local cache is gone rather
  than relying on pipeline.drop()'s (silently-failable) success.
- **Found via live testing, not in the original spec:** the naive version of this fix (clear the
  cache, keep using the same in-memory `pipeline` object) broke every full-refresh sync outright —
  dlt's `Pipeline` instance does not lazily recreate its on-disk working directory before
  `extract()`/`normalize()`/`load()`, so deleting that directory out from under an already-constructed
  pipeline object raises `FileNotFoundError: ... schemas/.` on the very next extract call. Fixed by
  re-creating the `pipeline` object (a fresh `dlt.pipeline(...)` call, same args) immediately after
  clearing the cache, in both call sites — this bootstraps a clean working directory exactly like a
  never-before-synced `pipeline_name` would. Locked in with `mock_dlt.pipeline.call_count` assertions
  in the new tests.

## Verification
- `pytest -x`: 4592 passed, 30 skipped, 0 failed (full suite)
- `ruff check dango/ tests/`: all checks passed
- `ruff format --check dango/ tests/`: all files formatted
- `mypy dango/`: no issues found in 240 source files
- New regression test (`test_full_refresh_clears_local_pipeline_cache_even_if_pipeline_drop_fails`,
  in both the native and dlt_source variants) confirmed to **fail** against the pre-fix code (local
  cache survives when pipeline.drop() fails) and **pass** against the fix — verified both ways by
  temporarily stashing the source change and re-running the test file (9 failures on pre-fix code,
  including both regression tests; 20/20 pass after re-applying the fix).
- **Live-verified on an isolated scratch project** (not tests/beta-1, not any production project;
  isolated via a fake `$HOME` so the real machine's `~/.dlt` and `~/.dango` were never touched):
  - Created a scratch dango project with a merge-based `dlt_native` source (`scratch_events`,
    incremental cursor on `updated_at`, primary_key `id`)
  - First sync: loaded 3 rows, cursor advanced to the latest `updated_at`
  - Added an older "backfill" row (`updated_at` earlier than the current cursor) to simulate the
    production scenario (a newly-added entity's full history arriving after the fact)
  - Confirmed a normal incremental sync filtered the backfill row out (stale-cursor behavior
    reproduced, matching the original bug report)
  - Ran `dango sync scratch_events --full-refresh -y`: this is exactly where the pipeline-recreation
    bug above was caught (`FileNotFoundError` on `schemas/.`) before the fix, and succeeds cleanly
    after it, loading all 4 rows including the backfill row
  - Confirmed `~/.dlt/pipelines/scratch_events_pipeline/` was actually gone immediately after the
    full-refresh command returned (checked via `ls` against the fake HOME), and a freshly-created
    directory existed afterward from the re-created pipeline object completing its own sync
  - Ran one more normal (non-full-refresh) sync afterward and confirmed all 4 rows, including the
    backfill row, remained present with no duplication — full history reload confirmed, not
    filtering by stale state

## Regression check
- Confirmed the local cache is only ever cleared when full_refresh=True — it's called inside the
  existing `if full_refresh:` block in both methods, and `test_non_full_refresh_sync_never_touches_local_pipeline_cache`
  asserts the helper is never called (and the directory is left untouched) on a normal sync.
- Confirmed `pipeline_name`'s origin before using it in `shutil.rmtree`:
  - In `_run_dlt_source`, the value passed is `source_name` (`source_config.name`), which is
    validated by `DataSource.validate_name_format()` — alphanumeric + underscore only, lowercased.
    No path-traversal characters are possible.
  - In `_run_dlt_native_source`, the value is `config.pipeline_name or source_name` — `pipeline_name`
    itself is an optional free-text `str | None` field on `DltNativeConfig` with **no format
    validator** (unlike `source_name`). This is pre-existing: `_backup_dlt_state()` already performs
    filesystem operations (`shutil.copytree`) on this exact path with this exact input, so this fix
    introduces no new trust boundary — it's authored by the project maintainer in `sources.yml`
    (dlt_native is explicitly documented as an "advanced users" registry-bypass feature), not
    exposed to any untrusted external input. Flagging this precisely rather than claiming blanket
    validation that doesn't exist.
- Confirmed `_backup_dlt_state`/`_restore_dlt_state`/`_cleanup_state_backup` are unchanged (only a
  new helper was added near `_backup_dlt_state`; the ordering — backup before drop, before clear —
  was verified by reading the surrounding code, not just trusting the prompt).

## Deviations from the original task spec
1. **`pipeline_name` variable doesn't exist in `_run_dlt_source`.** The spec assumed both methods
   have an in-scope `pipeline_name` variable. `_run_dlt_native_source` does
   (`pipeline_name = config.pipeline_name or source_name`); `_run_dlt_source` does not — its
   `dlt.pipeline(pipeline_name=source_name, ...)` uses `source_name` directly, and
   `_backup_dlt_state(source_name)` confirms this. Used `source_name` at that call site instead
   (using `pipeline_name` there would be a `NameError`). Locked in with a structural test
   (`TestClearLocalPipelineCacheCallSites`) asserting each method uses the correct variable.
2. **Pipeline-object re-creation, found via live testing** (see Summary above) — not in the original
   spec's proposed code, but required for the fix to work at all against real dlt, not just mocks.

Both `_run_dlt_native_source` and `_run_dlt_source` were updated identically in structure (helper
call site placement, comment explaining the trust boundary / pipeline re-creation) modulo the
`pipeline_name`/`source_name` variable-name difference above, which is itself pre-existing and
unrelated to this fix.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MyYKvCUZcrvQwMHh1sNWEp