### PR TITLE
1.0.8: Docker project-identity collision guard (Phase 1)

### DIFF
--- a/dango/cli/CLAUDE.md
+++ b/dango/cli/CLAUDE.md
@@ -18,6 +18,7 @@ Click-based command-line interface for all Dango operations — project init, so
 | `commands/auth.py` (666 lines) | `auth` group (13 subcommands: enable, disable, add-user, list-users, reset-password, deactivate-user, reactivate-user, delete-user, status, unlock, change-role, audit, recover) | `auth`, `auth_enable()`, `auth_add_user()`, `auth_change_role()`, `auth_status()`, etc. |
 | `commands/cleanup.py` (388 lines) | `cleanup` command — remove old log archives, dbt artifacts, Python cache | `cleanup()` |
 | `commands/doctor.py` (65 lines) | `doctor` command — check credential health for all configured sources | `doctor()` |
+| `commands/docker_audit.py` (~330 lines) | `docker-audit` command (1.0.8-Q8) — machine-wide diagnostic/cleanup for `dango-*` Docker resources, grouped by real Compose project identity (`com.docker.compose.project.working_dir` label) and classified orphaned / needs-attention / live. Deliberately separate from `dango doctor`, which is scoped to credential health only. | `docker_audit()`, `_build_groups()`, `_remove_group()` |
 | `commands/oauth.py` (842 lines) | `oauth` group (10 subcommands) | `oauth`, `oauth_setup()`, `oauth_status()`, `oauth_check()`, etc. |
 | `commands/transform.py` (343 lines) | `run`, `docs`, `generate` | `run()`, `docs()`, `generate()` |
 | `commands/upgrade.py` (236 lines) | `upgrade` command — local Dango upgrade via pip + migrations | `upgrade()`, `get_latest_version_cached()` |
@@ -80,6 +81,7 @@ dango (top-level group)
 ├── upgrade                     ← commands/upgrade.py
 ├── cleanup                     ← commands/cleanup.py
 ├── doctor                      ← commands/doctor.py
+├── docker-audit                ← commands/docker_audit.py
 ├── sync                        ← commands/source.py
 ├── run, docs, generate         ← commands/transform.py
 ├── validate                    ← commands/data.py

