### PR TITLE
1.0.8: README Prerequisites line understates Docker's scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dango gives you a complete data stack — ingestion, warehouse, transformations,
 
 ## Quick Start
 
-**Prerequisites:** Python 3.10-3.13, [Docker](https://docs.docker.com/desktop/) (for Metabase)
+**Prerequisites:** Python 3.10-3.13, [Docker](https://docs.docker.com/desktop/) (for Metabase and dbt docs)
 
 ```bash
 mkdir my-project && cd my-project


### PR DESCRIPTION
## Summary
- README's Prerequisites line said Docker is needed "(for Metabase)" — but `docker-compose.yml.j2` runs two services, `metabase` and `dbt-docs`, and the tech-stack table further down the same README already correctly says "Metabase and service orchestration." Fixed the Prerequisites line to match.

## Verification
- One-line docs change, no code affected. Pre-commit hooks pass.