### PR TITLE
1.0.8-W: Set Metabase Site URL for local proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ dango/                          # Python package source
 │   └── static/                 # Frontend HTML/CSS/JS
 │
 ├── visualization/              # Level 2 — Metabase integration
-│   ├── metabase.py             # Metabase API (1251 lines)
+│   ├── metabase.py             # Metabase API (1775 lines)
 │   └── dashboard_manager.py    # Dashboard export/import (1117 lines)
 │
 ├── platform/                   # Level 2 — Docker, network, file watcher, scheduling
@@ -343,7 +343,7 @@ Full exemption registry: [`docs/file-exemptions.yml`](docs/file-exemptions.yml)
 | `ingestion/dlt_runner.py` | 2885 | — (exempt, too risky) |
 | `ingestion/sources/registry.py` | 2340 | — (metadata-only) |
 | `cli/source_wizard.py` | 2610 | — |
-| `visualization/metabase.py` | 1251 | — |
+| `visualization/metabase.py` | 1775 | — |
 | `cli/init.py` | 1585 | — |
 | `visualization/dashboard_manager.py` | 1117 | — |
 | `cli/commands/platform.py` | 1136 | — (extracted from main.py by TASK-005) |

--- a/dango/visualization/CLAUDE.md
+++ b/dango/visualization/CLAUDE.md
@@ -24,7 +24,14 @@ Integrates with Metabase for dashboard provisioning, auto-setup, schema synchron
 ## Dependencies
 
 **Imports from:**
