### PR TITLE
1.0.8-X: Fix Metabase schema-sync race

### DIFF
--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -1250,7 +1250,15 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
         # Capture a baseline task id before triggering the re-sync, so the poll
         # below can identify the specific "sync" task this call triggers (as
         # opposed to some earlier/unrelated sync task for the same database).
-        baseline_task_id = 0
+        # baseline_task_id is intentionally left as None (not 0) when this
+        # lookup fails — defaulting to 0 would let ANY historical "sync" task
+        # for this database (there's almost always one, for any database past
+        # first setup) match "id > baseline" and be mistaken for the task this
+        # call is about to trigger, breaking the poll loop instantly on an
+        # already-finished, unrelated task. That's the same false-positive
+        # failure mode this whole fix exists to remove, just reached via a
+        # flaky baseline call instead of the old initial_sync_status field.
+        baseline_task_id: int | None = None
         try:
             baseline_resp = session.get(
                 f"{metabase_url}/api/task",
@@ -1260,13 +1268,9 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
             )
             if baseline_resp.status_code == 200:
                 baseline_tasks = baseline_resp.json().get("data", [])
-                if baseline_tasks:
-                    baseline_task_id = max(t.get("id", 0) for t in baseline_tasks)
+                baseline_task_id = max((t.get("id", 0) for t in baseline_tasks), default=0)
         except Exception:
-            # Non-fatal — worst case we just fall back to matching any "sync"
-            # task for this database, which is still far better than the old
-            # initial_sync_status check.
-            baseline_task_id = 0
+            baseline_task_id = None
 
         # Trigger sync
         response = session.post(
@@ -1278,42 +1282,74 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
         if response.status_code != 200:
             return False
 
-        # Wait for the async re-sync to settle (poll up to 30 seconds).
-        # initial_sync_status only reflects the database's one-time initial
-        # onboarding sync, not this re-scan — for any database past first
-        # setup that field is already "complete" and this poll would
-        # otherwise exit instantly, before the re-scan has actually found
-        # new tables. Instead, poll Metabase's task log (GET /api/task) for
-        # the specific "sync" task this sync_schema call triggered (its id
-        # is greater than the baseline captured above) and wait for its
-        # status to leave "started".
         import time
 
-        for _ in range(30):
-            time.sleep(1)
-            try:
-                task_resp = session.get(
-                    f"{metabase_url}/api/task",
-                    headers={"X-Metabase-Session": session_id},
-                    params={"db_id": database_id, "limit": 20},
-                    timeout=5,
-                )
-            except Exception:
-                continue
+        if baseline_task_id is None:
+            # Couldn't establish a pre-trigger baseline — without one we can't
+            # safely tell a newly-triggered "sync" task apart from an older,
+            # already-finished one (see note above), so the task-status poll
+            # below isn't safe to run. Fall back to a short fixed wait instead
+            # of guessing, then fall through to the metadata fetch as usual.
+            logger.warning(
+                "sync_metabase_schema: could not establish a baseline task id "
+                "before triggering the re-sync (GET /api/task failed) — "
+                "falling back to a fixed wait instead of task-status polling. "
+                "database_id=%s",
+                database_id,
+            )
+            time.sleep(5)
+        else:
+            # Wait for the async re-sync to settle. initial_sync_status only
+            # reflects the database's one-time initial onboarding sync, not
+            # this re-scan — for any database past first setup that field is
+            # already "complete" and this poll would otherwise exit instantly,
+            # before the re-scan has actually found new tables. Instead, poll
+            # Metabase's task log (GET /api/task) for the specific "sync" task
+            # this sync_schema call triggered (its id is greater than the
+            # baseline captured above) and wait for its status to leave
+            # "started". Bounded at 30 iterations of 1s sleep + up to 5s per
+            # request each — in the worst case (a consistently slow but not
+            # outright failing API) this can run longer than a strict 30s,
+            # up to roughly 30 * (1 + 5) = 180s.
+            for _ in range(30):
+                time.sleep(1)
+                try:
+                    task_resp = session.get(
+                        f"{metabase_url}/api/task",
+                        headers={"X-Metabase-Session": session_id},
+                        params={"db_id": database_id, "limit": 20},
+                        timeout=5,
+                    )
+                    if task_resp.status_code != 200:
+                        continue
+                    task_data = task_resp.json().get("data", [])
+                except Exception:
+                    continue
 
-            if task_resp.status_code != 200:
-                continue
+                sync_tasks = [
+                    t
+                    for t in task_data
+                    if t.get("task") == "sync" and t.get("id", 0) > baseline_task_id
+                ]
+                if not sync_tasks:
+                    continue
 
-            sync_tasks = [
-                t
-                for t in task_resp.json().get("data", [])
-                if t.get("task") == "sync" and t.get("id", 0) > baseline_task_id
-            ]
-            if not sync_tasks:
-                continue
-
-            latest_sync_task = max(sync_tasks, key=lambda t: t.get("id", 0))
-            if latest_sync_task.get("status") != "started":
+                latest_sync_task = max(sync_tasks, key=lambda t: t.get("id", 0))
+                status = latest_sync_task.get("status")
+                if status == "started":
+                    continue
+                if status != "success":
+                    # Covers "failed"/other terminal states and a missing
+                    # status field — still stop polling (the task is done,
+                    # just not successfully), but make sure this is visible
+                    # instead of silently reporting success below.
+                    logger.warning(
+                        "sync_metabase_schema: triggered re-sync task ended "
+                        "with unexpected status %r (task_id=%s, database_id=%s)",
+                        status,
+                        latest_sync_task.get("id"),
+                        database_id,
+                    )
                 break
 
         # Update table descriptions to guide users

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -1247,6 +1247,27 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
         if not session_id:
             return False
 
+        # Capture a baseline task id before triggering the re-sync, so the poll
+        # below can identify the specific "sync" task this call triggers (as
+        # opposed to some earlier/unrelated sync task for the same database).
+        baseline_task_id = 0
+        try:
+            baseline_resp = session.get(
+                f"{metabase_url}/api/task",
+                headers={"X-Metabase-Session": session_id},
+                params={"db_id": database_id, "limit": 1},
+                timeout=5,
+            )
+            if baseline_resp.status_code == 200:
+                baseline_tasks = baseline_resp.json().get("data", [])
+                if baseline_tasks:
+                    baseline_task_id = max(t.get("id", 0) for t in baseline_tasks)
+        except Exception:
+            # Non-fatal — worst case we just fall back to matching any "sync"
+            # task for this database, which is still far better than the old
+            # initial_sync_status check.
+            baseline_task_id = 0
+
         # Trigger sync
         response = session.post(
             f"{metabase_url}/api/database/{database_id}/sync_schema",
@@ -1257,24 +1278,43 @@ def sync_metabase_schema(project_root: Path, metabase_url: str = "http://localho
         if response.status_code != 200:
             return False
 
-        # Wait for sync to complete (poll up to 30 seconds)
+        # Wait for the async re-sync to settle (poll up to 30 seconds).
+        # initial_sync_status only reflects the database's one-time initial
+        # onboarding sync, not this re-scan — for any database past first
+        # setup that field is already "complete" and this poll would
+        # otherwise exit instantly, before the re-scan has actually found
+        # new tables. Instead, poll Metabase's task log (GET /api/task) for
+        # the specific "sync" task this sync_schema call triggered (its id
+        # is greater than the baseline captured above) and wait for its
+        # status to leave "started".
         import time
 
         for _ in range(30):
             time.sleep(1)
-            db_status = session.get(
-                f"{metabase_url}/api/database/{database_id}",
-                headers={"X-Metabase-Session": session_id},
-                timeout=5,
-            )
-            if db_status.status_code == 200:
-                # Check if sync is complete (no longer has 'initial_sync_status')
-                db_data = db_status.json()
-                if (
-                    not db_data.get("initial_sync_status")
-                    or db_data.get("initial_sync_status") == "complete"
-                ):
-                    break
+            try:
+                task_resp = session.get(
+                    f"{metabase_url}/api/task",
+                    headers={"X-Metabase-Session": session_id},
+                    params={"db_id": database_id, "limit": 20},
+                    timeout=5,
+                )
+            except Exception:
+                continue
+
+            if task_resp.status_code != 200:
+                continue
+
+            sync_tasks = [
+                t
+                for t in task_resp.json().get("data", [])
+                if t.get("task") == "sync" and t.get("id", 0) > baseline_task_id
+            ]
+            if not sync_tasks:
+                continue
+
+            latest_sync_task = max(sync_tasks, key=lambda t: t.get("id", 0))
+            if latest_sync_task.get("status") != "started":
+                break
 
         # Update table descriptions to guide users
         tables: list[dict[str, Any]] = []

--- a/tests/unit/test_metabase_schema_sync.py
+++ b/tests/unit/test_metabase_schema_sync.py
@@ -128,3 +128,86 @@ class TestSyncMetabaseSchemaTaskPoll:
         # Doesn't raise; falls through to fetch metadata after exhausting poll budget.
         assert result is True
         assert mock_sleep.call_count == 30
+
+    def test_falls_back_to_fixed_wait_when_baseline_fetch_fails(self, tmp_path: Path) -> None:
+        """If the pre-trigger baseline GET /api/task call fails, the function
+        must not silently default to task id 0 — that would let it mistake
+        an older, already-finished "sync" task for the one just triggered
+        (the same false-positive failure mode this fix exists to remove).
+        Instead it falls back to a fixed wait, with no task-status polling."""
+        import requests
+        import yaml
+
+        from dango.visualization.metabase import sync_metabase_schema
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            yaml.dump({"admin": {"email": "a@test.com", "password": "s"}, "database": {"id": 5}})
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        login_resp = MagicMock(status_code=200)
+        login_resp.json.return_value = {"id": "sess-abc"}
+        sync_resp = MagicMock(status_code=200)
+        baseline_fail_resp = MagicMock(status_code=500)
+        metadata_resp = MagicMock(status_code=200)
+        metadata_resp.json.return_value = {
+            "tables": [{"id": 1, "name": "stg_orders", "schema": "staging"}]
+        }
+
+        mock_session.post.side_effect = [login_resp, sync_resp]
+        # Baseline fetch fails (500) -> no task-status poll happens at all.
+        mock_session.get.side_effect = [baseline_fail_resp, metadata_resp]
+        mock_session.put.return_value = MagicMock(status_code=200)
+
+        with (
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.visualization.metabase.time.sleep") as mock_sleep,
+        ):
+            result = sync_metabase_schema(tmp_path)
+
+        assert result is True
+        mock_sleep.assert_called_once_with(5)  # fixed fallback wait, not the poll loop
+        assert mock_session.get.call_count == 2  # baseline attempt + metadata (no polling)
+
+    def test_logs_warning_when_sync_task_fails(self, tmp_path: Path) -> None:
+        """If the triggered sync task ends in a non-success terminal status
+        (e.g. "failed"), the poll must stop rather than retry forever, but
+        must log a warning instead of silently treating it as a success."""
+        import requests
+        import yaml
+
+        from dango.visualization.metabase import sync_metabase_schema
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            yaml.dump({"admin": {"email": "a@test.com", "password": "s"}, "database": {"id": 5}})
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        login_resp = MagicMock(status_code=200)
+        login_resp.json.return_value = {"id": "sess-abc"}
+        sync_resp = MagicMock(status_code=200)
+        metadata_resp = MagicMock(status_code=200)
+        metadata_resp.json.return_value = {
+            "tables": [{"id": 1, "name": "stg_orders", "schema": "staging"}]
+        }
+
+        mock_session.post.side_effect = [login_resp, sync_resp]
+        mock_session.get.side_effect = [_empty_task_resp(), _task_resp("failed"), metadata_resp]
+        mock_session.put.return_value = MagicMock(status_code=200)
+
+        with (
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.visualization.metabase.time.sleep"),
+            patch("dango.visualization.metabase.logger") as mock_logger,
+        ):
+            result = sync_metabase_schema(tmp_path)
+
+        # Still completes (doesn't raise, doesn't retry forever) — but the
+        # failure is now observable instead of silent.
+        assert result is True
+        warning_msgs = [c[0][0] for c in mock_logger.warning.call_args_list]
+        assert any("unexpected status" in msg for msg in warning_msgs)

--- a/tests/unit/test_metabase_schema_sync.py
+++ b/tests/unit/test_metabase_schema_sync.py
@@ -1,0 +1,130 @@
+"""tests/unit/test_metabase_schema_sync.py
+
+Unit tests for sync_metabase_schema()'s re-sync completion poll
+in dango/visualization/metabase.py.
+
+Split out from test_metabase_setup.py (which covers the rest of
+sync_metabase_schema()'s behavior) to keep both files under the
+project's 500-line-per-file limit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _empty_task_resp() -> MagicMock:
+    """Mock GET /api/task response with no prior tasks (used as poll baseline)."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"data": []}
+    return resp
+
+
+def _task_resp(status: str, task_id: int = 1, db_id: int = 5) -> MagicMock:
+    """Mock GET /api/task response containing one "sync" task with the given status."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {
+        "data": [{"id": task_id, "task": "sync", "status": status, "db_id": db_id}]
+    }
+    return resp
+
+
+@pytest.mark.unit
+class TestSyncMetabaseSchemaTaskPoll:
+    """Regression tests for the initial_sync_status completion-check bug.
+
+    initial_sync_status only reflects a database's one-time initial
+    onboarding sync, so it was already "complete" on the first poll for
+    any re-sync — these tests confirm the fix instead polls GET /api/task
+    for the specific "sync" task the sync_schema call triggered.
+    """
+
+    def test_waits_for_sync_task_to_finish(self, tmp_path: Path) -> None:
+        """The poll must keep checking GET /api/task across multiple
+        iterations while the triggered "sync" task is still "started",
+        not exit on the first poll."""
+        import requests
+        import yaml
+
+        from dango.visualization.metabase import sync_metabase_schema
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            yaml.dump({"admin": {"email": "a@test.com", "password": "s"}, "database": {"id": 5}})
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        login_resp = MagicMock(status_code=200)
+        login_resp.json.return_value = {"id": "sess-abc"}
+        sync_resp = MagicMock(status_code=200)
+        metadata_resp = MagicMock(status_code=200)
+        metadata_resp.json.return_value = {
+            "tables": [{"id": 1, "name": "stg_orders", "schema": "staging"}]
+        }
+
+        mock_session.post.side_effect = [login_resp, sync_resp]
+        # Baseline, then "started" x2 (must keep polling), then "success".
+        mock_session.get.side_effect = [
+            _empty_task_resp(),
+            _task_resp("started"),
+            _task_resp("started"),
+            _task_resp("success"),
+            metadata_resp,
+        ]
+        mock_session.put.return_value = MagicMock(status_code=200)
+
+        with (
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.visualization.metabase.time.sleep") as mock_sleep,
+        ):
+            result = sync_metabase_schema(tmp_path)
+
+        assert result is True
+        assert mock_sleep.call_count == 3  # kept polling past the first "started" check
+        assert mock_session.get.call_count == 5  # baseline + 3 polls + metadata
+
+    def test_times_out_gracefully_when_task_never_completes(self, tmp_path: Path) -> None:
+        """If the sync task never leaves 'started', return without raising
+        (matches existing timeout-tolerant behavior)."""
+        import requests
+        import yaml
+
+        from dango.visualization.metabase import sync_metabase_schema
+
+        creds_dir = tmp_path / ".dango"
+        creds_dir.mkdir()
+        (creds_dir / "metabase.yml").write_text(
+            yaml.dump({"admin": {"email": "a@test.com", "password": "s"}, "database": {"id": 5}})
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        login_resp = MagicMock(status_code=200)
+        login_resp.json.return_value = {"id": "sess-abc"}
+        sync_resp = MagicMock(status_code=200)
+        metadata_resp = MagicMock(status_code=200)
+        metadata_resp.json.return_value = {
+            "tables": [{"id": 1, "name": "stg_orders", "schema": "staging"}]
+        }
+
+        mock_session.post.side_effect = [login_resp, sync_resp]
+        # Task stays "started" for all 30 poll iterations — never settles.
+        mock_session.get.side_effect = [
+            _empty_task_resp(),
+            *([_task_resp("started")] * 30),
+            metadata_resp,
+        ]
+        mock_session.put.return_value = MagicMock(status_code=200)
+
+        with (
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.visualization.metabase.time.sleep") as mock_sleep,
+        ):
+            result = sync_metabase_schema(tmp_path)
+
+        # Doesn't raise; falls through to fetch metadata after exhausting poll budget.
+        assert result is True
+        assert mock_sleep.call_count == 30

--- a/tests/unit/test_metabase_setup.py
+++ b/tests/unit/test_metabase_setup.py
@@ -19,6 +19,22 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
+def _empty_task_resp() -> MagicMock:
+    """Mock GET /api/task response with no prior tasks (used as poll baseline)."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"data": []}
+    return resp
+
+
+def _task_resp(status: str, task_id: int = 1, db_id: int = 5) -> MagicMock:
+    """Mock GET /api/task response containing one "sync" task with the given status."""
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {
+        "data": [{"id": task_id, "task": "sync", "status": status, "db_id": db_id}]
+    }
+    return resp
+
+
 @pytest.mark.unit
 class TestSyncMetabaseSchema:
     """Test sync_metabase_schema API interactions."""
@@ -61,11 +77,6 @@ class TestSyncMetabaseSchema:
         sync_resp = MagicMock()
         sync_resp.status_code = 200
 
-        # Poll response — sync complete
-        poll_resp = MagicMock()
-        poll_resp.status_code = 200
-        poll_resp.json.return_value = {"initial_sync_status": "complete"}
-
         # Metadata response
         metadata_resp = MagicMock()
         metadata_resp.status_code = 200
@@ -81,7 +92,9 @@ class TestSyncMetabaseSchema:
         update_resp.status_code = 200
 
         mock_session.post.side_effect = [login_resp, sync_resp]
-        mock_session.get.side_effect = [poll_resp, metadata_resp]
+        # Baseline task lookup (no prior tasks), then the triggered "sync" task
+        # already showing as finished.
+        mock_session.get.side_effect = [_empty_task_resp(), _task_resp("success"), metadata_resp]
         mock_session.put.return_value = update_resp
 
         with (
@@ -208,16 +221,12 @@ class TestSyncMetabaseSchema:
         sync_resp = MagicMock()
         sync_resp.status_code = 200
 
-        poll_resp = MagicMock()
-        poll_resp.status_code = 200
-        poll_resp.json.return_value = {"initial_sync_status": "complete"}
-
         metadata_resp = MagicMock()
         metadata_resp.status_code = 200
         metadata_resp.json.return_value = {"tables": []}  # No tables
 
         mock_session.post.side_effect = [login_resp, sync_resp]
-        mock_session.get.side_effect = [poll_resp, metadata_resp]
+        mock_session.get.side_effect = [_empty_task_resp(), _task_resp("success"), metadata_resp]
 
         with (
             patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
@@ -250,8 +259,6 @@ class TestSyncMetabaseSchema:
         login_resp = MagicMock(status_code=200)
         login_resp.json.return_value = {"id": "sess-abc"}
         sync_resp = MagicMock(status_code=200)
-        poll_resp = MagicMock(status_code=200)
-        poll_resp.json.return_value = {"initial_sync_status": "complete"}
         metadata_resp = MagicMock(status_code=200)
         metadata_resp.json.return_value = {
             "tables": [
@@ -263,7 +270,7 @@ class TestSyncMetabaseSchema:
         update_resp = MagicMock(status_code=200)
 
         mock_session.post.side_effect = [login_resp, sync_resp]
-        mock_session.get.side_effect = [poll_resp, metadata_resp]
+        mock_session.get.side_effect = [_empty_task_resp(), _task_resp("success"), metadata_resp]
         mock_session.put.return_value = update_resp
 
         with (


### PR DESCRIPTION
## Summary
- Fixed `sync_metabase_schema()`'s completion check — previously polled
  `initial_sync_status`, which only reflects a database's one-time initial
  onboarding sync and is already "complete" for any re-sync, causing the
  function to return before newly-added tables were actually discovered.
- **Verification path taken: real Metabase API signal (option 2), not the
  stability-based fallback.** Confirmed live against a real Metabase +
  DuckDB container (built the actual `Dockerfile.metabase` image, ran a
  real Metabase server): `GET /api/task?db_id={id}` exposes a genuine
  per-invocation completion signal — triggering `sync_schema` creates a
  `task: "sync"` record whose `status` transitions `started` ->
  `success`/`failed` with `ended_at` populated on completion, unlike the
  stale `initial_sync_status` flag. The fix captures a baseline task id
  before triggering the re-sync, then polls `/api/task` for the specific
  task with `id` greater than that baseline, waiting for its `status` to
  leave `"started"` (up to 30s), before falling through to the existing
  metadata fetch and table-description logic (unchanged).
- **Nuance found during verification, documented for the next reader:**
  a bare `sync_schema` call on an already-open Metabase-DuckDB connection
  never discovers new tables no matter how long you poll (confirmed live:
  polled for 20s with zero result), because Metabase's DuckDB JDBC
  connection holds a stale snapshot. `refresh_metabase_connection()`
  (`metabase.py:1511`) restarts the Metabase container specifically to
  work around this. **Correction from an earlier revision of this
  description:** I originally claimed this was "already handled" for every
  caller because a restart always precedes the schema sync — that's only
  true for 3 of `sync_metabase_schema()`'s 7 call sites
  (`dlt_runner.py:3189`, `platform/scheduling/jobs.py:390`,
  `cli/commands/transform.py:129` call `refresh_metabase_connection()`
  first; `cli/commands/metabase_cmd.py:361`, `cli/commands/model.py:325`,
  `cli/commands/source.py:1126`, and `web/routes/initial_sync.py:307` do
  not). For those other 4 call sites this PR's fix can correctly observe
  the triggered task as `"success"` while the connection-staleness problem
  still silently prevented new tables from being found — that's a
  pre-existing gap in those call sites, not something this PR introduces
  or fixes, but it means the "already handled" framing was wrong. Flagged
  as a follow-up (not fixed here, out of this PR's scope per the task
  spec's "only touch the polling/completion-detection block").
- Re-testing the exact production sequence that *does* have the restart
  (add table -> restart container -> immediately run the poll) confirmed
  the new table is found within ~1.4s once the connection is fresh — so
  this PR's fix is what makes the *specific re-scan* reliably observed
  once the connection is already fresh, which is what actually matters
  once schemas/data volumes are large enough that the re-scan takes
  non-trivial time (my toy repro's tiny tables completed in ~90ms, too
  fast to expose the race directly, but the root-cause mechanism —
  polling a field that reflects a different, unrelated sync — is
  confirmed regardless of timing).

## Independent review + follow-up fixes
An independent code review (before merge, not a self-review) surfaced 9
findings against the original revision of this PR. Per discussion with the
coordinating session, 4 were fixed here; 3 are tracked as follow-up items
in `BUGS-FOUND.md` (out of scope for this PR); 2 are optional cleanup left
as-is.

**Fixed in this revision:**
1. `baseline_task_id` previously defaulted silently to `0` when the
   pre-trigger baseline `GET /api/task` call failed. On a database with
   prior sync-task history (i.e. any database past first setup — exactly
   the case this PR targets), that let an older, already-finished `"sync"`
   task match `id > 0` and cause the poll to break on its first iteration
   against the wrong task — reintroducing this PR's own bug under a
   narrower trigger. Now `baseline_task_id` is `None` on failure, and the
   function falls back to a fixed 5s wait instead of guessing.
2. `task_resp.json()` was called outside the `try/except` that wrapped
   the `session.get()` call, so a 200 response with a malformed body
   raised uncaught and aborted the whole function (skipping the
   table-description updates) instead of just skipping that poll
   iteration. Now wrapped in the same `try/except`.
3. The poll only checked `status != "started"`, treating a task that
   ended `"failed"` (or with a missing/unexpected status field) exactly
   like a successful completion, with nothing logged either way. Now
   logs a warning when the terminal status isn't `"success"`.
4. The `"up to 30 seconds"` comment was inaccurate — the loop bounds
   *iterations* (30), not wall-clock time, and each iteration's HTTP
   call can itself take up to `timeout=5`s, so the real worst case is
   closer to ~180s. Comment corrected to state this explicitly.

**Tracked as follow-up (not fixed here):** the connection-staleness gap
for 4 of 7 callers (see Nuance above), no locking between concurrent
callers racing on the same `database_id`, and the `limit: 1`/`limit: 20`
`/api/task` calls assuming newest-first ordering with no explicit sort
param (untested against a mature database with many historical tasks).

**Left as-is (optional, not worth blocking on):** the baseline-fetch and
poll-fetch `GET /api/task` calls are near-duplicate and could share a
helper; the `_empty_task_resp()`/`_task_resp()` test mock helpers are
duplicated verbatim across `test_metabase_setup.py` and
`test_metabase_schema_sync.py` rather than living in a shared
`conftest.py`.

## Verification
- `pytest -x`: 4658 passed, 0 failed, 30 skipped (pre-existing
  Docker/live-API-gated tests) — run in the foreground, full suite, twice
  (once before the review-driven fixes, once after).
- Live Metabase verification: built `dango/templates/Dockerfile.metabase`,
  ran a real Metabase container against a DuckDB warehouse file, added a
  database, confirmed `initial_sync_status` is `"complete"` from the very
  first poll (root cause confirmed), then confirmed `GET /api/task`
  exposes the `"sync"` task's real `started` -> `success` transition with
  `ended_at` set (fix's signal confirmed) — see Nuance section above for
  the connection-staleness finding uncovered along the way.
- New unit tests (`tests/unit/test_metabase_schema_sync.py`):
  `test_waits_for_sync_task_to_finish` (confirms the poll survives 3
  iterations while status is `"started"`, not just 1), 
  `test_times_out_gracefully_when_task_never_completes` (no exception if
  the task never settles within the 30-iteration budget),
  `test_falls_back_to_fixed_wait_when_baseline_fetch_fails` (confirms
  fix #1 — no silent 0-default, no task-status polling when the baseline
  is unknown), and `test_logs_warning_when_sync_task_fails` (confirms
  fix #3 — a `"failed"` terminal status is logged, not silently treated
  as success).
- Existing `tests/unit/test_metabase_setup.py::TestSyncMetabaseSchema`
  tests updated to mock the new `/api/task` calls instead of the old
  `initial_sync_status` poll; all still pass.
- `ruff check dango/` / `ruff format --check dango/`: clean.

## Regression check
- Table-description-update logic and the zero-tables check
  (`if not tables: return False`) are unchanged.
- Latency: the poll now depends on the task actually reaching a terminal
  status rather than exiting near-instantly on a stale flag — up to a
  few seconds more in the worst case, capped at the existing 30s
  iteration budget (see fix #4 above for why that's not a strict
  wall-clock cap). This is the correct trade-off (previously returned
  early and silently wrong).
- Grepped all 7 callers of `sync_metabase_schema()` — none depend on the
  old fast-but-broken return timing; all just check the boolean return
  value.
- If Metabase's `/api/task` response shape ever changes in a future
  version bump, this code path degrades gracefully (falls through to
  the metadata fetch on any non-200/error) but is unverified against
  future Metabase versions — flagged for whoever handles the next
  version bump to re-check, similar to PR #439's glibc/musl surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nn6RWFt5T69QR6gvQ27igT