--- a/dango/cli/commands/docker_audit.py
+++ b/dango/cli/commands/docker_audit.py
@@ -1,0 +1,383 @@
+"""dango/cli/commands/docker_audit.py
+
+Machine-wide diagnostic + cleanup for dango-managed Docker resources.
+
+Added by 1.0.8-Q8 after a real incident (2026-09-09, see
+v1.0.x-planning/1.0.8/BUGS-FOUND.md and dango/exceptions.py's
+DockerIdentityCollisionError): get_compose_project_name() derives a
+project's Docker Compose identity from an MD5 hash of its path string,
+which is not a stable identifier. When a scratch project's containers
+looked orphaned, a human/agent operator guessed which real project they
+belonged to and ran manual `docker compose down` + `docker volume rm` +
+`docker rmi` outside any `dango` command — destroying a different, real
+project's Metabase data.
+
+This command is the tool that should have existed: it reads Docker
+Compose's own `com.docker.compose.project.working_dir` label (the literal
+path used to create each container) instead of guessing, groups every
+dango-* resource on the machine by that ground truth, and only ever offers
+cleanup for the unambiguously-orphaned group.
+
+Deliberately NOT part of `dango doctor` (cli/commands/doctor.py), which is
+scoped specifically to credential health.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from dango.cli import console
+from dango.cli.utils import safe_confirm
+
+# Docker Compose's default naming conventions (live-verified against Docker
+# 28.5.1 / Compose v2.40.2 with a scratch compose project — see PR
+# description for the exact commands):
+#   - Named volume "foo" under project "dango-<hash>"  -> "dango-<hash>_foo"
+#   - A locally *built* service image (no explicit `image:` key) for
+#     service "metabase" under project "dango-<hash>"  -> "dango-<hash>-metabase"
+# dbt-docs uses the public `nginx:alpine` image directly (see
+# templates/docker-compose.yml.j2) and is never tagged with a dango-*
+# prefix, but the suffix is checked anyway for forward/cloud-template
+# compatibility — it is harmless if it never matches.
+_IMAGE_SUFFIXES = ("-metabase", "-dbt-docs")
+
+
+@dataclass
+class ResourceGroup:
+    """Every dango-* Docker resource sharing one Compose project name."""
+
+    project: str
+    working_dirs: list[str] = field(default_factory=list)
+    containers: list[str] = field(default_factory=list)
+    volumes: list[str] = field(default_factory=list)
+    images: list[str] = field(default_factory=list)
+    classification: str = ""  # "orphaned" | "needs_attention" | "live"
+
+
+def _list_dango_containers() -> list[dict[str, str]]:
+    """List every container (running or stopped), machine-wide, whose
+    com.docker.compose.project label starts with 'dango-'.
+
+    Returns [] if Docker is unavailable or the check fails — this is a
+    diagnostic listing, not a safety gate, so it fails open like the
+    identity guard in platform/docker.py.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                "label=com.docker.compose.project",
+                "--format",
+                '{{.ID}}\t{{.Names}}\t{{.Label "com.docker.compose.project"}}\t'
+                '{{.Label "com.docker.compose.project.working_dir"}}',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+    records = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) != 4:
+            continue
+        container_id, name, project, working_dir = parts
+        if not project.startswith("dango-"):
+            continue
+        records.append(
+            {"id": container_id, "name": name, "project": project, "working_dir": working_dir}
+        )
+    return records
+
+
+def _list_dango_volumes() -> list[str]:
+    """List every volume name, machine-wide, starting with 'dango-'."""
+    try:
+        result = subprocess.run(
+            ["docker", "volume", "ls", "--format", "{{.Name}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+    return [v.strip() for v in result.stdout.splitlines() if v.strip().startswith("dango-")]
+
+
+def _list_dango_images() -> list[str]:
+    """List every image repository name, machine-wide, starting with 'dango-'."""
+    try:
+        result = subprocess.run(
+            ["docker", "images", "--format", "{{.Repository}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+    return [i.strip() for i in result.stdout.splitlines() if i.strip().startswith("dango-")]
+
+
+def _project_from_resource_name(name: str) -> str | None:
+    """Derive the compose project name embedded in a dango-prefixed volume
+    or image name.
+
+    Volumes and images don't carry the working_dir label directly (only
+    containers do) — but Compose bakes the project name into their names
+    (``dango-<hash>_metabase-data`` for volumes, ``dango-<hash>-metabase``
+    for a locally-built image), so the project name can be recovered from
+    the name itself and cross-referenced against any container sharing it.
+    Returns None if the name doesn't match either known pattern.
+    """
+    if "_" in name:
+        candidate = name.rsplit("_", 1)[0]
+        if candidate.startswith("dango-"):
+            return candidate
+    for suffix in _IMAGE_SUFFIXES:
+        if name.endswith(suffix):
+            candidate = name[: -len(suffix)]
+            if candidate.startswith("dango-"):
+                return candidate
+    return None
+
+
+def _build_groups() -> list[ResourceGroup]:
+    """Collect every dango-* Docker resource machine-wide, grouped by
+    compose project name, and classify each group.
+
+    Classification (deliberately conservative — "if in doubt, needs
+    attention, never safe to clean"):
+      - No container exists for this project name (a bare orphaned volume
+        or image only): we have no working_dir label to verify against at
+        all -> "needs_attention".
+      - Containers exist but report more than one distinct working_dir
+        value for the same project name: this is the literal signature of
+        an identity collision (two different directories' containers
+        sharing one Compose project name at different points in time)
+        -> "needs_attention".
+      - Containers exist with exactly one working_dir value:
+          - that directory no longer exists on disk -> "orphaned" (safe to
+            offer for cleanup)
+          - that directory exists on disk -> "live" (a real project;
+            display only, never offer to remove it)
+    """
+    groups: dict[str, ResourceGroup] = {}
+
+    def _get(project: str) -> ResourceGroup:
+        if project not in groups:
+            groups[project] = ResourceGroup(project=project)
+        return groups[project]
+
+    for c in _list_dango_containers():
+        g = _get(c["project"])
+        g.containers.append(c["name"])
+        if c["working_dir"] and c["working_dir"] not in g.working_dirs:
+            g.working_dirs.append(c["working_dir"])
+
+    for v in _list_dango_volumes():
+        project = _project_from_resource_name(v)
+        if project:
+            _get(project).volumes.append(v)
+
+    for i in _list_dango_images():
+        project = _project_from_resource_name(i)
+        if project:
+            _get(project).images.append(i)
+
+    for g in groups.values():
+        if not g.containers:
+            g.classification = "needs_attention"
+        elif len(g.working_dirs) > 1:
+            g.classification = "needs_attention"
+        else:
+            working_dir = g.working_dirs[0]
+            g.classification = "orphaned" if not Path(working_dir).exists() else "live"
+
+    return sorted(groups.values(), key=lambda g: g.project)
+
+
+def _remove_group(group: ResourceGroup) -> None:
+    """Remove every container/volume/image in an orphaned group.
+
+    Caller (docker_audit()) guarantees this is only ever called for groups
+    classified "orphaned" — never "needs_attention" or "live".
+    """
+    if group.containers:
+        try:
+            result = subprocess.run(
+                ["docker", "rm", "-f", *group.containers],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                console.print(
+                    f"[green]✓[/green] Removed {len(group.containers)} "
+                    f"container(s) for {group.project}"
+                )
+            else:
+                console.print(
+                    f"[yellow]![/yellow] Could not remove containers for "
+                    f"{group.project}: {result.stderr.strip()}"
+                )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            console.print(f"[red]✗[/red] Failed to remove containers for {group.project}: {e}")
+
+    for vol in group.volumes:
+        try:
+            result = subprocess.run(
+                ["docker", "volume", "rm", vol], capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                console.print(f"[green]✓[/green] Removed volume {vol}")
+            else:
+                console.print(
+                    f"[yellow]![/yellow] Could not remove volume {vol}: {result.stderr.strip()}"
+                )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            console.print(f"[red]✗[/red] Failed to remove volume {vol}: {e}")
+
+    for img in group.images:
+        try:
+            result = subprocess.run(
+                ["docker", "rmi", img], capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                console.print(f"[green]✓[/green] Removed image {img}")
+            else:
+                console.print(
+                    f"[yellow]![/yellow] Could not remove image {img}: {result.stderr.strip()}"
+                )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            console.print(f"[red]✗[/red] Failed to remove image {img}: {e}")
+
+
+_STATUS_STYLE = {
+    "orphaned": "[yellow]Orphaned (safe to clean)[/yellow]",
+    "needs_attention": "[red]Needs attention[/red]",
+    "live": "[green]Live[/green]",
+}
+
+
+@click.command("docker-audit")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt before cleaning up.")
+@click.option(
+    "--dry-run", is_flag=True, help="List and classify resources only; never offer cleanup."
+)
+def docker_audit(yes: bool, dry_run: bool) -> None:
+    """List every dango-managed Docker resource on this machine and classify it.
+
+    Groups every ``dango-*`` container, volume, and image on the machine
+    (not just the current project) by their real Docker Compose project
+    identity, using Compose's own
+    ``com.docker.compose.project.working_dir`` label as ground truth rather
+    than guessing from names or hashes.
+
+    \b
+      - Orphaned:        working directory no longer exists — safe to clean.
+      - Needs attention: ambiguous (no container to verify against, or
+                          conflicting working_dir labels under one project
+                          name) — never auto-cleaned, investigate manually.
+      - Live:             working directory exists — a real project, shown
+                          for visibility only, never offered for removal.
+
+    Only the orphaned group can ever be cleaned, and only behind an
+    explicit confirmation prompt (or --yes).
+
+    Examples:
+
+    \b
+      dango docker-audit              List, classify, and offer cleanup
+      dango docker-audit --dry-run    List and classify only
+      dango docker-audit --yes        Clean up orphaned resources without prompting
+    """
+    console.print("🍡 [bold]Docker resource audit[/bold]\n")
+
+    groups = _build_groups()
+    if not groups:
+        console.print("[green]No dango-* Docker resources found on this machine.[/green]")
+        return
+
+    table = Table(title="Dango Docker resources", show_header=True, header_style="bold cyan")
+    table.add_column("Project", style="bold")
+    table.add_column("Working directory")
+    table.add_column("Containers", justify="right")
+    table.add_column("Volumes", justify="right")
+    table.add_column("Images", justify="right")
+    table.add_column("Status")
+
+    for g in groups:
+        if len(g.working_dirs) == 1:
+            wd_display = g.working_dirs[0]
+        elif g.working_dirs:
+            wd_display = "[red](multiple/conflicting)[/red]"
+        else:
+            wd_display = "[dim]unknown (no container)[/dim]"
+
+        table.add_row(
+            g.project,
+            wd_display,
+            str(len(g.containers)),
+            str(len(g.volumes)),
+            str(len(g.images)),
+            _STATUS_STYLE.get(g.classification, g.classification),
+        )
+
+    console.print(table)
+    console.print()
+
+    orphaned = [g for g in groups if g.classification == "orphaned"]
+    needs_attention = [g for g in groups if g.classification == "needs_attention"]
+
+    if needs_attention:
+        console.print(
+            f"[red]{len(needs_attention)} group(s) need attention[/red] — ambiguous identity, "
+            "never auto-cleaned. Investigate manually, e.g.:\n"
+            "  [dim]docker ps -a --filter label=com.docker.compose.project=<name>[/dim]\n"
+        )
+
+    if not orphaned:
+        console.print("[dim]No unambiguously orphaned resources to clean up.[/dim]")
+        return
+
+    console.print(
+        f"[yellow]{len(orphaned)} group(s) are orphaned[/yellow] "
+        "(working directory no longer exists on disk):"
+    )
+    for g in orphaned:
+        console.print(
+            f"  {g.project}: {len(g.containers)} container(s), "
+            f"{len(g.volumes)} volume(s), {len(g.images)} image(s)"
+        )
+    console.print()
+
+    if dry_run:
+        console.print("[dim]Dry run — re-run without --dry-run to clean these up.[/dim]")
+        return
+
+    if not yes and not safe_confirm(f"Remove {len(orphaned)} orphaned resource group(s)?"):
+        console.print("[yellow]Cancelled.[/yellow]")
+        return
+
+    for g in orphaned:
+        _remove_group(g)
+
+    console.print("\n[green]Cleanup complete.[/green]")

--- a/dango/cli/commands/platform.py
+++ b/dango/cli/commands/platform.py
@@ -146,6 +146,7 @@ def start(ctx: click.Context, yes: bool) -> None:
     Change port in .dango/project.yml under platform.port
     """
     from dango.config import ConfigLoader
+    from dango.exceptions import DockerIdentityCollisionError, format_structured_error
     from dango.platform.common.startup import (
         check_duckdb_version_alignment,
         ensure_dbt_schemas,
@@ -742,6 +743,21 @@ def start(ctx: click.Context, yes: bool) -> None:
         # User cancelled or intentional abort - re-raise without extra cleanup
         # (cleanup already handled where abort was raised)
         raise
+    except DockerIdentityCollisionError as e:
+        # Confirmed project-identity collision (BUGS-FOUND.md 2026-09-09) —
+        # do NOT attempt the generic rollback below, which would call
+        # stop_services() again for the same colliding compose project name.
+        # The whole point of this guard is to refuse to touch that project's
+        # containers at all until a human investigates.
+        console.print()
+        msg = format_structured_error(
+            what_failed="Docker project-identity collision detected",
+            causes=[str(e)],
+            suggested_fix="Run 'dango docker-audit' to investigate before taking any manual Docker action.",
+        )
+        console.print(f"[red]Error:[/red]\n{msg}")
+        console.print()
+        raise click.Abort() from e
     except Exception as e:
         # Unexpected error - roll back everything
         console.print()
@@ -798,6 +814,7 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
     from pathlib import Path
 
     from dango.config import ConfigLoader
+    from dango.exceptions import DockerIdentityCollisionError, format_structured_error
     from dango.platform import DockerManager
     from dango.platform.network import NetworkConfig
 
@@ -873,6 +890,14 @@ def stop(ctx: click.Context, stop_all: bool) -> None:
         console.print("[green]✅ All services stopped[/green]")
         console.print()
 
+    except DockerIdentityCollisionError as e:
+        msg = format_structured_error(
+            what_failed="Docker project-identity collision detected",
+            causes=[str(e)],
+            suggested_fix="Run 'dango docker-audit' to investigate before taking any manual Docker action.",
+        )
+        console.print(f"[red]Error:[/red]\n{msg}")
+        raise click.Abort() from e
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         from dango.exceptions import is_debug_mode

--- a/dango/cli/main.py
+++ b/dango/cli/main.py
@@ -17,6 +17,7 @@ from dango.cli.commands.dashboard import dashboard
 from dango.cli.commands.data import db, validate
 from dango.cli.commands.deploy import deploy
 from dango.cli.commands.dev import dev
+from dango.cli.commands.docker_audit import docker_audit
 from dango.cli.commands.doctor import doctor
 from dango.cli.commands.governance import governance
 from dango.cli.commands.local_backup import backup_group as local_backup_group
@@ -105,6 +106,7 @@ cli.add_command(serve)
 cli.add_command(upgrade)
 cli.add_command(cleanup)
 cli.add_command(doctor)
+cli.add_command(docker_audit)
 
 # --- Register command groups ---
 cli.add_command(source)

--- a/dango/exceptions.py
+++ b/dango/exceptions.py
@@ -39,6 +39,7 @@ __all__ = [
     "JobTimeoutError",
     "JobCancelledError",
     "VersionMismatchError",
+    "DockerIdentityCollisionError",
     "MigrationError",
     "MigrationDiscoveryError",
     "MigrationApplicationError",
@@ -269,6 +270,14 @@ class VersionMismatchError(InfrastructureError):
     """Python DuckDB and Metabase JDBC driver major.minor versions differ."""
 
     _default_error_code = "DANGO-U008"
+
+
+class DockerIdentityCollisionError(InfrastructureError):
+    """Raised when a Docker Compose project name already has containers
+    belonging to a different project directory than the one currently
+    being operated on."""
+
+    _default_error_code = "DANGO-U009"
 
 
 # ---------------------------------------------------------------------------

--- a/dango/platform/CLAUDE.md
+++ b/dango/platform/CLAUDE.md
@@ -73,7 +73,7 @@ platform/
 
 | File | Purpose | Key Symbols |
 |------|---------|-------------|
-| `docker.py` | Docker Compose lifecycle | `DockerManager`, `ServiceStatus` |
+| `docker.py` | Docker Compose lifecycle + project-identity collision guard (1.0.8-Q8) | `DockerManager`, `ServiceStatus`, `_get_existing_container_working_dirs()` |
 | `common/startup.py` | Shared startup helpers | `run_pending_migrations`, `ensure_dbt_schemas`, `check_duckdb_version_alignment`, `ensure_duckdb_driver`, `start_docker_services`, `setup_metabase_if_needed`, `import_dashboards` |
 | `local/network.py` | Shared nginx routing (local dev) | `NetworkConfig`, `NginxManager`, `HostsManager` |
 | `local/watcher.py` | File change detection | `DebouncedFileHandler`, `FileWatcher`, `MultiTargetWatcher`, `SyncTrigger` |
@@ -233,6 +233,7 @@ with patch.dict(sys.modules, {"paramiko": pm_mock}):
 ## Architecture Notes
 
 - **`docker.py` is shared** — both local and cloud use `DockerManager`. Cloud may add additional services but reuses the same Docker management abstraction.
+- **Project-identity collision guard (1.0.8-Q8)** — `get_compose_project_name()`'s MD5 path-hash is not a stable identifier (see its docstring and `DockerManager.compose_project_name`'s comment on the prior orphaning incident this same instability caused). `DockerManager._assert_no_identity_collision()` is called at the very start of both `start_services()` and `stop_services()`; it reads Docker's own `com.docker.compose.project.working_dir` label via `_get_existing_container_working_dirs()` and raises `DockerIdentityCollisionError` (`dango/exceptions.py`) on a confirmed mismatch against `self.project_root`. Fails open (never blocks) if the Docker check itself can't be performed — only a confirmed mismatch raises. `stop_services()` also re-verifies via the same label check after `docker compose down` reports exit 0, since exit 0 is not proof nothing is left running. `cli/commands/docker_audit.py` (`dango docker-audit`) is the machine-wide diagnostic/cleanup companion — this guard only protects the two DockerManager methods; it does not extend to the separate SSH-based `stop_services()`/`start_services()` in `cloud/backup.py` or the raw `docker compose stop/start` calls in `cloud/scheduled_backup.py`, which don't go through `DockerManager` at all.
 - **`local/` is local-only** — nginx routing and file watcher don't apply to cloud deployments (cloud uses Caddy, and `auto_sync=false`).
 - **`common/startup.py` raises, never displays** — no `console`, `click`, or `rich` imports. Callers (CLI, cloud serve) handle all user-facing output. Exception: `setup_metabase_if_needed()` swallows setup errors into the return dict rather than raising (callers decide severity).
 - **Shims for backwards compatibility** — existing code that imports from `dango.platform.watcher_lifecycle` continues to work without changes.

--- a/dango/platform/common/startup.py
+++ b/dango/platform/common/startup.py
@@ -155,6 +155,12 @@ def start_docker_services(project_root: Path) -> None:
     Raises:
         RuntimeError: If Docker daemon is not running, required ports are
             still occupied after cleanup, or services fail to start
+        DockerIdentityCollisionError: The compose project name for this
+            project root already has containers belonging to a confirmed
+            different project directory (raised by
+            ``DockerManager._assert_no_identity_collision()``, called at the
+            start of the ``stop_services()``/``start_services()`` calls
+            below). Never raised for Docker connectivity issues alone.
     """
     from dango.platform import DockerManager
 

--- a/dango/platform/docker.py
+++ b/dango/platform/docker.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
-from dango.exceptions import format_structured_error
+from dango.exceptions import DockerIdentityCollisionError, format_structured_error
 
 console = Console()
 
@@ -25,6 +25,44 @@ def get_compose_project_name(project_root: Path | str) -> str:
     """
     path_hash = hashlib.md5(str(project_root).encode(), usedforsecurity=False).hexdigest()[:8]
     return f"dango-{path_hash}"
+
+
+def _get_existing_container_working_dirs(compose_project_name: str) -> set[str]:
+    """Return the distinct com.docker.compose.project.working_dir label
+    values of any containers (running or stopped) that already exist under
+    this compose project name.
+
+    Empty set if none exist or if the check itself fails — this fails open
+    on Docker connectivity issues (unreachable daemon, missing CLI, slow
+    response) because this check exists to catch a *confirmed* mismatch, not
+    to add a general reliability dependency on Docker being reachable.
+
+    NOTE on ``--format`` syntax: the Go template helper for reading a single
+    label on ``docker ps`` is the ``.Label "<key>"`` method, NOT
+    ``index .Labels "<key>"`` (the latter fails at runtime — live-verified
+    against Docker 28.5.1: ``.Labels`` is a pre-joined ``k=v,k=v`` string on
+    this subcommand, not a map, so ``index`` cannot operate on it).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"label=com.docker.compose.project={compose_project_name}",
+                "--format",
+                '{{.Label "com.docker.compose.project.working_dir"}}',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return set()
+        return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return set()
 
 
 class ServiceStatus(str, Enum):
@@ -59,6 +97,40 @@ class DockerManager:
         env = os.environ.copy()
         env["COMPOSE_PROJECT_NAME"] = self.compose_project_name
         return env
+
+    def _assert_no_identity_collision(self) -> None:
+        """Refuse to proceed if this compose project name already belongs to
+        a different project directory.
+
+        Background: ``compose_project_name`` (above) is an MD5 hash of the
+        project's path string, truncated to 8 hex chars — not a stable
+        identifier (path casing, symlink resolution, or directory reuse can
+        change or collide it). On 2026-09-09 this class of bug destroyed a
+        real project's Metabase data: a scratch project's containers were
+        assumed-orphaned and torn down manually, but the compose project name
+        actually belonged to ``tests/beta-1``. This guard makes that mistake
+        structurally harder by checking Docker's own
+        ``com.docker.compose.project.working_dir`` label — the literal path
+        used to create the existing containers — against this instance's own
+        resolved path before any start/stop subprocess call proceeds.
+
+        Fails open (returns without raising) if the Docker check itself
+        can't be performed — see ``_get_existing_container_working_dirs()``.
+        Only a confirmed mismatch raises.
+        """
+        existing = _get_existing_container_working_dirs(self.compose_project_name)
+        if not existing:
+            return
+        current = str(self.project_root.resolve())
+        mismatched = existing - {current}
+        if mismatched:
+            raise DockerIdentityCollisionError(
+                f"Compose project '{self.compose_project_name}' already has containers "
+                f"belonging to a different project directory: {sorted(mismatched)}. "
+                f"Refusing to proceed — this is almost certainly a project-identity "
+                f"collision, not your project. Run 'dango docker-audit' to "
+                f"investigate before taking any manual action."
+            )
 
     def _metabase_image_exists(self) -> bool:
         """Check if the dango-metabase Docker image already exists locally."""
@@ -130,7 +202,16 @@ class DockerManager:
 
         Returns:
             True if successful, False otherwise
+
+        Raises:
+            DockerIdentityCollisionError: This compose project name already
+                has containers belonging to a different project directory
+                (confirmed via Docker's own working_dir label). Never raised
+                for Docker connectivity issues — see
+                ``_assert_no_identity_collision()``.
         """
+        self._assert_no_identity_collision()
+
         if not self.compose_file.exists():
             msg = format_structured_error(
                 what_failed="docker-compose.yml not found",
@@ -245,7 +326,16 @@ class DockerManager:
 
         Returns:
             True if successful, False otherwise
+
+        Raises:
+            DockerIdentityCollisionError: This compose project name already
+                has containers belonging to a different project directory
+                (confirmed via Docker's own working_dir label). Never raised
+                for Docker connectivity issues — see
+                ``_assert_no_identity_collision()``.
         """
+        self._assert_no_identity_collision()
+
         if not self.compose_file.exists():
             console.print("[yellow]Warning:[/yellow] docker-compose.yml not found")
             return True  # Nothing to stop
@@ -265,6 +355,19 @@ class DockerManager:
             )
 
             if result.returncode == 0:
+                # Honest reporting: `docker compose down` exiting 0 is not
+                # proof nothing is left running (BUGS-FOUND.md 2026-09-09 —
+                # this exact assumption contributed to the incident this
+                # module's identity guard exists to prevent). Re-verify via
+                # the same label-based check before claiming success.
+                survivors = _get_existing_container_working_dirs(self.compose_project_name)
+                if survivors:
+                    console.print(
+                        "[yellow]⚠[/yellow]  'docker compose down' exited successfully, but "
+                        f"container(s) still exist for project '{self.compose_project_name}'. "
+                        "Run 'docker ps -a' to inspect, or 'dango docker-audit' to investigate."
+                    )
+                    return False
                 console.print("[green]✓[/green] Services stopped")
                 self._warn_orphaned_containers()
                 return True

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -105,9 +105,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/platform/docker.py
-    lines: 508
+    lines: 611
     category: exempt
-    reason: "P0-3: Added all_projects parameter and conditional docker ps filtering for project-scoped container cleanup (+26 lines). Marginally over limit."
+    reason: "P0-3: Added all_projects parameter and conditional docker ps filtering for project-scoped container cleanup (+26 lines). 1.0.8-Q8: Added the project-identity collision guard (_get_existing_container_working_dirs(), DockerManager._assert_no_identity_collision(), called at the start of start_services()/stop_services()) plus honest stop-reporting re-verification after `docker compose down` — release-blocking fix for a real incident (BUGS-FOUND.md 2026-09-09) where an unstable path-hash compose project name led to a real project's Metabase data being destroyed. This logic must live alongside the Docker subprocess calls it guards, not in a new file."
     review_by: "v1.1"
 
   - file: tests/unit/test_process_manager.py

--- a/tests/unit/test_docker_cleanup_diagnostic.py
+++ b/tests/unit/test_docker_cleanup_diagnostic.py
@@ -1,0 +1,301 @@
+"""tests/unit/test_docker_cleanup_diagnostic.py
+
+Tests for `dango docker-audit` (dango/cli/commands/docker_audit.py), the
+machine-wide Docker resource diagnostic + cleanup command added in
+1.0.8-Q8. This is the tool that should have existed before the real
+2026-09-09 incident where an orphaned-looking scratch project's Docker
+Compose identity was confused with a different, real project's identity
+during manual cleanup, destroying that project's Metabase data.
+
+These are unit tests with mocked `subprocess.run`. Live verification
+against a real Docker daemon (a real orphaned scratch project created by
+`rm -rf`-ing its directory without stopping it first, and a real
+currently-running scratch project that must never be flagged as cleanable)
+was performed manually — see the PR description for the exact commands and
+output.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dango.cli.commands.docker_audit import (
+    ResourceGroup,
+    _build_groups,
+    _project_from_resource_name,
+    _remove_group,
+)
+
+
+def _docker_ps_line(container_id: str, name: str, project: str, working_dir: str) -> str:
+    return f"{container_id}\t{name}\t{project}\t{working_dir}"
+
+
+@pytest.mark.unit
+class TestProjectFromResourceName:
+    def test_volume_name_pattern(self):
+        assert _project_from_resource_name("dango-1fc60021_metabase-data") == "dango-1fc60021"
+
+    def test_image_name_pattern(self):
+        assert _project_from_resource_name("dango-1fc60021-metabase") == "dango-1fc60021"
+
+    def test_dbt_docs_image_suffix(self):
+        assert _project_from_resource_name("dango-1fc60021-dbt-docs") == "dango-1fc60021"
+
+    def test_no_match_returns_none(self):
+        assert _project_from_resource_name("unrelated-thing") is None
+
+    def test_non_dango_prefixed_volume_returns_none(self):
+        assert _project_from_resource_name("other-project_data") is None
+
+
+@pytest.mark.unit
+class TestBuildGroupsClassification:
+    """`_build_groups()` issues three subprocess.run calls in order:
+    containers (`docker ps -a`), volumes (`docker volume ls`), images
+    (`docker images`)."""
+
+    def test_orphaned_when_working_dir_missing(self, tmp_path):
+        """A container's working_dir no longer exists on disk -> orphaned,
+        safe to clean."""
+        missing_dir = str(tmp_path / "deleted-project")  # never created
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=_docker_ps_line(
+                        "abc123", "dango-aaa1111-metabase-1", "dango-aaa1111", missing_dir
+                    ),
+                ),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            groups = _build_groups()
+
+        assert len(groups) == 1
+        assert groups[0].classification == "orphaned"
+        assert groups[0].project == "dango-aaa1111"
+
+    def test_live_when_working_dir_exists(self, tmp_path):
+        """A container's working_dir exists on disk -> live, never offered
+        for cleanup."""
+        live_dir = tmp_path / "live-project"
+        live_dir.mkdir()
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=_docker_ps_line(
+                        "def456", "dango-bbb2222-metabase-1", "dango-bbb2222", str(live_dir)
+                    ),
+                ),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            groups = _build_groups()
+
+        assert len(groups) == 1
+        assert groups[0].classification == "live"
+
+    def test_needs_attention_when_no_container(self):
+        """A bare volume with no matching container -> needs_attention
+        (cannot verify anything about it), never auto-cleaned."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # no containers
+                MagicMock(returncode=0, stdout="dango-ccc3333_metabase-data\n"),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            groups = _build_groups()
+
+        assert len(groups) == 1
+        assert groups[0].classification == "needs_attention"
+        assert groups[0].project == "dango-ccc3333"
+        assert groups[0].volumes == ["dango-ccc3333_metabase-data"]
+
+    def test_needs_attention_when_multiple_working_dirs(self, tmp_path):
+        """Containers under the SAME project name reporting more than one
+        distinct working_dir -- the literal signature of an identity
+        collision -- must be flagged needs_attention, not orphaned or live,
+        regardless of whether either directory exists on disk."""
+        dir_a = str(tmp_path / "a")
+        dir_b = str(tmp_path / "b")
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=(
+                        _docker_ps_line("c1", "dango-ddd4444-metabase-1", "dango-ddd4444", dir_a)
+                        + "\n"
+                        + _docker_ps_line("c2", "dango-ddd4444-fake", "dango-ddd4444", dir_b)
+                    ),
+                ),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            groups = _build_groups()
+
+        assert len(groups) == 1
+        assert groups[0].classification == "needs_attention"
+        assert set(groups[0].working_dirs) == {dir_a, dir_b}
+
+    def test_volumes_and_images_cross_referenced_to_container_group(self, tmp_path):
+        """A volume and image sharing a project name with a live container
+        are folded into that same group, not treated as separate entries."""
+        live_dir = tmp_path / "live-project"
+        live_dir.mkdir()
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=_docker_ps_line(
+                        "abc", "dango-eee5555-metabase-1", "dango-eee5555", str(live_dir)
+                    ),
+                ),
+                MagicMock(returncode=0, stdout="dango-eee5555_metabase-data\n"),
+                MagicMock(returncode=0, stdout="dango-eee5555-metabase\n"),
+            ]
+            groups = _build_groups()
+
+        assert len(groups) == 1
+        g = groups[0]
+        assert g.classification == "live"
+        assert g.volumes == ["dango-eee5555_metabase-data"]
+        assert g.images == ["dango-eee5555-metabase"]
+
+    def test_fails_open_to_empty_on_docker_error(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            groups = _build_groups()
+        assert groups == []
+
+
+@pytest.mark.unit
+class TestRemoveGroupOnlyActsOnPassedGroup:
+    """_remove_group() has no classification awareness of its own — the
+    caller (docker_audit()) is responsible for only ever passing orphaned
+    groups. These tests confirm it only issues commands for the resources
+    listed on the group it's given, never anything else."""
+
+    @patch("dango.cli.commands.docker_audit.console")
+    def test_removes_containers_volumes_and_images_in_group(self, _mock_console):
+        group = ResourceGroup(
+            project="dango-fff6666",
+            working_dirs=["/deleted/path"],
+            containers=["dango-fff6666-metabase-1"],
+            volumes=["dango-fff6666_metabase-data"],
+            images=["dango-fff6666-metabase"],
+            classification="orphaned",
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _remove_group(group)
+
+        commands_run = [call.args[0] for call in mock_run.call_args_list]
+        assert ["docker", "rm", "-f", "dango-fff6666-metabase-1"] in commands_run
+        assert ["docker", "volume", "rm", "dango-fff6666_metabase-data"] in commands_run
+        assert ["docker", "rmi", "dango-fff6666-metabase"] in commands_run
+
+    @patch("dango.cli.commands.docker_audit.console")
+    def test_empty_group_issues_no_commands(self, _mock_console):
+        group = ResourceGroup(project="dango-000000", classification="orphaned")
+        with patch("subprocess.run") as mock_run:
+            _remove_group(group)
+        mock_run.assert_not_called()
+
+
+@pytest.mark.unit
+class TestDockerAuditCLIOnlyOffersOrphanedGroup:
+    """Integration-style test of the docker_audit() command itself: given a
+    mix of live / needs_attention / orphaned groups, only the orphaned one
+    may ever be removed, and only behind confirmation."""
+
+    def test_cleanup_skips_when_declined(self, tmp_path):
+        from click.testing import CliRunner
+
+        from dango.cli.commands.docker_audit import docker_audit
+
+        live_dir = tmp_path / "live"
+        live_dir.mkdir()
+        missing_dir = str(tmp_path / "gone")
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("dango.cli.commands.docker_audit._remove_group") as mock_remove,
+        ):
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=(
+                        _docker_ps_line("c1", "dango-live-1", "dango-1111", str(live_dir))
+                        + "\n"
+                        + _docker_ps_line("c2", "dango-orphan-1", "dango-2222", missing_dir)
+                    ),
+                ),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            runner = CliRunner()
+            result = runner.invoke(docker_audit, input="no\n")
+
+        assert result.exit_code == 0
+        mock_remove.assert_not_called()
+
+    def test_cleanup_with_yes_only_removes_orphaned_group(self, tmp_path):
+        from click.testing import CliRunner
+
+        from dango.cli.commands.docker_audit import docker_audit
+
+        live_dir = tmp_path / "live"
+        live_dir.mkdir()
+        missing_dir = str(tmp_path / "gone")
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("dango.cli.commands.docker_audit._remove_group") as mock_remove,
+        ):
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=(
+                        _docker_ps_line("c1", "dango-live-1", "dango-1111", str(live_dir))
+                        + "\n"
+                        + _docker_ps_line("c2", "dango-orphan-1", "dango-2222", missing_dir)
+                    ),
+                ),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            runner = CliRunner()
+            result = runner.invoke(docker_audit, ["--yes"])
+
+        assert result.exit_code == 0
+        mock_remove.assert_called_once()
+        removed_group = mock_remove.call_args[0][0]
+        assert removed_group.project == "dango-2222"
+        assert removed_group.classification == "orphaned"
+
+    def test_dry_run_never_removes_anything(self, tmp_path):
+        from click.testing import CliRunner
+
+        from dango.cli.commands.docker_audit import docker_audit
+
+        missing_dir = str(tmp_path / "gone")
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("dango.cli.commands.docker_audit._remove_group") as mock_remove,
+        ):
+            mock_run.side_effect = [
+                MagicMock(
+                    returncode=0,
+                    stdout=_docker_ps_line("c2", "dango-orphan-1", "dango-2222", missing_dir),
+                ),
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout=""),
+            ]
+            runner = CliRunner()
+            result = runner.invoke(docker_audit, ["--dry-run"])
+
+        assert result.exit_code == 0
+        mock_remove.assert_not_called()