-- No dango module imports (isolated module). Uses `requests` to call Metabase API, reads credentials from `.dango/metabase.yml` at runtime.
+- Mostly isolated (uses `requests` to call Metabase API, reads credentials from
+  `.dango/metabase.yml` at runtime), with one exception: `metabase.py`'s Site URL
+  handling (1.0.8-W — `_should_apply_local_site_url()`, `_apply_metabase_site_url_catchup()`)
+  lazy-imports `dango.config.ConfigLoader`, `dango.config.helpers.is_cloud_mode`, and
+  `dango.platform.local.network.NetworkConfig` to check deployment topology (cloud mode,
+  local shared-nginx registration) before writing a `localhost:{port}`-based Metabase Site
+  URL — all Level 0–2 imports, consistent with this module's Level 2 position in the
+  dependency hierarchy.
 - `DASHBOARD_QUERIES`' SQL (not Python imports) reads the `_dango_meta` schema tables written by `dango.utils.pipeline_health.materialize_pipeline_health()` (1.0.8-DASH-1) — `cli/commands/dashboard.py` calls that function (and `refresh_metabase_connection()`, below) before provisioning, not this module.
 
 **Used by:**

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -265,6 +265,42 @@ def _metabase_login(
     return response.json().get("id")
 
 
+def _set_metabase_site_url(
+    session: requests.Session,
+    metabase_url: str,
+    headers: dict[str, str],
+    project_root: Path,
+) -> None:
+    """PUT /api/setting/site-url so the local /metabase/ proxy serves correctly-pathed
+    JS assets — Metabase computes chunk-loading URLs from this setting, and the local
+    proxy (metabase_proxy.py) does not rewrite response bodies to compensate.
+
+    Shared by setup_metabase() (once, at initial setup) and refresh_metabase_connection()
+    (every sync-triggered restart — the only path that ever reaches an already-configured
+    project, i.e. one set up before this fix shipped). The PUT is idempotent — setting the
+    same value repeatedly is harmless — so callers do not need to check "was it already
+    set" before calling this. Never raises; failure is printed as a warning only.
+    """
+    try:
+        from dango.config import ConfigLoader
+
+        config = ConfigLoader(project_root).load_config()
+        web_port = config.platform.port
+        site_url = f"http://localhost:{web_port}/metabase/"
+        site_url_resp = session.put(
+            f"{metabase_url}/api/setting/site-url",
+            headers=headers,
+            json={"value": site_url},
+            timeout=10,
+        )
+        if site_url_resp.status_code == 200:
+            print(f"  ✓ Metabase Site URL set to {site_url}")
+        else:
+            print(f"  ⚠ Could not set Metabase Site URL: {site_url_resp.status_code}")
+    except Exception as e:  # noqa: BLE001
+        print(f"  ⚠ Could not set Metabase Site URL: {e}")
+
+
 class MetabaseProvisioner:
     """
     Provisions Metabase dashboards via API
@@ -971,6 +1007,9 @@ def setup_metabase(
 
         # At this point, we have headers with session token from either path
 
+        # Set Site URL so the local /metabase/ proxy serves correctly-pathed JS assets.
+        _set_metabase_site_url(session, metabase_url, headers, project_root)
+
         # Check for existing DuckDB connection to prevent duplicates
         existing_db_id = None
         db_name = f"{org_name} Analytics"
@@ -1561,6 +1600,32 @@ def refresh_metabase_connection(
             try:
                 response = session.get(f"{metabase_url}/api/health", timeout=1)
                 if response.status_code == 200:
+                    # Re-apply Site URL on every restart, not just at initial setup.
+                    # This is the only path that ever reaches a project whose
+                    # .dango/metabase.yml was created before this fix shipped —
+                    # setup_metabase() only runs once and won't retroactively fix
+                    # those projects. Best-effort: login + PUT are wrapped so a
+                    # failure here never turns a successful restart into a failure.
+                    try:
+                        creds_file = project_root / ".dango" / "metabase.yml"
+                        if creds_file.exists():
+                            with open(creds_file) as f:
+                                creds = yaml.safe_load(f) or {}
+                            admin = creds.get("admin", {})
+                            email = admin.get("email")
+                            password = admin.get("password")
+                            if email and password:
+                                session_id = _metabase_login(session, metabase_url, email, password)
+                                if session_id:
+                                    _set_metabase_site_url(
+                                        session,
+                                        metabase_url,
+                                        {"X-Metabase-Session": session_id},
+                                        project_root,
+                                    )
+                    except Exception:  # noqa: BLE001
+                        pass  # Not critical — site URL refresh is best-effort
+
                     return (True, None)
             except requests.exceptions.RequestException:  # noqa: BLE001
                 pass

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -284,11 +284,20 @@ def _should_apply_local_site_url(project_root: Path, cloud_mode: bool) -> bool:
 
     - **Cloud deployments** — Caddy fronts Metabase there with the real public
       domain/HTTPS, not ``localhost:{port}``.
-    - **Local custom-domain projects** — ``platform/local/network.py``'s shared
-      nginx routing can register a project under ``{project_name}.dango``
-      (or another domain) instead of ``localhost:{port}``.
+    - **Local shared-nginx-registered projects** — ``platform/local/network.py``'s
+      shared nginx routing serves a registered project at its routing.json
+      ``domain`` entry (``{project_name}.dango`` by default, or a custom domain),
+      not ``localhost:{port}`` — *any* registration means this module's computed
+      URL is wrong for that project, not just a non-default one. (An earlier
+      version of this check compared the registered domain to
+      ``f"{project_name}.dango"`` to detect a "custom" domain — but
+      ``NetworkConfig.register_project()`` always registers under exactly that
+      pattern for the current project name, so that comparison could never be
+      true for the only real caller and silently never skipped anything. Fixed
+      during review to treat any registration as disqualifying, regardless of
+      what the domain string is.)
 
-    The custom-domain check is defense in depth rather than an active concern
+    This registration check is defense in depth rather than an active concern
     today: grepping the codebase confirmed ``NetworkConfig.register_project()``
     is currently only ever called from the ``dango rename`` CLI command,
     conditional on a routing.json entry that nothing else creates — there is no
@@ -297,7 +306,9 @@ def _should_apply_local_site_url(project_root: Path, cloud_mode: bool) -> bool:
     mismatch (nothing set Site URL at all before this fix), so this check isn't
     closing a new gap for such projects — it's just making sure this PR doesn't
     start actively writing a wrong value where none was written before. Fully
-    correct Site URL handling for local custom domains is out of scope here.
+    correct Site URL handling for locally-routed/custom-domain projects (e.g.
+    writing ``http://{domain}/metabase/`` instead of skipping) is out of scope
+    here.
 
     Fails open (returns True) if project name / routing lookup can't be
     completed, matching the common case (no registration exists) rather than
@@ -310,8 +321,7 @@ def _should_apply_local_site_url(project_root: Path, cloud_mode: bool) -> bool:
         from dango.platform.local.network import NetworkConfig
 
         project_name = ConfigLoader(project_root).load_config().project.name
-        project_info = NetworkConfig().get_project_info(project_name)
-        if project_info and project_info.get("domain") != f"{project_name}.dango":
+        if NetworkConfig().get_project_info(project_name) is not None:
             return False
     except Exception:  # noqa: BLE001
         pass
@@ -322,9 +332,12 @@ def _safe_print(msg: str) -> None:
     """print() that can't itself violate a caller's "never raises" contract.
 
     A non-UTF-8 stdout (rare, but real: some CI runners, some Windows consoles)
-    could otherwise turn a ``UnicodeEncodeError`` on one of this module's own
-    status glyphs (✓/⚠) into an uncaught exception escaping from what's
-    supposed to be a best-effort, print-only status line.
+    could otherwise turn a ``UnicodeEncodeError`` on one of ``_set_metabase_site_url()``'s
+    own status glyphs (✓/⚠) into an uncaught exception escaping from what's supposed to
+    be a best-effort, print-only status line — its plain ``print()`` fallback branch
+    wasn't itself protected. Scoped to this PR's own new print calls only: the dozen-plus
+    pre-existing ✓/⚠/✗ prints elsewhere in this module (``setup_metabase()``, etc.) are a
+    pre-existing, unrelated risk this function does not attempt to cover.
     """
     try:
         print(msg)
@@ -378,6 +391,59 @@ def _set_metabase_site_url(
     except Exception as e:  # noqa: BLE001
         _safe_print(f"  ⚠ Could not set Metabase Site URL: {e}")
         return False
+
+
+def _apply_metabase_site_url_catchup(
+    session: requests.Session, metabase_url: str, project_root: Path
+) -> None:
+    """One-time catch-up for refresh_metabase_connection(): apply the Site URL fix to
+    a project whose .dango/metabase.yml was created before this fix shipped —
+    setup_metabase() only runs once per project and won't retroactively fix those.
+
+    Deliberately checks the "site_url_set" marker in metabase.yml (one cheap file
+    read) *before* calling `_should_apply_local_site_url()`, which does heavier I/O
+    (project.yml reparse + pydantic validation, a `NetworkConfig()` construction that
+    touches ``~/.dango/``). Once a project is caught up, every subsequent sync pays for
+    a single open()+yaml.safe_load() here and nothing else — not a repeated
+    config/routing reparse forever, which an earlier ordering of these checks did.
+
+    Never raises: every step is independently defensive, and the caller
+    (refresh_metabase_connection()) also wraps this call, so a failure here can never
+    turn a successful container restart into a reported failure.
+    """
+    creds_file = project_root / ".dango" / "metabase.yml"
+    if not creds_file.exists():
+        return
+    try:
+        with open(creds_file) as f:
+            creds = yaml.safe_load(f) or {}
+    except Exception:  # noqa: BLE001
+        return
+    if creds.get("site_url_set"):
+        return
+
+    from dango.config.helpers import is_cloud_mode
+
+    if not _should_apply_local_site_url(project_root, is_cloud_mode(project_root)):
+        return
+
+    admin = creds.get("admin", {})
+    email = admin.get("email")
+    password = admin.get("password")
+    if not email or not password:
+        return
+
+    session_id = _metabase_login(session, metabase_url, email, password)
+    if not session_id:
+        return
+
+    applied = _set_metabase_site_url(
+        session, metabase_url, {"X-Metabase-Session": session_id}, project_root
+    )
+    if applied:
+        creds["site_url_set"] = True
+        with open(creds_file, "w") as f:
+            yaml.safe_dump(creds, f, default_flow_style=False)
 
 
 class MetabaseProvisioner:
@@ -1653,8 +1719,6 @@ def refresh_metabase_connection(
     """
     import subprocess
 
-    from dango.config.helpers import is_cloud_mode
-
     session = requests.Session()
 
     try:
@@ -1690,45 +1754,12 @@ def refresh_metabase_connection(
             try:
                 response = session.get(f"{metabase_url}/api/health", timeout=1)
                 if response.status_code == 200:
-                    # One-time catch-up, not a recurring cost: apply Site URL for a
-                    # project whose .dango/metabase.yml was created before this fix
-                    # shipped — setup_metabase() only runs once per project and won't
-                    # retroactively fix those. The "site_url_set" marker (also written
-                    # by setup_metabase() itself, see there) means this login+PUT is
-                    # attempted at most once per project, on its first sync after
-                    # upgrading, not on every single sync forever — re-doing it every
-                    # restart would add a login POST + PUT (10s timeout each) on top of
-                    # this function's existing 20s health-poll budget, and repeatedly
-                    # transmit the admin password for no benefit once it's already
-                    # correct. Best-effort throughout: never turns a successful restart
-                    # into a reported failure.
+                    # See _apply_metabase_site_url_catchup()'s docstring for why this
+                    # is a bounded one-time catch-up (cheap on every call once done),
+                    # not a recurring cost paid on every sync forever. Best-effort:
+                    # never turns a successful restart into a reported failure.
                     try:
-                        if _should_apply_local_site_url(project_root, is_cloud_mode(project_root)):
-                            creds_file = project_root / ".dango" / "metabase.yml"
-                            if creds_file.exists():
-                                with open(creds_file) as f:
-                                    creds = yaml.safe_load(f) or {}
-                                if not creds.get("site_url_set"):
-                                    admin = creds.get("admin", {})
-                                    email = admin.get("email")
-                                    password = admin.get("password")
-                                    if email and password:
-                                        session_id = _metabase_login(
-                                            session, metabase_url, email, password
-                                        )
-                                        if session_id:
-                                            applied = _set_metabase_site_url(
-                                                session,
-                                                metabase_url,
-                                                {"X-Metabase-Session": session_id},
-                                                project_root,
-                                            )
-                                            if applied:
-                                                creds["site_url_set"] = True
-                                                with open(creds_file, "w") as f:
-                                                    yaml.safe_dump(
-                                                        creds, f, default_flow_style=False
-                                                    )
+                        _apply_metabase_site_url_catchup(session, metabase_url, project_root)
                     except Exception:  # noqa: BLE001
                         pass  # Not critical — site URL refresh is best-effort
 

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -249,11 +249,18 @@ def _metabase_login(
 ) -> str | None:
     """POST /api/session and return the session id, or None if login failed (non-200).
 
-    Shared by the three simple (single-attempt) login call sites. Does NOT
-    raise — callers decide what a failed login means for their own contract
-    (return False, raise click.ClickException, etc). setup_metabase() has its
-    own multi-path login/retry logic and does not use this helper — see
-    BUGS-FOUND.md for why.
+    Shared by three of this module's simple (single-attempt) login call sites:
+    ``MetabaseProvisioner.authenticate()``, ``sync_metabase_schema()``, and
+    ``refresh_metabase_connection()`` (added by 1.0.8-W's Site URL refresh — see
+    ``_set_metabase_site_url()`` below). Does NOT raise — callers decide what a
+    failed login means for their own contract (return False, swallow silently,
+    etc). ``setup_metabase()`` has its own multi-path login/retry logic and does
+    not use this helper — see BUGS-FOUND.md for why. ``set_metabase_telemetry()``
+    also does its own inline login rather than using this helper, since it needs
+    to distinguish a 401/403 (bad credentials) from other failures with a
+    different user-facing error message — a fourth, slightly-divergent copy of
+    the same "load creds from metabase.yml, then log in" shape; worth revisiting
+    as a shared helper if a fifth copy shows up.
     """
     response = session.post(
         f"{metabase_url}/api/session",
@@ -265,21 +272,91 @@ def _metabase_login(
     return response.json().get("id")
 
 
+def _should_apply_local_site_url(project_root: Path, cloud_mode: bool) -> bool:
+    """True only when the Site URL ``_set_metabase_site_url()`` computes
+    (``http://localhost:{config.platform.port}/metabase/``) is actually correct
+    for how this project is accessed.
+
+    Two cases make it wrong, not just unhelpful — Site URL also governs
+    Metabase's own password-reset/invite email links and other absolute URLs it
+    generates, not just JS asset paths, so writing the wrong value is a real
+    regression:
+
+    - **Cloud deployments** — Caddy fronts Metabase there with the real public
+      domain/HTTPS, not ``localhost:{port}``.
+    - **Local custom-domain projects** — ``platform/local/network.py``'s shared
+      nginx routing can register a project under ``{project_name}.dango``
+      (or another domain) instead of ``localhost:{port}``.
+
+    The custom-domain check is defense in depth rather than an active concern
+    today: grepping the codebase confirmed ``NetworkConfig.register_project()``
+    is currently only ever called from the ``dango rename`` CLI command,
+    conditional on a routing.json entry that nothing else creates — there is no
+    live registration path for a *fresh* project. A project actually using this
+    feature already has the same JS-asset-path bug via a different Site URL
+    mismatch (nothing set Site URL at all before this fix), so this check isn't
+    closing a new gap for such projects — it's just making sure this PR doesn't
+    start actively writing a wrong value where none was written before. Fully
+    correct Site URL handling for local custom domains is out of scope here.
+
+    Fails open (returns True) if project name / routing lookup can't be
+    completed, matching the common case (no registration exists) rather than
+    silently disabling the fix for every project over an unrelated I/O hiccup.
+    """
+    if cloud_mode:
+        return False
+    try:
+        from dango.config import ConfigLoader
+        from dango.platform.local.network import NetworkConfig
+
+        project_name = ConfigLoader(project_root).load_config().project.name
+        project_info = NetworkConfig().get_project_info(project_name)
+        if project_info and project_info.get("domain") != f"{project_name}.dango":
+            return False
+    except Exception:  # noqa: BLE001
+        pass
+    return True
+
+
+def _safe_print(msg: str) -> None:
+    """print() that can't itself violate a caller's "never raises" contract.
+
+    A non-UTF-8 stdout (rare, but real: some CI runners, some Windows consoles)
+    could otherwise turn a ``UnicodeEncodeError`` on one of this module's own
+    status glyphs (✓/⚠) into an uncaught exception escaping from what's
+    supposed to be a best-effort, print-only status line.
+    """
+    try:
+        print(msg)
+    except Exception:  # noqa: BLE001
+        try:
+            print(msg.encode("ascii", "replace").decode("ascii"))
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def _set_metabase_site_url(
     session: requests.Session,
     metabase_url: str,
     headers: dict[str, str],
     project_root: Path,
-) -> None:
+) -> bool:
     """PUT /api/setting/site-url so the local /metabase/ proxy serves correctly-pathed
     JS assets — Metabase computes chunk-loading URLs from this setting, and the local
     proxy (metabase_proxy.py) does not rewrite response bodies to compensate.
 
     Shared by setup_metabase() (once, at initial setup) and refresh_metabase_connection()
-    (every sync-triggered restart — the only path that ever reaches an already-configured
-    project, i.e. one set up before this fix shipped). The PUT is idempotent — setting the
-    same value repeatedly is harmless — so callers do not need to check "was it already
-    set" before calling this. Never raises; failure is printed as a warning only.
+    (a one-time catch-up on the first post-upgrade sync — see the "site_url_set" marker
+    handling there — for a project whose .dango/metabase.yml was created before this fix
+    shipped). The PUT is idempotent — setting the same value repeatedly is harmless — but
+    callers should still gate on `_should_apply_local_site_url()` first: this function
+    always computes a plain ``localhost:{port}`` URL and has no way to know if that's
+    wrong for a cloud/custom-domain project. Never raises; failure is printed as a
+    warning only.
+
+    Returns:
+        True if the PUT succeeded (200), False otherwise (including on any exception).
+        Callers use this to decide whether it's safe to persist a "site_url_set" marker.
     """
     try:
         from dango.config import ConfigLoader
@@ -294,11 +371,13 @@ def _set_metabase_site_url(
             timeout=10,
         )
         if site_url_resp.status_code == 200:
-            print(f"  ✓ Metabase Site URL set to {site_url}")
-        else:
-            print(f"  ⚠ Could not set Metabase Site URL: {site_url_resp.status_code}")
+            _safe_print(f"  ✓ Metabase Site URL set to {site_url}")
+            return True
+        _safe_print(f"  ⚠ Could not set Metabase Site URL: {site_url_resp.status_code}")
+        return False
     except Exception as e:  # noqa: BLE001
-        print(f"  ⚠ Could not set Metabase Site URL: {e}")
+        _safe_print(f"  ⚠ Could not set Metabase Site URL: {e}")
+        return False
 
 
 class MetabaseProvisioner:
@@ -1008,7 +1087,13 @@ def setup_metabase(
         # At this point, we have headers with session token from either path
 
         # Set Site URL so the local /metabase/ proxy serves correctly-pathed JS assets.
-        _set_metabase_site_url(session, metabase_url, headers, project_root)
+        # Skipped for cloud deployments (cloud_mode) and local custom-domain projects,
+        # where http://localhost:{port}/metabase/ would be the wrong Site URL to write
+        # — see _should_apply_local_site_url(). site_url_set is persisted below so
+        # refresh_metabase_connection() doesn't redundantly re-apply it on every sync.
+        site_url_set = False
+        if _should_apply_local_site_url(project_root, cloud_mode):
+            site_url_set = _set_metabase_site_url(session, metabase_url, headers, project_root)
 
         # Check for existing DuckDB connection to prevent duplicates
         existing_db_id = None
@@ -1219,6 +1304,9 @@ def setup_metabase(
             "admin": {"email": admin_email, "password": admin_password},
             "database": {"id": summary.get("duckdb_id"), "name": f"{org_name} Analytics"},
             "setup_completed_at": datetime.now(tz=timezone.utc).isoformat(),
+            # 1.0.8-W: lets refresh_metabase_connection() skip its own login+PUT once
+            # this is already True, instead of re-attempting it on every sync forever.
+            "site_url_set": site_url_set,
         }
 
         credentials_file.parent.mkdir(parents=True, exist_ok=True)
@@ -1565,6 +1653,8 @@ def refresh_metabase_connection(
     """
     import subprocess
 
+    from dango.config.helpers import is_cloud_mode
+
     session = requests.Session()
 
     try:
@@ -1600,29 +1690,45 @@ def refresh_metabase_connection(
             try:
                 response = session.get(f"{metabase_url}/api/health", timeout=1)
                 if response.status_code == 200:
-                    # Re-apply Site URL on every restart, not just at initial setup.
-                    # This is the only path that ever reaches a project whose
-                    # .dango/metabase.yml was created before this fix shipped —
-                    # setup_metabase() only runs once and won't retroactively fix
-                    # those projects. Best-effort: login + PUT are wrapped so a
-                    # failure here never turns a successful restart into a failure.
+                    # One-time catch-up, not a recurring cost: apply Site URL for a
+                    # project whose .dango/metabase.yml was created before this fix
+                    # shipped — setup_metabase() only runs once per project and won't
+                    # retroactively fix those. The "site_url_set" marker (also written
+                    # by setup_metabase() itself, see there) means this login+PUT is
+                    # attempted at most once per project, on its first sync after
+                    # upgrading, not on every single sync forever — re-doing it every
+                    # restart would add a login POST + PUT (10s timeout each) on top of
+                    # this function's existing 20s health-poll budget, and repeatedly
+                    # transmit the admin password for no benefit once it's already
+                    # correct. Best-effort throughout: never turns a successful restart
+                    # into a reported failure.
                     try:
-                        creds_file = project_root / ".dango" / "metabase.yml"
-                        if creds_file.exists():
-                            with open(creds_file) as f:
-                                creds = yaml.safe_load(f) or {}
-                            admin = creds.get("admin", {})
-                            email = admin.get("email")
-                            password = admin.get("password")
-                            if email and password:
-                                session_id = _metabase_login(session, metabase_url, email, password)
-                                if session_id:
-                                    _set_metabase_site_url(
-                                        session,
-                                        metabase_url,
-                                        {"X-Metabase-Session": session_id},
-                                        project_root,
-                                    )
+                        if _should_apply_local_site_url(project_root, is_cloud_mode(project_root)):
+                            creds_file = project_root / ".dango" / "metabase.yml"
+                            if creds_file.exists():
+                                with open(creds_file) as f:
+                                    creds = yaml.safe_load(f) or {}
+                                if not creds.get("site_url_set"):
+                                    admin = creds.get("admin", {})
+                                    email = admin.get("email")
+                                    password = admin.get("password")
+                                    if email and password:
+                                        session_id = _metabase_login(
+                                            session, metabase_url, email, password
+                                        )
+                                        if session_id:
+                                            applied = _set_metabase_site_url(
+                                                session,
+                                                metabase_url,
+                                                {"X-Metabase-Session": session_id},
+                                                project_root,
+                                            )
+                                            if applied:
+                                                creds["site_url_set"] = True
+                                                with open(creds_file, "w") as f:
+                                                    yaml.safe_dump(
+                                                        creds, f, default_flow_style=False
+                                                    )
                     except Exception:  # noqa: BLE001
                         pass  # Not critical — site URL refresh is best-effort
 

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -385,8 +385,11 @@ def _set_metabase_site_url(
     warning only.
 
     Returns:
-        True if the PUT succeeded (200), False otherwise (including on any exception).
-        Callers use this to decide whether it's safe to persist a "site_url_set" marker.
+        True if the PUT succeeded (2xx — Metabase's setting-PUT endpoints return 204 No
+        Content on success, not 200; see the sibling anon-tracking-enabled PUT above,
+        which already relies on this via raise_for_status()), False otherwise (including
+        on any exception). Callers use this to decide whether it's safe to persist a
+        "site_url_set" marker.
     """
     try:
         from dango.config import ConfigLoader
@@ -400,7 +403,7 @@ def _set_metabase_site_url(
             json={"value": site_url},
             timeout=10,
         )
-        if site_url_resp.status_code == 200:
+        if site_url_resp.ok:
             _safe_print(f"  ✓ Metabase Site URL set to {site_url}")
             return True
         _safe_print(f"  ⚠ Could not set Metabase Site URL: {site_url_resp.status_code}")

--- a/dango/visualization/metabase.py
+++ b/dango/visualization/metabase.py
@@ -251,16 +251,23 @@ def _metabase_login(
 
     Shared by three of this module's simple (single-attempt) login call sites:
     ``MetabaseProvisioner.authenticate()``, ``sync_metabase_schema()``, and
-    ``refresh_metabase_connection()`` (added by 1.0.8-W's Site URL refresh — see
-    ``_set_metabase_site_url()`` below). Does NOT raise — callers decide what a
-    failed login means for their own contract (return False, swallow silently,
-    etc). ``setup_metabase()`` has its own multi-path login/retry logic and does
-    not use this helper — see BUGS-FOUND.md for why. ``set_metabase_telemetry()``
-    also does its own inline login rather than using this helper, since it needs
-    to distinguish a 401/403 (bad credentials) from other failures with a
-    different user-facing error message — a fourth, slightly-divergent copy of
-    the same "load creds from metabase.yml, then log in" shape; worth revisiting
-    as a shared helper if a fifth copy shows up.
+    ``_apply_metabase_site_url_catchup()`` (added by 1.0.8-W's Site URL refresh — see
+    there and ``_set_metabase_site_url()`` below). Does NOT raise — callers decide
+    what a failed login means for their own contract (return False, swallow
+    silently, etc). ``setup_metabase()`` has its own multi-path login/retry logic and
+    does not use this helper — see BUGS-FOUND.md for why. ``set_metabase_telemetry()``
+    also does its own inline login rather than using this helper, since it needs to
+    distinguish a 401/403 (bad credentials) from other failures with a different
+    user-facing error message.
+
+    All four of the above (three real callers of this function, plus
+    ``set_metabase_telemetry()``'s own inline copy) also independently repeat the
+    "open .dango/metabase.yml, ``yaml.safe_load``, pull out ``admin.email``/
+    ``admin.password``" step before calling this — a shape that's now been copied
+    enough times that it's worth a shared loader, but each caller's error handling
+    on top of that shape differs enough (raise vs. return False vs. swallow
+    silently) that unifying it wasn't undertaken as part of this already-large PR;
+    left as an explicit follow-up rather than fixed here or left unacknowledged.
     """
     response = session.post(
         f"{metabase_url}/api/session",
@@ -313,18 +320,28 @@ def _should_apply_local_site_url(project_root: Path, cloud_mode: bool) -> bool:
     Fails open (returns True) if project name / routing lookup can't be
     completed, matching the common case (no registration exists) rather than
     silently disabling the fix for every project over an unrelated I/O hiccup.
+    The failure is logged at debug level (not printed — this runs on every sync
+    for a project that's never registered, so it must stay silent by default)
+    so a persistent lookup failure (e.g. a corrupted ``~/.dango/routing.json``)
+    is still traceable rather than invisibly swallowed.
     """
     if cloud_mode:
         return False
     try:
+        # load_project_context() (not the full load_config()) is enough here —
+        # only project.name is needed, and the full load also parses/validates
+        # sources.yml for no benefit to this check. _set_metabase_site_url()
+        # still does its own full load separately (it needs platform.port, a
+        # different section of project.yml) — this doesn't eliminate that
+        # second parse, just avoids a third, heavier one here.
         from dango.config import ConfigLoader
         from dango.platform.local.network import NetworkConfig
 
-        project_name = ConfigLoader(project_root).load_config().project.name
+        project_name = ConfigLoader(project_root).load_project_context().name
         if NetworkConfig().get_project_info(project_name) is not None:
             return False
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"should_apply_local_site_url_check_failed: {e}")
     return True
 
 
@@ -407,9 +424,34 @@ def _apply_metabase_site_url_catchup(
     a single open()+yaml.safe_load() here and nothing else — not a repeated
     config/routing reparse forever, which an earlier ordering of these checks did.
 
-    Never raises: every step is independently defensive, and the caller
-    (refresh_metabase_connection()) also wraps this call, so a failure here can never
-    turn a successful container restart into a reported failure.
+    Two known, accepted asymmetries from that marker design, left as-is rather than
+    fixed here (fixing either would mean re-doing the "one-time" work this ordering
+    exists to avoid):
+
+    - **Cloud/registered projects never get the "one-time" savings.**
+      `_should_apply_local_site_url()` returning False means the marker is never
+      written, so those projects *do* re-pay the project.yml/routing.json check on
+      every sync, indefinitely. This is intentional, not an oversight: it's what lets
+      a project whose topology later becomes plain-local (e.g. cloud deployment torn
+      down) get caught up automatically on a later sync, instead of being stuck
+      un-appliable forever. The cost is bounded to local file I/O (no network calls),
+      not the ~20s login+PUT budget.
+    - **The reverse direction has no correction path.** Once a project's marker is
+      True, it's never re-validated — a project that becomes cloud/registered *after*
+      already being marked keeps serving its earlier `localhost:{port}` Site URL
+      indefinitely, with no automatic re-check. In the current codebase this is a
+      narrow gap in practice: the only live path to local registration
+      (`dango rename`, see `_should_apply_local_site_url()`) only *updates* an
+      existing routing.json entry, it doesn't *create* one, so a project can't newly
+      become registered without already having been registered (itself requiring a
+      path this codebase doesn't currently expose either). Part of the same
+      already-disclosed "local custom-domain Site URL handling is out of scope"
+      follow-up gap, not a new one.
+
+    Never raises: the whole body is wrapped in its own try/except, so this
+    guarantee is self-contained rather than depending on the caller.
+    refresh_metabase_connection() also wraps this call as defense in depth, not
+    because this function relies on that wrapping to keep its own contract.
     """
     creds_file = project_root / ".dango" / "metabase.yml"
     if not creds_file.exists():
@@ -417,33 +459,33 @@ def _apply_metabase_site_url_catchup(
     try:
         with open(creds_file) as f:
             creds = yaml.safe_load(f) or {}
-    except Exception:  # noqa: BLE001
-        return
-    if creds.get("site_url_set"):
-        return
+        if creds.get("site_url_set"):
+            return
 
-    from dango.config.helpers import is_cloud_mode
+        from dango.config.helpers import is_cloud_mode
 
-    if not _should_apply_local_site_url(project_root, is_cloud_mode(project_root)):
-        return
+        if not _should_apply_local_site_url(project_root, is_cloud_mode(project_root)):
+            return
 
-    admin = creds.get("admin", {})
-    email = admin.get("email")
-    password = admin.get("password")
-    if not email or not password:
-        return
+        admin = creds.get("admin", {})
+        email = admin.get("email")
+        password = admin.get("password")
+        if not email or not password:
+            return
 
-    session_id = _metabase_login(session, metabase_url, email, password)
-    if not session_id:
-        return
+        session_id = _metabase_login(session, metabase_url, email, password)
+        if not session_id:
+            return
 
-    applied = _set_metabase_site_url(
-        session, metabase_url, {"X-Metabase-Session": session_id}, project_root
-    )
-    if applied:
-        creds["site_url_set"] = True
-        with open(creds_file, "w") as f:
-            yaml.safe_dump(creds, f, default_flow_style=False)
+        applied = _set_metabase_site_url(
+            session, metabase_url, {"X-Metabase-Session": session_id}, project_root
+        )
+        if applied:
+            creds["site_url_set"] = True
+            with open(creds_file, "w") as f:
+                yaml.safe_dump(creds, f, default_flow_style=False)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"metabase_site_url_catchup_failed: {e}")
 
 
 class MetabaseProvisioner:
@@ -1771,5 +1813,10 @@ def refresh_metabase_connection(
         return (False, "Metabase did not become healthy after restart")
 
     except Exception as e:
-        logger.warning("refresh_metabase_connection_error", error=str(e), exc_info=True)
+        # Pre-existing bug fixed in passing: `error=str(e)` isn't a valid stdlib
+        # logging kwarg (logger here is `logging.getLogger`, not structlog) — it
+        # raised TypeError instead of logging, replacing the real exception this
+        # was supposed to report with an unrelated one. Caught while touching this
+        # exact except block for 1.0.8-W; verified live (see PR description).
+        logger.warning(f"refresh_metabase_connection_error: {e}", exc_info=True)
         return (False, str(e))

--- a/docs/file-exemptions.yml
+++ b/docs/file-exemptions.yml
@@ -184,9 +184,9 @@ exemptions:
     review_by: "v1.1"
 
   - file: dango/visualization/metabase.py
-    lines: 1251
+    lines: 1775
     category: exempt
-    reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations. R12-I1 added cloud timeout + poll logging."
+    reason: "Metabase REST API wrapper. Methods map 1:1 to API endpoints — splitting would scatter related operations. R12-I1 added cloud timeout + poll logging. 1.0.8-W added Site URL handling (_should_apply_local_site_url, _apply_metabase_site_url_catchup)."
     review_by: "v1.1"
 
   - file: dango/visualization/dashboard_manager.py

--- a/tests/unit/test_metabase_site_url.py
+++ b/tests/unit/test_metabase_site_url.py
@@ -79,7 +79,7 @@ class TestSetupMetabaseSiteUrl:
         # Site-url PUT happens first (right after login), then the "set default
         # database" PUT further down in the DuckDB-connection block.
         mock_session = _mock_fresh_setup_session(
-            [MagicMock(status_code=200), MagicMock(status_code=200)]
+            [MagicMock(status_code=200, ok=True), MagicMock(status_code=200, ok=True)]
         )
 
         with (
@@ -100,6 +100,29 @@ class TestSetupMetabaseSiteUrl:
         creds_file = tmp_project_dir / ".dango" / "metabase.yml"
         assert yaml.safe_load(creds_file.read_text())["site_url_set"] is True
 
+    def test_setup_metabase_site_url_204_is_treated_as_success(self, tmp_project_dir: Path) -> None:
+        """Metabase's /api/setting/* PUT endpoints return 204 No Content on success, not
+        200 (confirmed live against a real Metabase instance during 1.0.8-T5 manual
+        verification -- a strict `== 200` check silently treated every real success as a
+        failure). Guards against regressing back to a status-code-200-only check."""
+        from dango.visualization.metabase import setup_metabase
+
+        mock_session = _mock_fresh_setup_session(
+            [MagicMock(status_code=204, ok=True), MagicMock(status_code=200, ok=True)]
+        )
+
+        with (
+            patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc"),
+            patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch(_NETWORK_CONFIG_GET_PROJECT_INFO, return_value=None),
+        ):
+            result = setup_metabase(tmp_project_dir, "test-project", "admin@example.com")
+
+        assert result["success"] is True
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        assert yaml.safe_load(creds_file.read_text())["site_url_set"] is True
+
     def test_setup_metabase_site_url_failure_does_not_block_setup(
         self, tmp_project_dir: Path
     ) -> None:
@@ -109,7 +132,7 @@ class TestSetupMetabaseSiteUrl:
         from dango.visualization.metabase import setup_metabase
 
         mock_session = _mock_fresh_setup_session(
-            [MagicMock(status_code=500), MagicMock(status_code=200)]
+            [MagicMock(status_code=500, ok=False), MagicMock(status_code=200, ok=True)]
         )
 
         with (

--- a/tests/unit/test_metabase_site_url.py
+++ b/tests/unit/test_metabase_site_url.py
@@ -1,0 +1,113 @@
+"""tests/unit/test_metabase_site_url.py
+
+1.0.8-W: Unit tests for setup_metabase()'s Metabase Site URL PUT
+(PUT /api/setting/site-url) in dango/visualization/metabase.py.
+
+Kept in its own file rather than folded into test_metabase_setup.py to avoid
+pushing that already-near-the-500-line-limit file over the file-size-check
+threshold. refresh_metabase_connection()'s Site URL refresh (the same fix
+applied on every restart, not just at initial setup) is covered separately
+in tests/unit/test_platform_startup.py::TestRefreshMetabaseConnection, next
+to its other refresh_metabase_connection() tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+def _mock_fresh_setup_session(put_side_effect: list[MagicMock]) -> MagicMock:
+    """Build a requests.Session mock for the fresh-Metabase-setup happy path
+    (session/properties -> setup -> login -> db list -> create db -> H2 list ->
+    collection list/create). `put_side_effect` lets callers vary what the
+    site-url / set-default PUT calls return without repeating the rest of the
+    mock scaffolding.
+    """
+    import requests
+
+    mock_session = MagicMock(spec=requests.Session)
+
+    props_resp = MagicMock(status_code=200)
+    props_resp.json.return_value = {"setup-token": "tok-abc"}
+    setup_resp = MagicMock(status_code=200)
+    login_resp = MagicMock(status_code=200)
+    login_resp.json.return_value = {"id": "sess-xyz"}
+    db_list_resp = MagicMock(status_code=200)
+    db_list_resp.json.return_value = {"data": []}
+    create_db_resp = MagicMock(status_code=200)
+    create_db_resp.json.return_value = {"id": 7}
+    h2_list_resp = MagicMock(status_code=200)
+    h2_list_resp.json.return_value = {"data": []}
+    coll_list_resp = MagicMock(status_code=200)
+    coll_list_resp.json.return_value = []
+    coll_create_resp = MagicMock(status_code=200)
+
+    mock_session.get.side_effect = [props_resp, db_list_resp, h2_list_resp, coll_list_resp]
+    mock_session.post.side_effect = [
+        setup_resp,
+        login_resp,
+        create_db_resp,
+        coll_create_resp,
+        coll_create_resp,
+    ]
+    mock_session.put.side_effect = put_side_effect
+
+    return mock_session
+
+
+@pytest.mark.unit
+class TestSetupMetabaseSiteUrl:
+    """Test setup_metabase()'s Site URL PUT (1.0.8-W)."""
+
+    def test_setup_metabase_sets_site_url(self, tmp_project_dir: Path) -> None:
+        """setup_metabase() PUTs the /metabase/-suffixed, web-port-based Site URL
+        right after login, before the DuckDB connection work. tmp_project_dir gives
+        config.platform.port == 8800 (default, no platform: override in project.yml).
+        """
+        from dango.visualization.metabase import setup_metabase
+
+        # Site-url PUT happens first (right after login), then the "set default
+        # database" PUT further down in the DuckDB-connection block.
+        mock_session = _mock_fresh_setup_session(
+            [MagicMock(status_code=200), MagicMock(status_code=200)]
+        )
+
+        with (
+            patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc"),
+            patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+        ):
+            result = setup_metabase(tmp_project_dir, "test-project", "admin@example.com")
+
+        assert result["success"] is True
+        assert mock_session.put.call_args_list[0] == call(
+            "http://localhost:3000/api/setting/site-url",
+            headers={"X-Metabase-Session": "sess-xyz"},
+            json={"value": "http://localhost:8800/metabase/"},
+            timeout=10,
+        )
+
+    def test_setup_metabase_site_url_failure_does_not_block_setup(
+        self, tmp_project_dir: Path
+    ) -> None:
+        """A non-200 from the site-url PUT must not stop the rest of setup_metabase()
+        (DuckDB connection, credentials save) from completing."""
+        from dango.visualization.metabase import setup_metabase
+
+        mock_session = _mock_fresh_setup_session(
+            [MagicMock(status_code=500), MagicMock(status_code=200)]
+        )
+
+        with (
+            patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc"),
+            patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+        ):
+            result = setup_metabase(tmp_project_dir, "test-project", "admin@example.com")
+
+        assert result["success"] is True
+        assert result["duckdb_connected"] is True
+        assert result["credentials_saved"] is True

--- a/tests/unit/test_metabase_site_url.py
+++ b/tests/unit/test_metabase_site_url.py
@@ -17,6 +17,13 @@ from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+import yaml
+
+# Patch target for NetworkConfig.get_project_info: dango.platform.local.network is
+# the source module (metabase.py lazy-imports it inside _should_apply_local_site_url()
+# rather than importing it at module level), so that's what must be patched -- patching
+# dango.visualization.metabase.NetworkConfig would silently no-op.
+_NETWORK_CONFIG_GET_PROJECT_INFO = "dango.platform.local.network.NetworkConfig.get_project_info"
 
 
 def _mock_fresh_setup_session(put_side_effect: list[MagicMock]) -> MagicMock:
@@ -79,6 +86,7 @@ class TestSetupMetabaseSiteUrl:
             patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc"),
             patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
             patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch(_NETWORK_CONFIG_GET_PROJECT_INFO, return_value=None),
         ):
             result = setup_metabase(tmp_project_dir, "test-project", "admin@example.com")
 
@@ -89,12 +97,15 @@ class TestSetupMetabaseSiteUrl:
             json={"value": "http://localhost:8800/metabase/"},
             timeout=10,
         )
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        assert yaml.safe_load(creds_file.read_text())["site_url_set"] is True
 
     def test_setup_metabase_site_url_failure_does_not_block_setup(
         self, tmp_project_dir: Path
     ) -> None:
         """A non-200 from the site-url PUT must not stop the rest of setup_metabase()
-        (DuckDB connection, credentials save) from completing."""
+        (DuckDB connection, credentials save) from completing, and must not mark
+        site_url_set so refresh_metabase_connection() retries it on the next sync."""
         from dango.visualization.metabase import setup_metabase
 
         mock_session = _mock_fresh_setup_session(
@@ -105,9 +116,61 @@ class TestSetupMetabaseSiteUrl:
             patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc"),
             patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
             patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch(_NETWORK_CONFIG_GET_PROJECT_INFO, return_value=None),
         ):
             result = setup_metabase(tmp_project_dir, "test-project", "admin@example.com")
 
         assert result["success"] is True
         assert result["duckdb_connected"] is True
         assert result["credentials_saved"] is True
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        assert yaml.safe_load(creds_file.read_text())["site_url_set"] is False
+
+    def test_setup_metabase_skips_site_url_in_cloud_mode(self, tmp_project_dir: Path) -> None:
+        """cloud_mode=True must skip the site-url PUT entirely -- Caddy fronts Metabase
+        with a real public domain/HTTPS on cloud deployments, not localhost:{port}."""
+        from dango.visualization.metabase import setup_metabase
+
+        set_default_resp = MagicMock(status_code=200)
+        mock_session = _mock_fresh_setup_session([set_default_resp])
+
+        with (
+            patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc"),
+            patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+        ):
+            result = setup_metabase(
+                tmp_project_dir, "test-project", "admin@example.com", cloud_mode=True
+            )
+
+        assert result["success"] is True
+        # Only the "set default database" PUT should fire -- no site-url PUT, and
+        # no NetworkConfig lookup either (cloud_mode short-circuits before that).
+        assert mock_session.put.call_count == 1
+        assert "site-url" not in mock_session.put.call_args_list[0][0][0]
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        assert yaml.safe_load(creds_file.read_text())["site_url_set"] is False
+
+    def test_setup_metabase_skips_site_url_for_custom_domain(self, tmp_project_dir: Path) -> None:
+        """A project registered under a non-default domain in the local shared-nginx
+        routing (platform/local/network.py) must not get a localhost:{port} Site URL
+        -- that's not how it's actually accessed. See _should_apply_local_site_url()."""
+        from dango.visualization.metabase import setup_metabase
+
+        set_default_resp = MagicMock(status_code=200)
+        mock_session = _mock_fresh_setup_session([set_default_resp])
+
+        with (
+            patch("dango.platform.docker.get_compose_project_name", return_value="dango-abc"),
+            patch("dango.visualization.metabase.wait_for_metabase_ready", return_value=True),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch(
+                _NETWORK_CONFIG_GET_PROJECT_INFO,
+                return_value={"domain": "custom.example.com", "backend_port": 8800},
+            ),
+        ):
+            result = setup_metabase(tmp_project_dir, "test-project", "admin@example.com")
+
+        assert result["success"] is True
+        assert mock_session.put.call_count == 1
+        assert "site-url" not in mock_session.put.call_args_list[0][0][0]

--- a/tests/unit/test_metabase_site_url.py
+++ b/tests/unit/test_metabase_site_url.py
@@ -151,10 +151,14 @@ class TestSetupMetabaseSiteUrl:
         creds_file = tmp_project_dir / ".dango" / "metabase.yml"
         assert yaml.safe_load(creds_file.read_text())["site_url_set"] is False
 
-    def test_setup_metabase_skips_site_url_for_custom_domain(self, tmp_project_dir: Path) -> None:
-        """A project registered under a non-default domain in the local shared-nginx
-        routing (platform/local/network.py) must not get a localhost:{port} Site URL
-        -- that's not how it's actually accessed. See _should_apply_local_site_url()."""
+    def test_setup_metabase_skips_site_url_for_registered_project(
+        self, tmp_project_dir: Path
+    ) -> None:
+        """A project registered in the local shared-nginx routing
+        (platform/local/network.py) must not get a localhost:{port} Site URL -- it's
+        actually accessed via its routing.json domain entry. See
+        _should_apply_local_site_url() (and TestShouldApplyLocalSiteUrl below for the
+        direct unit tests on that function's registered/not-registered logic)."""
         from dango.visualization.metabase import setup_metabase
 
         set_default_resp = MagicMock(status_code=200)
@@ -174,3 +178,67 @@ class TestSetupMetabaseSiteUrl:
         assert result["success"] is True
         assert mock_session.put.call_count == 1
         assert "site-url" not in mock_session.put.call_args_list[0][0][0]
+
+
+@pytest.mark.unit
+class TestShouldApplyLocalSiteUrl:
+    """Direct unit tests for _should_apply_local_site_url() (1.0.8-W review fix).
+
+    An earlier version of this function compared the registered domain to
+    ``f"{project_name}.dango"`` to detect a "custom" domain, but
+    ``NetworkConfig.register_project()`` (the only real caller, via `dango rename`)
+    always registers under exactly that pattern for the *current* project name -- so
+    that comparison could never be true and the check silently never skipped anything
+    for the one live registration path. Fixed to treat any registration as
+    disqualifying. test_skips_registered_project_even_with_default_domain_pattern
+    below is the positive control for that exact scenario.
+    """
+
+    def test_skips_in_cloud_mode_without_any_io(self, tmp_path: Path) -> None:
+        """cloud_mode=True short-circuits before ConfigLoader/NetworkConfig are even
+        touched -- verified by not patching either and still getting False back
+        (a bare tmp_path with no .dango/project.yml would otherwise raise)."""
+        from dango.visualization.metabase import _should_apply_local_site_url
+
+        assert _should_apply_local_site_url(tmp_path, cloud_mode=True) is False
+
+    def test_skips_registered_project_even_with_default_domain_pattern(
+        self, tmp_project_dir: Path
+    ) -> None:
+        """Positive control for the bug found in review: a project registered under
+        exactly the default f"{project_name}.dango" pattern (what `dango rename`
+        always produces) must still be skipped -- the domain string doesn't matter,
+        only whether a registration exists at all."""
+        from dango.visualization.metabase import _should_apply_local_site_url
+
+        project_name = "Test Project"  # matches tmp_project_dir's project.yml fixture
+        with patch(
+            _NETWORK_CONFIG_GET_PROJECT_INFO,
+            return_value={"domain": f"{project_name}.dango", "backend_port": 8800},
+        ):
+            assert _should_apply_local_site_url(tmp_project_dir, cloud_mode=False) is False
+
+    def test_skips_registered_project_with_a_different_domain(self, tmp_project_dir: Path) -> None:
+        """Also skips for a domain that doesn't match the default pattern at all."""
+        from dango.visualization.metabase import _should_apply_local_site_url
+
+        with patch(
+            _NETWORK_CONFIG_GET_PROJECT_INFO,
+            return_value={"domain": "custom.example.com", "backend_port": 8800},
+        ):
+            assert _should_apply_local_site_url(tmp_project_dir, cloud_mode=False) is False
+
+    def test_applies_for_unregistered_project(self, tmp_project_dir: Path) -> None:
+        """The common case: no shared-nginx registration exists -> True."""
+        from dango.visualization.metabase import _should_apply_local_site_url
+
+        with patch(_NETWORK_CONFIG_GET_PROJECT_INFO, return_value=None):
+            assert _should_apply_local_site_url(tmp_project_dir, cloud_mode=False) is True
+
+    def test_fails_open_when_config_cannot_be_loaded(self, tmp_path: Path) -> None:
+        """A bare tmp_path has no .dango/project.yml, so ConfigLoader.load_config()
+        raises ConfigNotFoundError -- caught, and the function fails open (True)
+        rather than silently disabling the fix for every project on an I/O hiccup."""
+        from dango.visualization.metabase import _should_apply_local_site_url
+
+        assert _should_apply_local_site_url(tmp_path, cloud_mode=False) is True

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -21,6 +21,12 @@ from dango.platform.common.startup import (
 )
 from dango.utils.driver import METABASE_DUCKDB_DRIVER_VERSION
 
+# Patch target for NetworkConfig.get_project_info: dango.platform.local.network is the
+# source module (metabase.py lazy-imports it inside _should_apply_local_site_url()
+# rather than importing it at module level), so that's what must be patched — patching
+# dango.visualization.metabase.NetworkConfig would silently no-op.
+_NETWORK_CONFIG_GET_PROJECT_INFO = "dango.platform.local.network.NetworkConfig.get_project_info"
+
 
 @pytest.mark.unit
 class TestRunPendingMigrations:
@@ -766,9 +772,11 @@ class TestRefreshMetabaseConnection:
 
     def test_reapplies_site_url_on_successful_restart(self, tmp_project_dir: Path) -> None:
         """1.0.8-W: an already-configured project (metabase.yml predates the Site URL
-        fix) only ever gets the fix applied via this path, since setup_metabase() runs
-        once and never retroactively fixes existing projects. tmp_project_dir gives
-        config.platform.port == 8800 (default, no platform: override)."""
+        fix, no site_url_set marker yet) gets the fix applied via this path exactly
+        once, since setup_metabase() runs once and never retroactively fixes existing
+        projects. tmp_project_dir gives config.platform.port == 8800 (default, no
+        platform: override). A successful PUT must also persist site_url_set: true so
+        future syncs skip the login+PUT entirely (see the marker-skip test below)."""
         import requests
         import yaml as yaml_module
 
@@ -809,6 +817,8 @@ class TestRefreshMetabaseConnection:
             patch("dango.platform.docker.DockerManager", return_value=mock_dm),
             patch("subprocess.run", mock_subprocess_run),
             patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.config.helpers.is_cloud_mode", return_value=False),
+            patch(_NETWORK_CONFIG_GET_PROJECT_INFO, return_value=None),
         ):
             result = refresh_metabase_connection(tmp_project_dir)
 
@@ -819,10 +829,12 @@ class TestRefreshMetabaseConnection:
             json={"value": "http://localhost:8800/metabase/"},
             timeout=10,
         )
+        assert yaml_module.safe_load(creds_file.read_text())["site_url_set"] is True
 
     def test_site_url_failure_does_not_block_refresh(self, tmp_project_dir: Path) -> None:
         """A site-url PUT failure (or login failure) must not turn a successful
-        container restart into a reported failure."""
+        container restart into a reported failure, and must not mark site_url_set so
+        the next sync retries it."""
         import requests
         import yaml as yaml_module
 
@@ -858,10 +870,107 @@ class TestRefreshMetabaseConnection:
             patch("dango.platform.docker.DockerManager", return_value=mock_dm),
             patch("subprocess.run", mock_subprocess_run),
             patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.config.helpers.is_cloud_mode", return_value=False),
+            patch(_NETWORK_CONFIG_GET_PROJECT_INFO, return_value=None),
         ):
             result = refresh_metabase_connection(tmp_project_dir)
 
         assert result == (True, None)
+        mock_session.put.assert_not_called()
+        assert "site_url_set" not in yaml_module.safe_load(creds_file.read_text())
+
+    def test_skips_site_url_when_already_marked_set(self, tmp_project_dir: Path) -> None:
+        """1.0.8-W: once site_url_set is true (written by a prior successful
+        setup_metabase() or refresh_metabase_connection() call), subsequent syncs must
+        not repeat the login POST + PUT -- that would add ~20s of latency budget and
+        retransmit the admin password on every single sync forever, for zero benefit
+        once it's already correct."""
+        import requests
+        import yaml as yaml_module
+
+        from dango.visualization.metabase import refresh_metabase_connection
+
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        creds_file.write_text(
+            yaml_module.dump(
+                {
+                    "metabase_url": "http://localhost:3000",
+                    "admin": {"email": "admin@example.com", "password": "secret"},
+                    "database": {"id": 5, "name": "Test Analytics"},
+                    "site_url_set": True,
+                }
+            )
+        )
+
+        mock_dm = MagicMock()
+        mock_dm.compose_project_name = "dango-abc123"
+
+        mock_subprocess_run = MagicMock(
+            side_effect=[
+                MagicMock(stdout="dango-abc123-metabase-1\n", returncode=0),  # docker ps
+                MagicMock(returncode=0),  # docker restart
+            ]
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        mock_session.get.return_value = MagicMock(status_code=200)  # /api/health
+
+        with (
+            patch("dango.platform.docker.DockerManager", return_value=mock_dm),
+            patch("subprocess.run", mock_subprocess_run),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.config.helpers.is_cloud_mode", return_value=False),
+            patch(_NETWORK_CONFIG_GET_PROJECT_INFO, return_value=None),
+        ):
+            result = refresh_metabase_connection(tmp_project_dir)
+
+        assert result == (True, None)
+        mock_session.post.assert_not_called()  # no login attempt
+        mock_session.put.assert_not_called()  # no site-url PUT
+
+    def test_skips_site_url_in_cloud_mode(self, tmp_project_dir: Path) -> None:
+        """cloud_mode must skip the login+PUT entirely (not just the PUT) -- Caddy
+        fronts Metabase with a real public domain there, and there's no reason to pay
+        a login POST for a value this function isn't going to write anyway."""
+        import requests
+        import yaml as yaml_module
+
+        from dango.visualization.metabase import refresh_metabase_connection
+
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        creds_file.write_text(
+            yaml_module.dump(
+                {
+                    "metabase_url": "http://localhost:3000",
+                    "admin": {"email": "admin@example.com", "password": "secret"},
+                    "database": {"id": 5, "name": "Test Analytics"},
+                }
+            )
+        )
+
+        mock_dm = MagicMock()
+        mock_dm.compose_project_name = "dango-abc123"
+
+        mock_subprocess_run = MagicMock(
+            side_effect=[
+                MagicMock(stdout="dango-abc123-metabase-1\n", returncode=0),  # docker ps
+                MagicMock(returncode=0),  # docker restart
+            ]
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        mock_session.get.return_value = MagicMock(status_code=200)  # /api/health
+
+        with (
+            patch("dango.platform.docker.DockerManager", return_value=mock_dm),
+            patch("subprocess.run", mock_subprocess_run),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+            patch("dango.config.helpers.is_cloud_mode", return_value=True),
+        ):
+            result = refresh_metabase_connection(tmp_project_dir)
+
+        assert result == (True, None)
+        mock_session.post.assert_not_called()
         mock_session.put.assert_not_called()
 
 

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -764,6 +764,106 @@ class TestRefreshMetabaseConnection:
         assert result[0] is False
         assert result[1] == "Metabase container not running"
 
+    def test_reapplies_site_url_on_successful_restart(self, tmp_project_dir: Path) -> None:
+        """1.0.8-W: an already-configured project (metabase.yml predates the Site URL
+        fix) only ever gets the fix applied via this path, since setup_metabase() runs
+        once and never retroactively fixes existing projects. tmp_project_dir gives
+        config.platform.port == 8800 (default, no platform: override)."""
+        import requests
+        import yaml as yaml_module
+
+        from dango.visualization.metabase import refresh_metabase_connection
+
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        creds_file.write_text(
+            yaml_module.dump(
+                {
+                    "metabase_url": "http://localhost:3000",
+                    "admin": {"email": "admin@example.com", "password": "secret"},
+                    "database": {"id": 5, "name": "Test Analytics"},
+                }
+            )
+        )
+
+        mock_dm = MagicMock()
+        mock_dm.compose_project_name = "dango-abc123"
+
+        mock_subprocess_run = MagicMock(
+            side_effect=[
+                MagicMock(stdout="dango-abc123-metabase-1\n", returncode=0),  # docker ps
+                MagicMock(returncode=0),  # docker restart
+            ]
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        mock_session.get.return_value = MagicMock(status_code=200)  # /api/health
+
+        login_resp = MagicMock(status_code=200)
+        login_resp.json.return_value = {"id": "sess-xyz"}
+        mock_session.post.return_value = login_resp  # /api/session (login)
+
+        site_url_resp = MagicMock(status_code=200)
+        mock_session.put.return_value = site_url_resp  # /api/setting/site-url
+
+        with (
+            patch("dango.platform.docker.DockerManager", return_value=mock_dm),
+            patch("subprocess.run", mock_subprocess_run),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+        ):
+            result = refresh_metabase_connection(tmp_project_dir)
+
+        assert result == (True, None)
+        mock_session.put.assert_called_once_with(
+            "http://localhost:3000/api/setting/site-url",
+            headers={"X-Metabase-Session": "sess-xyz"},
+            json={"value": "http://localhost:8800/metabase/"},
+            timeout=10,
+        )
+
+    def test_site_url_failure_does_not_block_refresh(self, tmp_project_dir: Path) -> None:
+        """A site-url PUT failure (or login failure) must not turn a successful
+        container restart into a reported failure."""
+        import requests
+        import yaml as yaml_module
+
+        from dango.visualization.metabase import refresh_metabase_connection
+
+        creds_file = tmp_project_dir / ".dango" / "metabase.yml"
+        creds_file.write_text(
+            yaml_module.dump(
+                {
+                    "metabase_url": "http://localhost:3000",
+                    "admin": {"email": "admin@example.com", "password": "secret"},
+                    "database": {"id": 5, "name": "Test Analytics"},
+                }
+            )
+        )
+
+        mock_dm = MagicMock()
+        mock_dm.compose_project_name = "dango-abc123"
+
+        mock_subprocess_run = MagicMock(
+            side_effect=[
+                MagicMock(stdout="dango-abc123-metabase-1\n", returncode=0),  # docker ps
+                MagicMock(returncode=0),  # docker restart
+            ]
+        )
+
+        mock_session = MagicMock(spec=requests.Session)
+        mock_session.get.return_value = MagicMock(status_code=200)  # /api/health
+        # Login fails outright — site-url refresh should be skipped, not raise.
+        mock_session.post.return_value = MagicMock(status_code=401)
+
+        with (
+            patch("dango.platform.docker.DockerManager", return_value=mock_dm),
+            patch("subprocess.run", mock_subprocess_run),
+            patch("dango.visualization.metabase.requests.Session", return_value=mock_session),
+        ):
+            result = refresh_metabase_connection(tmp_project_dir)
+
+        assert result == (True, None)
+        mock_session.put.assert_not_called()
+
 
 @pytest.mark.unit
 class TestCheckDuckdbVersionAlignment:

--- a/tests/unit/test_platform_startup.py
+++ b/tests/unit/test_platform_startup.py
@@ -725,6 +725,23 @@ class TestLinkMetabaseAdmin:
 class TestRefreshMetabaseConnection:
     """Tests for refresh_metabase_connection() container name resolution (BUG-118)."""
 
+    def test_unexpected_error_returns_gracefully_instead_of_masking_typeerror(
+        self, tmp_path: Path
+    ) -> None:
+        """1.0.8-W regression test: the outer `except Exception as e: logger.warning(...)`
+        block used to pass `error=str(e)` to stdlib logging.Logger.warning(), which isn't
+        a valid kwarg there (this module's `logger` is `logging.getLogger`, not
+        structlog) -- verified live to raise its own TypeError, silently replacing
+        whatever the real exception was. Positive control: force an exception inside the
+        try block and confirm the function now returns (False, <message>) instead of
+        raising."""
+        from dango.visualization.metabase import refresh_metabase_connection
+
+        with patch("dango.platform.docker.DockerManager", side_effect=RuntimeError("boom")):
+            result = refresh_metabase_connection(tmp_path)
+
+        assert result == (False, "boom")
+
     def test_uses_hash_based_container_name(self, tmp_path: Path) -> None:
         """BUG-118: refresh_metabase_connection uses DockerManager's hash-based name."""
         from dango.visualization.metabase import refresh_metabase_connection


### PR DESCRIPTION
## Summary
- `setup_metabase()` now sets Metabase's Site URL (`PUT /api/setting/site-url`) to the
  correct `/metabase/`-suffixed, `config.platform.port`-based URL, fixing broken JS asset
  loading (blank page, `Uncaught SyntaxError` on chunk loads) when accessing Metabase
  through the local proxy.
- **Scope expanded per coordinating-chat decision:** `refresh_metabase_connection()` (the
  function that restarts the Metabase container after every sync) also applies the fix,
  since it's the only path that ever reaches a project whose `.dango/metabase.yml` was
  created *before* this fix ships — `setup_metabase()` runs exactly once per project
  (guarded by `credentials_file.exists()`) and cannot retroactively fix already-configured
  projects.
- The actual PUT logic (read `config.platform.port`, build the `/metabase/`-suffixed URL,
  `PUT /api/setting/site-url`, print-and-swallow on failure) is factored into a shared
  private helper `_set_metabase_site_url()`, used by both call sites — no duplication.
- `refresh_metabase_connection()` did not previously authenticate with Metabase's API at
  all (it only restarts the Docker container and polls `/api/health`); it now also logs
  in using the admin credentials already saved in `.dango/metabase.yml` (via the existing
  `_metabase_login()` helper) so it has a session token to call the site-url endpoint with.
  This login + site-url call is wrapped in its own try/except, separate from
  `_set_metabase_site_url()`'s internal one, so any failure (missing/malformed credentials
  file, login failure) never turns a successful container restart into a reported failure.

## Update: independent review caught a real regression, now fixed
An independent code review of this PR (run via the `code-review` skill, cross-checked by
the coordinating chat) found that the original version applied the Site URL PUT
**unconditionally**. `http://localhost:{config.platform.port}/metabase/` is only correct
for the plain local (no cloud, no custom domain) access pattern:

- **Cloud deployments** are fronted by Caddy with a real public domain/HTTPS, not
  `localhost:{port}` — writing the local value there would be actively wrong, not just
  unhelpful. Site URL also governs Metabase's own password-reset/invite email links and
  other absolute URLs it generates, not just JS asset paths, so this was a real regression
  risk for cloud specifically.
- Since `refresh_metabase_connection()` now applies this on every sync (not just once),
  an unconditional PUT would have meant **recurring corruption** for cloud projects, not a
  one-time no-op.

Fixed by adding `_should_apply_local_site_url(project_root, cloud_mode)`, checked *before*
any login/PUT is attempted in both call sites:
- `setup_metabase()` already receives `cloud_mode` as a parameter — short-circuits on it,
  no config/network lookup needed.
- `refresh_metabase_connection()` now calls `dango.config.helpers.is_cloud_mode()` first.
- Both also skip when the project is registered under a non-default domain via
  `platform/local/network.py`'s shared nginx routing (the local custom-domain feature).
  This is defense in depth rather than an active concern today: grep confirmed
  `NetworkConfig.register_project()` is currently only ever called from the `dango rename`
  CLI command, conditional on a routing.json entry nothing else creates — there's no live
  registration path for a *fresh* project. A project actually using this feature already
  has the same JS-asset-path bug via a different Site URL mismatch (nothing set Site URL
  at all before this fix), so this check isn't closing a new gap for such projects — it's
  making sure this PR doesn't start actively writing a wrong value where none was written
  before. Fully correct Site URL handling for local custom domains is still out of scope
  and documented as a known follow-up gap.

Also added while addressing this, since it changes how often the PUT runs:
- A `site_url_set` marker persisted to `.dango/metabase.yml`. Without it,
  `refresh_metabase_connection()` would repeat a login POST + PUT on every single sync
  forever (~20s of extra latency budget and retransmitting the admin password, for zero
  benefit once it's already correct). Written by whichever of `setup_metabase()` /
  `refresh_metabase_connection()` first successfully applies the fix; the marker makes it
  a one-time catch-up, not a recurring cost.
- `_set_metabase_site_url()` now returns `bool` (PUT succeeded or not) so callers can
  decide whether it's safe to persist the marker.
- `_safe_print()` guards this module's own status glyphs (✓/⚠) so a non-UTF-8 stdout can't
  turn an already-caught PUT failure into a new, uncaught `UnicodeEncodeError` from the
  fallback print itself (the original fallback branch's own `print()` call wasn't
  protected).
- Updated `_metabase_login()`'s docstring, which claimed "three" call sites — grep-verified
  the actual current list instead of leaving a stale count now that a fourth caller exists.

## Update 2: second independent review pass, three more fixes
A second review pass (same `code-review` skill, run fresh against the pushed fix above)
found three more real issues, now fixed, plus two items I'm flagging as known
limitations rather than fixing in this PR (see below):

- **The custom-domain check from Update 1 was dead code.** `_should_apply_local_site_url()`
  compared the registered domain to `f"{project_name}.dango"` to detect a "custom" domain
  — but `NetworkConfig.register_project()` (the only real caller, via `dango rename`)
  *always* registers under exactly that pattern for the *current* project name. That
  comparison could never be true, so the check silently never skipped anything for the one
  live registration path — defeating its own stated purpose. **Fixed:** any registration at
  all now disqualifies (a registered project is accessed via its routing.json `domain`
  entry, not `localhost:{port}`, regardless of what that domain string happens to be). New
  positive-control test (`test_skips_registered_project_even_with_default_domain_pattern`)
  proves the fixed behavior on the exact scenario that was broken — see
  `TestShouldApplyLocalSiteUrl` for direct unit tests on this function.
- **Recurring I/O contradicting the "one-time catch-up" framing.** The `site_url_set`
  marker check ran *after* `_should_apply_local_site_url()`'s heavier work (a full
  `project.yml` reparse, a `NetworkConfig()` construction touching `~/.dango/`), so an
  already-caught-up project still paid for that local I/O on every single sync forever —
  not the network I/O (no login/PUT happened), but still unnecessary recurring work
  contradicting the docstring's own claim. **Fixed:** extracted the whole catch-up flow
  into `_apply_metabase_site_url_catchup()`, which now checks the marker first (one cheap
  file read) before calling `_should_apply_local_site_url()` at all.
- Extracting that helper also resolves a code-quality finding from this same pass: the
  catch-up logic was inlined 6 levels deep (`for → try → try → if → if → if`) directly in
  `refresh_metabase_connection()`'s health-poll loop, unlike `_set_metabase_site_url()`
  which was already its own function — inconsistent extraction made the orchestration
  harder to follow. It's now a named, independently-testable function.
- Also addressed: `_safe_print()`'s docstring narrowed to accurately state it only guards
  this PR's own two new print calls, not the dozen-plus pre-existing unguarded ✓/⚠ prints
  elsewhere in this module (it was implicitly overclaiming module-wide protection);
  `dango/visualization/CLAUDE.md`'s stale "No dango module imports (isolated module)"
  claim updated to document the three lazy `dango.*` imports this PR adds and why;
  `metabase.py`'s line count corrected (1251 → 1775, now genuinely accurate) in the two
  root `CLAUDE.md` monolithic-files entries and `docs/file-exemptions.yml`, all stale
  after this PR's growth.

**Flagged as known limitations, not fixed in this PR** (would meaningfully expand scope
beyond this PR's bug):
- **Unsynchronized read-modify-write on `.dango/metabase.yml`.** `refresh_metabase_connection()`
  is reachable from four independent, non-serialized call sites (`dlt_runner.py`,
  `web/routes/dbt.py`, `platform/scheduling/jobs.py`, `cli/commands/transform.py`), and
  its new catch-up path does a read-modify-write of the whole credentials file with no
  lock. This is currently self-converging for `site_url_set` specifically (whichever
  writer runs, the field ends up `True`), but it's a lost-update pattern on a file that
  also holds live admin credentials, and `DbtLock` doesn't cover this file. Properly fixing
  this means adding file locking to a *pre-existing* unprotected-write pattern shared by
  `setup_metabase()`, `_link_metabase_admin()`, and now this catch-up path — a bigger,
  separate change than this PR's scope. Flagging for the coordinating chat to decide
  whether that's worth a dedicated follow-up task.
- **Blocking I/O in an async web handler.** `web/routes/dbt.py`'s `run_dbt_model_task` is
  `async def` and calls `refresh_metabase_connection()` synchronously with no thread-pool
  offload. That function already did significant blocking work before this PR (Docker
  `subprocess.run()` restart + up to 20s of health-polling) — a pre-existing architectural
  issue matching `CLAUDE.md`'s documented "single worker uvicorn" constraint. This PR's
  catch-up adds at most one more ~20s hit (one login POST + one PUT, both 10s timeout), but
  only *once* per project, on the first sync after upgrading, thanks to the `site_url_set`
  marker — not a new *recurring* cost. Not fixing the broader blocking-I/O-in-async-handler
  pattern here; noting it in case the coordinating chat wants it tracked separately.

## Update 3: third independent review pass — self-contained contracts, one latent bug fixed
A third review pass found smaller robustness/consistency issues plus one genuinely
unrelated pre-existing bug it happened to surface:

- `_apply_metabase_site_url_catchup()` claimed "never raises" but only held because its
  caller wrapped it — the function's own body wasn't self-contained. Fixed: the whole body
  is now in its own try/except, so the guarantee doesn't depend on caller behavior.
- `_should_apply_local_site_url()`'s fail-open `except: pass` silently swallowed every
  error, including ones worth knowing about (e.g. a corrupted `~/.dango/routing.json`).
  Now logs at debug level (fail-open behavior unchanged — still deliberate). Also switched
  from a full `ConfigLoader.load_config()` to the lighter `load_project_context()`, since
  only `project.name` is needed and the full load also parses/validates `sources.yml` for
  no benefit here.
- **Found and fixed a real, pre-existing, unrelated bug** while adding that debug log,
  directly in the function this PR touches: the final `except Exception as e:` block did
  `logger.warning("...", error=str(e), exc_info=True)` — `error=` isn't a valid kwarg for
  stdlib `logging.Logger.warning()` (confirmed live: this module's `logger` is
  `logging.getLogger`, not structlog). That line itself raised `TypeError`, silently
  replacing whatever the real exception was with an unrelated one, every time this path
  fired. Fixed to a valid call shape. New positive-control regression test
  (`test_unexpected_error_returns_gracefully_instead_of_masking_typeerror`) forces an
  exception and confirms the function now returns `(False, message)` instead of raising.
- Documented two accepted asymmetries in the `site_url_set` marker design directly in
  `_apply_metabase_site_url_catchup()`'s docstring: cloud/registered projects never get the
  "one-time" savings (intentional — lets them self-correct if their topology later becomes
  plain-local), and a project that becomes cloud/registered *after* already being marked
  has no automatic re-check (an extension of the already-disclosed local-custom-domain
  follow-up gap, not a new one — and, per the grep in Update 1/2, not currently reachable
  since the only live registration path only updates an existing entry, never creates one).
- `_metabase_login()`'s docstring corrected (it named `refresh_metabase_connection()` as a
  direct caller, but that call now goes through `_apply_metabase_site_url_catchup()`), and
  revised to acknowledge that this PR's own new credential-loading code is itself another
  copy of the "open metabase.yml, pull out admin.email/password" shape the docstring
  already flagged as worth consolidating — rather than silently exceeding its own stated
  threshold without saying so.

## Why this fix (not the nginx config)
Metabase computes its own JS chunk-loading URLs from its internal **Site URL** setting,
not from how a reverse proxy in front of it is configured. Dango proxies Metabase through
`dango/web/routes/metabase_proxy.py` (mounted at `/metabase`), whose `_build_response()`
does a pure byte-for-byte passthrough — no HTML/JS rewriting. Since nothing previously told
Metabase its Site URL is `/metabase/`-prefixed, it assumed basename `/` and generated
chunk-loading requests that 404/mis-route once the browser is actually at
`http://localhost:8800/metabase/...`.

`dango/templates/nginx.conf.j2` is confirmed dead code (not referenced anywhere in the
Python codebase) and is untouched by this PR.

A previous attempt (commit `a98072e`, reverted same day by `effb900`) set
`MB_SITE_URL: "http://localhost:3000"` as a docker-compose env var — missing the
`/metabase/` suffix and using Metabase's internal port (3000) instead of the
browser-visible web UI port (8800, `config.platform.port`). That attempt was reverted on
the incorrect conclusion that the warning is cosmetic; it is not (see symptom above), and
the value was wrong on two counts. This PR uses the full `/metabase/`-suffixed URL and the
correct web UI port, applied via the live Admin API rather than a docker-compose env var —
which also means it recomputes the URL correctly regardless of what port the project is
actually configured on, instead of hardcoding one, and now (post-review) gates on
deployment topology so it doesn't apply where it would be wrong.

**This PR is scoped to local-only.** It does not touch or verify cloud deployment's
Caddy-based proxying, per the task's explicit instruction not to assume the local fix
covers cloud — it now actively *avoids* writing anything for cloud deployments (see Update
above) rather than just not addressing them. Whether cloud needs its own equivalent fix
(presumably setting Site URL to the public domain, via a different code path) is an open
follow-up question, not something this PR answers either way.

## Verification
- `pytest -x`: 4670 passed, 30 skipped, 0 failed (full suite, no regressions)
- `ruff check dango/`: all checks passed
- `ruff format --check dango/`: all files formatted
- `python3 scripts/check_file_sizes.py --all`: 406 checked, 82 exempt, all within limits
- Unit tests in `tests/unit/test_metabase_site_url.py::TestSetupMetabaseSiteUrl` (via
  `setup_metabase()`):
  - `test_setup_metabase_sets_site_url` — PUT made to `{metabase_url}/api/setting/site-url`
    with `json={"value": "http://localhost:8800/metabase/"}` when
    `config.platform.port == 8800`; `.dango/metabase.yml`'s `site_url_set` ends up `True`
  - `test_setup_metabase_site_url_failure_does_not_block_setup` — non-200 PUT doesn't stop
    DuckDB connection / credential save, and `site_url_set` stays `False` (so the next
    sync retries it)
  - `test_setup_metabase_skips_site_url_in_cloud_mode` — `cloud_mode=True` skips the PUT
    entirely, no `NetworkConfig` lookup
  - `test_setup_metabase_skips_site_url_for_registered_project` — a registered project
    skips the PUT
- Direct unit tests on the gate itself,
  `tests/unit/test_metabase_site_url.py::TestShouldApplyLocalSiteUrl` (added in Update 2):
  - `test_skips_in_cloud_mode_without_any_io` — cloud_mode short-circuits before any
    ConfigLoader/NetworkConfig call
  - `test_skips_registered_project_even_with_default_domain_pattern` — **positive control**
    for the dead-check bug: a registration under exactly `f"{project_name}.dango"` (what
    `dango rename` always produces) is still correctly skipped
  - `test_skips_registered_project_with_a_different_domain` — also skips for an unrelated
    domain string
  - `test_applies_for_unregistered_project` — the common case, no registration → `True`
  - `test_fails_open_when_config_cannot_be_loaded` — `ConfigNotFoundError` → fails open
- Unit tests in `tests/unit/test_platform_startup.py::TestRefreshMetabaseConnection`:
  - `test_unexpected_error_returns_gracefully_instead_of_masking_typeerror` — **positive
    control** for the pre-existing latent logger bug found and fixed in Update 3: forces
    an exception inside the try block, confirms `(False, message)` instead of a masking
    `TypeError`
  - `test_reapplies_site_url_on_successful_restart` — logs in with saved admin
    credentials, PUTs the correct site-url, and persists `site_url_set: true`
  - `test_site_url_failure_does_not_block_refresh` — login/PUT failure still returns
    `(True, None)`, and `site_url_set` is not written (so it retries next sync)
  - `test_skips_site_url_when_already_marked_set` — no login, no PUT, when the marker is
    already `True`
  - `test_skips_site_url_in_cloud_mode` — `is_cloud_mode()` True skips login+PUT entirely
  - Both pre-existing container-name-resolution tests (`test_uses_hash_based_container_name`,
    `test_returns_false_when_container_not_running`) still pass unmodified
- **Manual browser verification (requires Docker) was not performed in this session.**
  Ports 8800/3000 were already in use by another active local Metabase instance at the time
  of this session (likely beta-1 or a concurrent session) — per project rules, sessions must
  not run live Docker/browser tests against shared/already-running instances; that
  verification is the coordinating chat's job before merge (sequential, one PR at a time).
  Please verify in a real browser before merging: fresh `dango init` + `dango start`, open
  `http://localhost:<configured-port>/metabase/`, confirm no `Uncaught SyntaxError` in the
  console and the dashboard renders (not blank). Also worth spot-checking the
  `refresh_metabase_connection()` path specifically: run a sync on a project whose
  `.dango/metabase.yml` was created *before* this branch (simulating an already-configured
  project), confirm the Site URL gets corrected after the post-sync restart, and confirm a
  *second* sync does not repeat the login/PUT (marker skip).

## Regression check
- Site-url-set failure confirmed non-blocking on both call sites (see tests above).
- Grepped all callers: `setup_metabase()` is only called from
  `platform/common/startup.py` and `cli/init.py`; `refresh_metabase_connection()` is called
  from `dlt_runner.py`, `web/routes/dbt.py`, `platform/scheduling/jobs.py`, and
  `cli/commands/transform.py` (post-sync/post-dbt paths). None of these depend on internals
  this change touches.
- **Cloud deployments:** now actively excluded (see Update above), not just undocumented —
  this closes what an independent review flagged as a genuine regression risk.
- **Local custom-domain projects:** known, documented follow-up gap — see Update above for
  why this is pre-existing (not introduced by this PR) and why the defense-in-depth check
  is enough for now rather than a full fix.
- `dango/templates/nginx.conf.j2` and `platform/local/network.py` are untouched (only read
  from, via `NetworkConfig.get_project_info()`), as specified.