--- a/tests/unit/test_docker_identity_guard.py
+++ b/tests/unit/test_docker_identity_guard.py
@@ -1,0 +1,296 @@
+"""tests/unit/test_docker_identity_guard.py
+
+Tests for the Docker project-identity collision guard added in 1.0.8-Q8.
+
+Background: get_compose_project_name() derives a project's Docker Compose
+identity from an MD5 hash of its path string — not a stable identifier. On
+2026-09-09 this contributed to a real incident where a real project's
+Metabase data was destroyed during manual cleanup of what looked like an
+orphaned scratch project, based on an insufficiently-verified assumption
+about which project a compose project name actually belonged to.
+
+These are unit tests with mocked ``subprocess.run``. Live verification
+against a real Docker daemon (two real scratch directories forced to share
+one compose project name) was performed manually — see the PR description
+for the exact commands and output; that live check cannot be run in CI
+because it requires a real Docker daemon and mutates real containers.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from dango.exceptions import DockerIdentityCollisionError
+from dango.platform.docker import DockerManager, _get_existing_container_working_dirs
+
+
+@pytest.mark.unit
+class TestGetExistingContainerWorkingDirs:
+    def test_no_collision_when_no_existing_containers(self):
+        """Empty docker ps result -> empty set, no exception."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = _get_existing_container_working_dirs("dango-abc123")
+        assert result == set()
+
+    def test_uses_dot_label_format_not_index_labels(self):
+        """Regression guard for the exact --format syntax.
+
+        Live-verified against Docker 28.5.1 / Compose v2.40.2: the
+        prompt-proposed ``{{index .Labels "..."}}`` syntax FAILS at runtime
+        on `docker ps` (`.Labels` is a pre-joined "k=v,k=v" string on this
+        subcommand, not a map — `index` cannot operate on it). The correct
+        syntax is the ``.Label "<key>"`` method. This test locks in the
+        working syntax so a future "cleanup" doesn't silently reintroduce
+        the broken one (which would make the guard permanently fail open,
+        the exact class of unverified assumption this task exists to
+        eliminate).
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            _get_existing_container_working_dirs("dango-abc123")
+
+        call_args = mock_run.call_args[0][0]
+        format_arg = call_args[call_args.index("--format") + 1]
+        assert format_arg == '{{.Label "com.docker.compose.project.working_dir"}}'
+        assert "index" not in format_arg
+        assert ".Labels" not in format_arg
+
+    def test_returns_distinct_working_dirs(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="/path/a\n/path/a\n/path/b\n")
+            result = _get_existing_container_working_dirs("dango-abc123")
+        assert result == {"/path/a", "/path/b"}
+
+    def test_fails_open_on_nonzero_returncode(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = _get_existing_container_working_dirs("dango-abc123")
+        assert result == set()
+
+    def test_fails_open_on_timeout(self):
+        import subprocess as subprocess_module
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess_module.TimeoutExpired(cmd="docker", timeout=10)
+            result = _get_existing_container_working_dirs("dango-abc123")
+        assert result == set()
+
+    def test_fails_open_on_missing_docker_cli(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("docker not found")
+            result = _get_existing_container_working_dirs("dango-abc123")
+        assert result == set()
+
+
+@pytest.mark.unit
+class TestAssertNoIdentityCollision:
+    def test_no_collision_when_no_existing_containers(self, tmp_path):
+        """No existing containers under this project name -> guard passes silently."""
+        manager = DockerManager(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            manager._assert_no_identity_collision()  # must not raise
+
+    def test_no_collision_when_working_dir_matches(self, tmp_path):
+        """Existing containers under this project name whose working_dir
+        matches the current project root -> guard passes."""
+        manager = DockerManager(tmp_path)
+        current = str(tmp_path.resolve())
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"{current}\n")
+            manager._assert_no_identity_collision()  # must not raise
+
+    def test_raises_on_working_dir_mismatch(self, tmp_path):
+        """Existing containers under this project name with a *different*
+        working_dir -> DockerIdentityCollisionError, with the mismatched
+        path in the message."""
+        manager = DockerManager(tmp_path)
+        other_path = "/some/other/project/directory"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"{other_path}\n")
+            with pytest.raises(DockerIdentityCollisionError) as exc_info:
+                manager._assert_no_identity_collision()
+
+        assert other_path in str(exc_info.value)
+        assert manager.compose_project_name in str(exc_info.value)
+
+    def test_guard_fails_open_on_docker_error(self, tmp_path):
+        """docker ps subprocess raises/times out -> guard does not raise,
+        proceeds silently (fail-open)."""
+        import subprocess as subprocess_module
+
+        manager = DockerManager(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess_module.TimeoutExpired(cmd="docker", timeout=10)
+            manager._assert_no_identity_collision()  # must not raise
+
+    def test_partial_mismatch_still_raises(self, tmp_path):
+        """If the existing set contains BOTH the current working_dir and a
+        mismatched one (e.g. stale + fresh containers), the mismatch must
+        still be caught rather than short-circuited by the match."""
+        manager = DockerManager(tmp_path)
+        current = str(tmp_path.resolve())
+        other_path = "/some/other/project/directory"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"{current}\n{other_path}\n")
+            with pytest.raises(DockerIdentityCollisionError):
+                manager._assert_no_identity_collision()
+
+
+@pytest.mark.unit
+class TestStartStopCallTheGuard:
+    """start_services()/stop_services() must call the guard before doing
+    anything else, and must let a confirmed collision propagate as an
+    exception rather than swallowing it into a bool return."""
+
+    @patch("dango.platform.docker.console")
+    def test_start_services_raises_before_touching_docker(self, _mock_console, tmp_path):
+        manager = DockerManager(tmp_path)
+        other_path = "/some/other/project/directory"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"{other_path}\n")
+            with pytest.raises(DockerIdentityCollisionError):
+                manager.start_services()
+
+        # Only the guard's own `docker ps` call should have happened — no
+        # `docker compose up` subprocess call.
+        assert mock_run.call_count == 1
+        called_cmd = mock_run.call_args_list[0][0][0]
+        assert "ps" in called_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_stop_services_raises_before_touching_docker(self, _mock_console, tmp_path):
+        manager = DockerManager(tmp_path)
+        other_path = "/some/other/project/directory"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"{other_path}\n")
+            with pytest.raises(DockerIdentityCollisionError):
+                manager.stop_services()
+
+        assert mock_run.call_count == 1
+        called_cmd = mock_run.call_args_list[0][0][0]
+        assert "ps" in called_cmd
+
+    @patch("dango.platform.docker.console")
+    def test_start_services_proceeds_normally_with_no_collision(self, _mock_console, tmp_path):
+        """Regression check: the overwhelmingly common case (no existing
+        containers under this project name) must proceed exactly as
+        before — the guard adds one fast `docker ps` call, nothing else."""
+        (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+        manager = DockerManager(tmp_path)
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(manager, "is_docker_available", return_value=True),
+            patch.object(manager, "is_compose_available", return_value=True),
+            patch.object(manager, "get_compose_command", return_value=["docker", "compose"]),
+            patch.object(manager, "_metabase_image_exists", return_value=True),
+            patch.object(manager, "_print_service_urls"),
+        ):
+            # Only one real subprocess.run call is left unmocked-via-patch.object:
+            # the guard's `docker ps` (empty = no collision), followed by the
+            # actual `docker compose ... up -d` call.
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),
+                MagicMock(returncode=0, stdout="", stderr=""),
+            ]
+            result = manager.start_services()
+
+        assert result is True
+        assert mock_run.call_count == 2
+
+
+@pytest.mark.unit
+class TestStopServicesHonestReporting:
+    @patch("dango.platform.docker.console")
+    def test_stop_services_reports_failure_when_containers_survive_down(
+        self, _mock_console, tmp_path
+    ):
+        """`docker compose down` reports exit 0, but a follow-up `docker
+        ps` check still finds containers under this project name ->
+        stop_services() must not print/return unqualified success."""
+        (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+        manager = DockerManager(tmp_path)
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(manager, "get_compose_command", return_value=["docker", "compose"]),
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # guard: no collision
+                MagicMock(returncode=0, stdout="", stderr=""),  # docker compose down
+                MagicMock(returncode=0, stdout="/some/leftover/dir\n"),  # post-down verify
+            ]
+            result = manager.stop_services()
+
+        assert result is False
+
+    @patch("dango.platform.docker.console")
+    def test_stop_services_reports_success_when_containers_actually_gone(
+        self, _mock_console, tmp_path
+    ):
+        """Sanity check for the same code path: when the post-down
+        verification finds nothing, stop_services() still reports True."""
+        (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+        manager = DockerManager(tmp_path)
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch.object(manager, "get_compose_command", return_value=["docker", "compose"]),
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # guard: no collision
+                MagicMock(returncode=0, stdout="", stderr=""),  # docker compose down
+                MagicMock(returncode=0, stdout=""),  # post-down verify: nothing left
+            ]
+            result = manager.stop_services()
+
+        assert result is True
+
+
+@pytest.mark.unit
+class TestCLILayerCatchesCollision:
+    """`dango stop` must present a clean, structured error for a confirmed
+    identity collision — never a raw traceback. `dango start` is not
+    exercised here (its setup requires far more mocking of unrelated
+    startup steps); the exception-handling wiring is identical in shape for
+    both commands (see cli/commands/platform.py)."""
+
+    def test_stop_prints_structured_error_not_traceback(self, tmp_path):
+        from dango.cli.commands.platform import stop
+
+        mock_config = MagicMock()
+        mock_config.project.name = "test-project"
+
+        with (
+            patch("dango.cli.utils.require_project_context", return_value=tmp_path),
+            patch("dango.config.ConfigLoader") as mock_loader_cls,
+            patch(
+                "dango.platform.local.watcher_lifecycle.get_watcher_status",
+                return_value={"running": False},
+            ),
+            patch("dango.platform.local.watcher_lifecycle.stop_file_watcher", return_value=True),
+            patch("dango.platform.local.watcher_lifecycle.kill_orphan_watchers", return_value=0),
+            patch("dango.notebooks.manager.get_marimo_status", return_value={"running": False}),
+            patch("dango.notebooks.manager.stop_idle_checker"),
+            patch("dango.notebooks.manager.stop_marimo", return_value=True),
+            patch("dango.cli.helpers.process_manager.stop_fastapi_server"),
+            patch("dango.platform.DockerManager") as mock_manager_cls,
+        ):
+            mock_loader_cls.return_value.load_config.return_value = mock_config
+            mock_manager_cls.return_value.stop_services.side_effect = DockerIdentityCollisionError(
+                "Compose project 'dango-abc123' already has containers belonging to a "
+                "different project directory: ['/some/other/path']."
+            )
+
+            runner = CliRunner()
+            result = runner.invoke(stop, obj={})
+
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        assert "Docker project-identity collision detected" in result.output
+        assert "dango-abc123" in result.output


### PR DESCRIPTION
## Summary
- Real incident, 2026-09-09: a project's Docker Compose identity (an MD5 hash of its path string)
  collided/was confused with another real project's identity, leading to that project's Metabase
  data being destroyed via manual cleanup based on an insufficiently-verified assumption.
- Adds a hard identity-collision guard to start_services()/stop_services(), using Docker Compose's
  own com.docker.compose.project.working_dir label to verify a project name actually belongs to
  the project operating on it, before proceeding.
- Fixes stop_services() silently reporting success when docker compose down's exit code 0 didn't
  actually mean the containers were gone.
- Adds `dango docker-audit` — a new diagnostic/cleanup command that surfaces every dango-managed
  Docker resource on the machine, grouped by real project identity, so recovery from confusion (or
  a future incident) doesn't require manual docker ps/hash archaeology.
- This is Phase 1 of 2 — the root cause (unstable path-hash identity itself) is fixed separately
  in Q9, which depends on this task's helpers.

## Command name chosen: `docker-audit`

Surveyed `cli/commands/platform.py` and `cli/main.py`'s registration pattern before naming it.
`dango doctor` (`cli/commands/doctor.py`) is explicitly scoped to credential health only per its
own module docstring, so this is a new, separately-named top-level command — not an extension of
`doctor`. `docker-audit` was chosen over a `docker` group with subcommands because the command
does one thing (list + classify, with an opt-in cleanup step gated by confirmation), matching the
existing single-command shape of `cleanup` rather than the multi-subcommand shape of groups like
`remote`/`auth`.

## Verification

- `pytest -x`: 4641 passed, 30 skipped, 0 failed (full suite, not a subset)
- `ruff check dango/`: All checks passed
- `ruff format --check dango/`: passed (after running `ruff format` on the two new test files)
- `mypy dango/`: Success: no issues found in 241 source files

### Live-verified: exact `docker ps --format` label syntax (before trusting it)

The prompt's proposed syntax was **wrong** and fails at runtime against a real Docker daemon
(Docker 28.5.1 / Compose v2.40.2):

```
$ docker ps -a --filter "label=com.docker.compose.project=dango-testhash1" \
    --format '{{index .Labels "com.docker.compose.project.working_dir"}}'
failed to execute template: template: :1:2: executing "" at <index .Labels "com.docker.compose.project.working_dir">:
error calling index: cannot index slice/array with type string
```

`.Labels` on `docker ps` is a pre-joined `k=v,k=v` string, not a map, so `index` cannot operate on
it. The correct, live-verified syntax uses the `.Label` method instead:

```
$ docker ps -a --filter "label=com.docker.compose.project=dango-testhash1" \
    --format '{{.Label "com.docker.compose.project.working_dir"}}'
/private/tmp/.../scratchpad/docklab
```

`_get_existing_container_working_dirs()` in `dango/platform/docker.py` uses the corrected syntax,
with a code comment documenting why (so a future "cleanup" doesn't silently reintroduce the broken
form). A unit test (`test_uses_dot_label_format_not_index_labels`) locks in the working syntax.

### Live-verified: the guard blocks a real, reproduced identity collision

Used two real scratch directories (`liveA`, `liveB`) and monkeypatched `DockerManager.compose_project_name`
to force both to resolve to the same name (`dango-forcedcollision1`) — the actual MD5 hash
collision itself isn't practical to force by hand, per the task's own guidance, so this directly
exercises the guard function against two different real, resolved paths sharing one compose
project name, with real containers actually running under Docker.

```
=== Starting A under forced shared name ===
✓ Services started successfully
A start_services() -> True
=== B (different real directory, same forced name) calling stop_services() ===
CORRECTLY RAISED DockerIdentityCollisionError:
  Compose project 'dango-forcedcollision1' already has containers belonging to a different
  project directory: ['/private/tmp/.../scratchpad/liveA']. Refusing to proceed...
=== B calling start_services() ===
CORRECTLY RAISED DockerIdentityCollisionError: (same message)
=== A (legitimate owner) calling stop_services() - should succeed ===
✓ Services stopped
A stop_services() -> True
```

The legitimate owner (A) was never blocked; only the colliding directory (B) was refused, for both
`start_services()` and `stop_services()`.

### Live-verified: `dango docker-audit` correctly classifies real orphaned vs. real live resources

Created two real scratch projects with real running containers (`live-proj`, `orphan-proj`), then
`rm -rf`'d `orphan-proj`'s directory **without stopping it first** (reproducing exactly the
incident precondition) while `live-proj` kept running:

```
$ dango docker-audit --dry-run
┌────────────────┬───────────────────────────────┬────────────┬─────────┬────────┬───────────────────────┐
│ Project        │ Working directory              │ Containers │ Volumes │ Images │ Status                │
├────────────────┼───────────────────────────────-┼────────────┼─────────┼────────┼───────────────────────┤
│ dango-18115277 │ /private/tmp/.../live-proj      │          1 │       1 │      0 │ Live                  │
│ dango-217a153d │ /private/tmp/.../orphan-proj    │          1 │       1 │      0 │ Orphaned (safe to clean) │
│ ... (17 other pre-existing dangling dango-* volumes/images on this machine from unrelated past
│      test sessions, all correctly classified "Needs attention" since none has a matching
│      container to verify a working_dir against) ...
└────────────────┴────────────────────────────────┴────────────┴─────────┴────────┴───────────────────────┘
1 group(s) are orphaned (working directory no longer exists on disk):
  dango-217a153d: 1 container(s), 1 volume(s), 0 image(s)
```

Then ran `dango docker-audit --yes` and confirmed:
- The orphaned group (`dango-217a153d`) was removed: container + volume both gone afterward.
- The live group (`dango-18115277`) was completely untouched — container and volume both still
  present and running afterward.
- All 17 "needs attention" groups (real pre-existing machine state, not staged by me) were left
  untouched, as designed — this incidentally validated the conservative classification logic
  against messy real-world state, not just a clean synthetic scenario.

Additionally constructed a synthetic "needs attention" case (two containers under one compose
project name with two different `working_dir` labels, faked via a raw `docker run --label`
alongside a real `docker compose up`) to verify the multi-working-dir collision signature is
caught and never offered for cleanup — confirmed in output, then cleaned up.

All scratch containers/volumes/directories created for these tests were torn down manually after
verification; `tests/beta-1` and other existing project directories on the machine were never
touched.

## Regression check

- Confirmed the guard fails open (never blocks) when the Docker check itself errors — unit tests
  `test_guard_fails_open_on_docker_error`, `test_fails_open_on_timeout`,
  `test_fails_open_on_missing_docker_cli`, `test_fails_open_on_nonzero_returncode`.
- Confirmed the normal, non-colliding case proceeds exactly as before, at the cost of one extra
  fast `docker ps` call — `test_start_services_proceeds_normally_with_no_collision`.
- Confirmed the diagnostic command's cleanup path never touches a resource whose working_dir still
  exists on disk (live-verified above), and never touches an ambiguous "needs attention" group —
  unit tests `TestRemoveGroupOnlyActsOnPassedGroup`, `TestDockerAuditCLIOnlyOffersOrphanedGroup`.
- `DockerIdentityCollisionError` is caught explicitly at the CLI layer in both `dango start` and
  `dango stop` (`cli/commands/platform.py`), printed via the existing `format_structured_error()`
  pattern — no raw traceback reaches the user (verified via `test_stop_prints_structured_error_not_traceback`).
- `docker.py` grew from 508 to 611 lines (already had a pre-existing file-size exemption at 508 —
  updated `docs/file-exemptions.yml` with the new line count and reason, per repo convention). The
  guard logic must live alongside the Docker subprocess calls it protects, not in a separate file.
- Updated `dango/cli/CLAUDE.md` and `dango/platform/CLAUDE.md` to document the new command and
  guard (including the explicit note that this guard does not extend to the separate SSH-based
  `stop_services()`/`start_services()` in `cloud/backup.py` or the raw `docker compose` calls in
  `cloud/scheduled_backup.py`, which don't go through `DockerManager` — out of scope for this
  Phase 1 task).

## Deviations from the prompt (flagged per instructions)

1. **`docker ps --format` label syntax was wrong in the prompt** — see live verification above.
   Corrected to `{{.Label "<key>"}}`.
2. All file/line references in the prompt's "What to read first" section (docker.py line ranges,
   exceptions.py InfrastructureError location, doctor.py scope) were verified against live code
   and matched exactly — no other discrepancies found.
3. Command name (`docker-audit`) was chosen per the prompt's instruction to survey existing
   conventions rather than guess — not itself a deviation, but stating the choice explicitly as
   requested.

Do NOT merge — coordinating chat handles merges after beta-1 verification.